### PR TITLE
Fix Windows build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,10 @@ endif ()
 
 SET(CPACK_STRIP_FILES _game.so)
 
-IF (!WIN32)
+if (WIN32)
+    set_target_properties(_game PROPERTIES UNITY_BUILD OFF)
+else()
     cotire(_game)
     set_target_properties(_game PROPERTIES UNITY_BUILD ON)
-ENDIF ()
+endif ()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,5 @@ SET(CPACK_STRIP_FILES _game.so)
 
 IF (!WIN32)
     cotire(_game)
+    set_target_properties(_game PROPERTIES UNITY_BUILD ON)
 ENDIF ()
-
-set_target_properties(_game PROPERTIES UNITY_BUILD ON)


### PR DESCRIPTION
## Summary
- disable cotire unity build on Windows

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'game')*

------
https://chatgpt.com/codex/tasks/task_e_688ba97c5a688326a59e93cc586642ae