### PR TITLE
Improve quest logic and catacombs trigger

### DIFF
--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -89,6 +89,26 @@
       "monsters": "10"
     }
   },
+  "catacombs": {
+    "ref": "Cave",
+    "properties": {
+      "message": "Dusty catacombs crumble as you claim a sacred relic.",
+      "chance": "10",
+      "monster": {
+        "ref": "Pritz",
+        "properties": {
+          "affiliation": "gooby",
+          "controller": {
+            "class": "CGroundController",
+            "properties": {
+              "tileType": "ground"
+            }
+          }
+        }
+      },
+      "monsters": "10"
+    }
+  },
   "cave2": {
     "ref": "Cave",
     "properties": {

--- a/res/maps/nouraajd/map.json
+++ b/res/maps/nouraajd/map.json
@@ -40053,6 +40053,17 @@
         },
         {
           "height": 32,
+          "id": 103,
+          "name": "catacombs",
+          "rotation": 0,
+          "type": "catacombs",
+          "visible": true,
+          "width": 32,
+          "x": 704,
+          "y": 544
+        },
+        {
+          "height": 32,
           "id": 7,
           "name": "",
           "rotation": 0,
@@ -40873,7 +40884,7 @@
       "y": 0
     }
   ],
-  "nextobjectid": 103,
+  "nextobjectid": 104,
   "orientation": "orthogonal",
   "properties": {
     "x": "110",


### PR DESCRIPTION
## Summary
- add a completion message for MainQuest
- indent RolfQuest.onComplete correctly
- check `RELIC_RETURNED` flag for RetrieveRelicQuest
- spawn the holy relic in new catacombs trigger
- guard against restarting the AmuletQuest
- track amulet quest state from StartEvent
- add catacombs object to config and map

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_68812d1ade9c8326b3b2c7142d109fde