### PR TITLE
Update monster animation assets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #fall-of-nouraajd c++ dark fantasy game
-# Copyright (C) 2019  Andrzej Lis
+# Copyright (C) 2025  Andrzej Lis
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -135,6 +135,9 @@ configure_file(res/images/monsters/pritzmage/0.png images/monsters/pritzmage/0.p
 configure_file(res/images/monsters/pritzmage/3.png images/monsters/pritzmage/3.png COPYONLY)
 configure_file(res/images/monsters/pritzmage/1.png images/monsters/pritzmage/1.png COPYONLY)
 configure_file(res/images/monsters/gooby.png images/monsters/gooby.png COPYONLY)
+configure_file(res/images/monsters/cult_leader.png images/monsters/cult_leader.png COPYONLY)
+configure_file(res/images/monsters/cultist.png images/monsters/cultist.png COPYONLY)
+configure_file(res/images/monsters/goblin_thief.png images/monsters/goblin_thief.png COPYONLY)
 
 configure_file(res/images/monsters/octobogz/time.json images/monsters/octobogz/time.json COPYONLY)
 configure_file(res/images/monsters/octobogz/0.png images/monsters/octobogz/0.png COPYONLY)

--- a/res/config/monsters.json
+++ b/res/config/monsters.json
@@ -418,13 +418,13 @@
       }
     }
   },
-   "Cultist": {
+  "Cultist": {
     "class": "CCreature",
     "properties": {
       "actions": [
         { "ref": "Attack" }
       ],
-      "animation": "images/monsters/pritz",
+      "animation": "images/monsters/cultist",
       "fightController": { "class": "CMonsterFightController" },
       "label": "Cultist",
       "levelStats": {
@@ -463,7 +463,7 @@
       "actions": [
         { "ref": "Attack" }
       ],
-      "animation": "images/monsters/pritzmage",
+      "animation": "images/monsters/cult_leader",
       "fightController": { "class": "CMonsterFightController" },
       "label": "Cult Leader",
       "levelStats": {
@@ -502,7 +502,7 @@
       "actions": [
         { "ref": "Attack" }
       ],
-      "animation": "images/monsters/pritz",
+      "animation": "images/monsters/goblin_thief",
       "fightController": { "class": "CMonsterFightController" },
       "label": "Goblin Thief",
       "levelStats": {


### PR DESCRIPTION
## Summary
- include new monster images in CMake build
- reference new animation paths for Cultist, CultLeader, and GoblinThief
- update copyright year

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_68834cf20b908326b023325d3b4161fe