### PR TITLE
Fix big-object build error on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,5 @@ SET(CPACK_STRIP_FILES _game.so)
 
 IF (!WIN32)
     cotire(_game)
+    set_target_properties(_game PROPERTIES UNITY_BUILD ON)
 ENDIF ()
-
-set_target_properties(_game PROPERTIES UNITY_BUILD ON)


### PR DESCRIPTION
## Summary
- avoid unity builds on Windows to prevent huge object files

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_687cddb5b39883268529122c1a487f91