### PR TITLE
Add new amulet quest

### DIFF
--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -117,5 +117,107 @@
       "label": "Letter from Rolf",
       "text": "Lord Commander, The nightmarish Pritschers relentlessly assault us. Locals whisper of their lair, hidden within the desolate ruins of Nouraajd. Our forces wane, our defenses falter; we are on the brink. We lack the strength to purge their den. Reinforcements are our final hope. Sergeant Rolf."
     }
+  },
+  "preciousAmulet": {
+    "class": "CItem",
+    "properties": {
+      "name": "preciousAmulet",
+      "animation": "images/item",
+      "tags": [
+        "quest"
+      ]
+    }
+  },
+  "amuletQuest": {
+    "class": "AmuletQuest",
+    "properties": {
+      "description": "Find the stolen amulet for the old woman."
+    }
+  },
+  "questDialog": {
+    "class": "QuestDialog",
+    "properties": {
+      "states": [
+        {
+          "class": "CDialogState",
+          "properties": {
+            "stateId": "ENTRY",
+            "text": "As you walk through the village, you notice an old woman looking distressed. She seems to be in need of help.",
+            "options": [
+              {
+                "class": "CDialogOption",
+                "properties": {
+                  "number": 0,
+                  "nextStateId": "OLD_WOMAN_HELLO",
+                  "text": "Approach the old woman and ask if she needs help."
+                }
+              },
+              {
+                "ref": "exitOption",
+                "properties": {
+                  "number": 1
+                }
+              }
+            ]
+          }
+        },
+        {
+          "class": "CDialogState",
+          "properties": {
+            "stateId": "OLD_WOMAN_HELLO",
+            "text": "Oh, dear traveler! I'm in desperate need of help. My precious amulet has been stolen by the goblins in the nearby forest. It's been in my family for generations, and I can't bear the thought of losing it.",
+            "options": [
+              {
+                "class": "CDialogOption",
+                "properties": {
+                  "number": 0,
+                  "nextStateId": "ACCEPT_QUEST",
+                  "text": "Don't worry, I'll retrieve your amulet from the goblins."
+                }
+              },
+              {
+                "class": "CDialogOption",
+                "properties": {
+                  "number": 1,
+                  "nextStateId": "DECLINE_QUEST",
+                  "text": "I'm sorry, but I can't help you with that."
+                }
+              }
+            ]
+          }
+        },
+        {
+          "class": "CDialogState",
+          "properties": {
+            "stateId": "ACCEPT_QUEST",
+            "text": "Thank you, brave traveler! I'll be forever grateful if you can bring my amulet back. Please be careful, the goblins are cunning and dangerous.",
+            "options": [
+              {
+                "ref": "exitOption",
+                "properties": {
+                  "number": 0,
+                  "action": "startAmuletQuest"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "class": "CDialogState",
+          "properties": {
+            "stateId": "DECLINE_QUEST",
+            "text": "I understand. It's a dangerous task. I'll keep praying for someone to help me.",
+            "options": [
+              {
+                "ref": "exitOption",
+                "properties": {
+                  "number": 0
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 }

--- a/res/maps/nouraajd/map.json
+++ b/res/maps/nouraajd/map.json
@@ -40790,6 +40790,23 @@
           "width": 32,
           "x": 1376,
           "y": 3232
+        },
+        {
+          "height": 32,
+          "id": 99,
+          "name": "oldWoman",
+          "properties": {
+            "animation": "images/players/sorcerer"
+          },
+          "propertytypes": {
+            "animation": "string"
+          },
+          "rotation": 0,
+          "type": "CBuilding",
+          "visible": true,
+          "width": 32,
+          "x": 6080,
+          "y": 160
         }
       ],
       "opacity": 1,
@@ -40805,7 +40822,7 @@
       "y": 0
     }
   ],
-  "nextobjectid": 99,
+  "nextobjectid": 100,
   "orientation": "orthogonal",
   "properties": {
     "x": "110",

--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -36,6 +36,14 @@ def load(self, context):
         def onComplete(self):
             pass
 
+    @register(context)
+    class AmuletQuest(CQuest):
+        def isCompleted(self):
+            return self.getGame().getMap().getPlayer().hasItem(lambda it: it.getName() == 'preciousAmulet')
+
+        def onComplete(self):
+            pass
+
     @trigger(context, "onDestroy", "gooby1")
     class GoobyTrigger(CTrigger):
         def trigger(self, object, event):
@@ -97,3 +105,14 @@ def load(self, context):
     class TavernDialog2(CDialog):
         def askedAboutGirl(self):
             return self.getGame().getMap().getBoolProperty('ASKED_ABOUT_GIRL')
+
+    @trigger(context, "onEnter", "oldWoman")
+    class OldWomanTrigger(CTrigger):
+        def trigger(self, obj, event):
+            if event.getCause().isPlayer():
+                obj.getGame().getGuiHandler().showDialog(obj.getGame().createObject('questDialog'))
+
+    @register(context)
+    class QuestDialog(CDialog):
+        def startAmuletQuest(self):
+            self.getGame().getMap().getPlayer().addQuest('amuletQuest')


### PR DESCRIPTION
## Summary
- implement new amulet quest NPC and dialog
- register AmuletQuest and actions in map script
- spawn the quest giver at the north-east of Nouraajd map

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bee3e9a888326ba1cd74367124c37