### PR TITLE
Fix indentation error in Nouraajd RolfQuest

### DIFF
--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -32,11 +32,13 @@ def load(self, context):
 
     @register(context)
     class RolfQuest(CQuest):
-    def isCompleted(self):
-        return self.getGame().getMap().getPlayer().hasItem(lambda it: it.getName() == 'skullOfRolf')
+        def isCompleted(self):
+            return self.getGame().getMap().getPlayer().hasItem(
+                lambda it: it.getName() == 'skullOfRolf'
+            )
 
-    def onComplete(self):
-        pass
+        def onComplete(self):
+            pass
 
 
     @register(context)


### PR DESCRIPTION
## Summary
- fix indentation for `RolfQuest` in `res/maps/nouraajd/script.py`

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_6880b0ed479c8326b0ce58c7933d9f3f