### PR TITLE
Prevent monsters from chaining item uses in one turn

### DIFF
--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -178,14 +178,14 @@ bool CMonsterFightController::control(std::shared_ptr<CCreature> me, std::shared
         auto object = getLeastPowerfulItemWithTag(me, CTag::Heal);
         if (object) {
             me->useItem(object);
-            return control(me, opponent);
+            return true;
         }
     }
     if (me->getManaRatio() < 75) {
         auto object = getLeastPowerfulItemWithTag(me, CTag::Mana);
         if (object) {
             me->useItem(object);
-            return control(me, opponent);
+            return true;
         }
     }
     if (auto action = selectInteraction(me)) {

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -371,7 +371,8 @@ PYBIND11_MODULE(_game, m) {
         .def("getDistance", &CRangeController::getDistance, "Return desired distance from target.")
         .def("setDistance", &CRangeController::setDistance, "Set desired distance from target.");
     py::class_<CFightController, CGameObject, std::shared_ptr<CFightController>>(m, "CFightController",
-                                                                                 "Base fight controller.");
+                                                                                 "Base fight controller.")
+        .def("control", &CFightController::control, "Execute one fight-controller turn.");
 
     void (CRngHandler::*addRandomLoot)(const std::shared_ptr<CCreature> &, int) = &CRngHandler::addRandomLoot;
     py::class_<CRngHandler, CGameObject, std::shared_ptr<CRngHandler>>(m, "CRngHandler",

--- a/test.py
+++ b/test.py
@@ -1944,6 +1944,45 @@ class GameTest(unittest.TestCase):
         return True, ""
 
     @game_test
+    def test_monster_fight_controller_uses_only_one_heal_item_per_turn(self):
+        g, game_map, _player = load_game_map_with_player("test")
+        monster = g.createObject("GoblinThief")
+        monster.name = "unitTestMonsterController"
+        game_map.addObject(monster)
+        monster.moveTo(1, 1, 0)
+        monster.setHp(max(1, monster.getHpMax() // 4))
+
+        weak_potion = g.createObject("CPotion")
+        weak_potion.name = "unitTestWeakHeal"
+        weak_potion.typeId = "unitTestWeakHealPotion"
+        weak_potion.addTag("heal")
+        weak_potion.power = 1
+
+        strong_potion = g.createObject("CPotion")
+        strong_potion.name = "unitTestStrongHeal"
+        strong_potion.typeId = "unitTestStrongHealPotion"
+        strong_potion.addTag("heal")
+        strong_potion.power = 2
+
+        monster.addItem(weak_potion)
+        monster.addItem(strong_potion)
+
+        acted = monster.getFightController().control(monster, game_map.getPlayer())
+
+        self.assertTrue(acted)
+        self.assertEqual(0, monster.countItems("unitTestWeakHealPotion"))
+        self.assertEqual(1, monster.countItems("unitTestStrongHealPotion"))
+
+        return True, json.dumps(
+            {
+                "acted": acted,
+                "weak_remaining": monster.countItems("unitTestWeakHealPotion"),
+                "strong_remaining": monster.countItems("unitTestStrongHealPotion"),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_multi_enemy_combat_resolves_and_rewards_once(self):
         game, g, attacker, defenders = self.make_multi_enemy_combat_fixture()
 


### PR DESCRIPTION
## What changed
- changed `CMonsterFightController` so spending a healing or mana consumable ends that controller turn instead of recursively re-entering combat logic
- exposed `CFightController.control()` through the Python bindings so the behavior can be regression-tested directly
- added a regression test that creates a low-HP monster with two disposable heal potions and verifies one control call only consumes the weaker potion

## Why it changed
- the previous implementation called `control(me, opponent)` again immediately after each item use
- that let a monster drink multiple consumables and still attack during what should have been a single combat turn

## Validation performed
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py`
- attempted `./scripts/run_coverage.sh` twice

## Known limitations or follow-up work
- `./scripts/run_coverage.sh` is currently blocked by a reproducible coverage-build linker failure in `cmake-build-coverage` (`_game` link step reports missing just-built object files), so there is no coverage percentage result for this branch yet