### PR TITLE
Add validation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ cd cmake-build-release
 make _game
 python3 play.py
 </pre>
+### testing
+Run `python3 test.py` to execute the unit tests. Data validation tests run without
+needing the compiled `_game` module, but other tests require it to be built.


### PR DESCRIPTION
## Summary
- expand GameTest with json validity, plugin loader, indentation, and resource path checks
- note new tests in README

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_688b7573e6e08326a1e0afa47bd04b14