### PR TITLE
Fix NPC sprites

### DIFF
--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -162,12 +162,14 @@
   "questGiver": {
     "ref": "Warrior",
     "properties": {
+      "animation": "images/npc/questGiver",
       "controller": { "class": "CNpcRandomController" }
     }
   },
   "oldWoman": {
     "ref": "Sorcerer",
     "properties": {
+      "animation": "images/npc/oldWoman",
       "controller": { "class": "CNpcRandomController" }
     }
   },

--- a/res/maps/nouraajd/map.json
+++ b/res/maps/nouraajd/map.json
@@ -40807,7 +40807,7 @@
           "id": 99,
           "name": "oldWoman",
           "properties": {
-            "animation": "images/players/sorcerer"
+            "animation": "images/npc/oldWoman"
           },
           "propertytypes": {
             "animation": "string"
@@ -40858,7 +40858,7 @@
           "id": 102,
           "name": "questGiver",
           "properties": {
-            "animation": "images/players/warrior"
+            "animation": "images/npc/questGiver"
           },
           "propertytypes": {
             "animation": "string"


### PR DESCRIPTION
## Summary
- use dedicated NPC sprites for `questGiver` and `oldWoman`

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_6883468cb3388326aaa3ef5e4a55939d