### PR TITLE
Fix yDiff computation

### DIFF
--- a/src/gui/object/CProxyTargetGraphicsObject.cpp
+++ b/src/gui/object/CProxyTargetGraphicsObject.cpp
@@ -49,7 +49,7 @@ void CProxyTargetGraphicsObject::refresh() {
         int currentSizeY = getSizeY(gui);
 
         int xDiff = currentSizeX - prevX;
-        int yDiff = currentSizeX - prevY;
+        int yDiff = currentSizeY - prevY;
 
         for (int x = 0; x < std::max(prevX, currentSizeX); x++) {
             for (int y = 0; y < std::max(prevY, currentSizeY); y++) {


### PR DESCRIPTION
## Summary
- fix calculation of `yDiff` inside `CProxyTargetGraphicsObject::refresh`

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*
- `make _game` *(fails: build interrupted due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_6878eefa19dc8326a02a26e4c97499e7