### PR TITLE
Remove excessive signal debug logging

### DIFF
--- a/src/object/CGameObject.h
+++ b/src/object/CGameObject.h
@@ -151,7 +151,7 @@ public:
 
 template<bool now = false, typename... Args>
 void signal(std::string signal, Args... args) {
-    vstd::logger::debug(signal, args...);
+    // vstd::logger::debug(signal, args...);
     auto it = connections.begin();
     while (it != connections.end()) {
         auto [_signal, object, slot] = *it;


### PR DESCRIPTION
## Summary
- comment out C++ debug log for each signal emission

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_6880d9f7bdd08326b7276f0ce3d0d3d7