### PR TITLE
Avoid duplicate signal connections

### DIFF
--- a/src/object/CGameObject.cpp
+++ b/src/object/CGameObject.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CAnimation.h"
 #include "core/CMap.h"
 #include "core/CGame.h"
+#include <algorithm>
 
 std::function<bool(std::shared_ptr<CGameObject>, std::shared_ptr<CGameObject>)> CGameObject::name_comparator = [](
         std::shared_ptr<CGameObject> a, std::shared_ptr<CGameObject> b) {
@@ -159,7 +160,13 @@ std::shared_ptr<CAnimation> CGameObject::getGraphicsObject() {
 }
 
 void CGameObject::connect(std::string signal, std::shared_ptr<CGameObject> object, std::string slot) {
-    connections.emplace_back(signal, object, slot);
+    auto duplicate = std::find_if(connections.begin(), connections.end(), [&](auto &t) {
+        auto [_signal, _object, _slot] = t;
+        return signal == _signal && !_object.expired() && _object.lock() == object && slot == _slot;
+    });
+    if (duplicate == connections.end()) {
+        connections.emplace_back(signal, object, slot);
+    }
 }
 
 bool CGameObject::hasProperty(std::string name) {


### PR DESCRIPTION
## Summary
- include `<algorithm>` for connection search
- prevent duplicate signal-slot connections when connecting game objects

## Testing
- `python3 -m unittest -q test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_6880a73a46e88326927a580aae9f7d5d