### PR TITLE
Update copyright year

### DIFF
--- a/src/core/CWrapper.h
+++ b/src/core/CWrapper.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2020  Andrzej Lis
+Copyright (C) 2025  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Summary
- update header comment year in `CWrapper.h`

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_6881d907f2488326a879072a9dbfdf72