### PR TITLE
Fix quest flow and dialog IDs

### DIFF
--- a/res/maps/nouraajd/dialog4.json
+++ b/res/maps/nouraajd/dialog4.json
@@ -53,7 +53,7 @@
         {
           "class": "CDialogState",
           "properties": {
-            "stateId": "ASK_HELP",
+            "stateId": "ASK_HELP_REPEAT",
             "condition": "hasLetterQuest",
             "text": "You already agreed to deliver our letter. Please hurry to Father Beren.",
             "options": [
@@ -102,6 +102,13 @@
                 }
               }
             ]
+          }
+        },
+        {
+          "class": "CDialogState",
+          "properties": {
+            "stateId": "EXIT",
+            "text": ""
           }
         }
       ]

--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -89,14 +89,19 @@ def load(self, context):
     class CaveTrigger(CTrigger):
         def trigger(self, object, event):
             object.getGame().getGuiHandler().showMessage(object.getStringProperty("message"))
+            game_map = object.getGame().getMap()
+            player = game_map.getPlayer()
             gooby = object.getGame().createObject("gooby")
             gooby.setStringProperty("name", "gooby1")
-            object.getGame().getMap().addObject(gooby)
+            game_map.addObject(gooby)
             gooby.moveTo(100, 100, 0)
-            object.getGame().getMap().setBoolProperty('completedGooby', False)
-            object.getGame().getMap().getPlayer().addQuest("mainQuest")
-            object.getGame().getMap().getPlayer().addItem("skullOfRolf")
-            object.getGame().getMap().getPlayer().addItem('holyRelic')
+            game_map.setBoolProperty('completedGooby', False)
+            player.addQuest("mainQuest")
+            player.addItem("skullOfRolf")
+            game_map.setBoolProperty('completedRolf', True)
+            quests = player.getQuests()
+            if any(q.getName() == 'retrieveRelicQuest' for q in quests):
+                player.addItem('holyRelic')
 
     @trigger(context, "onDestroy", "cave2")
     class OctoBogzCaveTrigger(CTrigger):
@@ -219,7 +224,10 @@ def load(self, context):
             if player.hasItem(lambda it: it.getName() == 'letterToBeren'):
                 player.removeItem(lambda it: it.getName() == 'letterToBeren', True)
                 self.getGame().getMap().setBoolProperty('DELIVERED_LETTER', True)
-                player.addQuest('retrieveRelicQuest')
+                if player.hasItem(lambda it: it.getName() == 'holyRelic'):
+                    self.returnRelic()
+                else:
+                    player.addQuest('retrieveRelicQuest')
 
         def returnRelic(self):
             player = self.getGame().getMap().getPlayer()
@@ -291,4 +299,3 @@ def load(self, context):
                 player.addGold(50)
                 game.getMap().setBoolProperty('AMULET_RETURNED', True)
                 game.getGuiHandler().showMessage('The old woman gratefully rewards you with 50 gold.')
-                game.getMap().setBoolProperty('AMULET_RETURNED', True)


### PR DESCRIPTION
## Summary
- prevent early relic rewards and set `completedRolf` on skull pickup
- avoid instant quest completion if relic already found
- deduplicate amulet quest flag setting
- ensure unique Town Hall dialog states and add explicit EXIT state

## Testing
- `python3 test.py` *(fails: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_68811bceaf2883268cade82a47c48dcc