### PR TITLE
Add checks for missing texture files

### DIFF
--- a/src/gui/CAnimation.cpp
+++ b/src/gui/CAnimation.cpp
@@ -34,15 +34,20 @@ std::shared_ptr<CGameObject> CAnimation::getObject() {
 }
 
 void CStaticAnimation::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int frameTime) {
+    auto texture = gui->getTextureCache()->getTexture(object->getAnimation());
+    if (!texture) {
+        vstd::logger::error("CStaticAnimation: missing texture", object->getAnimation());
+        return;
+    }
     if (rotation == 0) {
         SDL_SAFE(
                 SDL_RenderCopy(gui->getRenderer(),
-                               gui->getTextureCache()->getTexture(object->getAnimation()),
+                               texture,
                                nullptr,
                                rect.get()));
     } else {
         SDL_SAFE(SDL_RenderCopyEx(gui->getRenderer(),
-                                  gui->getTextureCache()->getTexture(object->getAnimation()),
+                                  texture,
                                   nullptr,
                                   rect.get(),
                                   rotation,
@@ -99,8 +104,13 @@ void CDynamicAnimation::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<
                 break;
             }
         }
+        auto texture = gui->getTextureCache()->getTexture(paths[currFrame]);
+        if (!texture) {
+            vstd::logger::error("CDynamicAnimation: missing frame", paths[currFrame]);
+            return;
+        }
         SDL_SAFE(SDL_RenderCopy(gui->getRenderer(),
-                                gui->getTextureCache()->getTexture(paths[currFrame]),
+                                texture,
                                 nullptr,
                                 rect.get()));
     }

--- a/src/gui/object/CGameGraphicsObject.cpp
+++ b/src/gui/object/CGameGraphicsObject.cpp
@@ -220,8 +220,13 @@ bool CGameGraphicsObject::isVisible() {
 
 void CGameGraphicsObject::renderBackground(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int time) {
     if (!background.empty()) {
+        auto texture = gui->getTextureCache()->getTexture(background);
+        if (!texture) {
+            vstd::logger::error("CGameGraphicsObject: missing background", background);
+            return;
+        }
         SDL_SAFE(SDL_RenderCopy(gui->getRenderer(),
-                                gui->getTextureCache()->getTexture(background), nullptr, rect.get()));
+                                texture, nullptr, rect.get()));
     }
 }
 


### PR DESCRIPTION
## Summary
- handle null pointer surfaces when loading textures
- validate surfaces before processing alpha channel
- guard rendering code against missing textures

## Testing
- `python3 -m pytest -q`
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_68809c49793883269f2aa2927189be92