### PR TITLE
Clamp resources after equipment changes

### DIFF
--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -567,6 +567,8 @@ PYBIND11_MODULE(_game, m) {
         .def("hurt", hurtDmg, "Apply structured Damage object.")
         .def("hurt", hurtFloat, "Apply damage value (float), rounded to int.")
         .def("getWeapon", &CCreature::getWeapon, "Return equipped weapon or None.")
+        .def(
+            "unequipArmor", [](CCreature &creature) { creature.setArmor(nullptr); }, "Unequip current armor item.")
         .def("getHpRatio", &CCreature::getHpRatio, "Return HP percentage (0-100).")
         .def("isAlive", &CCreature::isAlive, "Return whether HP is above zero.")
         .def("getMana", &CCreature::getMana, "Return current mana.")

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -328,6 +328,9 @@ void CCreature::equipItem(std::string i, std::shared_ptr<CItem> newItem) {
             signal("equippedChanged");
         }
     }
+
+    hp = std::min(hp, getHpMax());
+    mana = std::min(mana, getManaMax());
 }
 
 bool CCreature::hasInInventory(std::shared_ptr<CItem> item) { return vstd::ctn(items, item); }

--- a/test.py
+++ b/test.py
@@ -1480,6 +1480,44 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_unequipping_armor_clamps_hp_and_mana_to_new_caps(self):
+        _g_hp, _game_map_hp, warrior = load_game_map_with_player("test", "Warrior")
+        warrior_hp_with_armor = warrior.getHpMax()
+        warrior.setHp(warrior_hp_with_armor)
+        warrior.unequipArmor()
+        warrior_hp_without_armor = warrior.getHpMax()
+
+        self.assertGreater(warrior_hp_with_armor, warrior_hp_without_armor)
+        self.assertEqual(warrior_hp_without_armor, warrior.getNumericProperty("hp"))
+        self.assertEqual(100, warrior.getHpRatio())
+
+        _g_mana, _game_map_mana, sorcerer = load_game_map_with_player("test", "Sorcerer")
+        sorcerer_stats = sorcerer.getStats()
+        sorcerer_mana_with_armor = sorcerer_stats.getNumericProperty(sorcerer_stats.getStringProperty("mainStat")) * 7
+        sorcerer.addManaProc(0)
+        sorcerer.unequipArmor()
+        sorcerer_stats_after_unequip = sorcerer.getStats()
+        sorcerer_mana_without_armor = (
+            sorcerer_stats_after_unequip.getNumericProperty(sorcerer_stats_after_unequip.getStringProperty("mainStat"))
+            * 7
+        )
+
+        self.assertGreater(sorcerer_mana_with_armor, sorcerer_mana_without_armor)
+        self.assertEqual(sorcerer_mana_without_armor, sorcerer.getMana())
+
+        return True, json.dumps(
+            {
+                "warrior_hp_with_armor": warrior_hp_with_armor,
+                "warrior_hp_without_armor": warrior_hp_without_armor,
+                "warrior_hp": warrior.getNumericProperty("hp"),
+                "sorcerer_mana_with_armor": sorcerer_mana_with_armor,
+                "sorcerer_mana_without_armor": sorcerer_mana_without_armor,
+                "sorcerer_mana": sorcerer.getMana(),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_crafting_config_is_valid(self):
         crafting_path = REPO_ROOT / "res/config/crafting.json"
         buildings_path = REPO_ROOT / "res/config/buildings.json"


### PR DESCRIPTION
## What changed
- clamp live HP and mana to their recalculated maxima after runtime equipment swaps
- exposed a small `unequipArmor()` creature helper in the Python bindings so the equipment-cap regression can be exercised directly
- added a regression covering both the HP overflow path on a Warrior and the mana overflow path on a Sorcerer

## Why it was changed
- unequipping stat-boosting gear could leave HP or mana above the new cap, and the engine would preserve that illegal state indefinitely because healing and mana restoration bail out once the resource is already above max
- that allowed players to carry extra HP or mana after removing equipment bonuses

## Validation performed
- `clang-format -i src/object/CCreature.cpp src/core/CModule.cpp`
- `black -l 120 test.py`
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py`
- `./scripts/run_coverage.sh` (`53.7%` line coverage, below the repository minimum `80%`)

## Known limitations / follow-up
- the repository-wide coverage gate still fails at `53.7%` line coverage versus the required `80%`; this branch does not resolve that broader coverage deficit