### PR TITLE
Consolidate pending gameplay bugfix drafts on main

### DIFF
--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -230,7 +230,10 @@
       "name": "letterToBeren",
       "label": "Sealed Letter",
       "description": "Mayor Irvin's sealed appeal to Father Beren, ink soaked with incense and desperation.",
-      "text": "Father Beren, Nouraajd sinks beneath plague and cult. I beg your guidance before the town breaks entirely.\n- Mayor Irvin"
+      "text": "Father Beren, Nouraajd sinks beneath plague and cult. I beg your guidance before the town breaks entirely.\n- Mayor Irvin",
+      "tags": [
+        "quest"
+      ]
     }
   },
   "deliverLetterQuest": {

--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -656,7 +656,7 @@ def load(self, context):
 
         def can_chart_wayfarer_route(self):
             player = self.getGame().getMap().getPlayer()
-            return player.getType() == "Wayfarer" and not player.getBoolProperty("charted_smuggler_route")
+            return player.getTypeId() == "Wayfarer" and not player.getBoolProperty("charted_smuggler_route")
 
         def chart_wayfarer_route(self):
             player = self.getGame().getMap().getPlayer()
@@ -731,7 +731,7 @@ def load(self, context):
 
         def can_inspect_stained_glass(self):
             player = self.getGame().getMap().getPlayer()
-            return player.getType() == "Inquisitor" and not player.getBoolProperty("inspected_stained_glass")
+            return player.getTypeId() == "Inquisitor" and not player.getBoolProperty("inspected_stained_glass")
 
         def inspect_stained_glass(self):
             player = self.getGame().getMap().getPlayer()

--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -298,6 +298,7 @@ def load(self, context):
                 _grant_quest(player, "deliverLetterQuest")
                 return True
             if state == "letter_in_hand":
+                _grant_quest(player, "deliverLetterQuest")
                 return True
             return False
 
@@ -683,9 +684,7 @@ def load(self, context):
             if not quest_system.needs_letter_delivery():
                 return False
             player = self.getGame().getMap().getPlayer()
-            if player.hasItem(self._is_letter_to_beren):
-                return True
-            return _player_has_quest(player, "deliverLetterQuest")
+            return player.hasItem(self._is_letter_to_beren)
 
         def can_offer_letter_work(self):
             quest_system = _quest_system_from(self)

--- a/res/maps/ritual/config.json
+++ b/res/maps/ritual/config.json
@@ -43,9 +43,6 @@
     "ref": "Cultist",
     "properties": {
       "animation": "images/npc/questGiver",
-      "controller": {
-        "class": "CNpcRandomController"
-      },
       "npc": true
     }
   },

--- a/res/maps/ritual/script.py
+++ b/res/maps/ritual/script.py
@@ -107,7 +107,8 @@ def load(self, context):
     @register(context)
     class RitualQuest(CQuest):
         def isCompleted(self):
-            return self.getGame().getMap().getBoolProperty("ritual_started")
+            game_map = self.getGame().getMap()
+            return game_map.getBoolProperty("leader_defeated") and not game_map.getBoolProperty("captive_lost")
 
         def onComplete(self):
             pass

--- a/res/plugins/interaction.py
+++ b/res/plugins/interaction.py
@@ -110,7 +110,7 @@ def load(self, context):
             second.hurt(damage)
 
         def configureEffect(self, effect):
-            if randint(1, 2) == 0:
+            if randint(1, 2) == 1:
                 return True
             return False
 

--- a/res/plugins/object.py
+++ b/res/plugins/object.py
@@ -25,16 +25,20 @@ def load(self, context):
     @register(context)
     class WayPoint(CBuilding):
         def onEnter(self, event):
-            if self.getExit():
-                event.getCause().setCoords(self.getExit())
+            exit_coords = self.getExit()
+            if exit_coords:
+                event.getCause().setCoords(exit_coords)
 
         # merge with onEnter logic
         def onTurn(self, event):
+            exit_coords = self.getExit()
+            if not exit_coords:
+                self.setBoolProperty("waypoint", False)
+                return
             self.setBoolProperty("waypoint", True)
-            exit = self.getExit()
-            self.setNumericProperty("x", exit.x)
-            self.setNumericProperty("y", exit.y)
-            self.setNumericProperty("z", exit.z)
+            self.setNumericProperty("x", exit_coords.x)
+            self.setNumericProperty("y", exit_coords.y)
+            self.setNumericProperty("z", exit_coords.z)
 
         def getExit(self):
             pass

--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -178,14 +178,14 @@ bool CMonsterFightController::control(std::shared_ptr<CCreature> me, std::shared
         auto object = getLeastPowerfulItemWithTag(me, CTag::Heal);
         if (object) {
             me->useItem(object);
-            return control(me, opponent);
+            return true;
         }
     }
     if (me->getManaRatio() < 75) {
         auto object = getLeastPowerfulItemWithTag(me, CTag::Mana);
         if (object) {
             me->useItem(object);
-            return control(me, opponent);
+            return true;
         }
     }
     if (auto action = selectInteraction(me)) {

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -542,6 +542,7 @@ PYBIND11_MODULE(_game, m) {
     auto ceffect = py::class_<CEffect, CWrapper<CEffect>, std::shared_ptr<CEffect>, CGameObject>(
                        m, "CEffect", "Base status effect class.")
                        .def(py::init_alias<>())
+                       .def("apply", &CEffect::apply, "Apply one effect tick to the given creature.")
                        .def("getBonus", &CEffect::getBonus, "Return effect stat bonus object.")
                        .def("setBonus", &CEffect::setBonus, "Set effect stat bonus object.")
                        .def("getCaster", &CEffect::getCaster, "Return creature that applied the effect.")

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -569,6 +569,8 @@ PYBIND11_MODULE(_game, m) {
         .def("hurt", hurtDmg, "Apply structured Damage object.")
         .def("hurt", hurtFloat, "Apply damage value (float), rounded to int.")
         .def("getWeapon", &CCreature::getWeapon, "Return equipped weapon or None.")
+        .def(
+            "unequipArmor", [](CCreature &creature) { creature.setArmor(nullptr); }, "Unequip current armor item.")
         .def("getHpRatio", &CCreature::getHpRatio, "Return HP percentage (0-100).")
         .def("isAlive", &CCreature::isAlive, "Return whether HP is above zero.")
         .def("getMana", &CCreature::getMana, "Return current mana.")

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -371,7 +371,8 @@ PYBIND11_MODULE(_game, m) {
         .def("getDistance", &CRangeController::getDistance, "Return desired distance from target.")
         .def("setDistance", &CRangeController::setDistance, "Set desired distance from target.");
     py::class_<CFightController, CGameObject, std::shared_ptr<CFightController>>(m, "CFightController",
-                                                                                 "Base fight controller.");
+                                                                                 "Base fight controller.")
+        .def("control", &CFightController::control, "Execute one fight-controller turn.");
 
     void (CRngHandler::*addRandomLoot)(const std::shared_ptr<CCreature> &, int) = &CRngHandler::addRandomLoot;
     py::class_<CRngHandler, CGameObject, std::shared_ptr<CRngHandler>>(m, "CRngHandler",

--- a/src/core/CStats.h
+++ b/src/core/CStats.h
@@ -32,6 +32,7 @@ class Stats : public CGameObject {
          V_PROPERTY(Stats, int, block, getBlock, setBlock),
          V_PROPERTY(Stats, int, dmgMin, getDmgMin, setDmgMin),
          V_PROPERTY(Stats, int, dmgMax, getDmgMax, setDmgMax),
+         V_PROPERTY(Stats, int, attack, getAttack, setAttack),
          V_PROPERTY(Stats, int, hit, getHit, setHit),
          V_PROPERTY(Stats, int, crit, getCrit, setCrit),
          V_PROPERTY(Stats, int, fireResist, getFireResist, setFireResist),

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -452,7 +452,7 @@ void CCreature::afterMove() {
 
     auto fightPred = [self](std::shared_ptr<CMapObject> object) {
         auto other = vstd::cast<CCreature>(object);
-        return other && self != object && !self->isNpc() && !other->isNpc() &&
+        return other && self != object && !self->isNpc() && !other->isNpc() && !self->isAffiliatedWith(object) &&
                self->getMap()->getObjectByName(self->getName()) && object->getMap()->getObjectByName(object->getName());
     };
 

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -328,6 +328,9 @@ void CCreature::equipItem(std::string i, std::shared_ptr<CItem> newItem) {
             signal("equippedChanged");
         }
     }
+
+    hp = std::min(hp, getHpMax());
+    mana = std::min(mana, getManaMax());
 }
 
 bool CCreature::hasInInventory(std::shared_ptr<CItem> item) { return vstd::ctn(items, item); }

--- a/src/object/CEffect.cpp
+++ b/src/object/CEffect.cpp
@@ -32,11 +32,11 @@ std::shared_ptr<CCreature> CEffect::getCaster() { return caster; }
 std::shared_ptr<CCreature> CEffect::getVictim() { return victim; }
 
 void CEffect::apply(std::shared_ptr<CCreature> creature) {
-  timeLeft--;
-  if (timeLeft == 0) {
-  } else {
+    if (timeLeft <= 0) {
+        return;
+    }
     onEffect();
-  }
+    timeLeft--;
 }
 
 std::shared_ptr<Stats> CEffect::getBonus() { return bonus; }
@@ -46,16 +46,15 @@ void CEffect::setBonus(std::shared_ptr<Stats> value) { bonus = value; }
 int CEffect::getDuration() { return duration; }
 
 void CEffect::setDuration(int duration) {
-  this->duration = duration;
-  timeLeft = timeTotal = duration;
+    this->duration = duration;
+    timeLeft = timeTotal = duration;
 }
 
 void CEffect::onEffect() {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "onEffect");
-      !override.is_none()) {
-    PY_SAFE(override(); return;)
-  }
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "onEffect"); !override.is_none()) {
+        PY_SAFE(override(); return;)
+    }
 }
 
 void CEffect::setCaster(std::shared_ptr<CCreature> value) { caster = value; }

--- a/test.py
+++ b/test.py
@@ -2275,6 +2275,42 @@ class GameTest(unittest.TestCase):
         return failed == [], failed
 
     @game_test
+    def test_effect_apply_uses_full_duration(self):
+        game = load_game_module()
+        seen_time_left = []
+
+        class CountingEffect(game.CEffect):
+            def onEffect(self):
+                seen_time_left.append(self.getTimeLeft())
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGame(g, "empty")
+
+        creature = g.createObject("CCreature")
+        effect = CountingEffect()
+        effect.duration = 3
+
+        effect.apply(creature)
+        effect.apply(creature)
+        effect.apply(creature)
+        effect.apply(creature)
+
+        self.assertEqual(
+            [3, 2, 1],
+            seen_time_left,
+            "A duration-N effect should tick exactly N times and expose the final tick to onEffect().",
+        )
+        self.assertEqual(0, effect.getTimeLeft())
+
+        return True, json.dumps(
+            {
+                "seen_time_left": seen_time_left,
+                "time_left": effect.getTimeLeft(),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_fights(self):
         game = load_game_module()
 

--- a/test.py
+++ b/test.py
@@ -2960,6 +2960,48 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_nouraajd_letter_reissue_and_quest_tag_regression(self):
+        game = load_game_module()
+        g, game_map, player = load_game_map_with_player("nouraajd")
+        town_hall = g.createObject("townHallDialog")
+
+        town_hall.give_letter()
+        self.assertTrue(
+            player.hasItem(lambda it: it.getName() == "letterToBeren" and it.hasTag(game.CTag.QUEST)),
+            "The mayor's letter should be tagged as a quest item so it cannot be sold or dropped.",
+        )
+        self.assertTrue(town_hall.has_letter_quest())
+        self.assertFalse(town_hall.can_offer_letter_work())
+
+        player.removeQuestItem(lambda it: it.getName() == "letterToBeren")
+        self.assertFalse(player.hasItem(lambda it: it.getName() == "letterToBeren"))
+        self.assertEqual(game_map.getStringProperty("quest_state_beren_chain"), "letter_in_hand")
+        self.assertFalse(town_hall.has_letter_quest())
+        self.assertTrue(
+            town_hall.can_offer_letter_work(),
+            "The mayor should reissue the letter if an older save or scripted state has lost the item.",
+        )
+
+        town_hall.give_letter()
+        self.assertTrue(
+            player.hasItem(lambda it: it.getName() == "letterToBeren" and it.hasTag(game.CTag.QUEST)),
+            "Reissued letters should stay protected as quest items.",
+        )
+        self.assertIn("deliverLetterQuest", quest_names(player))
+
+        return True, json.dumps(
+            {
+                "quest_state_beren_chain": game_map.getStringProperty("quest_state_beren_chain"),
+                "has_letter": player.hasItem(lambda it: it.getName() == "letterToBeren"),
+                "letter_is_quest_item": player.hasItem(
+                    lambda it: it.getName() == "letterToBeren" and it.hasTag(game.CTag.QUEST)
+                ),
+                "quests": quest_names(player),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_nouraajd_octobogz_before_letter_and_relic_return_regression(self):
         g, game_map, player = load_game_map_with_player("nouraajd")
         town_hall = g.createObject("townHallDialog")

--- a/test.py
+++ b/test.py
@@ -2282,6 +2282,33 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_attack_bonus_reflection_affects_hit_rolls(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGame(g, "empty")
+
+        creature = g.createObject("CCreature")
+        base_stats = g.createObject("Stats")
+        base_stats.hit = 0
+        base_stats.crit = 0
+        base_stats.dmgMin = 1
+        base_stats.dmgMax = 1
+        base_stats.damage = 0
+        creature.baseStats = base_stats
+
+        level_stats = g.createObject("Stats")
+        level_stats.attack = 100
+        creature.levelStats = level_stats
+        creature.level = 1
+
+        rolls = [creature.getDmg() for _ in range(20)]
+
+        self.assertEqual([1] * len(rolls), rolls)
+
+        return True, json.dumps({"rolls": rolls})
+
+    @game_test
     def test_create_object_without_config_logs_fallback(self):
         game = load_game_module()
 

--- a/test.py
+++ b/test.py
@@ -1450,6 +1450,35 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_disabled_teleporter_does_not_publish_waypoint(self):
+        _g, game_map, _player = load_game_map_with_player("test", "Warrior")
+        active_teleporter = find_runtime_object(game_map, "teleporter1")
+        teleporter = find_runtime_object(game_map, "teleporter2")
+        teleporter_coords = teleporter.getCoords()
+
+        self.assertFalse(teleporter.getBoolProperty("waypoint"))
+
+        advance_map_only(game_map, 1)
+
+        self.assertTrue(active_teleporter.getBoolProperty("waypoint"))
+        self.assertEqual(teleporter_coords.x, active_teleporter.getNumericProperty("x"))
+        self.assertEqual(teleporter_coords.y, active_teleporter.getNumericProperty("y"))
+        self.assertEqual(teleporter_coords.z, active_teleporter.getNumericProperty("z"))
+        self.assertFalse(teleporter.getBoolProperty("enabled"))
+        self.assertFalse(teleporter.getBoolProperty("waypoint"))
+
+        return True, json.dumps(
+            {
+                "active_name": active_teleporter.getName(),
+                "active_waypoint": active_teleporter.getBoolProperty("waypoint"),
+                "disabled_name": teleporter.getName(),
+                "disabled_enabled": teleporter.getBoolProperty("enabled"),
+                "disabled_waypoint": teleporter.getBoolProperty("waypoint"),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_take_mana_clamps_at_zero(self):
         game = load_game_module()
         g = game.CGameLoader.loadGame()

--- a/test.py
+++ b/test.py
@@ -1944,6 +1944,22 @@ class GameTest(unittest.TestCase):
         return True, ""
 
     @game_test
+    def test_shadow_bolt_can_configure_its_effect(self):
+        game = load_game_module()
+        original_randint = game.randint
+        try:
+            game.randint = lambda lower, upper: lower
+            g = game.CGameLoader.loadGame()
+
+            shadow_bolt = g.createObject("ShadowBolt")
+            effect = g.createObject("AbyssalShadowsEffect")
+
+            self.assertTrue(shadow_bolt.configureEffect(effect))
+        finally:
+            game.randint = original_randint
+        return True, ""
+
+    @game_test
     def test_multi_enemy_combat_resolves_and_rewards_once(self):
         game, g, attacker, defenders = self.make_multi_enemy_combat_fixture()
 

--- a/test.py
+++ b/test.py
@@ -1989,6 +1989,45 @@ class GameTest(unittest.TestCase):
         return True, ""
 
     @game_test
+    def test_monster_fight_controller_uses_only_one_heal_item_per_turn(self):
+        g, game_map, _player = load_game_map_with_player("test")
+        monster = g.createObject("GoblinThief")
+        monster.name = "unitTestMonsterController"
+        game_map.addObject(monster)
+        monster.moveTo(1, 1, 0)
+        monster.setHp(max(1, monster.getHpMax() // 4))
+
+        weak_potion = g.createObject("CPotion")
+        weak_potion.name = "unitTestWeakHeal"
+        weak_potion.typeId = "unitTestWeakHealPotion"
+        weak_potion.addTag("heal")
+        weak_potion.power = 1
+
+        strong_potion = g.createObject("CPotion")
+        strong_potion.name = "unitTestStrongHeal"
+        strong_potion.typeId = "unitTestStrongHealPotion"
+        strong_potion.addTag("heal")
+        strong_potion.power = 2
+
+        monster.addItem(weak_potion)
+        monster.addItem(strong_potion)
+
+        acted = monster.getFightController().control(monster, game_map.getPlayer())
+
+        self.assertTrue(acted)
+        self.assertEqual(0, monster.countItems("unitTestWeakHealPotion"))
+        self.assertEqual(1, monster.countItems("unitTestStrongHealPotion"))
+
+        return True, json.dumps(
+            {
+                "acted": acted,
+                "weak_remaining": monster.countItems("unitTestWeakHealPotion"),
+                "strong_remaining": monster.countItems("unitTestStrongHealPotion"),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_multi_enemy_combat_resolves_and_rewards_once(self):
         game, g, attacker, defenders = self.make_multi_enemy_combat_fixture()
 

--- a/test.py
+++ b/test.py
@@ -1509,6 +1509,44 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_unequipping_armor_clamps_hp_and_mana_to_new_caps(self):
+        _g_hp, _game_map_hp, warrior = load_game_map_with_player("test", "Warrior")
+        warrior_hp_with_armor = warrior.getHpMax()
+        warrior.setHp(warrior_hp_with_armor)
+        warrior.unequipArmor()
+        warrior_hp_without_armor = warrior.getHpMax()
+
+        self.assertGreater(warrior_hp_with_armor, warrior_hp_without_armor)
+        self.assertEqual(warrior_hp_without_armor, warrior.getNumericProperty("hp"))
+        self.assertEqual(100, warrior.getHpRatio())
+
+        _g_mana, _game_map_mana, sorcerer = load_game_map_with_player("test", "Sorcerer")
+        sorcerer_stats = sorcerer.getStats()
+        sorcerer_mana_with_armor = sorcerer_stats.getNumericProperty(sorcerer_stats.getStringProperty("mainStat")) * 7
+        sorcerer.addManaProc(0)
+        sorcerer.unequipArmor()
+        sorcerer_stats_after_unequip = sorcerer.getStats()
+        sorcerer_mana_without_armor = (
+            sorcerer_stats_after_unequip.getNumericProperty(sorcerer_stats_after_unequip.getStringProperty("mainStat"))
+            * 7
+        )
+
+        self.assertGreater(sorcerer_mana_with_armor, sorcerer_mana_without_armor)
+        self.assertEqual(sorcerer_mana_without_armor, sorcerer.getMana())
+
+        return True, json.dumps(
+            {
+                "warrior_hp_with_armor": warrior_hp_with_armor,
+                "warrior_hp_without_armor": warrior_hp_without_armor,
+                "warrior_hp": warrior.getNumericProperty("hp"),
+                "sorcerer_mana_with_armor": sorcerer_mana_with_armor,
+                "sorcerer_mana_without_armor": sorcerer_mana_without_armor,
+                "sorcerer_mana": sorcerer.getMana(),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_crafting_config_is_valid(self):
         crafting_path = REPO_ROOT / "res/config/crafting.json"
         buildings_path = REPO_ROOT / "res/config/buildings.json"

--- a/test.py
+++ b/test.py
@@ -3614,6 +3614,26 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_ritual_captive_stays_at_prison(self):
+        g, game_map = load_game_map("ritual")
+        captive_definition = find_map_object_definition("ritual", "ritualCaptive")
+        captive = find_runtime_object(game_map, "ritualCaptive")
+        initial_coords = captive.getCoords()
+        expected_coords = (captive_definition["x"] // 32, captive_definition["y"] // 32, 0)
+
+        advance_map_only(game_map, 20)
+
+        captive = find_runtime_object(game_map, "ritualCaptive")
+        current_coords = captive.getCoords()
+        current_triplet = (current_coords.x, current_coords.y, current_coords.z)
+        initial_triplet = (initial_coords.x, initial_coords.y, initial_coords.z)
+
+        self.assertEqual(expected_coords, initial_triplet)
+        self.assertEqual(expected_coords, current_triplet)
+
+        return True, json.dumps({"initial_coords": initial_triplet, "current_coords": current_triplet}, sort_keys=True)
+
+    @game_test
     def test_ritual_trigger_targets(self):
         script_path = REPO_ROOT / "res/maps/ritual/script.py"
         with open(script_path) as f:

--- a/test.py
+++ b/test.py
@@ -3415,6 +3415,69 @@ class GameTest(unittest.TestCase):
         return True, json.dumps({"quests": quest_names(player)}, sort_keys=True)
 
     @game_test
+    def test_ritual_quest_requires_successful_disruption(self):
+        g, game_map, player = load_game_map_with_player("ritual")
+
+        game_map.removeObjectByName("anchorNorth")
+        advance(g, 1)
+        self.assertTrue(game_map.getBoolProperty("ritual_started"))
+        self.assertIn(
+            "ritualQuest",
+            quest_names(player),
+            "Starting the ritual should not immediately complete the main ritual quest.",
+        )
+
+        game_map.removeObjectByName("anchorCrypt")
+        game_map.removeObjectByName("anchorSanctum")
+        self.assertTrue(game_map.getBoolProperty("leader_spawned"))
+
+        game_map.removeObjectByName("ritualLeader")
+        advance(g, 1)
+        self.assertTrue(game_map.getBoolProperty("leader_defeated"))
+        self.assertFalse(game_map.getBoolProperty("captive_lost"))
+        self.assertNotIn(
+            "ritualQuest",
+            quest_names(player),
+            "Defeating the leader before the captive is lost should complete the ritual disruption quest.",
+        )
+
+        return True, json.dumps(
+            {
+                "ritual_started": game_map.getBoolProperty("ritual_started"),
+                "leader_spawned": game_map.getBoolProperty("leader_spawned"),
+                "leader_defeated": game_map.getBoolProperty("leader_defeated"),
+                "captive_lost": game_map.getBoolProperty("captive_lost"),
+                "quests": quest_names(player),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
+    def test_ritual_quest_failure_does_not_complete(self):
+        g, game_map, player = load_game_map_with_player("ritual")
+
+        game_map.removeObjectByName("anchorNorth")
+        advance(g, 71)
+        self.assertTrue(game_map.getBoolProperty("ritual_started"))
+        self.assertTrue(game_map.getBoolProperty("captive_lost"))
+        self.assertTrue(game_map.getBoolProperty("bad_ending"))
+        self.assertIn(
+            "ritualQuest",
+            quest_names(player),
+            "The ritual quest should not complete on the bad ending path where the ritual succeeds.",
+        )
+
+        return True, json.dumps(
+            {
+                "ritual_started": game_map.getBoolProperty("ritual_started"),
+                "captive_lost": game_map.getBoolProperty("captive_lost"),
+                "bad_ending": game_map.getBoolProperty("bad_ending"),
+                "quests": quest_names(player),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_ritual_trigger_targets(self):
         script_path = REPO_ROOT / "res/maps/ritual/script.py"
         with open(script_path) as f:

--- a/test.py
+++ b/test.py
@@ -3477,6 +3477,46 @@ class GameTest(unittest.TestCase):
         return failed == [], json.dumps({"failed": failed, "checks": checks})
 
     @game_test
+    def test_nouraajd_class_specific_dialog_routes_unlock_for_type_ids(self):
+        g_wayfarer, _, wayfarer = load_game_map_with_player("nouraajd", "Wayfarer")
+        town_hall_wayfarer = g_wayfarer.createObject("townHallDialog")
+        beren_wayfarer = g_wayfarer.createObject("berenDialog")
+
+        self.assertEqual("CPlayer", wayfarer.getType())
+        self.assertEqual("Wayfarer", wayfarer.getTypeId())
+        self.assertTrue(town_hall_wayfarer.can_chart_wayfarer_route())
+        self.assertFalse(beren_wayfarer.can_inspect_stained_glass())
+
+        town_hall_wayfarer.chart_wayfarer_route()
+        self.assertEqual(1, wayfarer.getNumericProperty("wayfarer_routes"))
+        self.assertFalse(town_hall_wayfarer.can_chart_wayfarer_route())
+
+        g_inquisitor, _, inquisitor = load_game_map_with_player("nouraajd", "Inquisitor")
+        town_hall_inquisitor = g_inquisitor.createObject("townHallDialog")
+        beren_inquisitor = g_inquisitor.createObject("berenDialog")
+
+        self.assertEqual("CPlayer", inquisitor.getType())
+        self.assertEqual("Inquisitor", inquisitor.getTypeId())
+        self.assertFalse(town_hall_inquisitor.can_chart_wayfarer_route())
+        self.assertTrue(beren_inquisitor.can_inspect_stained_glass())
+
+        beren_inquisitor.inspect_stained_glass()
+        self.assertEqual(1, inquisitor.getNumericProperty("inquisitor_clues"))
+        self.assertFalse(beren_inquisitor.can_inspect_stained_glass())
+
+        return True, json.dumps(
+            {
+                "wayfarer_type": wayfarer.getType(),
+                "wayfarer_type_id": wayfarer.getTypeId(),
+                "wayfarer_routes": wayfarer.getNumericProperty("wayfarer_routes"),
+                "inquisitor_type": inquisitor.getType(),
+                "inquisitor_type_id": inquisitor.getTypeId(),
+                "inquisitor_clues": inquisitor.getNumericProperty("inquisitor_clues"),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_ritual_dialog_integrity(self):
         config = json.loads((REPO_ROOT / "res/maps/ritual/config.json").read_text())
         dialog_defs = {

--- a/test.py
+++ b/test.py
@@ -2127,6 +2127,41 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_affiliated_creatures_do_not_fight_on_overlap(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGame(g, "empty")
+        allies = []
+        for x_pos in (0, 1):
+            creature = g.createObject("GoblinThief")
+            creature.baseStats.hit = 100
+            creature.baseStats.dmgMin = 10
+            creature.baseStats.dmgMax = 10
+            creature.baseStats.crit = 0
+            creature.hp = 1
+            creature.setStringProperty("affiliation", "encounter-pack")
+            g.getMap().addObject(creature)
+            creature.moveTo(x_pos, 0, 0)
+            allies.append(creature)
+
+        allies[1].moveTo(0, 0, 0)
+
+        remaining = sorted(creature.getName() for creature in allies if g.getMap().getObjectByName(creature.getName()))
+        occupants = sorted(obj.getName() for obj in g.getMap().getObjectsAtCoords(allies[0].getCoords()))
+
+        expected = sorted(creature.getName() for creature in allies)
+        self.assertEqual(expected, remaining)
+        self.assertEqual(expected, occupants)
+
+        return True, json.dumps(
+            {
+                "occupants": occupants,
+                "remaining": remaining,
+            }
+        )
+
+    @game_test
     def test_multi_enemy_combat_stale_loop_terminates(self):
         game, g, attacker, defenders = self.make_multi_enemy_combat_fixture()
 


### PR DESCRIPTION
## What was changed
- consolidated the open gameplay bugfix draft branches into one branch rebased on `main`
- preserved all 11 fixes from the superseded draft PRs (#199, #200, #201, #202, #203, #204, #205, #206, #207, #208, #209)
- resolved the overlapping `test.py` conflicts so the merged regression coverage stays intact on one branch

## Why it was changed
- the draft fixes were already compatible and easier to review, validate, and land as one rebased stack
- this replaces the scattered draft PRs with a single integration point on top of current `main`

## Validation performed
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py`
- `./scripts/run_coverage.sh`

## Known limitations or follow-up work
- the required build and test suites passed on the consolidated branch
- the coverage script still fails the repository gate at `53.4%` line coverage versus the configured `80.0%` minimum; this is not introduced by the consolidation itself and remains follow-up work for the repo-wide coverage baseline