### PR TITLE
Support multi-enemy combat encounters

### DIFF
--- a/res/config/panels.json
+++ b/res/config/panels.json
@@ -57,7 +57,7 @@
         {
           "class": "CListView",
           "properties": {
-            "allowOversize": false,
+            "allowOversize": true,
             "collection": "getEffects",
             "layout": {
               "class": "CLayout",
@@ -236,6 +236,27 @@
                 "y": 100
               }
             }
+          }
+        },
+        {
+          "class": "CListView",
+          "properties": {
+            "allowOversize": false,
+            "callback": "enemiesCallback",
+            "collection": "enemiesCollection",
+            "layout": {
+              "class": "CLayout",
+              "properties": {
+                "h": "10%",
+                "w": "40%",
+                "x": "30%",
+                "y": "5%"
+              }
+            },
+            "select": "enemiesSelect",
+            "showEmpty": false,
+            "xPrefferedSize": 4,
+            "yPrefferedSize": 1
           }
         },
         {

--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "core/CController.h"
+#include <algorithm>
+
 #include "core/CGame.h"
 #include "core/CMap.h"
 #include "gui/panel/CGameFightPanel.h"
@@ -302,11 +304,27 @@ void CFightController::start(std::shared_ptr<CCreature> me,
 void CFightController::end(std::shared_ptr<CCreature> me,
                            std::shared_ptr<CCreature> opponent) {}
 
+void CFightController::setOpponents(
+    std::shared_ptr<CCreature> me,
+    const std::vector<std::shared_ptr<CCreature>> &opponents) {}
+
+std::shared_ptr<CCreature>
+CFightController::selectOpponent(
+    std::shared_ptr<CCreature> me,
+    const std::vector<std::shared_ptr<CCreature>> &opponents,
+    std::shared_ptr<CCreature> opponent) {
+  auto current = std::find(opponents.begin(), opponents.end(), opponent);
+  if (current != opponents.end()) {
+    return *current;
+  }
+  return opponents.empty() ? std::shared_ptr<CCreature>() : opponents.front();
+}
+
 void CPlayerFightController::start(std::shared_ptr<CCreature> me,
                                    std::shared_ptr<CCreature> opponent) {
   vstd::if_not_null(me->getMap()->getGame()->getGui(), [&](auto gui) {
     fightPanel = me->getGame()->createObject<CGameFightPanel>("fightPanel");
-    fightPanel->setEnemy(opponent);
+    fightPanel->setEnemies({opponent});
     gui->pushChild(fightPanel);
     return 0;
   });
@@ -317,7 +335,9 @@ bool CPlayerFightController::control(std::shared_ptr<CCreature> me,
   bool used = false;
   vstd::if_not_null(me->getMap()->getGame()->getGui(), [&](auto gui) {
     // TODO: what about mana cost?
-    me->useAction(fightPanel->selectInteraction(), opponent);
+    auto target = fightPanel && fightPanel->getEnemy() ? fightPanel->getEnemy()
+                                                       : opponent;
+    me->useAction(fightPanel->selectInteraction(), target);
     used = true;
   });
   return used;
@@ -326,9 +346,31 @@ bool CPlayerFightController::control(std::shared_ptr<CCreature> me,
 void CPlayerFightController::end(std::shared_ptr<CCreature> me,
                                  std::shared_ptr<CCreature> opponent) {
   vstd::if_not_null(me->getMap()->getGame()->getGui(), [&](auto gui) {
-    fightPanel->close();
-    fightPanel = nullptr;
+    if (fightPanel) {
+      fightPanel->close();
+      fightPanel = nullptr;
+    }
   });
+}
+
+void CPlayerFightController::setOpponents(
+    std::shared_ptr<CCreature> me,
+    const std::vector<std::shared_ptr<CCreature>> &opponents) {
+  if (fightPanel && !opponents.empty()) {
+    fightPanel->setEnemies(opponents);
+  }
+}
+
+std::shared_ptr<CCreature>
+CPlayerFightController::selectOpponent(
+    std::shared_ptr<CCreature> me,
+    const std::vector<std::shared_ptr<CCreature>> &opponents,
+    std::shared_ptr<CCreature> opponent) {
+  setOpponents(me, opponents);
+  if (fightPanel && fightPanel->getEnemy()) {
+    return fightPanel->getEnemy();
+  }
+  return CFightController::selectOpponent(me, opponents, opponent);
 }
 
 bool CPlayerController::isCompleted(std::shared_ptr<CPlayer> player) {

--- a/src/core/CController.h
+++ b/src/core/CController.h
@@ -17,6 +17,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 
+#include <vector>
+
 #include "core/CPathFinder.h"
 #include "core/CTags.h"
 #include "object/CObject.h"
@@ -63,6 +65,15 @@ public:
 
   virtual void end(std::shared_ptr<CCreature> me,
                    std::shared_ptr<CCreature> opponent);
+
+  virtual void
+  setOpponents(std::shared_ptr<CCreature> me,
+               const std::vector<std::shared_ptr<CCreature>> &opponents);
+
+  virtual std::shared_ptr<CCreature>
+  selectOpponent(std::shared_ptr<CCreature> me,
+                 const std::vector<std::shared_ptr<CCreature>> &opponents,
+                 std::shared_ptr<CCreature> opponent);
 };
 
 class CMonsterFightController : public CFightController {
@@ -90,6 +101,15 @@ public:
 
   void end(std::shared_ptr<CCreature> me,
            std::shared_ptr<CCreature> opponent) override;
+
+  void setOpponents(
+      std::shared_ptr<CCreature> me,
+      const std::vector<std::shared_ptr<CCreature>> &opponents) override;
+
+  std::shared_ptr<CCreature>
+  selectOpponent(std::shared_ptr<CCreature> me,
+                 const std::vector<std::shared_ptr<CCreature>> &opponents,
+                 std::shared_ptr<CCreature> opponent) override;
 
 private:
   std::shared_ptr<CGameFightPanel> fightPanel;

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -484,7 +484,17 @@ PYBIND11_MODULE(_game, m) {
 
     py::class_<CFightHandler, std::shared_ptr<CFightHandler>>(m, "CFightHandler",
                                                                               "Combat resolution service.")
-        .def("fight", &CFightHandler::fight, "Run a fight between two creatures.");
+        .def("fight", &CFightHandler::fight, "Run a fight between two creatures.")
+        .def("fightMany",
+             [](std::shared_ptr<CCreature> attacker, const py::iterable &opponents) {
+               std::vector<std::shared_ptr<CCreature>> encounter;
+               for (const auto &opponent : opponents) {
+                 encounter.push_back(
+                     opponent.cast<std::shared_ptr<CCreature>>());
+               }
+               return CFightHandler::fightMany(attacker, encounter);
+             },
+             "Run a fight between one creature and multiple opponents.");
 
     py::class_<CMarket, CGameObject, std::shared_ptr<CMarket>>(m, "CMarket",
                                                                                       "Trading inventory and prices.");

--- a/src/gui/panel/CGameFightPanel.cpp
+++ b/src/gui/panel/CGameFightPanel.cpp
@@ -16,10 +16,28 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "CGameFightPanel.h"
+#include <algorithm>
+#include <unordered_set>
+
 #include "core/CMap.h"
 #include "gui/CAnimation.h"
 #include "gui/CTextureCache.h"
+#include "gui/object/CProxyTargetGraphicsObject.h"
 #include "gui/object/CStatsGraphicsObject.h"
+
+namespace {
+void refresh_proxy_children(const std::shared_ptr<CGameGraphicsObject> &object) {
+  if (!object) {
+    return;
+  }
+  if (auto proxy = vstd::cast<CProxyTargetGraphicsObject>(object)) {
+    proxy->refreshAll();
+  }
+  for (const auto &child : object->getChildren()) {
+    refresh_proxy_children(child);
+  }
+}
+} // namespace
 
 CListView::collection_pointer
 CGameFightPanel::interactionsCollection(std::shared_ptr<CGui> gui) {
@@ -44,7 +62,7 @@ void CGameFightPanel::interactionsCallback(
     // TODO: rethink moving selection to CListView
     selected.reset();
   }
-  refreshViews();
+  refreshEncounterViews();
 }
 
 bool CGameFightPanel::interactionsSelect(std::shared_ptr<CGui> gui, int index,
@@ -72,7 +90,7 @@ void CGameFightPanel::itemsCallback(
     gui->getGame()->getMap()->getPlayer()->useItem(newSelection);
     selectedItem.reset();
   }
-  refreshViews();
+  refreshEncounterViews();
 }
 
 bool CGameFightPanel::itemsSelect(std::shared_ptr<CGui> gui, int index,
@@ -90,9 +108,14 @@ bool CGameFightPanel::mouseEvent(std::shared_ptr<CGui> gui,
     selected.reset();
     selectedItem.reset();
     finalSelected.reset();
-    refreshViews();
+    refreshEncounterViews();
   }
   return true;
+}
+
+void CGameFightPanel::refreshEncounterViews() {
+  refreshViews();
+  refresh_proxy_children(this->ptr<CGameFightPanel>());
 }
 
 std::shared_ptr<CInteraction> CGameFightPanel::selectInteraction() {
@@ -100,10 +123,68 @@ std::shared_ptr<CInteraction> CGameFightPanel::selectInteraction() {
   auto ret = finalSelected.lock();
   finalSelected.reset();
   selected.reset();
-  refreshViews();
+  refreshEncounterViews();
   return ret;
 }
 
 std::shared_ptr<CCreature> CGameFightPanel::getEnemy() { return enemy.lock(); }
 
-void CGameFightPanel::setEnemy(std::shared_ptr<CCreature> en) { enemy = en; }
+void CGameFightPanel::setEnemy(std::shared_ptr<CCreature> en) {
+  if (en && en->isAlive() &&
+      std::find(enemies.begin(), enemies.end(), en) == enemies.end()) {
+    enemies.push_back(en);
+  }
+  enemy = en && en->isAlive() ? en : nullptr;
+  if (enemy.lock()) {
+    refreshEncounterViews();
+  } else {
+    refreshViews();
+  }
+}
+
+void CGameFightPanel::setEnemies(
+    const std::vector<std::shared_ptr<CCreature>> &value) {
+  enemies.clear();
+  std::unordered_set<std::string> names;
+  for (const auto &candidate : value) {
+    if (candidate && candidate->isAlive() &&
+        names.insert(candidate->getName()).second) {
+      enemies.push_back(candidate);
+    }
+  }
+
+  auto current = enemy.lock();
+  auto current_it = std::find(enemies.begin(), enemies.end(), current);
+  enemy = current_it != enemies.end()
+              ? *current_it
+              : (enemies.empty() ? std::shared_ptr<CCreature>() : enemies.front());
+  if (enemy.lock()) {
+    refreshEncounterViews();
+  } else {
+    refreshViews();
+  }
+}
+
+CListView::collection_pointer
+CGameFightPanel::enemiesCollection(std::shared_ptr<CGui> gui) {
+  auto collection = std::make_shared<CListView::collection_type>();
+  for (const auto &candidate : enemies) {
+    collection->push_back(candidate);
+  }
+  return collection;
+}
+
+void CGameFightPanel::enemiesCallback(
+    std::shared_ptr<CGui> gui, int index,
+    std::shared_ptr<CGameObject> _newSelection) {
+  auto newSelection = vstd::cast<CCreature>(_newSelection);
+  if (newSelection && newSelection->isAlive()) {
+    enemy = newSelection;
+    refreshEncounterViews();
+  }
+}
+
+bool CGameFightPanel::enemiesSelect(std::shared_ptr<CGui> gui, int index,
+                                    std::shared_ptr<CGameObject> object) {
+  return object && enemy.lock() && enemy.lock() == object;
+}

--- a/src/gui/panel/CGameFightPanel.h
+++ b/src/gui/panel/CGameFightPanel.h
@@ -17,6 +17,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 
+#include <vector>
+
 #include "CGamePanel.h"
 #include "gui/panel/CListView.h"
 #include "object/CPlayer.h"
@@ -35,6 +37,12 @@ class CGameFightPanel : public CGamePanel {
                   int, std::shared_ptr<CGameObject>),
          V_METHOD(CGameFightPanel, itemsSelect, bool, std::shared_ptr<CGui>,
                   int, std::shared_ptr<CGameObject>),
+         V_METHOD(CGameFightPanel, enemiesCollection,
+                  CListView::collection_pointer, std::shared_ptr<CGui>),
+         V_METHOD(CGameFightPanel, enemiesCallback, void, std::shared_ptr<CGui>,
+                  int, std::shared_ptr<CGameObject>),
+         V_METHOD(CGameFightPanel, enemiesSelect, bool, std::shared_ptr<CGui>,
+                  int, std::shared_ptr<CGameObject>),
          V_METHOD(CGameFightPanel, getEnemy, std::shared_ptr<CCreature>))
 
 public:
@@ -46,13 +54,18 @@ public:
 
   void setEnemy(std::shared_ptr<CCreature> en);
 
+  void setEnemies(const std::vector<std::shared_ptr<CCreature>> &value);
+
 private:
+  std::vector<std::shared_ptr<CCreature>> enemies;
   std::weak_ptr<CCreature> enemy;
   std::weak_ptr<CInteraction> selected;
   std::weak_ptr<CItem> selectedItem;
   std::weak_ptr<CInteraction> finalSelected;
   bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
                   int button, int x, int y) override;
+
+  void refreshEncounterViews();
 
 public:
   CListView::collection_pointer
@@ -71,4 +84,12 @@ public:
 
   bool itemsSelect(std::shared_ptr<CGui> gui, int index,
                    std::shared_ptr<CGameObject> object);
+
+  CListView::collection_pointer enemiesCollection(std::shared_ptr<CGui> gui);
+
+  void enemiesCallback(std::shared_ptr<CGui> gui, int index,
+                       std::shared_ptr<CGameObject> _newSelection);
+
+  bool enemiesSelect(std::shared_ptr<CGui> gui, int index,
+                     std::shared_ptr<CGameObject> object);
 };

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -40,8 +40,12 @@ bool CListView::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type,
     int yIndex = y / tileSize;
     if (xIndex < getSizeX(gui) && yIndex < getSizeY(gui)) {
       int i = (xIndex + (yIndex * getSizeX(gui)));
-      invokeCallback(gui, shiftIndex(gui, i),
-                     calculateIndices(gui).find(shiftIndex(gui, i))->second);
+      auto indices = calculateIndices(gui);
+      auto shiftedIndex = shiftIndex(gui, i);
+      auto found = indices.find(shiftedIndex);
+      if (found != indices.end()) {
+        invokeCallback(gui, shiftedIndex, found->second);
+      }
     }
   }
   return true;

--- a/src/handler/CFightHandler.cpp
+++ b/src/handler/CFightHandler.cpp
@@ -16,55 +16,241 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "CFightHandler.h"
+#include <algorithm>
+#include <unordered_set>
+
 #include "core/CController.h"
 #include "core/CGame.h"
 #include "core/CMap.h"
 #include "core/CTags.h"
 #include "object/CCreature.h"
 
-bool CFightHandler::fight(std::shared_ptr<CCreature> a,
-                          std::shared_ptr<CCreature> b) {
-  bool retVal = false;
-  a->getFightController()->start(a, b);
-  b->getFightController()->start(b, a);
+namespace {
+using encounter_type = std::vector<std::shared_ptr<CCreature>>;
 
-  auto state = [](const std::shared_ptr<CCreature> &creature) {
-    return std::make_tuple(creature->getHp(), creature->getMana(),
-                           creature->getEffects().size(),
-                           creature->getInInventory().size());
-  };
+auto creature_state(const std::shared_ptr<CCreature> &creature) {
+  return std::make_tuple(creature->getName(), creature->getHp(),
+                         creature->getMana(), creature->getEffects().size(),
+                         creature->getInInventory().size());
+}
 
-  int stale_turns = 0;
-  for (int turn = 0; turn < 100 && stale_turns < 20; ++turn) {
-    auto before = std::make_pair(state(a), state(b));
-    applyEffects(a);
-    if (!a->isAlive()) {
-      // TODO: who was the caster? we should gratify him
-      defeatedCreature(b, a);
-      retVal = true;
-      break;
-    }
-    if (!CTags::isTagPresent(a->getEffects(), CTag::Stun)) {
-      a->getFightController()->control(a, b);
-      if (!b->isAlive()) {
-        defeatedCreature(a, b);
-        retVal = true;
-        break;
-      }
-    }
-    auto after = std::make_pair(state(a), state(b));
-    stale_turns = after == before ? stale_turns + 1 : 0;
-    a.swap(b);
+auto encounter_state(const std::shared_ptr<CCreature> &attacker,
+                     const encounter_type &opponents) {
+  std::vector<decltype(creature_state(attacker))> state;
+  state.push_back(creature_state(attacker));
+  for (const auto &opponent : opponents) {
+    state.push_back(creature_state(opponent));
+  }
+  return state;
+}
+
+bool is_present(const std::shared_ptr<CCreature> &creature) {
+  return creature && creature->getMap() &&
+         creature->getMap()->getObjectByName(creature->getName());
+}
+
+encounter_type sanitize_opponents(const std::shared_ptr<CCreature> &attacker,
+                                  const encounter_type &opponents) {
+  if (!attacker || !attacker->isAlive() || !is_present(attacker)) {
+    return {};
   }
 
-  a->getFightController()->end(a, b);
-  b->getFightController()->end(b, a);
+  encounter_type living;
+  std::unordered_set<std::string> names;
+  for (const auto &candidate : opponents) {
+    if (!candidate || candidate == attacker || !candidate->isAlive() ||
+        !is_present(candidate)) {
+      continue;
+    }
+    if (names.insert(candidate->getName()).second) {
+      living.push_back(candidate);
+    }
+  }
+  std::sort(living.begin(), living.end(),
+            [](const auto &left, const auto &right) {
+              return left->getName() < right->getName();
+            });
+  return living;
+}
 
-  return retVal;
+std::shared_ptr<CCreature>
+resolve_target(const std::shared_ptr<CCreature> &attacker,
+               const encounter_type &opponents,
+               std::shared_ptr<CCreature> current) {
+  auto controller = attacker->getFightController();
+  controller->setOpponents(attacker, opponents);
+  auto selected = controller->selectOpponent(attacker, opponents, current);
+  return selected ? selected
+                  : (opponents.empty() ? std::shared_ptr<CCreature>()
+                                       : opponents.front());
+}
+
+bool remove_dead_opponents(const std::shared_ptr<CCreature> &winner,
+                           encounter_type &opponents) {
+  bool changed = false;
+  const bool reward_winner =
+      winner && winner->isAlive() && is_present(winner);
+  opponents.erase(
+      std::remove_if(opponents.begin(), opponents.end(),
+                     [&](const auto &opponent) {
+                       if (!opponent || !is_present(opponent)) {
+                         changed = true;
+                         return true;
+                       }
+                       if (opponent->isAlive()) {
+                         return false;
+                       }
+                       changed = true;
+                       if (reward_winner) {
+                         CFightHandler::defeatedCreature(winner, opponent);
+                       } else if (is_present(opponent)) {
+                         opponent->getMap()->removeObject(opponent);
+                       }
+                       return true;
+                     }),
+      opponents.end());
+  return changed;
+}
+
+void defeat_attacker(const std::shared_ptr<CCreature> &attacker,
+                     const encounter_type &opponents,
+                     const std::shared_ptr<CCreature> &preferredWinner) {
+  auto winner = preferredWinner;
+  if (!winner || !winner->isAlive() || !is_present(winner) ||
+      std::find(opponents.begin(), opponents.end(), winner) ==
+          opponents.end()) {
+    winner = opponents.empty() ? std::shared_ptr<CCreature>()
+                               : opponents.front();
+  }
+  if (winner) {
+    CFightHandler::defeatedCreature(winner, attacker);
+  } else if (is_present(attacker)) {
+    attacker->getMap()->removeObject(attacker);
+  }
+}
+
+} // namespace
+
+bool CFightHandler::fight(std::shared_ptr<CCreature> a,
+                          std::shared_ptr<CCreature> b) {
+  return fightMany(a, {b});
+}
+
+bool CFightHandler::fightMany(
+    std::shared_ptr<CCreature> attacker,
+    const std::vector<std::shared_ptr<CCreature>> &encounterOpponents) {
+  auto opponents = sanitize_opponents(attacker, encounterOpponents);
+  if (opponents.empty()) {
+    return false;
+  }
+
+  auto allOpponents = opponents;
+  auto current = opponents.front();
+  attacker->getFightController()->setOpponents(attacker, opponents);
+  attacker->getFightController()->start(attacker, current);
+  for (const auto &opponent : allOpponents) {
+    opponent->getFightController()->start(opponent, attacker);
+  }
+
+  int stale_turns = 0;
+  bool resolved = false;
+  for (int turn = 0;
+       turn < 100 && stale_turns < 20 && attacker->isAlive() &&
+       !opponents.empty();
+       ++turn) {
+    current = resolve_target(attacker, opponents, current);
+    auto before = encounter_state(attacker, opponents);
+
+    applyEffects(attacker);
+    if (!attacker->isAlive()) {
+      // TODO: who was the caster? we should gratify him
+      defeat_attacker(attacker, opponents, current);
+      resolved = true;
+      break;
+    }
+
+    if (!CTags::isTagPresent(attacker->getEffects(), CTag::Stun)) {
+      attacker->getFightController()->control(attacker, current);
+      remove_dead_opponents(attacker, opponents);
+      if (!attacker->isAlive()) {
+        defeat_attacker(attacker, opponents, current);
+        resolved = true;
+        break;
+      }
+      if (opponents.empty()) {
+        resolved = true;
+        break;
+      }
+      current = resolve_target(attacker, opponents, current);
+    }
+
+    for (size_t i = 0; i < opponents.size() && attacker->isAlive();) {
+      auto opponent = opponents[i];
+      if (!opponent || !is_present(opponent)) {
+        opponents.erase(opponents.begin() + i);
+        if (opponents.empty()) {
+          resolved = true;
+          break;
+        }
+        current = resolve_target(attacker, opponents, current);
+        continue;
+      }
+      applyEffects(opponent);
+      if (!opponent->isAlive()) {
+        if (remove_dead_opponents(attacker, opponents)) {
+          if (opponents.empty()) {
+            resolved = true;
+            break;
+          }
+          current = resolve_target(attacker, opponents, current);
+        }
+        continue;
+      }
+      if (!CTags::isTagPresent(opponent->getEffects(), CTag::Stun)) {
+        opponent->getFightController()->control(opponent, attacker);
+        if (!attacker->isAlive()) {
+          remove_dead_opponents(attacker, opponents);
+          defeat_attacker(attacker, opponents, opponent);
+          resolved = true;
+          break;
+        }
+      }
+      if (remove_dead_opponents(attacker, opponents)) {
+        if (opponents.empty()) {
+          resolved = true;
+          break;
+        }
+        current = resolve_target(attacker, opponents, current);
+        continue;
+      }
+      ++i;
+    }
+
+    if (resolved || !attacker->isAlive()) {
+      break;
+    }
+    if (opponents.empty()) {
+      resolved = true;
+      break;
+    }
+
+    auto after = encounter_state(attacker, opponents);
+    stale_turns = after == before ? stale_turns + 1 : 0;
+  }
+
+  attacker->getFightController()->end(attacker, current);
+  for (const auto &opponent : allOpponents) {
+    opponent->getFightController()->end(opponent, attacker);
+  }
+
+  return resolved;
 }
 
 void CFightHandler::defeatedCreature(const std::shared_ptr<CCreature> &a,
                                      const std::shared_ptr<CCreature> &b) {
+  if (!a || !b || !is_present(b)) {
+    return;
+  }
   vstd::logger::debug(a->to_string(), a->getName(), "defeated", b->to_string());
   a->addExpScaled(b->getScale());
   // TODO: loot handler

--- a/src/handler/CFightHandler.h
+++ b/src/handler/CFightHandler.h
@@ -17,6 +17,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 
+#include <vector>
+
 #include "core/CGlobal.h"
 
 class CCreature;
@@ -24,6 +26,10 @@ class CCreature;
 class CFightHandler {
 public:
   static bool fight(std::shared_ptr<CCreature> a, std::shared_ptr<CCreature> b);
+
+  static bool
+  fightMany(std::shared_ptr<CCreature> attacker,
+            const std::vector<std::shared_ptr<CCreature>> &opponents);
 
   static void defeatedCreature(const std::shared_ptr<CCreature> &a,
                                const std::shared_ptr<CCreature> &b);

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -17,6 +17,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "CCreature.h"
 #include <algorithm>
+#include <vector>
+
 #include "core/CController.h"
 #include "core/CGame.h"
 #include "core/CJsonUtil.h"
@@ -451,7 +453,12 @@ void CCreature::afterMove() {
                self->getMap()->getObjectByName(self->getName()) && object->getMap()->getObjectByName(object->getName());
     };
 
-    auto fightAction = [self](auto object) { CFightHandler::fight(self, vstd::cast<CCreature>(object)); };
+    std::vector<std::shared_ptr<CCreature>> opponents;
+    auto fightAction = [&opponents](auto object) {
+        if (auto creature = vstd::cast<CCreature>(object)) {
+            opponents.push_back(creature);
+        }
+    };
 
     auto eventAction = [self](auto object) {
         self->getMap()->getEventHandler()->gameEvent(
@@ -459,6 +466,9 @@ void CCreature::afterMove() {
     };
 
     getMap()->forObjectsAtCoords(this->getCoords(), fightAction, fightPred);
+    if (!opponents.empty()) {
+        CFightHandler::fightMany(self, opponents);
+    }
     getMap()->forObjectsAtCoords(this->getCoords(), eventAction, visitablePredicate);
 }
 

--- a/test.py
+++ b/test.py
@@ -1605,6 +1605,40 @@ class GameTest(unittest.TestCase):
 
         return True, ""
 
+    def make_multi_enemy_combat_fixture(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGame(g, "empty")
+        attacker = g.createObject("Warrior")
+        attacker.baseStats.hit = 100
+        attacker.baseStats.dmgMin = 10
+        attacker.baseStats.dmgMax = 10
+        attacker.baseStats.crit = 0
+        attacker.moveTo(0, 0, 0)
+        g.getMap().addObject(attacker)
+
+        defenders = []
+        for item_id in ("Scroll", "TownPortalScroll"):
+            defender = g.createObject("GoblinThief")
+            defender.baseStats.hit = 0
+            defender.baseStats.dmgMin = 0
+            defender.baseStats.dmgMax = 0
+            defender.baseStats.crit = 0
+            defender.level = 0
+            defender.sw = 0
+            defender.hp = 1
+            defender.addItem(item_id)
+            defender.moveTo(1, 0, 0)
+            g.getMap().addObject(defender)
+            defenders.append(defender)
+
+        return game, g, attacker, defenders
+
+    def expected_scaled_exp_gain(self, attacker, defenders):
+        attacker_level = attacker.getLevel()
+        return sum(int(250 * pow(2, -(attacker_level - (defender.level + defender.sw)))) for defender in defenders)
+
     @game_test
     def test_combat_invariants(self):
         game = load_game_module()
@@ -1628,6 +1662,123 @@ class GameTest(unittest.TestCase):
         one_side_took_damage = attacker.getHpRatio() < attacker_hp_before or defender.getHpRatio() < defender_hp_before
         self.assertTrue(one_side_took_damage)
         return True, ""
+
+    @game_test
+    def test_multi_enemy_combat_resolves_and_rewards_once(self):
+        game, g, attacker, defenders = self.make_multi_enemy_combat_fixture()
+
+        exp_before = attacker.exp
+        scroll_before = attacker.countItems("Scroll")
+        town_portal_before = attacker.countItems("TownPortalScroll")
+        expected_exp = exp_before + self.expected_scaled_exp_gain(attacker, defenders)
+        started = time.monotonic()
+        result = game.CFightHandler.fightMany(attacker, defenders)
+        elapsed = time.monotonic() - started
+
+        remaining = [defender.getName() for defender in defenders if g.getMap().getObjectByName(defender.getName())]
+
+        self.assertTrue(result)
+        self.assertLess(elapsed, 2.0)
+        self.assertTrue(attacker.isAlive())
+        self.assertEqual([], remaining)
+        self.assertEqual(expected_exp, attacker.exp)
+        self.assertEqual(scroll_before + 1, attacker.countItems("Scroll"))
+        self.assertEqual(town_portal_before + 1, attacker.countItems("TownPortalScroll"))
+
+        return True, json.dumps(
+            {
+                "elapsed": elapsed,
+                "exp_before": exp_before,
+                "exp_after": attacker.exp,
+                "scrolls": attacker.countItems("Scroll"),
+                "town_portal_scrolls": attacker.countItems("TownPortalScroll"),
+                "remaining": remaining,
+            }
+        )
+
+    @game_test
+    def test_multi_enemy_combat_from_movement_path(self):
+        game, g, attacker, defenders = self.make_multi_enemy_combat_fixture()
+
+        fight_coords = defenders[0].getCoords()
+        before_names = sorted(obj.getName() for obj in g.getMap().getObjectsAtCoords(fight_coords))
+        exp_before = attacker.exp
+        expected_exp = exp_before + self.expected_scaled_exp_gain(attacker, defenders)
+        attacker.moveTo(fight_coords.x, fight_coords.y, fight_coords.z)
+
+        remaining = [defender.getName() for defender in defenders if g.getMap().getObjectByName(defender.getName())]
+        occupant_names = sorted(obj.getName() for obj in g.getMap().getObjectsAtCoords(attacker.getCoords()))
+
+        self.assertEqual(2, len(before_names))
+        self.assertEqual([], remaining)
+        self.assertEqual([attacker.getName()], occupant_names)
+        self.assertEqual(expected_exp, attacker.exp)
+
+        return True, json.dumps(
+            {
+                "before_names": before_names,
+                "occupants_after": occupant_names,
+                "remaining": remaining,
+                "exp_before": exp_before,
+                "exp_after": attacker.exp,
+            }
+        )
+
+    @game_test
+    def test_multi_enemy_combat_stale_loop_terminates(self):
+        game, g, attacker, defenders = self.make_multi_enemy_combat_fixture()
+
+        attacker.setFightController(g.createObject("CFightController"))
+        for defender in defenders:
+            defender.setFightController(g.createObject("CFightController"))
+
+        exp_before = attacker.exp
+        started = time.monotonic()
+        result = game.CFightHandler.fightMany(attacker, defenders)
+        elapsed = time.monotonic() - started
+
+        remaining = sorted(
+            defender.getName() for defender in defenders if g.getMap().getObjectByName(defender.getName())
+        )
+
+        self.assertFalse(result)
+        self.assertLess(elapsed, 2.0)
+        self.assertTrue(attacker.isAlive())
+        self.assertEqual(exp_before, attacker.exp)
+        self.assertEqual(sorted(defender.getName() for defender in defenders), remaining)
+
+        return True, json.dumps(
+            {
+                "elapsed": elapsed,
+                "exp_before": exp_before,
+                "exp_after": attacker.exp,
+                "remaining": remaining,
+            }
+        )
+
+    @game_test
+    def test_single_opponent_fight_wrapper_still_works(self):
+        game, g, attacker, defenders = self.make_multi_enemy_combat_fixture()
+
+        defender = defenders[0]
+        exp_before = attacker.exp
+        expected_exp = exp_before + self.expected_scaled_exp_gain(attacker, [defender])
+
+        result = game.CFightHandler.fight(attacker, defender)
+
+        self.assertTrue(result)
+        self.assertIsNone(g.getMap().getObjectByName(defender.getName()))
+        self.assertIsNotNone(g.getMap().getObjectByName(defenders[1].getName()))
+        self.assertEqual(expected_exp, attacker.exp)
+
+        return True, json.dumps(
+            {
+                "defeated": defender.getName(),
+                "remaining": defenders[1].getName(),
+                "exp_before": exp_before,
+                "exp_after": attacker.exp,
+            }
+        )
 
     @game_test
     def test_creature_damage_roll_normalizes_inverted_range(self):


### PR DESCRIPTION
## What was changed
- added a one-vs-many encounter path in `CFightHandler` while keeping `fight(attacker, opponent)` as a backward-compatible wrapper
- updated movement-triggered combat entry to gather co-located hostile creatures into one encounter
- extended fight controllers and the fight panel so the player can inspect and switch the current living target during a multi-enemy encounter
- exposed `CFightHandler.fightMany(...)` to Python for deterministic regression coverage
- added focused regression tests for one-vs-many combat, stale-loop termination, reward accounting, movement-path encounter entry, and wrapper compatibility

## Why it was changed
Combat entry already came from creature movement onto a tile that can contain multiple creatures, but the fight loop, controller API, and fight UI only handled one opponent at a time. This change keeps the existing 1v1 flow intact while allowing a single encounter/session to resolve against multiple hostiles on the same tile.

## Validation performed
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 -m unittest test.GameTest.test_multi_enemy_combat_resolves_and_rewards_once -v`
- `python3 -m unittest test.GameTest.test_multi_enemy_combat_from_movement_path -v`
- `python3 -m unittest test.GameTest.test_multi_enemy_combat_stale_loop_terminates -v`
- `python3 -m unittest test.GameTest.test_single_opponent_fight_wrapper_still_works -v`
- `python3 -m unittest test.GameTest.test_nouraajd_relic_before_letter_regression -v`
- attempted `python3 test.py`
- attempted `./scripts/run_coverage.sh`

## Known limitations or follow-up work
- `python3 test.py` does not complete cleanly in this environment because the untouched late-suite test `test_nouraajd_quest_state_machine` runs for minutes at high CPU after the suite reaches the Nouraajd quest regressions
- `./scripts/run_coverage.sh` reaches its Python-suite phase and then stalls for the same reason, so no final scoped coverage percentage was produced in this run
- manual gameplay verification is still needed for fight-panel targeting UX and real campaign encounters