### PR TITLE
Restore reflected attack bonuses on stats

### DIFF
--- a/src/core/CStats.h
+++ b/src/core/CStats.h
@@ -32,6 +32,7 @@ class Stats : public CGameObject {
          V_PROPERTY(Stats, int, block, getBlock, setBlock),
          V_PROPERTY(Stats, int, dmgMin, getDmgMin, setDmgMin),
          V_PROPERTY(Stats, int, dmgMax, getDmgMax, setDmgMax),
+         V_PROPERTY(Stats, int, attack, getAttack, setAttack),
          V_PROPERTY(Stats, int, hit, getHit, setHit),
          V_PROPERTY(Stats, int, crit, getCrit, setCrit),
          V_PROPERTY(Stats, int, fireResist, getFireResist, setFireResist),

--- a/test.py
+++ b/test.py
@@ -2125,6 +2125,33 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_attack_bonus_reflection_affects_hit_rolls(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGame(g, "empty")
+
+        creature = g.createObject("CCreature")
+        base_stats = g.createObject("Stats")
+        base_stats.hit = 0
+        base_stats.crit = 0
+        base_stats.dmgMin = 1
+        base_stats.dmgMax = 1
+        base_stats.damage = 0
+        creature.baseStats = base_stats
+
+        level_stats = g.createObject("Stats")
+        level_stats.attack = 100
+        creature.levelStats = level_stats
+        creature.level = 1
+
+        rolls = [creature.getDmg() for _ in range(20)]
+
+        self.assertEqual([1] * len(rolls), rolls)
+
+        return True, json.dumps({"rolls": rolls})
+
+    @game_test
     def test_create_object_without_config_logs_fallback(self):
         game = load_game_module()
 


### PR DESCRIPTION
## What was changed
- added `attack` to the reflected `Stats` property list so stat aggregation and JSON-loaded bonuses reach the concrete attack field used by combat
- added a regression test that gives a creature a level-based attack bonus and asserts every roll lands when the bonus should force a guaranteed hit

## Why it was changed
- weapon and other stat bonuses using `attack` were being stored as dynamic properties instead of the real `Stats::attack` field, so hit chance modifiers from authored content never affected combat accuracy

## Validation performed
- clang-format -i src/core/CStats.h
- black -l 120 test.py
- cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)
- ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
- python3 test.py
- ./scripts/run_coverage.sh

## Known limitations or follow-up work
- coverage still fails the repository gate: 53.3% line coverage vs the required 80.0%
- untracked .codex/ and coverage/ directories were left untouched