### PR TITLE
Fix tile refresh timing

### DIFF
--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -187,7 +187,7 @@ void CMap::addObject(const std::shared_ptr<CMapObject> &mapObject) {
     }
     mapObjects.insert(std::make_pair(mapObject->getName(), mapObject));
     getEventHandler()->gameEvent(mapObject, std::make_shared<CGameEvent>(CGameEvent::Type::onCreate));
-    signal("objectChanged", mapObject->getCoords());
+    signal<true>("objectChanged", mapObject->getCoords());
 }
 
 void CMap::removeObject(const std::shared_ptr<CMapObject> &mapObject) {
@@ -196,7 +196,7 @@ void CMap::removeObject(const std::shared_ptr<CMapObject> &mapObject) {
         return it.second == mapObject->getName();
     });
     getEventHandler()->gameEvent(mapObject, std::make_shared<CGameEvent>(CGameEvent::Type::onDestroy));
-    signal("objectChanged", mapObject->getCoords());
+    signal<true>("objectChanged", mapObject->getCoords());
 }
 
 int CMap::getEntryX() {
@@ -386,8 +386,8 @@ void CMap::objectMoved(const std::shared_ptr<CMapObject> &object, Coords _old, C
     mapObjectsCache.insert(std::make_pair(_new, object->getName()));
 
     //TODO: check if it`s correct
-    signal("objectChanged", _old);
-    signal("objectChanged", _new);
+    signal<true>("objectChanged", _old);
+    signal<true>("objectChanged", _new);
 }
 
 std::set<std::shared_ptr<CMapObject>> CMap::getObjectsAtCoords(Coords coords) {

--- a/src/gui/object/CProxyTargetGraphicsObject.cpp
+++ b/src/gui/object/CProxyTargetGraphicsObject.cpp
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CProxyTargetGraphicsObject.h"
 
 #include <utility>
+#include <algorithm>
 #include "CProxyGraphicsObject.h"
 #include "gui/CLayout.h"
 #include "gui/CGui.h"
@@ -26,11 +27,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 void CProxyTargetGraphicsObject::refresh() {
     vstd::with<void>(getGui(), [this](auto gui) {
         int prevX = 0, prevY = 0;
-        if (!proxyObjects.empty()) {
-            auto last_x = proxyObjects.rbegin();
-            prevX = last_x->first + 1;
-            if (!last_x->second.empty()) {
-                prevY = last_x->second.rbegin()->first + 1;
+        for (const auto &x_pair : proxyObjects) {
+            prevX = std::max(prevX, x_pair.first + 1);
+            if (!x_pair.second.empty()) {
+                prevY = std::max(prevY, x_pair.second.rbegin()->first + 1);
             }
         }
 


### PR DESCRIPTION
## Summary
- compute previous proxy grid bounds by scanning all proxy objects
- send `objectChanged` signals immediately to avoid flicker when teleporting

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_6880beeb2b148326bd76341e01708673