### PR TITLE
Fix ritual quest completion timing

### DIFF
--- a/res/maps/ritual/script.py
+++ b/res/maps/ritual/script.py
@@ -107,7 +107,8 @@ def load(self, context):
     @register(context)
     class RitualQuest(CQuest):
         def isCompleted(self):
-            return self.getGame().getMap().getBoolProperty("ritual_started")
+            game_map = self.getGame().getMap()
+            return game_map.getBoolProperty("leader_defeated") and not game_map.getBoolProperty("captive_lost")
 
         def onComplete(self):
             pass

--- a/test.py
+++ b/test.py
@@ -3289,6 +3289,69 @@ class GameTest(unittest.TestCase):
         return True, json.dumps({"quests": quest_names(player)}, sort_keys=True)
 
     @game_test
+    def test_ritual_quest_requires_successful_disruption(self):
+        g, game_map, player = load_game_map_with_player("ritual")
+
+        game_map.removeObjectByName("anchorNorth")
+        advance(g, 1)
+        self.assertTrue(game_map.getBoolProperty("ritual_started"))
+        self.assertIn(
+            "ritualQuest",
+            quest_names(player),
+            "Starting the ritual should not immediately complete the main ritual quest.",
+        )
+
+        game_map.removeObjectByName("anchorCrypt")
+        game_map.removeObjectByName("anchorSanctum")
+        self.assertTrue(game_map.getBoolProperty("leader_spawned"))
+
+        game_map.removeObjectByName("ritualLeader")
+        advance(g, 1)
+        self.assertTrue(game_map.getBoolProperty("leader_defeated"))
+        self.assertFalse(game_map.getBoolProperty("captive_lost"))
+        self.assertNotIn(
+            "ritualQuest",
+            quest_names(player),
+            "Defeating the leader before the captive is lost should complete the ritual disruption quest.",
+        )
+
+        return True, json.dumps(
+            {
+                "ritual_started": game_map.getBoolProperty("ritual_started"),
+                "leader_spawned": game_map.getBoolProperty("leader_spawned"),
+                "leader_defeated": game_map.getBoolProperty("leader_defeated"),
+                "captive_lost": game_map.getBoolProperty("captive_lost"),
+                "quests": quest_names(player),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
+    def test_ritual_quest_failure_does_not_complete(self):
+        g, game_map, player = load_game_map_with_player("ritual")
+
+        game_map.removeObjectByName("anchorNorth")
+        advance(g, 71)
+        self.assertTrue(game_map.getBoolProperty("ritual_started"))
+        self.assertTrue(game_map.getBoolProperty("captive_lost"))
+        self.assertTrue(game_map.getBoolProperty("bad_ending"))
+        self.assertIn(
+            "ritualQuest",
+            quest_names(player),
+            "The ritual quest should not complete on the bad ending path where the ritual succeeds.",
+        )
+
+        return True, json.dumps(
+            {
+                "ritual_started": game_map.getBoolProperty("ritual_started"),
+                "captive_lost": game_map.getBoolProperty("captive_lost"),
+                "bad_ending": game_map.getBoolProperty("bad_ending"),
+                "quests": quest_names(player),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_ritual_trigger_targets(self):
         script_path = REPO_ROOT / "res/maps/ritual/script.py"
         with open(script_path) as f:


### PR DESCRIPTION
## What changed
- changed `RitualQuest` so it completes only after the ritual leader is defeated while the captive is still recoverable, instead of completing as soon as the ritual starts
- added regressions covering the ritual start path, the successful disruption path, and the bad-ending failure path

## Why it was changed
- the ritual quest was disappearing from the active log the moment the ritual began because it was keyed to `ritual_started`
- that also marked the quest complete on failed runs where the captive was lost, which contradicted the quest's stated goal of disrupting the ritual

## Validation performed
- `black -l 120 test.py`
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py`
- `./scripts/run_coverage.sh` (`53.5%` line coverage, below the repository minimum `80%`)

## Known limitations / follow-up
- the repository-wide coverage gate still fails at `53.5%` line coverage versus the required `80%`; this branch does not resolve that broader coverage deficit