### PR TITLE
Keep the ritual captive fixed at the prison

### DIFF
--- a/res/maps/ritual/config.json
+++ b/res/maps/ritual/config.json
@@ -43,9 +43,6 @@
     "ref": "Cultist",
     "properties": {
       "animation": "images/npc/questGiver",
-      "controller": {
-        "class": "CNpcRandomController"
-      },
       "npc": true
     }
   },

--- a/test.py
+++ b/test.py
@@ -3289,6 +3289,26 @@ class GameTest(unittest.TestCase):
         return True, json.dumps({"quests": quest_names(player)}, sort_keys=True)
 
     @game_test
+    def test_ritual_captive_stays_at_prison(self):
+        g, game_map = load_game_map("ritual")
+        captive_definition = find_map_object_definition("ritual", "ritualCaptive")
+        captive = find_runtime_object(game_map, "ritualCaptive")
+        initial_coords = captive.getCoords()
+        expected_coords = (captive_definition["x"] // 32, captive_definition["y"] // 32, 0)
+
+        advance_map_only(game_map, 20)
+
+        captive = find_runtime_object(game_map, "ritualCaptive")
+        current_coords = captive.getCoords()
+        current_triplet = (current_coords.x, current_coords.y, current_coords.z)
+        initial_triplet = (initial_coords.x, initial_coords.y, initial_coords.z)
+
+        self.assertEqual(expected_coords, initial_triplet)
+        self.assertEqual(expected_coords, current_triplet)
+
+        return True, json.dumps({"initial_coords": initial_triplet, "current_coords": current_triplet}, sort_keys=True)
+
+    @game_test
     def test_ritual_trigger_targets(self):
         script_path = REPO_ROOT / "res/maps/ritual/script.py"
         with open(script_path) as f:


### PR DESCRIPTION
## What was changed
- removed the random NPC controller from `ritualCaptive` so the captive stays at the stained-glass prison instead of roaming the chapel
- added a regression test that advances the ritual map for 20 turns and asserts the captive remains at the authored prison coordinates

## Why it was changed
- the ritual finale rescue trigger is attached to entering the captive object, so letting the captive wander made the climax resolve at arbitrary positions instead of at the prison cell described by the map and dialog

## Validation performed
- black -l 120 test.py
- cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)
- ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
- python3 test.py
- ./scripts/run_coverage.sh

## Known limitations or follow-up work
- coverage still fails the repository gate: 53.4% line coverage vs the required 80.0%
- untracked .codex/ and coverage/ directories were left untouched