### PR TITLE
Fix pointer mismatch when picking up items

### DIFF
--- a/src/object/CItem.cpp
+++ b/src/object/CItem.cpp
@@ -27,9 +27,11 @@ CItem::~CItem() {
 
 void CItem::onEnter(std::shared_ptr<CGameEvent> event) {
     if (std::shared_ptr<CCreature> visitor = vstd::cast<CCreature>(vstd::cast<CGameEventCaused>(event)->getCause())) {
-        auto item = this->ptr<CItem>();
+        // ensure the item added to the inventory shares the same control block
+        // as the one stored inside the map
+        auto item = vstd::cast<CItem>(getMap()->getObjectByName(getName()));
         visitor->addItem(item);
-        this->getMap()->removeObject(item);
+        getMap()->removeObject(item);
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure `CItem::onEnter` uses the map-managed shared pointer when moving the item to inventory

## Testing
- `pytest -q` *(no tests discovered)*
- `python3 test.py` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688090f0f3188326b6bbc5cb303c62cc