### PR TITLE
Fix signpost message for NPCs

### DIFF
--- a/res/plugins/object.py
+++ b/res/plugins/object.py
@@ -58,7 +58,10 @@ def load(self, context):
     @register(context)
     class SignPost(CBuilding):
         def onEnter(self, event):
-            self.getMap().getGame().getGuiHandler().showInfo(self.getStringProperty('text'), True)
+            if event.getCause().isPlayer():
+                self.getMap().getGame().getGuiHandler().showInfo(
+                    self.getStringProperty('text'), True
+                )
 
     @register(context)
     class Chest(CBuilding):


### PR DESCRIPTION
## Summary
- only show signpost message when the player enters

## Testing
- `python3 test.py` *(fails: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_6889aa8a64148326af94caa3a0e353ab