### PR TITLE
Use type ids for Nouraajd class dialog gates

### DIFF
--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -655,7 +655,7 @@ def load(self, context):
 
         def can_chart_wayfarer_route(self):
             player = self.getGame().getMap().getPlayer()
-            return player.getType() == "Wayfarer" and not player.getBoolProperty("charted_smuggler_route")
+            return player.getTypeId() == "Wayfarer" and not player.getBoolProperty("charted_smuggler_route")
 
         def chart_wayfarer_route(self):
             player = self.getGame().getMap().getPlayer()
@@ -732,7 +732,7 @@ def load(self, context):
 
         def can_inspect_stained_glass(self):
             player = self.getGame().getMap().getPlayer()
-            return player.getType() == "Inquisitor" and not player.getBoolProperty("inspected_stained_glass")
+            return player.getTypeId() == "Inquisitor" and not player.getBoolProperty("inspected_stained_glass")
 
         def inspect_stained_glass(self):
             player = self.getGame().getMap().getPlayer()

--- a/test.py
+++ b/test.py
@@ -3215,6 +3215,46 @@ class GameTest(unittest.TestCase):
         return failed == [], json.dumps({"failed": failed, "checks": checks})
 
     @game_test
+    def test_nouraajd_class_specific_dialog_routes_unlock_for_type_ids(self):
+        g_wayfarer, _, wayfarer = load_game_map_with_player("nouraajd", "Wayfarer")
+        town_hall_wayfarer = g_wayfarer.createObject("townHallDialog")
+        beren_wayfarer = g_wayfarer.createObject("berenDialog")
+
+        self.assertEqual("CPlayer", wayfarer.getType())
+        self.assertEqual("Wayfarer", wayfarer.getTypeId())
+        self.assertTrue(town_hall_wayfarer.can_chart_wayfarer_route())
+        self.assertFalse(beren_wayfarer.can_inspect_stained_glass())
+
+        town_hall_wayfarer.chart_wayfarer_route()
+        self.assertEqual(1, wayfarer.getNumericProperty("wayfarer_routes"))
+        self.assertFalse(town_hall_wayfarer.can_chart_wayfarer_route())
+
+        g_inquisitor, _, inquisitor = load_game_map_with_player("nouraajd", "Inquisitor")
+        town_hall_inquisitor = g_inquisitor.createObject("townHallDialog")
+        beren_inquisitor = g_inquisitor.createObject("berenDialog")
+
+        self.assertEqual("CPlayer", inquisitor.getType())
+        self.assertEqual("Inquisitor", inquisitor.getTypeId())
+        self.assertFalse(town_hall_inquisitor.can_chart_wayfarer_route())
+        self.assertTrue(beren_inquisitor.can_inspect_stained_glass())
+
+        beren_inquisitor.inspect_stained_glass()
+        self.assertEqual(1, inquisitor.getNumericProperty("inquisitor_clues"))
+        self.assertFalse(beren_inquisitor.can_inspect_stained_glass())
+
+        return True, json.dumps(
+            {
+                "wayfarer_type": wayfarer.getType(),
+                "wayfarer_type_id": wayfarer.getTypeId(),
+                "wayfarer_routes": wayfarer.getNumericProperty("wayfarer_routes"),
+                "inquisitor_type": inquisitor.getType(),
+                "inquisitor_type_id": inquisitor.getTypeId(),
+                "inquisitor_clues": inquisitor.getNumericProperty("inquisitor_clues"),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_ritual_dialog_integrity(self):
         config = json.loads((REPO_ROOT / "res/maps/ritual/config.json").read_text())
         dialog_defs = {


### PR DESCRIPTION
## What was changed
- switched the Wayfarer and Inquisitor dialog condition checks in the Nouraajd script from `getType()` to `getTypeId()`
- added a runtime regression test that loads real `Wayfarer` and `Inquisitor` players, proves they are runtime `CPlayer`s, and verifies the intended class-specific dialog routes unlock and consume correctly

## Why it was changed
- those dialog gates were checking the runtime class name instead of the configured player template id, so the authored class-specific town hall and chapel options were unreachable for the intended classes

## Validation performed
- black -l 120 res/maps/nouraajd/script.py test.py
- cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)
- ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
- python3 test.py
- ./scripts/run_coverage.sh

## Known limitations or follow-up work
- scoped coverage passed at 80.6% line coverage
- untracked .codex/ and coverage/ directories were left untouched