### PR TITLE
Remove unnecessary upgrade command from configure script

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 sudo apt update
-sudo apt upgrade -y
 sudo apt install build-essential cmake -y
 sudo apt install python3-dev -y
 sudo apt install libboost-dev libboost-filesystem-dev libboost-python-dev -y


### PR DESCRIPTION
## Summary
- tidy configure.sh and remove `sudo apt upgrade -y`

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_6880d858ded08326a31c6993715dd6c0