### PR TITLE
Fix ShadowBolt effect application roll

### DIFF
--- a/res/plugins/interaction.py
+++ b/res/plugins/interaction.py
@@ -110,7 +110,7 @@ def load(self, context):
             second.hurt(damage)
 
         def configureEffect(self, effect):
-            if randint(1, 2) == 0:
+            if randint(1, 2) == 1:
                 return True
             return False
 

--- a/test.py
+++ b/test.py
@@ -1944,6 +1944,22 @@ class GameTest(unittest.TestCase):
         return True, ""
 
     @game_test
+    def test_shadow_bolt_can_configure_its_effect(self):
+        game = load_game_module()
+        original_randint = game.randint
+        try:
+            game.randint = lambda lower, upper: lower
+            g = game.CGameLoader.loadGame()
+
+            shadow_bolt = g.createObject("ShadowBolt")
+            effect = g.createObject("AbyssalShadowsEffect")
+
+            self.assertTrue(shadow_bolt.configureEffect(effect))
+        finally:
+            game.randint = original_randint
+        return True, ""
+
+    @game_test
     def test_multi_enemy_combat_resolves_and_rewards_once(self):
         game, g, attacker, defenders = self.make_multi_enemy_combat_fixture()
 


### PR DESCRIPTION
## What changed
- fixed the `ShadowBolt` interaction so its effect gate checks for a reachable RNG outcome
- added a regression test that forces the lower RNG bound and verifies `ShadowBolt` can configure `AbyssalShadowsEffect`

## Why it changed
- `ShadowBolt.configureEffect()` compared `randint(1, 2)` against `0`
- the engine RNG returns values within the supplied bounds, so that branch was unreachable and the effect never applied in combat

## Validation performed
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py`

## Known limitations or follow-up work
- this change only fixes the unreachable proc roll and adds regression coverage for that behavior