### PR TITLE
Fix quest giver triggering combat

### DIFF
--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -163,14 +163,16 @@
     "ref": "Warrior",
     "properties": {
       "animation": "images/npc/questGiver",
-      "controller": { "class": "CNpcRandomController" }
+      "controller": { "class": "CNpcRandomController" },
+      "npc": true
     }
   },
   "oldWoman": {
     "ref": "Sorcerer",
     "properties": {
       "animation": "images/npc/oldWoman",
-      "controller": { "class": "CNpcRandomController" }
+      "controller": { "class": "CNpcRandomController" },
+      "npc": true
     }
   },
   "letterFromRolf": {

--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -22,185 +22,163 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 std::map<int, std::pair<int, int>> CMap::getBounds() { return boundaries; }
 
-void CMap::removeObjectByName(std::string name) {
-  this->removeObject(this->getObjectByName(name));
-}
+void CMap::removeObjectByName(std::string name) { this->removeObject(this->getObjectByName(name)); }
 
 std::string CMap::addObjectByName(std::string name, Coords coords) {
-  if (this->canStep(coords)) {
-    std::shared_ptr<CMapObject> object =
-        getGame()->createObject<CMapObject>(name);
-    if (object) {
-      addObject(object);
-      object->moveTo(coords.x, coords.y, coords.z);
-      return name;
+    if (this->canStep(coords)) {
+        std::shared_ptr<CMapObject> object = getGame()->createObject<CMapObject>(name);
+        if (object) {
+            addObject(object);
+            object->moveTo(coords.x, coords.y, coords.z);
+            return name;
+        }
     }
-  }
-  return "";
+    return "";
 }
 
 void CMap::replaceTile(std::string name, Coords coords) {
-  removeTile(coords.x, coords.y, coords.z);
-  addTile(getGame()->createObject<CTile>(name), coords.x, coords.y, coords.z);
+    removeTile(coords.x, coords.y, coords.z);
+    addTile(getGame()->createObject<CTile>(name), coords.x, coords.y, coords.z);
 }
 
-Coords CMap::getLocationByName(std::string name) {
-  return this->getObjectByName(name)->getCoords();
-}
+Coords CMap::getLocationByName(std::string name) { return this->getObjectByName(name)->getCoords(); }
 
 std::shared_ptr<CPlayer> CMap::getPlayer() {
-  // TODO: think of better solution after save
-  if (!player) {
-    for (auto object : getObjects()) {
-      if (object->getName() == "player") {
-        // TODO: what about duplicated triggers?
-        setPlayer(vstd::cast<CPlayer>(object));
-        break;
-      }
+    // TODO: think of better solution after save
+    if (!player) {
+        for (auto object : getObjects()) {
+            if (object->getName() == "player") {
+                // TODO: what about duplicated triggers?
+                setPlayer(vstd::cast<CPlayer>(object));
+                break;
+            }
+        }
     }
-  }
-  return player;
+    return player;
 }
 
 void CMap::setPlayer(std::shared_ptr<CPlayer> player) {
-  player->setName("player");
-  player->setController(getGame()->createObject<CPlayerController>());
-  player->setFightController(getGame()->createObject<CPlayerFightController>());
+    player->setName("player");
+    player->setController(getGame()->createObject<CPlayerController>());
+    player->setFightController(getGame()->createObject<CPlayerFightController>());
 
-  auto restartTrigger = std::make_shared<CCustomTrigger>(
-      "player", "onDestroy", [](auto object, auto event) {
+    auto restartTrigger = std::make_shared<CCustomTrigger>("player", "onDestroy", [](auto object, auto event) {
         auto _player = vstd::cast<CPlayer>(object);
         _player->getMap()->addObject(_player);
-        _player->moveTo(object->getMap()->getEntryX(),
-                        object->getMap()->getEntryY(),
-                        object->getMap()->getEntryZ());
+        _player->moveTo(object->getMap()->getEntryX(), object->getMap()->getEntryY(), object->getMap()->getEntryZ());
         _player->setHp(1);
-      });
+    });
 
-  auto turnTrigger = std::make_shared<CCustomTrigger>(
-      "player", "onTurn", [](auto object, auto event) {
+    auto turnTrigger = std::make_shared<CCustomTrigger>("player", "onTurn", [](auto object, auto event) {
         auto _player = vstd::cast<CPlayer>(object);
         _player->addMana(_player->getManaRegRate());
         _player->incTurn();
         _player->checkQuests();
-      });
+    });
 
-  getEventHandler()->registerTrigger(restartTrigger);
-  getEventHandler()->registerTrigger(turnTrigger);
+    getEventHandler()->registerTrigger(restartTrigger);
+    getEventHandler()->registerTrigger(turnTrigger);
 
-  addObject(player);
-  player->moveTo(entryx, entryy, entryz);
-  this->player = player;
+    addObject(player);
+    player->moveTo(entryx, entryy, entryz);
+    this->player = player;
 }
 
 std::shared_ptr<CEventHandler> CMap::getEventHandler() {
-  return eventHandler.get(
-      [this]() { return std::make_shared<CEventHandler>(); });
+    return eventHandler.get([this]() { return std::make_shared<CEventHandler>(); });
 }
 
 void CMap::moveTile(std::shared_ptr<CTile> tile, int x, int y, int z) {
-  Coords coords = tile->getCoords();
-  auto it = tiles.find(coords);
-  if (it != tiles.end()) {
-    tiles.erase(it);
-  }
-  tiles.insert(std::make_pair(Coords(x, y, z), tile));
-  signal("tileChanged", Coords(x, y, z));
+    Coords coords = tile->getCoords();
+    auto it = tiles.find(coords);
+    if (it != tiles.end()) {
+        tiles.erase(it);
+    }
+    tiles.insert(std::make_pair(Coords(x, y, z), tile));
+    signal("tileChanged", Coords(x, y, z));
 }
 
 bool CMap::addTile(std::shared_ptr<CTile> tile, int x, int y, int z) {
-  if (this->contains(x, y, z)) {
-    return false;
-  }
-  tiles.insert(std::make_pair(Coords(x, y, z), tile));
-  tile->moveTo(x, y, z);
-  //    signal("tileChanged", Coords(x, y, z)); //moveTo already sends signal
-  return true;
+    if (this->contains(x, y, z)) {
+        return false;
+    }
+    tiles.insert(std::make_pair(Coords(x, y, z), tile));
+    tile->moveTo(x, y, z);
+    //    signal("tileChanged", Coords(x, y, z)); //moveTo already sends signal
+    return true;
 }
 
 void CMap::removeTile(int x, int y, int z) {
-  this->tiles.erase(this->tiles.find(Coords(x, y, z)));
-  signal("tileChanged", Coords(x, y, z));
+    this->tiles.erase(this->tiles.find(Coords(x, y, z)));
+    signal("tileChanged", Coords(x, y, z));
 }
 
 std::shared_ptr<CTile> CMap::getTile(int x, int y, int z) {
-  Coords coords(x, y, z);
-  std::shared_ptr<CTile> tile;
-  auto it = this->tiles.find(coords);
-  if (it == this->tiles.end()) {
-    if (vstd::ctn(boundaries, z) &&
-        (x < 0 || y < 0 || x > boundaries[z].first ||
-         y > boundaries[z].second)) {
-      tile = getGame()->createObject<CTile>("MountainTile");
+    Coords coords(x, y, z);
+    std::shared_ptr<CTile> tile;
+    auto it = this->tiles.find(coords);
+    if (it == this->tiles.end()) {
+        if (vstd::ctn(boundaries, z) && (x < 0 || y < 0 || x > boundaries[z].first || y > boundaries[z].second)) {
+            tile = getGame()->createObject<CTile>("MountainTile");
+        } else {
+            tile = getGame()->createObject<CTile>(vstd::ctn(boundaries, z) && !defaultTiles[z].empty() ? defaultTiles[z]
+                                                                                                       : "GrassTile");
+        }
+        if (tile) {
+            this->addTile(tile, x, y, z);
+        }
     } else {
-      tile = getGame()->createObject<CTile>(
-          vstd::ctn(boundaries, z) && !defaultTiles[z].empty() ? defaultTiles[z]
-                                                               : "GrassTile");
+        tile = (*it).second;
     }
-    if (tile) {
-      this->addTile(tile, x, y, z);
-    }
-  } else {
-    tile = (*it).second;
-  }
-  return tile;
+    return tile;
 }
 
-std::shared_ptr<CTile> CMap::getTile(Coords coords) {
-  return this->getTile(coords.x, coords.y, coords.z);
-}
+std::shared_ptr<CTile> CMap::getTile(Coords coords) { return this->getTile(coords.x, coords.y, coords.z); }
 
 bool CMap::canStep(int x, int y, int z) {
-  Coords coords(x, y, z);
-  auto it = this->tiles.find(coords);
-  for (const auto &object : getObjectsAtCoords(coords)) {
-    if (!object->getCanStep()) {
-      return false;
+    Coords coords(x, y, z);
+    auto it = this->tiles.find(coords);
+    for (const auto &object : getObjectsAtCoords(coords)) {
+        if (!object->getCanStep()) {
+            return false;
+        }
     }
-  }
-  if (it != this->tiles.end()) {
-    return (*it).second->canStep();
-  }
-  std::pair<int, int> bound = boundaries[z];
-  return !(x < 0 || y < 0 || x > bound.first || y > bound.second);
+    if (it != this->tiles.end()) {
+        return (*it).second->canStep();
+    }
+    std::pair<int, int> bound = boundaries[z];
+    return !(x < 0 || y < 0 || x > bound.first || y > bound.second);
 }
 
-bool CMap::canStep(Coords coords) {
-  return canStep(coords.x, coords.y, coords.z);
-}
+bool CMap::canStep(Coords coords) { return canStep(coords.x, coords.y, coords.z); }
 
 bool CMap::contains(int x, int y, int z) {
-  Coords coords(x, y, z);
-  auto it = tiles.find(coords);
-  return it != tiles.end();
+    Coords coords(x, y, z);
+    auto it = tiles.find(coords);
+    return it != tiles.end();
 }
 
 void CMap::addObject(const std::shared_ptr<CMapObject> &mapObject) {
-  vstd::fail_if(vstd::ctn(mapObjects, mapObject->getName()),
-                "Map object already exists: " + mapObject->getName());
-  std::shared_ptr<CCreature> creature = vstd::cast<CCreature>(mapObject);
-  if (creature.get()) {
-    if (creature->getLevel() == 0) {
-      creature->addExp(0);
-      creature->heal(0);
-      creature->addMana(0);
+    vstd::fail_if(vstd::ctn(mapObjects, mapObject->getName()), "Map object already exists: " + mapObject->getName());
+    std::shared_ptr<CCreature> creature = vstd::cast<CCreature>(mapObject);
+    if (creature.get()) {
+        if (creature->getLevel() == 0) {
+            creature->addExp(0);
+            creature->heal(0);
+            creature->addMana(0);
+        }
+        creature->addExp(0);
     }
-    creature->addExp(0);
-  }
-  mapObjects.insert(std::make_pair(mapObject->getName(), mapObject));
-  getEventHandler()->gameEvent(
-      mapObject, std::make_shared<CGameEvent>(CGameEvent::Type::onCreate));
-  signal("objectChanged", mapObject->getCoords());
+    mapObjects.insert(std::make_pair(mapObject->getName(), mapObject));
+    getEventHandler()->gameEvent(mapObject, std::make_shared<CGameEvent>(CGameEvent::Type::onCreate));
+    signal("objectChanged", mapObject->getCoords());
 }
 
 void CMap::removeObject(const std::shared_ptr<CMapObject> &mapObject) {
-  mapObjects.erase(mapObjects.find(mapObject->getName()));
-  vstd::erase_if(mapObjectsCache, [mapObject](auto it) {
-    return it.second == mapObject->getName();
-  });
-  getEventHandler()->gameEvent(
-      mapObject, std::make_shared<CGameEvent>(CGameEvent::Type::onDestroy));
-  signal("objectChanged", mapObject->getCoords());
+    mapObjects.erase(mapObjects.find(mapObject->getName()));
+    vstd::erase_if(mapObjectsCache, [mapObject](auto it) { return it.second == mapObject->getName(); });
+    getEventHandler()->gameEvent(mapObject, std::make_shared<CGameEvent>(CGameEvent::Type::onDestroy));
+    signal("objectChanged", mapObject->getCoords());
 }
 
 int CMap::getEntryX() { return entryx; }
@@ -210,11 +188,11 @@ int CMap::getEntryY() { return entryy; }
 int CMap::getEntryZ() { return entryz; }
 
 std::shared_ptr<CMapObject> CMap::getObjectByName(const std::string &name) {
-  auto it = mapObjects.find(name);
-  if (it != mapObjects.end()) {
-    return (*it).second;
-  }
-  return std::shared_ptr<CMapObject>();
+    auto it = mapObjects.find(name);
+    if (it != mapObjects.end()) {
+        return (*it).second;
+    }
+    return std::shared_ptr<CMapObject>();
 }
 
 bool CMap::isMoving() { return moving; }
@@ -231,83 +209,71 @@ bool CMap::isMoving() { return moving; }
 //     }
 // }
 
-void CMap::forObjects(
-    std::function<void(std::shared_ptr<CMapObject>)> func,
-    std::function<bool(std::shared_ptr<CMapObject>)> predicate) {
-  auto clone = mapObjects;
-  for (std::shared_ptr<CMapObject> object :
-       clone | boost::adaptors::map_values |
-           boost::adaptors::filtered(predicate)) {
-    func(object);
-  }
+void CMap::forObjects(std::function<void(std::shared_ptr<CMapObject>)> func,
+                      std::function<bool(std::shared_ptr<CMapObject>)> predicate) {
+    auto clone = mapObjects;
+    for (std::shared_ptr<CMapObject> object :
+         clone | boost::adaptors::map_values | boost::adaptors::filtered(predicate)) {
+        func(object);
+    }
 }
 
 void CMap::forTiles(std::function<void(std::shared_ptr<CTile>)> func,
                     std::function<bool(std::shared_ptr<CTile>)> predicate) {
-  for (std::shared_ptr<CTile> tile : (tiles | boost::adaptors::map_values |
-                                      boost::adaptors::filtered(predicate))) {
-    func(tile);
-  }
+    for (std::shared_ptr<CTile> tile : (tiles | boost::adaptors::map_values | boost::adaptors::filtered(predicate))) {
+        func(tile);
+    }
 }
 
-void CMap::removeObjects(
-    std::function<bool(std::shared_ptr<CMapObject>)> func) {
-  auto clone = mapObjects;
-  for (std::shared_ptr<CMapObject> object :
-       clone | boost::adaptors::map_values | boost::adaptors::filtered(func)) {
-    removeObject(object);
-  }
+void CMap::removeObjects(std::function<bool(std::shared_ptr<CMapObject>)> func) {
+    auto clone = mapObjects;
+    for (std::shared_ptr<CMapObject> object : clone | boost::adaptors::map_values | boost::adaptors::filtered(func)) {
+        removeObject(object);
+    }
 }
 
 void CMap::move() {
-  auto map = this->ptr<CMap>();
+    auto map = this->ptr<CMap>();
 
-  if (map->moving) {
-    vstd::logger::fatal("Invalid move request");
-  }
-
-  map->moving = true;
-
-  vstd::logger::debug("Turn:", map->turn);
-
-  // TODO: map->applyEffects();
-
-  map->forObjects([map](std::shared_ptr<CMapObject> mapObject) {
-    map->getEventHandler()->gameEvent(
-        mapObject, std::make_shared<CGameEvent>(CGameEvent::Type::onTurn));
-  });
-
-  auto pred = [](std::shared_ptr<CMapObject> object) {
-    return vstd::castable<Moveable>(object);
-  };
-
-  std::shared_ptr<std::list<std::pair<std::shared_ptr<CCreature>, Coords>>>
-      coordinates = std::make_shared<
-          std::list<std::pair<std::shared_ptr<CCreature>, Coords>>>();
-
-  auto controller = [map, coordinates](std::shared_ptr<CMapObject> object) {
-    auto creature = vstd::cast<CCreature>(object);
-    return creature->getController()->control(creature)->thenLater(
-        [creature, coordinates](Coords coords) {
-          coordinates->push_back(std::make_pair(creature, coords));
-        });
-  };
-
-  auto end_callback = [map, coordinates](std::set<void *>) {
-    for (auto [creature, coords] : *coordinates) {
-      creature->moveTo(coords);
+    if (map->moving) {
+        vstd::logger::fatal("Invalid move request");
     }
-    map->moving = false;
-    map->turn++;
-    map->signal("turnPassed");
-  };
 
-  vstd::join(map->mapObjects | boost::adaptors::map_values |
-             boost::adaptors::filtered(pred) |
-             boost::adaptors::transformed(controller))
-      ->thenLater(end_callback);
+    map->moving = true;
 
-  vstd::wait_until([map]() { return !map->moving; });
+    vstd::logger::debug("Turn:", map->turn);
+
+    // TODO: map->applyEffects();
+
+    map->forObjects([map](std::shared_ptr<CMapObject> mapObject) {
+        map->getEventHandler()->gameEvent(mapObject, std::make_shared<CGameEvent>(CGameEvent::Type::onTurn));
+    });
+
+    auto pred = [](std::shared_ptr<CMapObject> object) { return vstd::castable<Moveable>(object); };
+
+    std::shared_ptr<std::list<std::pair<std::shared_ptr<CCreature>, Coords>>> coordinates =
+        std::make_shared<std::list<std::pair<std::shared_ptr<CCreature>, Coords>>>();
+
+    auto controller = [map, coordinates](std::shared_ptr<CMapObject> object) {
+        auto creature = vstd::cast<CCreature>(object);
+        return creature->getController()->control(creature)->thenLater(
+            [creature, coordinates](Coords coords) { coordinates->push_back(std::make_pair(creature, coords)); });
+    };
+
+    auto end_callback = [map, coordinates](std::set<void *>) {
+        for (auto [creature, coords] : *coordinates) {
+            creature->moveTo(coords);
+        }
+        map->moving = false;
+        map->turn++;
+        map->signal("turnPassed");
+    };
+
+    vstd::join(map->mapObjects | boost::adaptors::map_values | boost::adaptors::filtered(pred) |
+               boost::adaptors::transformed(controller))
+        ->thenLater(end_callback);
+
+    vstd::wait_until([map]() { return !map->moving; });
 }
 
 int CMap::getTurn() { return turn; }
@@ -315,101 +281,89 @@ int CMap::getTurn() { return turn; }
 void CMap::setTurn(int turn) { this->turn = turn; }
 
 void CMap::setTiles(std::set<std::shared_ptr<CTile>> objects) {
-  for (const auto &ob : objects) {
-    tiles[ob->getCoords()] = ob;
-  }
+    for (const auto &ob : objects) {
+        tiles[ob->getCoords()] = ob;
+    }
 }
 
 std::set<std::shared_ptr<CTile>> CMap::getTiles() {
-  return vstd::cast<std::set<std::shared_ptr<CTile>>>(
-      tiles | boost::adaptors::map_values);
+    return vstd::cast<std::set<std::shared_ptr<CTile>>>(tiles | boost::adaptors::map_values);
 }
 
 void CMap::setObjects(std::set<std::shared_ptr<CMapObject>> objects) {
-  for (auto ob : objects) {
-    mapObjects[ob->getName()] = ob;
-  }
+    for (auto ob : objects) {
+        mapObjects[ob->getName()] = ob;
+    }
 }
 
 std::set<std::shared_ptr<CMapObject>> CMap::getObjects() {
-  return vstd::cast<std::set<std::shared_ptr<CMapObject>>>(
-      mapObjects | boost::adaptors::map_values);
+    return vstd::cast<std::set<std::shared_ptr<CMapObject>>>(mapObjects | boost::adaptors::map_values);
 }
 
 void CMap::dumpPaths(std::string path) {
-  CPathFinder::saveMap(
-      getPlayer()->getCoords(),
-      [this](auto coords) { return this->canStep(coords); }, path,
-      [this](auto coords) {
-        for (auto ob : getObjectsAtCoords(coords)) {
-          if (ob->getBoolProperty("waypoint")) {
-            return std::make_pair(true, Coords(ob->getNumericProperty("x"),
-                                               ob->getNumericProperty("y"),
-                                               ob->getNumericProperty("z")));
-          }
-        }
-        return std::make_pair(false, ZERO);
-      });
+    CPathFinder::saveMap(
+        getPlayer()->getCoords(), [this](auto coords) { return this->canStep(coords); }, path,
+        [this](auto coords) {
+            for (auto ob : getObjectsAtCoords(coords)) {
+                if (ob->getBoolProperty("waypoint")) {
+                    return std::make_pair(true, Coords(ob->getNumericProperty("x"), ob->getNumericProperty("y"),
+                                                       ob->getNumericProperty("z")));
+                }
+            }
+            return std::make_pair(false, ZERO);
+        });
 }
 
-std::set<std::shared_ptr<CTrigger>> CMap::getTriggers() {
-  return getEventHandler()->getTriggers();
-}
+std::set<std::shared_ptr<CTrigger>> CMap::getTriggers() { return getEventHandler()->getTriggers(); }
 
 void CMap::setTriggers(std::set<std::shared_ptr<CTrigger>> triggers) {
-  for (auto trigger : triggers) {
-    getEventHandler()->registerTrigger(trigger);
-  }
+    for (auto trigger : triggers) {
+        getEventHandler()->registerTrigger(trigger);
+    }
 }
 
 void CMap::setMapName(std::string mapName) { this->mapName = mapName; }
 
 std::string CMap::getMapName() { return mapName; }
 
-void CMap::objectMoved(const std::shared_ptr<CMapObject> &object, Coords _old,
-                       Coords _new) {
-  vstd::erase_if(mapObjectsCache,
-                 [object](auto it) { return it.second == object->getName(); });
+void CMap::objectMoved(const std::shared_ptr<CMapObject> &object, Coords _old, Coords _new) {
+    vstd::erase_if(mapObjectsCache, [object](auto it) { return it.second == object->getName(); });
 
-  mapObjectsCache.insert(std::make_pair(_new, object->getName()));
+    mapObjectsCache.insert(std::make_pair(_new, object->getName()));
 
-  // TODO: check if it`s correct
-  signal("objectChanged", _old);
-  signal("objectChanged", _new);
+    // TODO: check if it`s correct
+    signal("objectChanged", _old);
+    signal("objectChanged", _new);
 }
 
 std::set<std::shared_ptr<CMapObject>> CMap::getObjectsAtCoords(Coords coords) {
-  std::set<std::shared_ptr<CMapObject>> ret;
-  auto range = mapObjectsCache.equal_range(coords);
-  for (auto it = range.first; it != range.second; it++) {
-    if (auto ob = getObjectByName(it->second)) {
-      ret.insert(ob);
+    std::set<std::shared_ptr<CMapObject>> ret;
+    auto range = mapObjectsCache.equal_range(coords);
+    for (auto it = range.first; it != range.second; it++) {
+        if (auto ob = getObjectByName(it->second)) {
+            ret.insert(ob);
+        }
     }
-  }
-  return ret;
+    return ret;
 }
 
-void CMap::forObjectsAtCoords(
-    Coords coords, std::function<void(std::shared_ptr<CMapObject>)> func,
-    std::function<bool(std::shared_ptr<CMapObject>)> predicate) {
-  auto clone = getObjectsAtCoords(coords);
-  for (auto object : clone) {
-    if (predicate(object)) {
-      func(object);
+void CMap::forObjectsAtCoords(Coords coords, std::function<void(std::shared_ptr<CMapObject>)> func,
+                              std::function<bool(std::shared_ptr<CMapObject>)> predicate) {
+    auto clone = getObjectsAtCoords(coords);
+    for (auto object : clone) {
+        if (predicate(object)) {
+            func(object);
+        }
     }
-  }
 }
 
-void CMap::addObject(const std::shared_ptr<CMapObject> &mapObject,
-                     Coords coords) {
-  if (this->canStep(coords)) {
-    if (mapObject) {
-      addObject(mapObject);
-      mapObject->moveTo(coords.x, coords.y, coords.z);
+void CMap::addObject(const std::shared_ptr<CMapObject> &mapObject, Coords coords) {
+    if (this->canStep(coords)) {
+        if (mapObject) {
+            addObject(mapObject);
+            mapObject->moveTo(coords.x, coords.y, coords.z);
+        }
     }
-  }
 }
 
-Coords CMap::getEntry() {
-  return Coords(getEntryX(), getEntryY(), getEntryZ());
-}
+Coords CMap::getEntry() { return Coords(getEntryX(), getEntryY(), getEntryZ()); }

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -21,23 +21,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CJsonUtil.h"
 #include "core/CMap.h"
 
-bool visitablePredicate(std::shared_ptr<CMapObject> object) {
-  return vstd::cast<Visitable>(object).operator bool();
-};
+bool visitablePredicate(std::shared_ptr<CMapObject> object) { return vstd::cast<Visitable>(object).operator bool(); };
 
-void CCreature::setActions(std::set<std::shared_ptr<CInteraction>> value) {
-  actions = value;
-}
+void CCreature::setActions(std::set<std::shared_ptr<CInteraction>> value) { actions = value; }
 
-std::set<std::shared_ptr<CInteraction>> CCreature::getActions() {
-  return actions;
-}
+std::set<std::shared_ptr<CInteraction>> CCreature::getActions() { return actions; }
 
 int CCreature::getExp() { return exp; }
 
 void CCreature::setExp(int exp) {
-  this->exp = exp;
-  this->addExp(0);
+    this->exp = exp;
+    this->addExp(0);
 }
 
 CCreature::CCreature() {}
@@ -45,141 +39,130 @@ CCreature::CCreature() {}
 CCreature::~CCreature() {}
 
 void CCreature::addExpScaled(int scale) {
-  int rank = level - scale;
-  // TODO: rethink this
-  this->addExp(250 * pow(2, -rank));
+    int rank = level - scale;
+    // TODO: rethink this
+    this->addExp(250 * pow(2, -rank));
 }
 
 void CCreature::addExp(int exp) {
-  if (!isAlive()) {
-    return;
-  }
-  this->exp += exp;
-  while (this->exp >= getExpForNextLevel()) {
-    this->levelUp();
-  }
+    if (!isAlive()) {
+        return;
+    }
+    this->exp += exp;
+    while (this->exp >= getExpForNextLevel()) {
+        this->levelUp();
+    }
 }
 
 int CCreature::getExpForNextLevel() { return getExpForLevel(level + 1); }
 
 std::shared_ptr<CInteraction> CCreature::getLevelAction() {
-  std::string levelString = std::to_string(level);
-  if (vstd::ctn(levelling, levelString)) {
-    return getGame()->getObjectHandler()->clone<CInteraction>(
-        levelling[levelString]);
-  } else {
-    return nullptr;
-  }
+    std::string levelString = std::to_string(level);
+    if (vstd::ctn(levelling, levelString)) {
+        return getGame()->getObjectHandler()->clone<CInteraction>(levelling[levelString]);
+    } else {
+        return nullptr;
+    }
 }
 
 std::shared_ptr<Stats> CCreature::getLevelStats() { return levelStats; }
 
-void CCreature::setLevelStats(std::shared_ptr<Stats> _value) {
-  levelStats = _value;
-}
+void CCreature::setLevelStats(std::shared_ptr<Stats> _value) { levelStats = _value; }
 
 void CCreature::addItem(std::shared_ptr<CItem> item) {
-  std::set<std::shared_ptr<CItem>> list;
-  list.insert(item);
-  addItems(list);
+    std::set<std::shared_ptr<CItem>> list;
+    list.insert(item);
+    addItems(list);
 }
 
 void CCreature::removeItem(std::shared_ptr<CItem> item, bool quest) {
-  // TODO: this check should be more polymorphic
-  if (!quest && vstd::castable<CPlayer>(this->ptr<CCreature>()) &&
-      item->hasTag("quest")) {
-    vstd::logger::fatal("Tried to drop quest item");
-  } else {
-    if (items.erase(item)) {
-      signal("inventoryChanged");
+    // TODO: this check should be more polymorphic
+    if (!quest && vstd::castable<CPlayer>(this->ptr<CCreature>()) && item->hasTag("quest")) {
+        vstd::logger::fatal("Tried to drop quest item");
+    } else {
+        if (items.erase(item)) {
+            signal("inventoryChanged");
+        }
     }
-  }
 }
 
-void CCreature::removeItem(
-    std::function<bool(std::shared_ptr<CItem>)> item_pred, bool quest) {
-  for (auto item : items) {
-    if (item_pred(item)) {
-      removeItem(item, quest);
+void CCreature::removeItem(std::function<bool(std::shared_ptr<CItem>)> item_pred, bool quest) {
+    for (auto item : items) {
+        if (item_pred(item)) {
+            removeItem(item, quest);
+        }
     }
-  }
 }
 
 std::set<std::shared_ptr<CItem>> CCreature::getInInventory() { return items; }
 
-std::set<std::shared_ptr<CInteraction>> CCreature::getInteractions() {
-  return actions;
-}
+std::set<std::shared_ptr<CInteraction>> CCreature::getInteractions() { return actions; }
 
 CItemMap CCreature::getEquipped() { return equipped; }
 
 void CCreature::setEquipped(CItemMap value) {
-  equipped = value; // TODO: rethink equipped changed here
+    equipped = value; // TODO: rethink equipped changed here
 }
 
 void CCreature::addItems(std::set<std::shared_ptr<CItem>> items) {
-  for (std::shared_ptr<CItem> it : items) {
-    this->items.insert(it);
-    signal("inventoryChanged");
-  }
+    for (std::shared_ptr<CItem> it : items) {
+        this->items.insert(it);
+        signal("inventoryChanged");
+    }
 }
 
-void CCreature::addItem(std::string item) {
-  addItem(getGame()->createObject<CItem>(item));
-}
+void CCreature::addItem(std::string item) { addItem(getGame()->createObject<CItem>(item)); }
 
 void CCreature::heal(int i) {
-  vstd::fail_if(i < 0, "Tried to heal negative value!");
-  auto hpMax = getHpMax();
-  if (hp > hpMax) {
-    return;
-  }
-  if (i == 0) {
-    hp = hpMax;
-  } else {
-    hp += i;
-  }
-  if (hp > hpMax) {
-    hp = hpMax;
-  }
+    vstd::fail_if(i < 0, "Tried to heal negative value!");
+    auto hpMax = getHpMax();
+    if (hp > hpMax) {
+        return;
+    }
+    if (i == 0) {
+        hp = hpMax;
+    } else {
+        hp += i;
+    }
+    if (hp > hpMax) {
+        hp = hpMax;
+    }
 }
 
 void CCreature::healProc(float i) {
-  int tmp = hp;
-  heal(i / 100.0 * getHpMax());
-  vstd::logger::debug(to_string(), "restored", hp - tmp, "hp");
+    int tmp = hp;
+    heal(i / 100.0 * getHpMax());
+    vstd::logger::debug(to_string(), "restored", hp - tmp, "hp");
 }
 
 void CCreature::hurt(int i) {
-  std::shared_ptr<Damage> damage = std::make_shared<Damage>();
-  damage->setNormal(i);
-  hurt(damage);
+    std::shared_ptr<Damage> damage = std::make_shared<Damage>();
+    damage->setNormal(i);
+    hurt(damage);
 }
 
 void CCreature::hurt(float i) { hurt(int(round(i))); }
 
 int CCreature::getExpRatio() {
-  return (float)((exp - getExpForLevel(level))) /
-         (float)(getExpForLevel(level + 1) - getExpForLevel(level)) * 100.0;
+    return (float)((exp - getExpForLevel(level))) / (float)(getExpForLevel(level + 1) - getExpForLevel(level)) * 100.0;
 }
 
 // TODO: resistance and blocking to be more generic
 void CCreature::takeDamage(int rawDamage) {
-  auto stats = getStats();
-  if (rawDamage < 0) {
-    rawDamage = 0;
-  }
-  int damageAfterArmor = rawDamage * ((100 - stats->getArmor()) / 100.0);
-  if (damageAfterArmor < 0) {
-    damageAfterArmor = 0;
-  }
-  if (rand() >= stats->getBlock()) {
-    vstd::logger::debug(to_string(), "armor saved from",
-                        rawDamage - damageAfterArmor, "damage");
-    hp -= damageAfterArmor;
-  } else {
-    vstd::logger::debug(getName(), "blocked", rawDamage, "damage");
-  }
+    auto stats = getStats();
+    if (rawDamage < 0) {
+        rawDamage = 0;
+    }
+    int damageAfterArmor = rawDamage * ((100 - stats->getArmor()) / 100.0);
+    if (damageAfterArmor < 0) {
+        damageAfterArmor = 0;
+    }
+    if (rand() >= stats->getBlock()) {
+        vstd::logger::debug(to_string(), "armor saved from", rawDamage - damageAfterArmor, "damage");
+        hp -= damageAfterArmor;
+    } else {
+        vstd::logger::debug(getName(), "blocked", rawDamage, "damage");
+    }
 }
 
 CInteractionMap CCreature::getLevelling() { return levelling; }
@@ -187,41 +170,40 @@ CInteractionMap CCreature::getLevelling() { return levelling; }
 void CCreature::setLevelling(CInteractionMap value) { levelling = value; }
 
 void CCreature::setItems(std::set<std::shared_ptr<CItem>> value) {
-  items = value; // TODO: rethink inventory changed here
+    items = value; // TODO: rethink inventory changed here
 }
 
 std::set<std::shared_ptr<CItem>> CCreature::getItems() { return items; }
 
 void CCreature::hurt(std::shared_ptr<Damage> damage) {
-  auto stats = getStats();
-  takeDamage(damage->getNormal() * (100 - stats->getNormalResist()) / 100.0);
-  takeDamage(damage->getThunder() * (100 - stats->getThunderResist()) / 100.0);
-  takeDamage(damage->getFrost() * (100 - stats->getFrostResist()) / 100.0);
-  takeDamage(damage->getFire() * (100 - stats->getFireResist()) / 100.0);
-  takeDamage(damage->getShadow() * (100 - stats->getShadowResist()) / 100.0);
+    auto stats = getStats();
+    takeDamage(damage->getNormal() * (100 - stats->getNormalResist()) / 100.0);
+    takeDamage(damage->getThunder() * (100 - stats->getThunderResist()) / 100.0);
+    takeDamage(damage->getFrost() * (100 - stats->getFrostResist()) / 100.0);
+    takeDamage(damage->getFire() * (100 - stats->getFireResist()) / 100.0);
+    takeDamage(damage->getShadow() * (100 - stats->getShadowResist()) / 100.0);
 
-  vstd::logger::debug(getType(), "took damage:", JSONIFY(damage));
+    vstd::logger::debug(getType(), "took damage:", JSONIFY(damage));
 }
 
 int CCreature::getDmg() {
-  auto stats = getStats();
-  int critDice = rand() % 100;
-  int attDice = rand() % 100;
-  // TODO: crashes if min damage is greater than max. duh.
-  int dmg = rand() % (stats->getDmgMax() + 1 - stats->getDmgMin()) +
-            stats->getDmgMin();
-  dmg += stats->getDamage();
-  attDice -= stats->getAttack();
-  if (attDice < stats->getHit()) {
-    if (critDice < stats->getCrit()) {
-      dmg *= 2;
-      vstd::logger::debug("Critical!");
+    auto stats = getStats();
+    int critDice = rand() % 100;
+    int attDice = rand() % 100;
+    // TODO: crashes if min damage is greater than max. duh.
+    int dmg = rand() % (stats->getDmgMax() + 1 - stats->getDmgMin()) + stats->getDmgMin();
+    dmg += stats->getDamage();
+    attDice -= stats->getAttack();
+    if (attDice < stats->getHit()) {
+        if (critDice < stats->getCrit()) {
+            dmg *= 2;
+            vstd::logger::debug("Critical!");
+        }
+        return dmg;
+    } else {
+        vstd::logger::debug("Missed!");
+        return 0;
     }
-    return dmg;
-  } else {
-    vstd::logger::debug("Missed!");
-    return 0;
-  }
 }
 
 int CCreature::getScale() { return level + sw; }
@@ -229,23 +211,21 @@ int CCreature::getScale() { return level + sw; }
 bool CCreature::isAlive() { return hp > 0; }
 
 void CCreature::addAction(std::shared_ptr<CInteraction> action) {
-  if (!action) {
-    return;
-  }
-  actions.insert(action);
-  signal("interactionsChanged");
+    if (!action) {
+        return;
+    }
+    actions.insert(action);
+    signal("interactionsChanged");
 }
 
 void CCreature::addEffect(std::shared_ptr<CEffect> effect) {
-  if (vstd::ctn(effects, effect, CGameObject::name_comparator)) {
-    vstd::logger::debug(effect->to_string(),
-                        "skipping already present effect for",
-                        this->to_string());
-  } else {
-    vstd::logger::debug(effect->to_string(), "starts for", this->to_string());
-    effects.insert(effect);
-    signal("effectsChanged");
-  }
+    if (vstd::ctn(effects, effect, CGameObject::name_comparator)) {
+        vstd::logger::debug(effect->to_string(), "skipping already present effect for", this->to_string());
+    } else {
+        vstd::logger::debug(effect->to_string(), "starts for", this->to_string());
+        effects.insert(effect);
+        signal("effectsChanged");
+    }
 }
 
 int CCreature::getMana() { return mana; }
@@ -253,57 +233,57 @@ int CCreature::getMana() { return mana; }
 void CCreature::setMana(int mana) { this->mana = mana; }
 
 void CCreature::addMana(int i) {
-  vstd::fail_if(i < 0, "Tried to add negative mana!");
-  auto manaMax = getManaMax();
-  if (mana > manaMax) {
-    return;
-  }
-  if (i == 0) {
-    mana = manaMax;
-  } else {
-    mana += i;
-  }
-  if (mana > manaMax) {
-    mana = manaMax;
-  }
+    vstd::fail_if(i < 0, "Tried to add negative mana!");
+    auto manaMax = getManaMax();
+    if (mana > manaMax) {
+        return;
+    }
+    if (i == 0) {
+        mana = manaMax;
+    } else {
+        mana += i;
+    }
+    if (mana > manaMax) {
+        mana = manaMax;
+    }
 }
 
 void CCreature::addManaProc(float i) {
-  int tmp = mana;
-  addMana(i / 100.0 * getManaMax());
-  vstd::logger::debug(to_string(), "restored", mana - tmp, "mana");
+    int tmp = mana;
+    addMana(i / 100.0 * getManaMax());
+    vstd::logger::debug(to_string(), "restored", mana - tmp, "mana");
 }
 
 void CCreature::takeMana(int i) {
-  vstd::fail_if(i < 0, "Tried to take negative mana value!");
-  mana -= i;
+    vstd::fail_if(i < 0, "Tried to take negative mana value!");
+    mana -= i;
 }
 
 bool CCreature::isPlayer() {
-  const std::shared_ptr<CPlayer> player = getMap()->getPlayer();
-  return player && player == this->ptr<CPlayer>();
+    const std::shared_ptr<CPlayer> player = getMap()->getPlayer();
+    return player && player == this->ptr<CPlayer>();
 }
 
 int CCreature::getHpRatio() {
-  auto hpMax = getHpMax();
-  if (hp > hpMax) {
-    return 100;
-  }
-  return (float)hp / (float)hpMax * 100.0;
+    auto hpMax = getHpMax();
+    if (hp > hpMax) {
+        return 100;
+    }
+    return (float)hp / (float)hpMax * 100.0;
 }
 
 int CCreature::getManaRatio() {
-  auto manaMax = getManaMax();
-  if (mana > manaMax) {
-    return 100;
-  }
-  if (manaMax == 0) {
-    return 100;
-  }
-  if (mana < 0) {
-    return 0;
-  }
-  return (float)mana / (float)manaMax * 100.0;
+    auto manaMax = getManaMax();
+    if (mana > manaMax) {
+        return 100;
+    }
+    if (manaMax == 0) {
+        return 100;
+    }
+    if (mana < 0) {
+        return 0;
+    }
+    return (float)mana / (float)manaMax * 100.0;
 }
 
 int CCreature::getHp() { return hp; }
@@ -312,110 +292,93 @@ int CCreature::getManaMax() { return getStats()->getMainValue() * 7; }
 
 int CCreature::getLevel() { return level; }
 
-void CCreature::setWeapon(std::shared_ptr<CWeapon> weapon) {
-  this->equipItem(std::to_string(0), weapon);
-}
+void CCreature::setWeapon(std::shared_ptr<CWeapon> weapon) { this->equipItem(std::to_string(0), weapon); }
 
-void CCreature::setArmor(std::shared_ptr<CArmor> armor) {
-  this->equipItem(std::to_string(3), armor);
-}
+void CCreature::setArmor(std::shared_ptr<CArmor> armor) { this->equipItem(std::to_string(3), armor); }
 
 // TODO: make method unequip instead of equip null
 void CCreature::equipItem(std::string i, std::shared_ptr<CItem> newItem) {
-  vstd::fail_if(newItem && !getMap()->getGame()->getSlotConfiguration()->canFit(
-                               i, newItem),
-                "Tried to insert" + (newItem ? newItem->getType() : "null") +
-                    "into slot" + i);
+    vstd::fail_if(newItem && !getMap()->getGame()->getSlotConfiguration()->canFit(i, newItem),
+                  "Tried to insert" + (newItem ? newItem->getType() : "null") + "into slot" + i);
 
-  if (vstd::ctn(equipped, i)) {
-    std::shared_ptr<CItem> oldItem = equipped.at(i);
+    if (vstd::ctn(equipped, i)) {
+        std::shared_ptr<CItem> oldItem = equipped.at(i);
 
-    getMap()->getEventHandler()->gameEvent(
-        oldItem, std::make_shared<CGameEventCaused>(CGameEvent::Type::onUnequip,
-                                                    this->ptr<CCreature>()));
-    this->addItem(oldItem);
-    if (newItem == oldItem) {
-      newItem = nullptr;
+        getMap()->getEventHandler()->gameEvent(
+            oldItem, std::make_shared<CGameEventCaused>(CGameEvent::Type::onUnequip, this->ptr<CCreature>()));
+        this->addItem(oldItem);
+        if (newItem == oldItem) {
+            newItem = nullptr;
+        }
     }
-  }
-  if (newItem) {
-    getMap()->getEventHandler()->gameEvent(
-        newItem, std::make_shared<CGameEventCaused>(CGameEvent::Type::onEquip,
-                                                    this->ptr<CCreature>()));
-    removeItem(newItem);
-    equipped[i] = newItem;
-    signal("equippedChanged");
-  } else {
-    if (equipped.erase(i)) {
-      signal("equippedChanged");
+    if (newItem) {
+        getMap()->getEventHandler()->gameEvent(
+            newItem, std::make_shared<CGameEventCaused>(CGameEvent::Type::onEquip, this->ptr<CCreature>()));
+        removeItem(newItem);
+        equipped[i] = newItem;
+        signal("equippedChanged");
+    } else {
+        if (equipped.erase(i)) {
+            signal("equippedChanged");
+        }
     }
-  }
 }
 
-bool CCreature::hasInInventory(std::shared_ptr<CItem> item) {
-  return vstd::ctn(items, item);
+bool CCreature::hasInInventory(std::shared_ptr<CItem> item) { return vstd::ctn(items, item); }
+
+bool CCreature::hasInInventory(std::function<bool(std::shared_ptr<CItem>)> item) {
+    return std::any_of(items.begin(), items.end(), item);
 }
 
-bool CCreature::hasInInventory(
-    std::function<bool(std::shared_ptr<CItem>)> item) {
-  return std::any_of(items.begin(), items.end(), item);
-}
-
-bool CCreature::hasItem(std::shared_ptr<CItem> item) {
-  return hasInInventory(item) || hasEquipped(item);
-}
+bool CCreature::hasItem(std::shared_ptr<CItem> item) { return hasInInventory(item) || hasEquipped(item); }
 
 bool CCreature::hasItem(std::function<bool(std::shared_ptr<CItem>)> item) {
-  return hasInInventory(item) || hasEquipped(item);
+    return hasInInventory(item) || hasEquipped(item);
 }
 
-std::shared_ptr<CWeapon> CCreature::getWeapon() {
-  return vstd::cast<CWeapon>(getItemAtSlot("0"));
-}
+std::shared_ptr<CWeapon> CCreature::getWeapon() { return vstd::cast<CWeapon>(getItemAtSlot("0")); }
 
-std::shared_ptr<CArmor> CCreature::getArmor() {
-  return vstd::cast<CArmor>(getItemAtSlot("3"));
-}
+std::shared_ptr<CArmor> CCreature::getArmor() { return vstd::cast<CArmor>(getItemAtSlot("3")); }
 
 // TODO: get rid of this, calculate level automatically
 void CCreature::levelUp() {
-  level++;
-  // TODO: dynamic action calculation
-  addAction(getLevelAction());
-  heal(0);
-  addMana(0);
-  if (level > 1) {
-    vstd::logger::debug(to_string(), "is now level:", level);
-  }
+    level++;
+    // TODO: dynamic action calculation
+    addAction(getLevelAction());
+    heal(0);
+    addMana(0);
+    if (level > 1) {
+        vstd::logger::debug(to_string(), "is now level:", level);
+    }
 }
 
 std::set<std::shared_ptr<CItem>> CCreature::getAllItems() {
-  std::set<std::shared_ptr<CItem>> allItems;
-  allItems.insert(items.begin(), items.end());
-  for (auto it : equipped) {
-    if (it.second) {
-      allItems.insert(it.second);
+    std::set<std::shared_ptr<CItem>> allItems;
+    allItems.insert(items.begin(), items.end());
+    for (auto it : equipped) {
+        if (it.second) {
+            allItems.insert(it.second);
+        }
     }
-  }
-  return allItems;
+    return allItems;
 }
 
 bool CCreature::hasEquipped(std::function<bool(std::shared_ptr<CItem>)> item) {
-  for (auto it : equipped) {
-    if (item(it.second)) {
-      return true;
+    for (auto it : equipped) {
+        if (item(it.second)) {
+            return true;
+        }
     }
-  }
-  return false;
+    return false;
 }
 
 bool CCreature::hasEquipped(std::shared_ptr<CItem> item) {
-  for (auto it : equipped) {
-    if (it.second == item) {
-      return true;
+    for (auto it : equipped) {
+        if (it.second == item) {
+            return true;
+        }
     }
-  }
-  return false;
+    return false;
 }
 
 int CCreature::getSw() const { return sw; }
@@ -424,29 +387,27 @@ void CCreature::setSw(int _value) { sw = _value; }
 
 std::shared_ptr<Stats> CCreature::getBaseStats() { return baseStats; }
 
-void CCreature::setBaseStats(std::shared_ptr<Stats> _value) {
-  baseStats = _value;
-}
+void CCreature::setBaseStats(std::shared_ptr<Stats> _value) { baseStats = _value; }
 
 int CCreature::getHpMax() {
-  return getStats()->getStamina() * 7;
-  ;
+    return getStats()->getStamina() * 7;
+    ;
 }
 
 std::shared_ptr<CItem> CCreature::getItemAtSlot(std::string slot) {
-  if (vstd::ctn(equipped, slot)) {
-    return equipped.at(slot);
-  }
-  return nullptr;
+    if (vstd::ctn(equipped, slot)) {
+        return equipped.at(slot);
+    }
+    return nullptr;
 }
 
 std::string CCreature::getSlotWithItem(std::shared_ptr<CItem> item) {
-  for (auto it = equipped.begin(); it != equipped.end(); it++) {
-    if ((*it).second == item) {
-      return (*it).first;
+    for (auto it = equipped.begin(); it != equipped.end(); it++) {
+        if ((*it).second == item) {
+            return (*it).first;
+        }
     }
-  }
-  return "-1";
+    return "-1";
 }
 
 void CCreature::setHp(int value) { hp = value; }
@@ -458,54 +419,45 @@ int CCreature::getGold() { return gold; }
 void CCreature::setGold(int value) { gold = value; }
 
 void CCreature::beforeMove() {
-  auto self = this->ptr<CCreature>();
+    auto self = this->ptr<CCreature>();
 
-  auto func = [self](std::shared_ptr<CMapObject> object) {
-    self->getMap()->getEventHandler()->gameEvent(
-        object,
-        std::make_shared<CGameEventCaused>(CGameEvent::Type::onLeave, self));
-  };
+    auto func = [self](std::shared_ptr<CMapObject> object) {
+        self->getMap()->getEventHandler()->gameEvent(
+            object, std::make_shared<CGameEventCaused>(CGameEvent::Type::onLeave, self));
+    };
 
-  getMap()->forObjectsAtCoords(getCoords(), func, visitablePredicate);
+    getMap()->forObjectsAtCoords(getCoords(), func, visitablePredicate);
 }
 
 void CCreature::afterMove() {
-  auto self = this->ptr<CCreature>();
+    auto self = this->ptr<CCreature>();
 
-  if (getMap()->getTile(this->getCoords())) {
-    getMap()->getTile(this->getCoords())->onStep(this->ptr<CCreature>());
-  }
+    if (getMap()->getTile(this->getCoords())) {
+        getMap()->getTile(this->getCoords())->onStep(this->ptr<CCreature>());
+    }
 
-  auto fightPred = [self](std::shared_ptr<CMapObject> object) {
-    return vstd::cast<CCreature>(object) && self != object &&
-           !self->isAffiliatedWith(object)
-           // TODO: better
-           && self->getMap()->getObjectByName(self->getName()) &&
-           object->getMap()->getObjectByName(object->getName());
-  };
+    auto fightPred = [self](std::shared_ptr<CMapObject> object) {
+        auto other = vstd::cast<CCreature>(object);
+        return other && self != object && !self->isNpc() && !other->isNpc() &&
+               self->getMap()->getObjectByName(self->getName()) && object->getMap()->getObjectByName(object->getName());
+    };
 
-  auto fightAction = [self](auto object) {
-    CFightHandler::fight(self, vstd::cast<CCreature>(object));
-  };
+    auto fightAction = [self](auto object) { CFightHandler::fight(self, vstd::cast<CCreature>(object)); };
 
-  auto eventAction = [self](auto object) {
-    self->getMap()->getEventHandler()->gameEvent(
-        object,
-        std::make_shared<CGameEventCaused>(CGameEvent::Type::onEnter, self));
-  };
+    auto eventAction = [self](auto object) {
+        self->getMap()->getEventHandler()->gameEvent(
+            object, std::make_shared<CGameEventCaused>(CGameEvent::Type::onEnter, self));
+    };
 
-  getMap()->forObjectsAtCoords(this->getCoords(), fightAction, fightPred);
-  getMap()->forObjectsAtCoords(this->getCoords(), eventAction,
-                               visitablePredicate);
+    getMap()->forObjectsAtCoords(this->getCoords(), fightAction, fightPred);
+    getMap()->forObjectsAtCoords(this->getCoords(), eventAction, visitablePredicate);
 }
 
 void CCreature::addGold(int gold) { this->setGold(this->getGold() + gold); }
 
 void CCreature::takeGold(int gold) { this->setGold(this->getGold() - gold); }
 
-std::set<std::shared_ptr<CEffect>> CCreature::getEffects() const {
-  return effects;
-}
+std::set<std::shared_ptr<CEffect>> CCreature::getEffects() const { return effects; }
 
 void CCreature::onEnter(std::shared_ptr<CGameEvent>) {}
 
@@ -513,89 +465,75 @@ void CCreature::onLeave(std::shared_ptr<CGameEvent>) {}
 
 void CCreature::onDestroy(std::shared_ptr<CGameEvent>) { effects.clear(); }
 
-void CCreature::setEffects(const std::set<std::shared_ptr<CEffect>> &value) {
-  effects = value;
-}
+void CCreature::setEffects(const std::set<std::shared_ptr<CEffect>> &value) { effects = value; }
 
 std::shared_ptr<CController> CCreature::getController() {
-  return controller ? controller : std::make_shared<CController>();
+    return controller ? controller : std::make_shared<CController>();
 }
 
-void CCreature::setController(std::shared_ptr<CController> controller) {
-  this->controller = controller;
-}
+void CCreature::setController(std::shared_ptr<CController> controller) { this->controller = controller; }
 
 std::string CCreature::to_string() {
-  return vstd::join({CGameObject::to_string(), "(",
-                     vstd::join({vstd::str(getPosX()), vstd::str(getPosY()),
-                                 vstd::str(getPosZ())},
-                                ","),
-                     ")"},
-                    "");
+    return vstd::join({CGameObject::to_string(), "(",
+                       vstd::join({vstd::str(getPosX()), vstd::str(getPosY()), vstd::str(getPosZ())}, ","), ")"},
+                      "");
 }
 
-std::shared_ptr<CFightController> CCreature::getFightController() {
-  return fightController;
+std::shared_ptr<CFightController> CCreature::getFightController() { return fightController; }
+
+void CCreature::setFightController(std::shared_ptr<CFightController> fightController) {
+    CCreature::fightController = fightController;
 }
 
-void CCreature::setFightController(
-    std::shared_ptr<CFightController> fightController) {
-  CCreature::fightController = fightController;
-}
+bool CCreature::isNpc() { return npc; }
+
+void CCreature::setNpc(bool value) { npc = value; }
 
 // TODO: make this a CGameEvent
-void CCreature::useAction(std::shared_ptr<CInteraction> action,
-                          std::shared_ptr<CCreature> creature) {
-  vstd::fail_if(!vstd::ctn(actions, action));
-  action->onAction(this->ptr<CCreature>(), creature);
-  if (creature->getArmor()) {
-    if (creature->getArmor()->getInteraction()) {
-      creature->getArmor()->getInteraction()->onAction(creature,
-                                                       this->ptr<CCreature>());
+void CCreature::useAction(std::shared_ptr<CInteraction> action, std::shared_ptr<CCreature> creature) {
+    vstd::fail_if(!vstd::ctn(actions, action));
+    action->onAction(this->ptr<CCreature>(), creature);
+    if (creature->getArmor()) {
+        if (creature->getArmor()->getInteraction()) {
+            creature->getArmor()->getInteraction()->onAction(creature, this->ptr<CCreature>());
+        }
     }
-  }
 }
 
 void CCreature::removeEffect(std::shared_ptr<CEffect> effect) {
-  effects.erase(effect);
-  signal("effectsChanged");
+    effects.erase(effect);
+    signal("effectsChanged");
 }
 
 void CCreature::useItem(std::shared_ptr<CItem> item) {
-  vstd::fail_if(!vstd::ctn(items, item), "Tried to use item not in inventory!");
-  getMap()->getEventHandler()->gameEvent(
-      item,
-      std::make_shared<CGameEventCaused>(CGameEvent::Type::onUse, this->ptr()));
-  if (item->isDisposable()) {
-    removeItem(item);
-  }
+    vstd::fail_if(!vstd::ctn(items, item), "Tried to use item not in inventory!");
+    getMap()->getEventHandler()->gameEvent(item,
+                                           std::make_shared<CGameEventCaused>(CGameEvent::Type::onUse, this->ptr()));
+    if (item->isDisposable()) {
+        removeItem(item);
+    }
 }
 
 void CCreature::setLevel(int level) { this->level = level; }
 
 int CCreature::getExpForLevel(int level) { return (level - 1) * level * 500; }
 
-void CCreature::removeQuestItem(std::shared_ptr<CItem> item) {
-  removeItem(item, true);
-}
+void CCreature::removeQuestItem(std::shared_ptr<CItem> item) { removeItem(item, true); }
 
-void CCreature::removeQuestItem(
-    std::function<bool(std::shared_ptr<CItem>)> item) {
-  removeItem(item, true);
-}
+void CCreature::removeQuestItem(std::function<bool(std::shared_ptr<CItem>)> item) { removeItem(item, true); }
 
 std::shared_ptr<Stats> CCreature::getStats() {
-  std::shared_ptr<Stats> ret = std::make_shared<Stats>();
-  ret->setMainStat(getBaseStats()->getMainStat());
-  ret->addBonus(getBaseStats());
-  for (int i = 0; i < level; i++) {
-    ret->addBonus(getLevelStats());
-  }
-  for (auto [slot, item] : getEquipped()) {
-    ret->addBonus(item->getBonus());
-  }
-  for (auto effect : getEffects()) {
-    ret->addBonus(effect->getBonus());
-  }
-  return ret;
+    std::shared_ptr<Stats> ret = std::make_shared<Stats>();
+    ret->setMainStat(getBaseStats()->getMainStat());
+    ret->addBonus(getBaseStats());
+    for (int i = 0; i < level; i++) {
+        ret->addBonus(getLevelStats());
+    }
+    for (auto [slot, item] : getEquipped()) {
+        ret->addBonus(item->getBonus());
+    }
+    for (auto effect : getEffects()) {
+        ret->addBonus(effect->getBonus());
+    }
+    return ret;
 }

--- a/src/object/CCreature.h
+++ b/src/object/CCreature.h
@@ -45,244 +45,236 @@ typedef std::map<std::string, std::shared_ptr<CItem>> CItemMap;
 
 class CCreature : public CMapObject, public Moveable, public Visitable {
 
-  V_META(CCreature, CMapObject, V_PROPERTY(CCreature, int, exp, getExp, setExp),
-         V_PROPERTY(CCreature, int, gold, getGold, setGold),
-         V_PROPERTY(CCreature, int, level, getLevel, setLevel),
-         V_PROPERTY(CCreature, int, mana, getMana, setMana),
-         V_PROPERTY(CCreature, int, hp, getHp, setHp),
-         V_PROPERTY(CCreature, int, sw, getSw, setSw),
-         V_PROPERTY(CCreature, CInteractionMap, levelling, getLevelling,
-                    setLevelling),
-         V_PROPERTY(CCreature, CItemMap, equipped, getEquipped, setEquipped),
-         V_PROPERTY(CCreature, std::shared_ptr<Stats>, baseStats, getBaseStats,
-                    setBaseStats),
-         V_PROPERTY(CCreature, std::shared_ptr<Stats>, levelStats,
-                    getLevelStats, setLevelStats),
-         V_PROPERTY(CCreature, std::set<std::shared_ptr<CInteraction>>, actions,
-                    getActions, setActions),
-         V_PROPERTY(CCreature, std::set<std::shared_ptr<CItem>>, items,
-                    getItems, setItems),
-         V_PROPERTY(CCreature, std::set<std::shared_ptr<CEffect>>, effects,
-                    getEffects, setEffects),
-         V_PROPERTY(CCreature, std::shared_ptr<CController>, controller,
-                    getController, setController),
-         V_PROPERTY(CCreature, std::shared_ptr<CFightController>,
-                    fightController, getFightController, setFightController),
-         V_METHOD(CCreature, getManaMax, int),
-         V_METHOD(CCreature, getHpMax, int),
-         V_METHOD(CCreature, getManaRegRate, int))
+    V_META(CCreature, CMapObject, V_PROPERTY(CCreature, int, exp, getExp, setExp),
+           V_PROPERTY(CCreature, int, gold, getGold, setGold), V_PROPERTY(CCreature, int, level, getLevel, setLevel),
+           V_PROPERTY(CCreature, int, mana, getMana, setMana), V_PROPERTY(CCreature, int, hp, getHp, setHp),
+           V_PROPERTY(CCreature, int, sw, getSw, setSw),
+           V_PROPERTY(CCreature, CInteractionMap, levelling, getLevelling, setLevelling),
+           V_PROPERTY(CCreature, CItemMap, equipped, getEquipped, setEquipped),
+           V_PROPERTY(CCreature, std::shared_ptr<Stats>, baseStats, getBaseStats, setBaseStats),
+           V_PROPERTY(CCreature, std::shared_ptr<Stats>, levelStats, getLevelStats, setLevelStats),
+           V_PROPERTY(CCreature, std::set<std::shared_ptr<CInteraction>>, actions, getActions, setActions),
+           V_PROPERTY(CCreature, std::set<std::shared_ptr<CItem>>, items, getItems, setItems),
+           V_PROPERTY(CCreature, std::set<std::shared_ptr<CEffect>>, effects, getEffects, setEffects),
+           V_PROPERTY(CCreature, std::shared_ptr<CController>, controller, getController, setController),
+           V_PROPERTY(CCreature, std::shared_ptr<CFightController>, fightController, getFightController,
+                      setFightController),
+           V_PROPERTY(CCreature, bool, npc, isNpc, setNpc), V_METHOD(CCreature, getManaMax, int),
+           V_METHOD(CCreature, getHpMax, int), V_METHOD(CCreature, getManaRegRate, int))
 
-public:
-  CCreature();
+  public:
+    CCreature();
 
-  virtual ~CCreature();
+    virtual ~CCreature();
 
-  void setActions(std::set<std::shared_ptr<CInteraction>> value);
+    void setActions(std::set<std::shared_ptr<CInteraction>> value);
 
-  std::set<std::shared_ptr<CInteraction>> getActions();
+    std::set<std::shared_ptr<CInteraction>> getActions();
 
-  void setItems(std::set<std::shared_ptr<CItem>> value);
+    void setItems(std::set<std::shared_ptr<CItem>> value);
 
-  std::set<std::shared_ptr<CItem>> getItems();
+    std::set<std::shared_ptr<CItem>> getItems();
 
-  std::set<std::shared_ptr<CEffect>> getEffects() const;
+    std::set<std::shared_ptr<CEffect>> getEffects() const;
 
-  virtual void onEnter(std::shared_ptr<CGameEvent>) override;
+    virtual void onEnter(std::shared_ptr<CGameEvent>) override;
 
-  virtual void onLeave(std::shared_ptr<CGameEvent>) override;
+    virtual void onLeave(std::shared_ptr<CGameEvent>) override;
 
-  virtual void onDestroy(std::shared_ptr<CGameEvent>);
+    virtual void onDestroy(std::shared_ptr<CGameEvent>);
 
-  void setEffects(const std::set<std::shared_ptr<CEffect>> &value);
+    void setEffects(const std::set<std::shared_ptr<CEffect>> &value);
 
-  int getExp();
+    int getExp();
 
-  void setExp(int exp);
+    void setExp(int exp);
 
-  int getExpRatio();
+    int getExpRatio();
 
-  int getExpForNextLevel();
+    int getExpForNextLevel();
 
-  int getExpForLevel(int level);
+    int getExpForLevel(int level);
 
-  void heal(int i);
+    void heal(int i);
 
-  void healProc(float i);
+    void healProc(float i);
 
-  void hurt(std::shared_ptr<Damage> damage);
+    void hurt(std::shared_ptr<Damage> damage);
 
-  void hurt(int i);
+    void hurt(int i);
 
-  void hurt(float i);
+    void hurt(float i);
 
-  int getDmg();
+    int getDmg();
 
-  int getScale();
+    int getScale();
 
-  bool isAlive();
+    bool isAlive();
 
-  virtual std::set<std::shared_ptr<CItem>> getAllItems();
+    virtual std::set<std::shared_ptr<CItem>> getAllItems();
 
-  void addAction(std::shared_ptr<CInteraction> action);
+    void addAction(std::shared_ptr<CInteraction> action);
 
-  void addEffect(std::shared_ptr<CEffect> effect);
+    void addEffect(std::shared_ptr<CEffect> effect);
 
-  void removeEffect(std::shared_ptr<CEffect> effect);
+    void removeEffect(std::shared_ptr<CEffect> effect);
 
-  int getMana();
+    int getMana();
 
-  void setMana(int mana);
+    void setMana(int mana);
 
-  void addMana(int i);
+    void addMana(int i);
 
-  void addManaProc(float i);
+    void addManaProc(float i);
 
-  void takeMana(int i);
+    void takeMana(int i);
 
-  bool isPlayer();
+    bool isPlayer();
 
-  int getHpRatio();
+    int getHpRatio();
 
-  void setWeapon(std::shared_ptr<CWeapon> weapon);
+    void setWeapon(std::shared_ptr<CWeapon> weapon);
 
-  void setArmor(std::shared_ptr<CArmor> armor);
+    void setArmor(std::shared_ptr<CArmor> armor);
 
-  std::shared_ptr<CWeapon> getWeapon();
+    std::shared_ptr<CWeapon> getWeapon();
 
-  std::shared_ptr<CArmor> getArmor();
+    std::shared_ptr<CArmor> getArmor();
 
-  int getManaRatio();
+    int getManaRatio();
 
-  int getLevel();
+    int getLevel();
 
-  void setLevel(int level);
+    void setLevel(int level);
 
-  void addExpScaled(int scale);
+    void addExpScaled(int scale);
 
-  void addExp(int exp);
+    void addExp(int exp);
 
-  void addItems(std::set<std::shared_ptr<CItem>> items);
+    void addItems(std::set<std::shared_ptr<CItem>> items);
 
-  void addItem(std::shared_ptr<CItem> item);
+    void addItem(std::shared_ptr<CItem> item);
 
-  void addItem(std::string item);
+    void addItem(std::string item);
 
-  void removeItem(std::shared_ptr<CItem> item, bool quest = false);
+    void removeItem(std::shared_ptr<CItem> item, bool quest = false);
 
-  void removeItem(std::function<bool(std::shared_ptr<CItem>)> item,
-                  bool quest = false);
+    void removeItem(std::function<bool(std::shared_ptr<CItem>)> item, bool quest = false);
 
-  void removeQuestItem(std::shared_ptr<CItem> item);
+    void removeQuestItem(std::shared_ptr<CItem> item);
 
-  void removeQuestItem(std::function<bool(std::shared_ptr<CItem>)> item);
+    void removeQuestItem(std::function<bool(std::shared_ptr<CItem>)> item);
 
-  std::set<std::shared_ptr<CItem>> getInInventory();
+    std::set<std::shared_ptr<CItem>> getInInventory();
 
-  CItemMap getEquipped();
+    CItemMap getEquipped();
 
-  void setEquipped(CItemMap value);
+    void setEquipped(CItemMap value);
 
-  std::set<std::shared_ptr<CInteraction>> getInteractions();
+    std::set<std::shared_ptr<CInteraction>> getInteractions();
 
-  bool hasEquipped(std::shared_ptr<CItem> item);
+    bool hasEquipped(std::shared_ptr<CItem> item);
 
-  bool hasEquipped(std::function<bool(std::shared_ptr<CItem>)> item);
+    bool hasEquipped(std::function<bool(std::shared_ptr<CItem>)> item);
 
-  void equipItem(std::string i, std::shared_ptr<CItem> newItem);
+    void equipItem(std::string i, std::shared_ptr<CItem> newItem);
 
-  bool hasInInventory(std::shared_ptr<CItem> item);
+    bool hasInInventory(std::shared_ptr<CItem> item);
 
-  bool hasInInventory(std::function<bool(std::shared_ptr<CItem>)> item);
+    bool hasInInventory(std::function<bool(std::shared_ptr<CItem>)> item);
 
-  bool hasItem(std::shared_ptr<CItem> item);
+    bool hasItem(std::shared_ptr<CItem> item);
 
-  bool hasItem(std::function<bool(std::shared_ptr<CItem>)> item);
+    bool hasItem(std::function<bool(std::shared_ptr<CItem>)> item);
 
-  int getGold();
+    int getGold();
 
-  void setGold(int value);
+    void setGold(int value);
 
-  int getManaMax();
+    int getManaMax();
 
-  int getManaRegRate();
+    int getManaRegRate();
 
-  int getHp();
+    int getHp();
 
-  void setHp(int value);
+    void setHp(int value);
 
-  int getHpMax();
+    int getHpMax();
 
-  std::shared_ptr<CItem> getItemAtSlot(std::string slot);
+    std::shared_ptr<CItem> getItemAtSlot(std::string slot);
 
-  std::string getSlotWithItem(std::shared_ptr<CItem> item);
+    std::string getSlotWithItem(std::shared_ptr<CItem> item);
 
-  CInteractionMap getLevelling();
+    CInteractionMap getLevelling();
 
-  void setLevelling(CInteractionMap value);
+    void setLevelling(CInteractionMap value);
 
-  std::shared_ptr<Stats> getBaseStats();
+    std::shared_ptr<Stats> getBaseStats();
 
-  void setBaseStats(std::shared_ptr<Stats> value);
+    void setBaseStats(std::shared_ptr<Stats> value);
 
-  std::shared_ptr<Stats> getLevelStats();
+    std::shared_ptr<Stats> getLevelStats();
 
-  void setLevelStats(std::shared_ptr<Stats> value);
+    void setLevelStats(std::shared_ptr<Stats> value);
 
-  int getSw() const;
+    int getSw() const;
 
-  void setSw(int value);
+    void setSw(int value);
 
-  virtual void beforeMove();
+    virtual void beforeMove();
 
-  virtual void afterMove();
+    virtual void afterMove();
 
-  void addGold(int gold);
+    void addGold(int gold);
 
-  void takeGold(int gold);
+    void takeGold(int gold);
 
-  std::shared_ptr<CController> getController();
+    std::shared_ptr<CController> getController();
 
-  void setController(std::shared_ptr<CController> controller);
+    void setController(std::shared_ptr<CController> controller);
 
-  virtual std::string to_string() override;
+    virtual std::string to_string() override;
 
-  std::shared_ptr<CFightController> getFightController();
+    std::shared_ptr<CFightController> getFightController();
 
-  void setFightController(std::shared_ptr<CFightController> fightController);
+    void setFightController(std::shared_ptr<CFightController> fightController);
+    bool isNpc();
+    void setNpc(bool value);
 
-  void useAction(std::shared_ptr<CInteraction> action,
-                 std::shared_ptr<CCreature> creature);
+    void useAction(std::shared_ptr<CInteraction> action, std::shared_ptr<CCreature> creature);
 
-  void useItem(std::shared_ptr<CItem> item);
+    void useItem(std::shared_ptr<CItem> item);
 
-  std::shared_ptr<Stats> getStats();
+    std::shared_ptr<Stats> getStats();
 
-protected:
-  virtual void levelUp();
+  protected:
+    virtual void levelUp();
 
-private:
-  std::set<std::shared_ptr<CItem>> items;
-  std::set<std::shared_ptr<CInteraction>> actions;
-  std::set<std::shared_ptr<CEffect>> effects;
+  private:
+    std::set<std::shared_ptr<CItem>> items;
+    std::set<std::shared_ptr<CInteraction>> actions;
+    std::set<std::shared_ptr<CEffect>> effects;
 
-  std::map<std::string, std::shared_ptr<CItem>> equipped;
-  std::map<std::string, std::shared_ptr<CInteraction>> levelling;
+    std::map<std::string, std::shared_ptr<CItem>> equipped;
+    std::map<std::string, std::shared_ptr<CInteraction>> levelling;
 
-  std::shared_ptr<CController> controller;
+    std::shared_ptr<CController> controller;
 
-  std::shared_ptr<CFightController> fightController;
+    std::shared_ptr<CFightController> fightController;
 
-  int gold = 0;
-  int exp = 0;
-  int level = 0;
-  int sw = 0;
-  int mana = 0;
-  int hp = 0;
+    int gold = 0;
+    int exp = 0;
+    int level = 0;
+    int sw = 0;
+    int mana = 0;
+    int hp = 0;
 
-  std::shared_ptr<Stats> baseStats = std::make_shared<Stats>();
-  std::shared_ptr<Stats> levelStats = std::make_shared<Stats>();
+    std::shared_ptr<Stats> baseStats = std::make_shared<Stats>();
+    std::shared_ptr<Stats> levelStats = std::make_shared<Stats>();
 
-  void takeDamage(int i);
+    void takeDamage(int i);
 
-  std::shared_ptr<CInteraction> getLevelAction();
+    std::shared_ptr<CInteraction> getLevelAction();
+
+    bool npc = false;
 };


### PR DESCRIPTION
## Summary
- mark friendly NPCs with `npc: true` instead of affiliations
- add an `npc` flag to `CCreature` and skip combat if either creature has it
- remove default player affiliation logic

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_688b63d257288326add5ade35ceb8037