### PR TITLE
Fix shared_ptr mismatches when removing objects

### DIFF
--- a/res/plugins/object.py
+++ b/res/plugins/object.py
@@ -82,7 +82,7 @@ def load(self, context):
                                 mon = self.getObjectProperty('monster').clone()
                                 self.getMap().addObject(mon)
                                 mon.moveTo(location.x + i, location.y + j, location.z)
-                self.getMap().removeObject(self.ptr());  # TODO: WHY
+                self.getMap().removeObjectByName(self.getName())
 
         def onTurn(self, event):
             chance = self.getNumericProperty("chance");

--- a/src/object/CItem.cpp
+++ b/src/object/CItem.cpp
@@ -27,8 +27,9 @@ CItem::~CItem() {
 
 void CItem::onEnter(std::shared_ptr<CGameEvent> event) {
     if (std::shared_ptr<CCreature> visitor = vstd::cast<CCreature>(vstd::cast<CGameEventCaused>(event)->getCause())) {
-        this->getMap()->removeObject(this->ptr<CMapObject>());
-        visitor->addItem(this->ptr<CItem>());
+        auto self_from_map = vstd::cast<CItem>(getMap()->getObjectByName(getName()));
+        getMap()->removeObject(self_from_map);
+        visitor->addItem(self_from_map);
     }
 }
 


### PR DESCRIPTION
## Summary
- use the `CMap` copy of an item when adding it to inventory
- call `removeObjectByName` in the `Cave` Python plugin instead of `self.ptr()`

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_688096d5962c8326bea3672f0b08e73a