### PR TITLE
Apply unified naming conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,22 @@ Testing section.
 - Keep lines under 120 characters where practical.
 - Python variable and function names should be in `snake_case`.
 - C++ class names should use `CamelCase`.
+- Classes decorated with `@trigger` should use `CamelCase` with a `Trigger` suffix.
+- Reserve `UPPER_SNAKE_CASE` for global or constant-like properties and `snake_case` for local ones.
+- Keep camelCase for object and item ids referenced from JSON.
+- Engine methods may stay in CamelCase, but new Python-only methods should use `snake_case`.
+
+### Naming Conventions for Triggers and Variables
+The project mixes C++ and Python, so consistent naming is critical:
+
+- **Trigger classes** should be in `CamelCase` and end with `Trigger`, e.g. `MarketTrigger`.
+- **Python methods and local variables** use `snake_case` so that dialog actions
+  and quest checks match their definitions in scripts.
+- **Global flags** shared across maps are written in `UPPER_SNAKE_CASE` while
+  temporary or object-specific properties remain `snake_case`.
+- **Object and item identifiers** in JSON stay in `camelCase`; use the same
+  IDs when referencing them from Python.
+- Engine methods exposed from C++ keep their original `CamelCase` form.
 
 ## Commit Messages
 Describe changes clearly in the commit message.

--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -251,7 +251,7 @@
                 "ref": "exitOption",
                 "properties": {
                   "number": 0,
-                  "action": "startAmuletQuest"
+                  "action": "start_amulet_quest"
                 }
               }
             ]
@@ -289,7 +289,7 @@
                 "ref": "exitOption",
                 "properties": {
                   "number": 0,
-                  "action": "completeAmuletQuest"
+                  "action": "complete_amulet_quest"
                 }
               }
             ]

--- a/res/maps/nouraajd/dialog.json
+++ b/res/maps/nouraajd/dialog.json
@@ -13,7 +13,7 @@
                 "class": "CDialogOption",
                 "properties": {
                   "number": 0,
-                  "action": "openDoor",
+                  "action": "open_door",
                   "nextStateId": "WELCOME",
                   "text": "I offer my assistance. (present the letter)"
                 }
@@ -96,7 +96,7 @@
     "properties": {
       "nextStateId": "INKEEPER_ABOUT_GIRL",
       "text": "What dark purpose did they pursue?",
-      "action": "askedAboutGirl"
+      "action": "asked_about_girl"
     }
   },
   "askAboutMarumi": {
@@ -110,7 +110,7 @@
     "ref": "exitOption",
     "properties": {
       "text": "Enough of this. Bring me a tankard of ale.",
-      "action": "sellBeer"
+      "action": "sell_beer"
     }
   },
   "shouldGo": {

--- a/res/maps/nouraajd/dialog2.json
+++ b/res/maps/nouraajd/dialog2.json
@@ -81,7 +81,7 @@
                 "properties": {
                   "number": 0,
                   "nextStateId": "ACCEPT_QUEST",
-                  "action": "acceptQuest",
+                  "action": "accept_quest",
                   "text": "I'll take on this challenge and rid the cave of the OctoBogz."
                 }
               },

--- a/res/maps/nouraajd/dialog3.json
+++ b/res/maps/nouraajd/dialog3.json
@@ -4,7 +4,7 @@
     "properties": {
       "text": "Be a man and stop crying.",
       "nextStateId": "VICTOR_SPEECH",
-      "action": "talkedToVictor"
+      "action": "talked_to_victor"
     }
   },
   "whatsWrong": {
@@ -12,7 +12,7 @@
     "properties": {
       "text": "What`s wrong? Why are You crying?",
       "nextStateId": "VICTOR_SPEECH",
-      "action": "talkedToVictor"
+      "action": "talked_to_victor"
     }
   },
   "tavernDialog2": {
@@ -123,7 +123,7 @@
                   "text": "I've ran into group of priests of Marumi Baso that were looking for a girl around the city, maybe they are responsible for your daughter's disappearance?",
                   "number": 1,
                   "nextStateId": "SUGGEST_TOWN_HALL",
-                  "condition": "askedAboutGirl"
+                  "condition": "asked_about_girl"
                 }
               }
             ]

--- a/res/maps/nouraajd/dialog4.json
+++ b/res/maps/nouraajd/dialog4.json
@@ -53,7 +53,7 @@
         {
           "class": "CDialogState",
           "properties": {
-            "stateId": "ASK_HELP",
+            "stateId": "ASK_HELP_REPEAT",
             "condition": "has_letter_quest",
             "text": "You already agreed to deliver our letter. Please hurry to Father Beren.",
             "options": [

--- a/res/maps/nouraajd/dialog4.json
+++ b/res/maps/nouraajd/dialog4.json
@@ -36,7 +36,7 @@
                 "class": "CDialogOption",
                 "properties": {
                   "number": 0,
-                  "action": "giveLetter",
+                  "action": "give_letter",
                   "nextStateId": "THANKS",
                   "text": "I'll deliver it."
                 }
@@ -54,7 +54,7 @@
           "class": "CDialogState",
           "properties": {
             "stateId": "ASK_HELP",
-            "condition": "hasLetterQuest",
+            "condition": "has_letter_quest",
             "text": "You already agreed to deliver our letter. Please hurry to Father Beren.",
             "options": [
               {
@@ -83,7 +83,7 @@
           "class": "CDialogState",
           "properties": {
             "stateId": "ENTRY",
-            "condition": "talkedToVictor",
+            "condition": "talked_to_victor",
             "text": "Among dusty ledgers you find a handwritten note describing the Cult of Marumi Baso. A decade ago they hid their chapel behind a wooden door in the courtyard. The author claims they sacrifice girls resembling their dead prophet's daughter to preserve a mysterious stained glass and extend the prophet's life.",
             "options": [
               {
@@ -91,7 +91,7 @@
                 "properties": {
                   "text": "Search the courtyard",
                   "number": 0,
-                  "action": "spawnCultists",
+                  "action": "spawn_cultists",
                   "nextStateId": "EXIT"
                 }
               },

--- a/res/maps/nouraajd/dialog5.json
+++ b/res/maps/nouraajd/dialog5.json
@@ -13,7 +13,7 @@
                 "class": "CDialogOption",
                 "properties": {
                   "number": 0,
-                  "action": "deliverLetter",
+                  "action": "deliver_letter",
                   "nextStateId": "LETTER_DELIVERED",
                   "text": "I carry a letter for you."
                 }
@@ -22,7 +22,7 @@
                 "class": "CDialogOption",
                 "properties": {
                   "number": 1,
-                  "action": "returnRelic",
+                  "action": "return_relic",
                   "nextStateId": "RELIC_RETURNED",
                   "text": "I recovered the relic."
                 }
@@ -31,7 +31,7 @@
                 "class": "CDialogOption",
                 "properties": {
                   "number": 2,
-                  "action": "finishCleanse",
+                  "action": "finish_cleanse",
                   "nextStateId": "CAVE_PURGED",
                   "text": "The cave has been cleansed."
                 }

--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -12,8 +12,8 @@ def load(self, context):
             if event.getCause().isPlayer():
                 self.getMap().getGame().getGuiHandler().showMessage(self.getStringProperty('text'))
                 self.getMap().removeAll(lambda ob: ob.getStringProperty('type') == self.getStringProperty('type'))
-                self.getMap().setBoolProperty('completedRolf', False)
-                self.getMap().setBoolProperty('completedOctoBogz', False)
+                self.getMap().setBoolProperty('completed_rolf', False)
+                self.getMap().setBoolProperty('completed_octobogz', False)
                 self.getMap().getPlayer().addQuest("rolfQuest")
                 self.getMap().getPlayer().addItem("letterFromRolf")
 
@@ -25,7 +25,7 @@ def load(self, context):
     @register(context)
     class MainQuest(CQuest):
         def isCompleted(self):
-            return self.getGame().getMap().getBoolProperty('completedGooby')
+            return self.getGame().getMap().getBoolProperty('completed_gooby')
 
         def onComplete(self):
             pass
@@ -66,7 +66,7 @@ def load(self, context):
     @register(context)
     class OctoBogzQuest(CQuest):
         def isCompleted(self):
-            return self.getGame().getMap().getBoolProperty('completedOctoBogz')
+            return self.getGame().getMap().getBoolProperty('completed_octobogz')
 
         def onComplete(self):
             pass
@@ -83,7 +83,7 @@ def load(self, context):
     class GoobyTrigger(CTrigger):
         def trigger(self, object, event):
             object.getGame().getGuiHandler().showMessage("Gooby killed!!!")
-            object.getGame().getMap().setBoolProperty('completedGooby', True)
+            object.getGame().getMap().setBoolProperty('completed_gooby', True)
 
     @trigger(context, "onDestroy", "cave1")
     class CaveTrigger(CTrigger):
@@ -93,7 +93,7 @@ def load(self, context):
             gooby.setStringProperty("name", "gooby1")
             object.getGame().getMap().addObject(gooby)
             gooby.moveTo(100, 100, 0)
-            object.getGame().getMap().setBoolProperty('completedGooby', False)
+            object.getGame().getMap().setBoolProperty('completed_gooby', False)
             object.getGame().getMap().getPlayer().addQuest("mainQuest")
             object.getGame().getMap().getPlayer().addItem("skullOfRolf")
             object.getGame().getMap().getPlayer().addItem('holyRelic')
@@ -109,7 +109,7 @@ def load(self, context):
             else:
                 object.getGame().getGuiHandler().showMessage('The OctoBogz are defeated!')
             game_map.setBoolProperty('OCTOBOGZ_CLEARED', True)
-            game_map.setBoolProperty('completedOctoBogz', True)
+            game_map.setBoolProperty('completed_octobogz', True)
 
     @trigger(context, "onEnter", "market1")
     class MarketTrigger(CTrigger):
@@ -125,7 +125,7 @@ def load(self, context):
 
     @register(context)
     class DoorDialog(CDialog):
-        def openDoor(self):
+        def open_door(self):
             self.getGame().getMap().removeAll(lambda ob: ob.getName().startswith('nouraajdDoorTrigger'))
             self.getGame().getMap().getObjectByName('nouraajdDoor').setBoolProperty('opened', True)
 
@@ -144,18 +144,18 @@ def load(self, context):
 
     @register(context)
     class TavernDialog1(CDialog):
-        def sellBeer(self):
+        def sell_beer(self):
             print("sellBeer")
 
-        def askedAboutGirl(self):
+        def asked_about_girl(self):
             self.getGame().getMap().setBoolProperty('ASKED_ABOUT_GIRL', True)
 
     @register(context)
     class TavernDialog2(CDialog):
-        def askedAboutGirl(self):
+        def asked_about_girl(self):
             return self.getGame().getMap().getBoolProperty('ASKED_ABOUT_GIRL')
 
-        def talkedToVictor(self):
+        def talked_to_victor(self):
             self.getGame().getMap().setBoolProperty('TALKED_TO_VICTOR', True)
 
     @trigger(context, "onEnter", "nouraajdTownHall")
@@ -166,7 +166,7 @@ def load(self, context):
 
     @register(context)
     class TownHallDialog(CDialog):
-        def giveLetter(self):
+        def give_letter(self):
             player = self.getGame().getMap().getPlayer()
             if not player.hasItem(lambda it: it.getName() == 'letterToBeren'):
                 player.addItem('letterToBeren')
@@ -175,17 +175,17 @@ def load(self, context):
             if not any(q.getName() == 'deliverLetterQuest' for q in quests):
                 player.addQuest('deliverLetterQuest')
 
-        def hasLetterQuest(self):
+        def has_letter_quest(self):
             player = self.getGame().getMap().getPlayer()
             if player.hasItem(lambda it: it.getName() == 'letterToBeren'):
                 return True
             quests = player.getQuests()
             return any(q.getName() == 'deliverLetterQuest' for q in quests)
 
-        def talkedToVictor(self):
+        def talked_to_victor(self):
             return self.getGame().getMap().getBoolProperty('TALKED_TO_VICTOR')
 
-        def spawnCultists(self):
+        def spawn_cultists(self):
             game = self.getGame()
             player = game.getMap().getPlayer()
             loc = player.getCoords()
@@ -214,21 +214,21 @@ def load(self, context):
 
     @register(context)
     class BerenDialog(CDialog):
-        def deliverLetter(self):
+        def deliver_letter(self):
             player = self.getGame().getMap().getPlayer()
             if player.hasItem(lambda it: it.getName() == 'letterToBeren'):
                 player.removeItem(lambda it: it.getName() == 'letterToBeren', True)
                 self.getGame().getMap().setBoolProperty('DELIVERED_LETTER', True)
                 player.addQuest('retrieveRelicQuest')
 
-        def returnRelic(self):
+        def return_relic(self):
             player = self.getGame().getMap().getPlayer()
             if player.hasItem(lambda it: it.getName() == 'holyRelic'):
                 player.removeItem(lambda it: it.getName() == 'holyRelic', True)
                 self.getGame().getMap().setBoolProperty('RELIC_RETURNED', True)
                 player.addQuest('cleanseCaveQuest')
 
-        def finishCleanse(self):
+        def finish_cleanse(self):
             if self.getGame().getMap().getBoolProperty('OCTOBOGZ_CLEARED'):
                 self.getGame().getMap().setBoolProperty('CAVE_PURGED', True)
                 self.getGame().getGuiHandler().showMessage('The town is safe once more.')
@@ -237,9 +237,9 @@ def load(self, context):
 
     @register(context)
     class OctoBogzDialog(CDialog):
-        def acceptQuest(self):
+        def accept_quest(self):
             self.getGame().getMap().getPlayer().addQuest('octoBogzQuest')
-            self.getGame().getMap().setBoolProperty('completedOctoBogz', False)
+            self.getGame().getMap().setBoolProperty('completed_octobogz', False)
 
     @trigger(context, "onDestroy", "cultLeaderQuest")
     class CultLeaderQuestTrigger(CTrigger):
@@ -271,7 +271,7 @@ def load(self, context):
 
     @register(context)
     class QuestDialog(CDialog):
-        def startAmuletQuest(self):
+        def start_amulet_quest(self):
             game = self.getGame()
             player = game.getMap().getPlayer()
             player.addQuest('amuletQuest')
@@ -283,7 +283,7 @@ def load(self, context):
 
     @register(context)
     class QuestReturnDialog(CDialog):
-        def completeAmuletQuest(self):
+        def complete_amulet_quest(self):
             game = self.getGame()
             player = game.getMap().getPlayer()
             if player.hasItem(lambda it: it.getName() == 'preciousAmulet'):


### PR DESCRIPTION
## Summary
- adopt naming guidance in `AGENTS.md`
- rename quest and dialog variables to snake_case
- update trigger dialog action names
- update map config references
- document naming conventions

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_68811b9e14ac832698034daa38371c83