### PR TITLE
Reformat long lines

### DIFF
--- a/src/core/CSerialization.cpp
+++ b/src/core/CSerialization.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2021  Andrzej Lis
+Copyright (C) 2025  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -266,13 +266,15 @@ std::shared_ptr<json> array_serialize(const std::set<std::shared_ptr<CGameObject
     return arr;
 }
 
-std::set<std::shared_ptr<CGameObject> > array_deserialize(const std::shared_ptr<CGame> &map,
-                                                          const std::shared_ptr<json> &object) {
+std::set<std::shared_ptr<CGameObject> > array_deserialize(
+        const std::shared_ptr<CGame> &map,
+        const std::shared_ptr<json> &object) {
     std::set<std::shared_ptr<CGameObject> > objects;
     for (unsigned int i = 0; i < object->size(); i++) {
-        objects.insert(CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(map,
-                                                                                                             CJsonUtil::clone(
-                                                                                                                     &(*object)[i])));
+        objects.insert(
+                CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(
+                        map,
+                        CJsonUtil::clone(&(*object)[i])));
     }
     return objects;
 }

--- a/src/core/CTypes.h
+++ b/src/core/CTypes.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2019  Andrzej Lis
+Copyright (C) 2025  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -26,8 +26,9 @@ public:
 
     static std::unordered_map<std::string, std::function<std::shared_ptr<CGameObject>()>> *builders();
 
-    static std::unordered_map<std::pair<boost::typeindex::type_index, boost::typeindex::type_index>, std::shared_ptr<CSerializerBase>> *
-    serializers();
+    static std::unordered_map<std::pair<boost::typeindex::type_index,
+                                        boost::typeindex::type_index>,
+                                std::shared_ptr<CSerializerBase>> *serializers();
 
     static std::unordered_set<boost::typeindex::type_index> *pointer_types();
 
@@ -35,8 +36,10 @@ public:
 
     static std::unordered_set<boost::typeindex::type_index> *map_types();
 
-    static std::unordered_map<boost::typeindex::type_index, std::function<void(std::shared_ptr<CGameObject>,
-                                                                               std::string, boost::any)>> *setters();
+    static std::unordered_map<boost::typeindex::type_index,
+                              std::function<void(std::shared_ptr<CGameObject>,
+                                                 std::string,
+                                                 boost::any)>> *setters();
 
     static bool is_map_type(boost::typeindex::type_index index);
 

--- a/src/core/CUtil.h
+++ b/src/core/CUtil.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2019  Andrzej Lis
+Copyright (C) 2025  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -119,9 +119,12 @@ namespace vstd {
 }
 
 template<typename F>
-auto sdl_safe(F f,
-              typename vstd::disable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, int>::value>::type * = 0,
-              typename vstd::disable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, void>::value>::type * = 0) {
+auto sdl_safe(
+        F f,
+        typename vstd::disable_if<
+                vstd::is_same<typename vstd::function_traits<F>::return_type, int>::value>::type * = 0,
+        typename vstd::disable_if<
+                vstd::is_same<typename vstd::function_traits<F>::return_type, void>::value>::type * = 0) {
     auto return_value = f();
     if (!return_value) {
         vstd::logger::error(SDL_GetError());
@@ -130,9 +133,12 @@ auto sdl_safe(F f,
 }
 
 template<typename F>
-auto sdl_safe(F f,
-              typename vstd::enable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, int>::value>::type * = 0,
-              typename vstd::disable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, void>::value>::type * = 0) {
+auto sdl_safe(
+        F f,
+        typename vstd::enable_if<
+                vstd::is_same<typename vstd::function_traits<F>::return_type, int>::value>::type * = 0,
+        typename vstd::disable_if<
+                vstd::is_same<typename vstd::function_traits<F>::return_type, void>::value>::type * = 0) {
     auto return_value = f();
     if (return_value == -1) {
         vstd::logger::error(SDL_GetError());
@@ -141,9 +147,12 @@ auto sdl_safe(F f,
 }
 
 template<typename F>
-void sdl_safe(F f,
-              typename vstd::disable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, int>::value>::type * = 0,
-              typename vstd::enable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, void>::value>::type * = 0) {
+void sdl_safe(
+        F f,
+        typename vstd::disable_if<
+                vstd::is_same<typename vstd::function_traits<F>::return_type, int>::value>::type * = 0,
+        typename vstd::enable_if<
+                vstd::is_same<typename vstd::function_traits<F>::return_type, void>::value>::type * = 0) {
     f();
 }
 

--- a/src/gui/object/CMapGraphicsObject.cpp
+++ b/src/gui/object/CMapGraphicsObject.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2021  Andrzej Lis
+Copyright (C) 2025  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -138,12 +138,14 @@ void CMapGraphicsObject::initialize() {
                                && self->getGui()->getGame() != nullptr
                                && self->getGui()->getGame()->getMap() != nullptr;
                     }, [self]() {
-                        self->getGui()->getGame()->getMap()->connect("turnPassed", self,
-                                                                     "refreshAll");
-                        self->getGui()->getGame()->getMap()->connect("tileChanged", self,
-                                                                     "refreshObject");//TODO: current lazy tile loading may cause event spam
-                        self->getGui()->getGame()->getMap()->connect("objectChanged", self,
-                                                                     "refreshObject");//TODO: current lazy tile loading may cause event spam
+                        self->getGui()->getGame()->getMap()->connect(
+                                "turnPassed", self, "refreshAll");
+                        self->getGui()->getGame()->getMap()->connect(
+                                "tileChanged", self,
+                                "refreshObject"); // TODO: current lazy tile loading may cause event spam
+                        self->getGui()->getGame()->getMap()->connect(
+                                "objectChanged", self,
+                                "refreshObject"); // TODO: current lazy tile loading may cause event spam
                         self->refresh();
                     }
     );


### PR DESCRIPTION
## Summary
- wrap sdl_safe template parameters for readability
- reformat array_deserialize call
- split long serializer and setter declarations
- tidy map graphics event connections
- update copyright

## Testing
- `python3 test.py` *(fails: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_6881d9067d008326b3581ae8afe23c3b