### PR TITLE
Fix effect tick duration off-by-one

### DIFF
--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -541,6 +541,7 @@ PYBIND11_MODULE(_game, m) {
     auto ceffect = py::class_<CEffect, CWrapper<CEffect>, std::shared_ptr<CEffect>, CGameObject>(
                        m, "CEffect", "Base status effect class.")
                        .def(py::init_alias<>())
+                       .def("apply", &CEffect::apply, "Apply one effect tick to the given creature.")
                        .def("getBonus", &CEffect::getBonus, "Return effect stat bonus object.")
                        .def("setBonus", &CEffect::setBonus, "Set effect stat bonus object.")
                        .def("getCaster", &CEffect::getCaster, "Return creature that applied the effect.")

--- a/src/object/CEffect.cpp
+++ b/src/object/CEffect.cpp
@@ -32,11 +32,11 @@ std::shared_ptr<CCreature> CEffect::getCaster() { return caster; }
 std::shared_ptr<CCreature> CEffect::getVictim() { return victim; }
 
 void CEffect::apply(std::shared_ptr<CCreature> creature) {
-  timeLeft--;
-  if (timeLeft == 0) {
-  } else {
+    if (timeLeft <= 0) {
+        return;
+    }
     onEffect();
-  }
+    timeLeft--;
 }
 
 std::shared_ptr<Stats> CEffect::getBonus() { return bonus; }
@@ -46,16 +46,15 @@ void CEffect::setBonus(std::shared_ptr<Stats> value) { bonus = value; }
 int CEffect::getDuration() { return duration; }
 
 void CEffect::setDuration(int duration) {
-  this->duration = duration;
-  timeLeft = timeTotal = duration;
+    this->duration = duration;
+    timeLeft = timeTotal = duration;
 }
 
 void CEffect::onEffect() {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "onEffect");
-      !override.is_none()) {
-    PY_SAFE(override(); return;)
-  }
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "onEffect"); !override.is_none()) {
+        PY_SAFE(override(); return;)
+    }
 }
 
 void CEffect::setCaster(std::shared_ptr<CCreature> value) { caster = value; }

--- a/test.py
+++ b/test.py
@@ -2191,6 +2191,42 @@ class GameTest(unittest.TestCase):
         return failed == [], failed
 
     @game_test
+    def test_effect_apply_uses_full_duration(self):
+        game = load_game_module()
+        seen_time_left = []
+
+        class CountingEffect(game.CEffect):
+            def onEffect(self):
+                seen_time_left.append(self.getTimeLeft())
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGame(g, "empty")
+
+        creature = g.createObject("CCreature")
+        effect = CountingEffect()
+        effect.duration = 3
+
+        effect.apply(creature)
+        effect.apply(creature)
+        effect.apply(creature)
+        effect.apply(creature)
+
+        self.assertEqual(
+            [3, 2, 1],
+            seen_time_left,
+            "A duration-N effect should tick exactly N times and expose the final tick to onEffect().",
+        )
+        self.assertEqual(0, effect.getTimeLeft())
+
+        return True, json.dumps(
+            {
+                "seen_time_left": seen_time_left,
+                "time_left": effect.getTimeLeft(),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_fights(self):
         game = load_game_module()
 


### PR DESCRIPTION
## What changed
- fixed `CEffect::apply()` so duration-based effects tick before decrementing their remaining time and stop cleanly once expired
- exposed `CEffect.apply()` in the Python bindings so effect timing can be regression-tested directly
- added a regression proving a duration-3 effect ticks exactly three times and exposes the final tick to `onEffect()`

## Why it was changed
- status effects that implement their behavior in `onEffect()` were running one turn short because the engine decremented first and skipped the final tick at `timeLeft == 0`
- that meant duration-1 effects never ticked at all, and longer effects like `LethalPoisonEffect` under-delivered their authored duration

## Validation performed
- `clang-format -i src/object/CEffect.cpp src/core/CModule.cpp`
- `black -l 120 test.py`
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py`
- `./scripts/run_coverage.sh` (`53.4%` line coverage, below the repository minimum `80%`)

## Known limitations / follow-up
- the repository-wide coverage gate still fails at `53.4%` line coverage versus the required `80%`; this branch does not resolve that broader coverage deficit