### PR TITLE
Fix entry state name in OctoBogz dialog

### DIFF
--- a/res/maps/nouraajd/dialog2.json
+++ b/res/maps/nouraajd/dialog2.json
@@ -6,7 +6,7 @@
         {
           "class": "CDialogState",
           "properties": {
-            "stateId": "INIT",
+            "stateId": "ENTRY",
             "text": "Whoa! Hold on there, stranger! Are you headed east, beyond the river?",
             "options": [
               {


### PR DESCRIPTION
## Summary
- fix OctoBogz dialog to use standard `ENTRY` state id

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_688b71e1c144832696ccd9cc7f5237b9