### PR TITLE
Implement Town Portal Scroll

### DIFF
--- a/res/config/items.json
+++ b/res/config/items.json
@@ -64,6 +64,15 @@
       "singleUse": false
     }
   },
+  "TownPortalScroll": {
+    "class": "TownPortalScroll",
+    "properties": {
+      "animation": "images/items/scroll",
+      "label": "Scroll of Town Portal",
+      "power": 0,
+      "singleUse": true
+    }
+  },
   "UndestructibleBelt": {
     "class": "CBelt",
     "properties": {

--- a/res/maps/nouraajd/map.json
+++ b/res/maps/nouraajd/map.json
@@ -40694,7 +40694,7 @@
           "id": 84,
           "name": "nouraajdDoor",
           "properties": {
-            "animation": "images\/misc\/closed_door"
+            "animation": "images/misc/closed_door"
           },
           "propertytypes": {
             "animation": "string"
@@ -40762,7 +40762,7 @@
           "id": 97,
           "name": "nouraajdTavern",
           "properties": {
-            "animation": "images\/buildings\/tavern"
+            "animation": "images/buildings/tavern"
           },
           "propertytypes": {
             "animation": "string"
@@ -40779,7 +40779,7 @@
           "id": 98,
           "name": "nouraajdTownHall",
           "properties": {
-            "animation": "images\/buildings\/town_hall"
+            "animation": "images/buildings/town_hall"
           },
           "propertytypes": {
             "animation": "string"
@@ -40807,7 +40807,24 @@
           "width": 32,
           "x": 6080,
           "y": 160
-        }
+        },
+        {
+          "height": 32,
+          "id": 100,
+          "name": "townPortalScroll",
+          "properties": {
+            "animation": "images/items/scroll"
+          },
+          "propertytypes": {
+            "animation": "string"
+          },
+          "rotation": 0,
+          "type": "TownPortalScroll",
+          "visible": true,
+          "width": 32,
+          "x": 3456,
+          "y": 3520
+        },
       ],
       "opacity": 1,
       "properties": {
@@ -40822,7 +40839,7 @@
       "y": 0
     }
   ],
-  "nextobjectid": 100,
+  "nextobjectid": 101,
   "orientation": "orthogonal",
   "properties": {
     "x": "110",
@@ -40841,7 +40858,7 @@
     {
       "columns": 4,
       "firstgid": 1,
-      "image": "..\/..\/images\/terrain.png",
+      "image": "../../images/terrain.png",
       "imageheight": 96,
       "imagewidth": 128,
       "margin": 0,

--- a/res/plugins/object.py
+++ b/res/plugins/object.py
@@ -18,6 +18,7 @@ def load(self, context):
     from game import CBuilding
     from game import Coords
     from game import register
+    from game import CScroll
     @register(context)
     class WayPoint(CBuilding):
         def onEnter(self, event):
@@ -93,3 +94,14 @@ def load(self, context):
                 self.getMap().addObject(mon)
                 mon.moveTo(location.x, location.y, location.z)
                 self.incProperty("monsters", -1);
+
+    @register(context)
+    class TownPortalScroll(CScroll):
+        def onUse(self, event):
+            cur_map = event.getCause().getMap()
+            event.getCause().moveTo(
+                cur_map.getEntryX(), cur_map.getEntryY(), cur_map.getEntryZ()
+            )
+
+        def isDisposable(self):
+            return True

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -208,6 +208,10 @@ BOOST_PYTHON_MODULE (_game) {
         class_<CPotion, bases<CItem>, boost::noncopyable, std::shared_ptr<CPotion>>("CPotionBase");
         class_<CWrapper<CPotion>, bases<CPotion>, boost::noncopyable, std::shared_ptr<CWrapper<CPotion>>>("CPotion")
                 .def("onUse", &CWrapper<CPotion>::onUse);
+        class_<CScroll, bases<CItem>, boost::noncopyable, std::shared_ptr<CScroll>>("CScrollBase");
+        class_<CWrapper<CScroll>, bases<CScroll>, boost::noncopyable, std::shared_ptr<CWrapper<CScroll>>>("CScroll")
+                .def("onUse", &CWrapper<CScroll>::onUse)
+                .def("isDisposable", &CWrapper<CScroll>::isDisposable);
 
         class_<CGameEvent, bases<CGameObject>, boost::noncopyable, std::shared_ptr<CGameEvent>>("CGameEvent");
         class_<CGameEventCaused, bases<CGameEvent>, boost::noncopyable, std::shared_ptr<CGameEventCaused>>(

--- a/src/core/CTypes.cpp
+++ b/src/core/CTypes.cpp
@@ -159,6 +159,9 @@ namespace
                         CTypes::register_type<CGloves, CItem, CMapObject, CGameObject>();
                         CTypes::register_type<CScroll, CItem, CMapObject, CGameObject>();
                     }
+                        {
+                            CTypes::register_type<CWrapper<CScroll>, CScroll, CItem, CMapObject, CGameObject>();
+                        }
 
                     CTypes::register_type<CCreature, CMapObject, CGameObject>();
                     {

--- a/src/core/CWrapper.h
+++ b/src/core/CWrapper.h
@@ -130,6 +130,27 @@ public:
 };
 
 template<>
+class CWrapper<CScroll> : public CScroll, public boost::python::wrapper<CWrapper<CScroll>> {
+V_META(CWrapper<T>, CScroll, vstd::meta::empty())
+public:
+    void onUse(std::shared_ptr<CGameEvent> event) final {
+        if (auto f = this->get_override("onUse")) {
+            PY_SAFE (f(event))
+        } else {
+            this->CScroll::onUse(event);
+        }
+    }
+
+    bool isDisposable() override {
+        if (auto f = this->get_override("isDisposable")) {
+            PY_SAFE_RET_VAL (return f(), false)
+        } else {
+            return this->CScroll::isDisposable();
+        }
+    }
+};
+
+template<>
 class CWrapper<CTrigger> : public CTrigger, public boost::python::wrapper<CWrapper<CTrigger>> {
 V_META(CWrapper<T>, CTrigger, vstd::meta::empty())
 public:

--- a/todo.txt
+++ b/todo.txt
@@ -13,7 +13,6 @@
     //TODO: implement move points
     //TODO: implement dijkstra
 //TODO: what if we return to oldMap after switch?
-//TODO: scroll of town portal
 //TODO: make function to compare objects
 //TODO: load assets from map
 //TODO: make question items not droppable and not selectable


### PR DESCRIPTION
## Summary
- add new TownPortalScroll item and object logic
- include Python class to return to map entry when used
- expose CScroll base class to Python
- register CScroll with type system and wrappers
- update map to contain town portal scroll pickup
- clean up TODO list

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_687c805b05e4832694052b2fe84cf9fd