### PR TITLE
Fix crash from warrior dialog event

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,13 +91,15 @@ Follow these steps to verify quests remain consistent:
 1. **Check ids**
     - Ensure every quest id in `res/maps/<map>/config.json` matches the
       class name in the corresponding `script.py` file.
-2. **Playtest**
+2. **Short descriptions**
+    - Keep quest descriptions brief; a single sentence is enough for the quest log.
+3. **Playtest**
     - Build the game and start it with `python3 play.py`.
     - Accept each available quest and open the quest log with **j** to
       confirm it appears.
     - Progress the objectives and verify completed quests move to the
       "completed" section.
-3. **Run tests**
+4. **Run tests**
     - Execute `python3 test.py` to ensure the game still loads with the
       updated quests.
 

--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -56,7 +56,7 @@
   "octoBogzQuest": {
     "class": "OctoBogzQuest",
     "properties": {
-      "description": "Eliminate the OctoBogz menace."
+      "description": "Clear the OctoBogz from the cave east of Nouraajd."
     }
   },
   "skullOfRolf": {

--- a/res/maps/nouraajd/dialog2.json
+++ b/res/maps/nouraajd/dialog2.json
@@ -100,20 +100,7 @@
           "class": "CDialogState",
           "properties": {
             "stateId": "ACCEPT_QUEST",
-            "text": "Travel east across the river and locate the cave infested with OctoBogz. The cave entrance is partially hidden by large boulders and sand, making it difficult to find. As you approach, you can hear strange, guttural noises echoing from within.",
-            "event": {
-              "class": "CEvent",
-              "properties": {
-                "type": "Quest",
-                "title": "The OctoBogz Menace",
-                "description": "Eliminate the OctoBogz threat in the cave to the east of Nouraajd and uncover the origin of these creatures. A generous reward is offered by the group of travelers who have banded together seeking help.",
-                "rewards": {
-                  "gold": 1000,
-                  "item": "unique weapon with shadow damage",
-                  "reputation": "Nouraajd reputation boost"
-                }
-              }
-            }
+            "text": "Travel east across the river and locate the cave infested with OctoBogz. The cave entrance is partially hidden by large boulders and sand, making it difficult to find. As you approach, you can hear strange, guttural noises echoing from within."
           }
         },
         {

--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -72,7 +72,13 @@ def load(self, context):
             return self.getGame().getMap().getBoolProperty('completed_octobogz')
 
         def onComplete(self):
-            pass
+            game = self.getGame()
+            player = game.getMap().getPlayer()
+            player.addGold(1000)
+            player.addItem('ShadowBlade')
+            game.getGuiHandler().showMessage(
+                'The travelers reward you with 1000 gold and the Shadow Blade.'
+            )
 
     @register(context)
     class AmuletQuest(CQuest):


### PR DESCRIPTION
## Summary
- remove unsupported event from `dialog2.json`
- expand OctoBogz quest description in `config.json`
- reward player for completing OctoBogz quest
- shortened OctoBogz quest description
- clarify quest description style in `AGENTS.md`

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_688277373ae88326a6f25d18840d4c4d