### PR TITLE
Fix disabled teleporter waypoint publishing

### DIFF
--- a/res/plugins/object.py
+++ b/res/plugins/object.py
@@ -25,16 +25,20 @@ def load(self, context):
     @register(context)
     class WayPoint(CBuilding):
         def onEnter(self, event):
-            if self.getExit():
-                event.getCause().setCoords(self.getExit())
+            exit_coords = self.getExit()
+            if exit_coords:
+                event.getCause().setCoords(exit_coords)
 
         # merge with onEnter logic
         def onTurn(self, event):
+            exit_coords = self.getExit()
+            if not exit_coords:
+                self.setBoolProperty("waypoint", False)
+                return
             self.setBoolProperty("waypoint", True)
-            exit = self.getExit()
-            self.setNumericProperty("x", exit.x)
-            self.setNumericProperty("y", exit.y)
-            self.setNumericProperty("z", exit.z)
+            self.setNumericProperty("x", exit_coords.x)
+            self.setNumericProperty("y", exit_coords.y)
+            self.setNumericProperty("z", exit_coords.z)
 
         def getExit(self):
             pass

--- a/test.py
+++ b/test.py
@@ -1450,6 +1450,35 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_disabled_teleporter_does_not_publish_waypoint(self):
+        _g, game_map, _player = load_game_map_with_player("test", "Warrior")
+        active_teleporter = find_runtime_object(game_map, "teleporter1")
+        teleporter = find_runtime_object(game_map, "teleporter2")
+        teleporter_coords = teleporter.getCoords()
+
+        self.assertFalse(teleporter.getBoolProperty("waypoint"))
+
+        advance_map_only(game_map, 1)
+
+        self.assertTrue(active_teleporter.getBoolProperty("waypoint"))
+        self.assertEqual(teleporter_coords.x, active_teleporter.getNumericProperty("x"))
+        self.assertEqual(teleporter_coords.y, active_teleporter.getNumericProperty("y"))
+        self.assertEqual(teleporter_coords.z, active_teleporter.getNumericProperty("z"))
+        self.assertFalse(teleporter.getBoolProperty("enabled"))
+        self.assertFalse(teleporter.getBoolProperty("waypoint"))
+
+        return True, json.dumps(
+            {
+                "active_name": active_teleporter.getName(),
+                "active_waypoint": active_teleporter.getBoolProperty("waypoint"),
+                "disabled_name": teleporter.getName(),
+                "disabled_enabled": teleporter.getBoolProperty("enabled"),
+                "disabled_waypoint": teleporter.getBoolProperty("waypoint"),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_take_mana_clamps_at_zero(self):
         game = load_game_module()
         g = game.CGameLoader.loadGame()


### PR DESCRIPTION
## What changed
- fixed `WayPoint` turn handling so waypoint metadata is only published when a real exit exists
- updated `WayPoint.onEnter()` to reuse the resolved exit instead of calling `getExit()` twice
- added a regression test covering the test-map case where `teleporter2` is disabled and should not become a waypoint

## Why it changed
- disabled teleporters returned no exit, but `WayPoint.onTurn()` still marked them as waypoints before dereferencing the missing exit
- that left bogus waypoint state behind for disabled teleporters instead of treating them as inactive

## Validation performed
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py`

## Known limitations or follow-up work
- `black -l 120` was not usable in this sandbox because it hung spawning worker processes, so formatting was verified by inspection and tests