### PR TITLE
Add root AGENTS.md with guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Repository Guidelines
+
+## Testing
+Run `python3 test.py` from the repository root. This test suite requires the compiled `_game` module. If the module or dependencies are missing, tests may fail; note this in the Testing section.
+
+## Code Style
+- Use four spaces for indentation in both Python and C++ files.
+- Keep lines under 120 characters where practical.
+- Python variable and function names should be in `snake_case`.
+- C++ class names should use `CamelCase`.
+
+## Commit Messages
+Describe changes clearly in the commit message. If multiple logical changes are made, separate them into individual commits when possible.


### PR DESCRIPTION
## Summary
- introduce repository guidelines in AGENTS.md

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_687c7c96f03483269e5c6c6e6605abb6