### PR TITLE
Prevent affiliated encounter creatures from fighting each other

### DIFF
--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -449,7 +449,7 @@ void CCreature::afterMove() {
 
     auto fightPred = [self](std::shared_ptr<CMapObject> object) {
         auto other = vstd::cast<CCreature>(object);
-        return other && self != object && !self->isNpc() && !other->isNpc() &&
+        return other && self != object && !self->isNpc() && !other->isNpc() && !self->isAffiliatedWith(object) &&
                self->getMap()->getObjectByName(self->getName()) && object->getMap()->getObjectByName(object->getName());
     };
 

--- a/test.py
+++ b/test.py
@@ -2005,6 +2005,41 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_affiliated_creatures_do_not_fight_on_overlap(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGame(g, "empty")
+        allies = []
+        for x_pos in (0, 1):
+            creature = g.createObject("GoblinThief")
+            creature.baseStats.hit = 100
+            creature.baseStats.dmgMin = 10
+            creature.baseStats.dmgMax = 10
+            creature.baseStats.crit = 0
+            creature.hp = 1
+            creature.setStringProperty("affiliation", "encounter-pack")
+            g.getMap().addObject(creature)
+            creature.moveTo(x_pos, 0, 0)
+            allies.append(creature)
+
+        allies[1].moveTo(0, 0, 0)
+
+        remaining = sorted(creature.getName() for creature in allies if g.getMap().getObjectByName(creature.getName()))
+        occupants = sorted(obj.getName() for obj in g.getMap().getObjectsAtCoords(allies[0].getCoords()))
+
+        expected = sorted(creature.getName() for creature in allies)
+        self.assertEqual(expected, remaining)
+        self.assertEqual(expected, occupants)
+
+        return True, json.dumps(
+            {
+                "occupants": occupants,
+                "remaining": remaining,
+            }
+        )
+
+    @game_test
     def test_multi_enemy_combat_stale_loop_terminates(self):
         game, g, attacker, defenders = self.make_multi_enemy_combat_fixture()
 


### PR DESCRIPTION
## What was changed
- skipped movement-triggered combat between creatures that share an affiliation
- added a regression test that moves two same-affiliation creatures onto one tile and asserts they both remain present

## Why it was changed
- random encounter packs are spawned onto the same tile and given a shared affiliation, but overlap combat ignored that affiliation and made pack members kill each other on spawn

## Validation performed
- clang-format -i src/object/CCreature.cpp
- black -l 120 test.py
- cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)
- ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
- python3 test.py
- ./scripts/run_coverage.sh

## Known limitations or follow-up work
- coverage still fails the repository gate: 52.6% line coverage vs the required 80.0%
- untracked .codex/ and coverage/ directories were left untouched