### PR TITLE
Fix Nouraajd letter reissue path

### DIFF
--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -230,7 +230,10 @@
       "name": "letterToBeren",
       "label": "Sealed Letter",
       "description": "Mayor Irvin's sealed appeal to Father Beren, ink soaked with incense and desperation.",
-      "text": "Father Beren, Nouraajd sinks beneath plague and cult. I beg your guidance before the town breaks entirely.\n- Mayor Irvin"
+      "text": "Father Beren, Nouraajd sinks beneath plague and cult. I beg your guidance before the town breaks entirely.\n- Mayor Irvin",
+      "tags": [
+        "quest"
+      ]
     }
   },
   "deliverLetterQuest": {

--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -298,6 +298,7 @@ def load(self, context):
                 _grant_quest(player, "deliverLetterQuest")
                 return True
             if state == "letter_in_hand":
+                _grant_quest(player, "deliverLetterQuest")
                 return True
             return False
 
@@ -683,9 +684,7 @@ def load(self, context):
             if not quest_system.needs_letter_delivery():
                 return False
             player = self.getGame().getMap().getPlayer()
-            if player.hasItem(self._is_letter_to_beren):
-                return True
-            return _player_has_quest(player, "deliverLetterQuest")
+            return player.hasItem(self._is_letter_to_beren)
 
         def can_offer_letter_work(self):
             quest_system = _quest_system_from(self)

--- a/test.py
+++ b/test.py
@@ -2876,6 +2876,48 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_nouraajd_letter_reissue_and_quest_tag_regression(self):
+        game = load_game_module()
+        g, game_map, player = load_game_map_with_player("nouraajd")
+        town_hall = g.createObject("townHallDialog")
+
+        town_hall.give_letter()
+        self.assertTrue(
+            player.hasItem(lambda it: it.getName() == "letterToBeren" and it.hasTag(game.CTag.QUEST)),
+            "The mayor's letter should be tagged as a quest item so it cannot be sold or dropped.",
+        )
+        self.assertTrue(town_hall.has_letter_quest())
+        self.assertFalse(town_hall.can_offer_letter_work())
+
+        player.removeQuestItem(lambda it: it.getName() == "letterToBeren")
+        self.assertFalse(player.hasItem(lambda it: it.getName() == "letterToBeren"))
+        self.assertEqual(game_map.getStringProperty("quest_state_beren_chain"), "letter_in_hand")
+        self.assertFalse(town_hall.has_letter_quest())
+        self.assertTrue(
+            town_hall.can_offer_letter_work(),
+            "The mayor should reissue the letter if an older save or scripted state has lost the item.",
+        )
+
+        town_hall.give_letter()
+        self.assertTrue(
+            player.hasItem(lambda it: it.getName() == "letterToBeren" and it.hasTag(game.CTag.QUEST)),
+            "Reissued letters should stay protected as quest items.",
+        )
+        self.assertIn("deliverLetterQuest", quest_names(player))
+
+        return True, json.dumps(
+            {
+                "quest_state_beren_chain": game_map.getStringProperty("quest_state_beren_chain"),
+                "has_letter": player.hasItem(lambda it: it.getName() == "letterToBeren"),
+                "letter_is_quest_item": player.hasItem(
+                    lambda it: it.getName() == "letterToBeren" and it.hasTag(game.CTag.QUEST)
+                ),
+                "quests": quest_names(player),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_nouraajd_octobogz_before_letter_and_relic_return_regression(self):
         g, game_map, player = load_game_map_with_player("nouraajd")
         town_hall = g.createObject("townHallDialog")


### PR DESCRIPTION
## What changed
- made `letterToBeren` a quest-tagged item so normal inventory and trade flows cannot discard it
- updated the Nouraajd letter quest flow so the mayor treats a missing letter as needing reissue rather than blocking on the quest log alone
- added a regression test covering tagged issuance and reissuing the letter after forced removal

## Why it was changed
- losing or selling the mayor's letter could strand the Beren quest chain because delivery requires the physical item
- the fix protects fresh letters from normal loss and preserves progress for saves that have already lost the item

## Validation performed
- `black -l 120 test.py`
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py`
- `./scripts/run_coverage.sh` (fails in `cmake-build-coverage` because the built `_game` module cannot be imported: `ImportError: dynamic module does not define module export function (PyInit__game)`)

## Known limitations / follow-up
- the coverage build is currently broken independently of this change, so no scoped line coverage percentage was produced
- existing saves that already hold an old untagged copy of the letter are only fully protected after the letter is reissued