### PR TITLE
Make the last Qt snapshot buildable again

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vstd"]
-	path = vstd
-	url = https://andrzej_lis3@bitbucket.org/andrzej_lis3/vstd.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,32 @@
-cmake_minimum_required(VERSION 3.3)
-project(game)
-
-set(Qt5_DIR $ENV{QT_CMAKE})
-
-include($ENV{COTIRE_CMAKE}/cotire.cmake)
+cmake_minimum_required(VERSION 3.16)
+project(game LANGUAGES CXX)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(Qt5 COMPONENTS Widgets OpenGL REQUIRED)
+find_package(QT NAMES Qt6 REQUIRED COMPONENTS Widgets OpenGL OpenGLWidgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets OpenGL OpenGLWidgets)
 
-set(BOOST_INCLUDEDIR $ENV{BOOST_INC})
-set(BOOST_LIBRARYDIR $ENV{BOOST_LIB})
-find_package(Boost 1.58 COMPONENTS system python3 thread REQUIRED)
+find_package(Python3 REQUIRED COMPONENTS Development)
+set(PYTHONLIBS_FOUND ON)
 
-set(PYTHON_LIBRARY $ENV{PYTHON_LIB}/libpython34.a)
-set(PYTHON_INCLUDE_DIR $ENV{PYTHON_INC})
-find_package(PythonLibs REQUIRED)
+set(BOOST_PYTHON_COMPONENT "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
+set(Boost_NO_BOOST_CMAKE ON)
+find_package(Boost 1.58 REQUIRED COMPONENTS system ${BOOST_PYTHON_COMPONENT})
+find_package(Threads REQUIRED)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -include cmath -Wno-deprecated-declarations -Wno-unused-local-typedefs -Wno-attributes")
+add_compile_options(
+        -include
+        cmath
+        -Wno-deprecated-declarations
+        -Wno-unused-local-typedefs
+        -Wno-attributes)
+add_compile_definitions(QT_NO_KEYWORDS QT_NO_FOREACH)
 
 set(SOURCE_FILES
         controller/CController.cpp
@@ -133,24 +141,22 @@ set(SOURCE_FILES
         core/CTypes.cpp
         core/CTypes.h
         core/CUtil.cpp
-        core/CUtil.h)
+        core/CUtil.h
+        gui/CMainWindow.ui
+        gui/CScriptWindow.ui
+        resources/resources.qrc)
 
 add_subdirectory(vstd)
 
-qt5_wrap_ui(FOMRS_SOURCE_FILES gui/CMainWindow.ui gui/CScriptWindow.ui)
-qt5_add_resources(RESOURCE_FILES resources/resources.qrc)
+add_executable(game ${SOURCE_FILES})
 
-include_directories(${Boost_INCLUDE_DIRS})
-include_directories(${PYTHON_INCLUDE_DIRS})
+target_include_directories(game PRIVATE ${Boost_INCLUDE_DIRS})
+target_include_directories(game PRIVATE ${Python3_INCLUDE_DIRS})
 
-add_executable(game ${SOURCE_FILES} ${FOMRS_SOURCE_FILES} ${RESOURCE_FILES})
-
-add_custom_command(TARGET game PRE_BUILD COMMAND format.py WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
-qt5_use_modules(game Widgets)
-qt5_use_modules(game OpenGL)
-
-target_link_libraries(game ${Boost_LIBRARIES})
-target_link_libraries(game ${PYTHON_LIBRARIES})
-
-cotire(game)
+target_link_libraries(game PRIVATE
+        Qt${QT_VERSION_MAJOR}::Widgets
+        Qt${QT_VERSION_MAJOR}::OpenGL
+        Qt${QT_VERSION_MAJOR}::OpenGLWidgets
+        ${Boost_LIBRARIES}
+        Python3::Python
+        Threads::Threads)

--- a/core/CDefines.h
+++ b/core/CDefines.h
@@ -1,4 +1,12 @@
 #pragma once
+#ifdef PY_SAFE
+#undef PY_SAFE
+#endif
+
+#ifdef PY_SAFE_RET
+#undef PY_SAFE_RET
+#endif
+
 #define GAME_PROPERTY(CLASS)\
   Q_DECLARE_METATYPE(std::shared_ptr<CLASS>)\
   Q_DECLARE_METATYPE(std::set<std::shared_ptr<CLASS>>)\
@@ -6,5 +14,4 @@
   Q_DECLARE_METATYPE(CLASS##Map)\
 
 #define PY_SAFE(x) try{x}catch(...){qDebug()<<"";PyErr_Print();PyErr_Clear();}
-#define PY_SAFE_RET(x) try{x}catch(...){qDebug()<<"";PyErr_Print();PyErr_Clear();return nullptr;}
-
+#define PY_SAFE_RET(x) try{x}catch(...){qDebug()<<"";PyErr_Print();PyErr_Clear();return {};}

--- a/core/CGlobal.h
+++ b/core/CGlobal.h
@@ -16,7 +16,6 @@
 #include <QBitmap>
 #include <QDateTime>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QDirIterator>
 #include <QDrag>
 #include <QFile>
@@ -44,11 +43,12 @@
 #include <QSet>
 #include <QString>
 #include <QStringList>
+#include <QSurfaceFormat>
 #include <QtGlobal>
 #include <QThread>
 #include <QThreadPool>
 #include <QTimer>
-#include <QtOpenGL/QGLWidget>
+#include <QOpenGLWidget>
 #include <queue>
 #include <QVariant>
 #include <QWidget>

--- a/core/CMain.cpp
+++ b/core/CMain.cpp
@@ -41,6 +41,12 @@ namespace vstd {
         };
     }
 
+    std::function<void ( std::function<void() > ) > get_call_now_handler() {
+        return [] ( std::function<void() > f ) {
+            f();
+        };
+    }
+
     std::function<void ( std::function<void() > ) > get_call_later_block_handler() {
         return [] ( std::function<void() > f ) {
             QApplication::sendEvent ( CInvocationHandler::instance(),
@@ -54,6 +60,36 @@ namespace vstd {
                 while ( !pred() ) {
                     QApplication::processEvents ( QEventLoop::WaitForMoreEvents );
                 }
+            } );
+        };
+    }
+
+    std::function<void ( std::function<bool() >, std::function<void() > ) > get_call_when_handler() {
+        return [] ( std::function<bool() > pred, std::function<void() > f ) {
+            QTimer *timer = new QTimer ( CInvocationHandler::instance() );
+            QObject::connect ( timer, &QTimer::timeout, [pred, f, timer]() {
+                if ( pred() ) {
+                    timer->stop();
+                    timer->deleteLater();
+                    f();
+                }
+            } );
+            timer->start ( 1 );
+        };
+    }
+
+    std::function<void ( int, std::function<void() > ) > get_call_delayed_async_handler() {
+        return [] ( int millis, std::function<void() > f ) {
+            QTimer::singleShot ( millis, [f]() {
+                vstd::call_async ( f );
+            } );
+        };
+    }
+
+    std::function<void ( int, std::function<void() > ) > get_call_delayed_later_handler() {
+        return [] ( int millis, std::function<void() > f ) {
+            QTimer::singleShot ( millis, [f]() {
+                vstd::call_later ( f );
             } );
         };
     }
@@ -73,4 +109,3 @@ int main ( int argc, char *argv[] ) {
     }
     return 0;
 }
-

--- a/core/CPathFinder.cpp
+++ b/core/CPathFinder.cpp
@@ -10,7 +10,7 @@ typedef std::function<bool ( const Coords &, const Coords & ) > Compare;
 typedef std::priority_queue<Coords, std::vector<Coords>, Compare> Queue;
 typedef std::shared_ptr<std::unordered_map<Coords, int>> Values;
 
-static force_inline void dump ( Values values, Coords start, Coords end ) {
+static inline void dump ( Values values, Coords start, Coords end ) {
     int x = 0;
     int y = 0;
     double mval = 0;
@@ -37,7 +37,7 @@ static force_inline void dump ( Values values, Coords start, Coords end ) {
     img.save ( QString::fromStdString ( stream.str() ), "png" );
 }
 
-static force_inline Coords getNextStep ( const Coords &start, const Coords &goal, Values values ) {
+static inline Coords getNextStep ( const Coords &start, const Coords &goal, Values values ) {
     Coords target = start;
     for ( Coords coords:NEAR_COORDS ( start ) ) {
         if ( vstd::ctn ( ( *values ), coords ) &&
@@ -50,7 +50,7 @@ static force_inline Coords getNextStep ( const Coords &start, const Coords &goal
     return target;
 }
 
-static force_inline Values fillValues ( std::function<bool ( const Coords & ) > canStep,
+static inline Values fillValues ( std::function<bool ( const Coords & ) > canStep,
                                         const Coords &goal, const Coords &start ) {
     Queue nodes ( [start] ( const Coords &a, const Coords &b ) {
         double dista = ( a.x - start.x ) * ( a.x - start.x ) +

--- a/core/CSerialization.cpp
+++ b/core/CSerialization.cpp
@@ -217,7 +217,8 @@ int CSerialization::getGenericPropertyType ( std::shared_ptr<QJsonObject> object
     } else if ( CJsonUtil::isMap ( object ) ) {
         return qRegisterMetaType<std::map<QString, std::shared_ptr<CGameObject>>>();
     }
-    return vstd::fail<int> ( "Unable to determine property type!" );
+    vstd::fail ( "Unable to determine property type!" );
+    return 0;
 }
 
 

--- a/core/CSerialization.h
+++ b/core/CSerialization.h
@@ -49,15 +49,24 @@ public:
 
     template<typename T=Serialized, typename V=Deserialized>
     static T serialize ( V deserialized, typename std::enable_if<vstd::is_map<V>::value>::type * = 0 ) {
-        return CSerializerFunction<T, std::map<QString, std::shared_ptr<CGameObject> >>::serialize (
-                   vstd::cast<std::map<QString, std::shared_ptr<CGameObject> >> ( deserialized ) );
+        std::map<QString, std::shared_ptr<CGameObject> > casted;
+        for ( const auto &entry : deserialized ) {
+            casted[entry.first] = std::static_pointer_cast<CGameObject> ( entry.second );
+        }
+        return CSerializerFunction<T, std::map<QString, std::shared_ptr<CGameObject> >>::serialize ( casted );
     }
 
     template<typename T=Serialized, typename V=Deserialized>
     static V deserialize ( std::shared_ptr<CMap> map, T serialized,
                            typename std::enable_if<vstd::is_map<V>::value>::type * = 0 ) {
-        return vstd::cast<V> (
-                   CSerializerFunction<T, std::map<QString, std::shared_ptr<CGameObject> >>::deserialize ( map, serialized ) );
+        V casted;
+        auto objects =
+            CSerializerFunction<T, std::map<QString, std::shared_ptr<CGameObject> >>::deserialize ( map, serialized );
+        for ( const auto &entry : objects ) {
+            casted[entry.first] =
+                std::dynamic_pointer_cast<typename V::mapped_type::element_type> ( entry.second );
+        }
+        return casted;
     }
 };
 
@@ -121,7 +130,8 @@ class CSerialization {
 
     template<typename Serialized, typename Deserialized>
     static std::shared_ptr<CSerializerBase> serializer() {
-        return serializer ( vstd::type_pair<Serialized, Deserialized>() );
+        return serializer ( std::make_pair ( qRegisterMetaType<Serialized>(),
+                                             qRegisterMetaType<Deserialized>() ) );
     }
 
 public:
@@ -163,4 +173,3 @@ private:
 Q_DECLARE_METATYPE ( std::shared_ptr<QJsonObject> )
 
 Q_DECLARE_METATYPE ( std::shared_ptr<QJsonArray> )
-

--- a/core/CTypes.h
+++ b/core/CTypes.h
@@ -15,7 +15,8 @@ public:
 
     template<typename Serialized, typename Deserialized>
     static void register_serializer() {
-        serializers() [vstd::type_pair<Serialized, Deserialized>()] =
+        serializers() [std::make_pair ( qRegisterMetaType<Serialized>(),
+                                        qRegisterMetaType<Deserialized>() )] =
             std::make_shared<CSerializer<Serialized, Deserialized>>
             ();
     }
@@ -27,22 +28,22 @@ public:
 
     template<typename T>
     static void register_predicate() {
-        function_converter<bool, std::shared_ptr<T>>();
+        vstd::function_converter<bool, std::shared_ptr<T>>();
     }
 
     template<typename T>
     static void register_supplier() {
-        function_converter<std::shared_ptr<T>>();
+        vstd::function_converter<std::shared_ptr<T>>();
     }
 
     template<typename T>
     static void register_consumer() {
-        function_converter<std::shared_ptr<T>>();
+        vstd::function_converter<std::shared_ptr<T>>();
     }
 
     template<typename T, typename U=CGameObject>
     static void register_cast() {
-        implicitly_convertible_cast<std::shared_ptr<U>, std::shared_ptr<T>>();
+        vstd::implicitly_convertible_cast<std::shared_ptr<U>, std::shared_ptr<T>>();
     }
 
     template<typename T>
@@ -63,5 +64,4 @@ public:
         register_cast<T>();
     }
 };
-
 

--- a/core/CUtil.cpp
+++ b/core/CUtil.cpp
@@ -76,7 +76,7 @@ CInvocationHandler *CInvocationHandler::instance() {
 
 bool CInvocationHandler::event ( QEvent *event ) {
     if ( event->type() == CInvocationEvent::TYPE ) {
-        vstd::call ( static_cast<CInvocationEvent *> ( event )->getTarget() );
+        vstd::functional::call ( static_cast<CInvocationEvent *> ( event )->getTarget() );
         return true;
     }
     return false;

--- a/core/CUtil.h
+++ b/core/CUtil.h
@@ -67,22 +67,8 @@ private:
 namespace std {
     template<>
     struct hash<Coords> {
-        force_inline std::size_t  operator() ( const Coords &coords ) const {
+        std::size_t operator() ( const Coords &coords ) const {
             return vstd::hash_combine ( coords.x, coords.y, coords.z );
-        }
-    };
-
-    template<>
-    struct hash<QString> {
-        force_inline std::size_t operator() ( const QString &string ) const {
-            return vstd::hash_combine ( string.toStdString() );
-        }
-    };
-
-    template<>
-    struct hash<std::pair<int, int>> {
-        force_inline std::size_t operator() ( const std::pair<int, int> &pair ) const {
-            return vstd::hash_combine ( pair.first, pair.second );
         }
     };
 }

--- a/gui/CGameView.cpp
+++ b/gui/CGameView.cpp
@@ -15,7 +15,11 @@ CGameView::CGameView ( QString mapName, QString playerType ) {
     setHorizontalScrollBarPolicy ( Qt::ScrollBarAlwaysOff );
     setVerticalScrollBarPolicy ( Qt::ScrollBarAlwaysOff );
     setViewportUpdateMode ( QGraphicsView::BoundingRectViewportUpdate );
-    setViewport ( new QGLWidget ( QGLFormat ( QGL::SampleBuffers ) ) );
+    QSurfaceFormat format;
+    format.setSamples ( 4 );
+    QOpenGLWidget *viewport = new QOpenGLWidget();
+    viewport->setFormat ( format );
+    setViewport ( viewport );
     setViewportUpdateMode ( QGraphicsView::FullViewportUpdate );
     vstd::call_later ( [this, mapName, playerType]() {
         game = CGameLoader::loadGame ( this->ptr() );
@@ -74,4 +78,3 @@ std::shared_ptr<CGame> CGameView::getGame() const {
 void CGameView::centerOn ( std::shared_ptr<CPlayer> player ) {
     this->QGraphicsView::centerOn ( player.get() );
 }
-

--- a/handler/CScriptHandler.h
+++ b/handler/CScriptHandler.h
@@ -66,7 +66,7 @@ public:
     template<typename Return=void, typename ...Args>
     Return callCreatedFunction ( QString functionCode, std::initializer_list<QString> args, Args ...params ) {
         return createFunction<Return, Args...> (
-                   "FUNC" + vstd::to_hex_hash<QString> ( functionCode ),
+                   "FUNC" + QString::fromStdString ( vstd::to_hex_hash ( functionCode ) ),
                    functionCode, args ) ( params... );
     }
 

--- a/object/CItem.cpp
+++ b/object/CItem.cpp
@@ -64,6 +64,14 @@ CArmor::CArmor() {
 
 }
 
+CArmor::CArmor ( const CArmor & ) : CItem() {
+
+}
+
+CArmor::CArmor ( QString name ) : CItem() {
+    setObjectName ( name );
+}
+
 std::shared_ptr<CInteraction> CItem::getInteraction() {
     return interaction;
 }
@@ -77,7 +85,15 @@ CBelt::CBelt() {
 
 }
 
+CBelt::CBelt ( const CBelt & ) : CItem() {
+
+}
+
 CBoots::CBoots() {
+
+}
+
+CBoots::CBoots ( const CBoots & ) : CItem() {
 
 }
 
@@ -85,7 +101,15 @@ CGloves::CGloves() {
 
 }
 
+CGloves::CGloves ( const CGloves & ) : CItem() {
+
+}
+
 CHelmet::CHelmet() {
+
+}
+
+CHelmet::CHelmet ( const CHelmet & ) : CItem() {
 
 }
 
@@ -93,7 +117,15 @@ CSmallWeapon::CSmallWeapon() {
 
 }
 
+CSmallWeapon::CSmallWeapon ( const CSmallWeapon & ) : CWeapon() {
+
+}
+
 CWeapon::CWeapon() : CItem() {
+
+}
+
+CWeapon::CWeapon ( const CWeapon & ) : CItem() {
 
 }
 
@@ -109,7 +141,15 @@ CPotion::CPotion() {
 
 }
 
+CPotion::CPotion ( const CPotion & ) : CItem() {
+
+}
+
 CScroll::CScroll() {
+
+}
+
+CScroll::CScroll ( const CScroll & ) : CItem() {
 
 }
 
@@ -124,4 +164,3 @@ void CScroll::setText ( const QString &value ) {
 void CScroll::onUse ( std::shared_ptr<CGameEvent> ) {
     getMap()->getGame()->getGuiHandler()->showMessage ( text );
 }
-

--- a/object/CPlayer.cpp
+++ b/object/CPlayer.cpp
@@ -6,6 +6,10 @@ CPlayer::CPlayer() {
 
 }
 
+CPlayer::CPlayer ( const CPlayer & ) : CCreature() {
+
+}
+
 CPlayer::~CPlayer() {
 
 }

--- a/vstd/.gitignore
+++ b/vstd/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+/cmake-build-debug/
+/cmake-build-release/

--- a/vstd/CMakeLists.txt
+++ b/vstd/CMakeLists.txt
@@ -1,0 +1,49 @@
+# MIT License
+#
+# Copyright (c) 2025 Andrzej Lis
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+cmake_minimum_required(VERSION 3.3)
+project(vstd)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+
+FIND_PACKAGE(Boost 1.58 COMPONENTS system REQUIRED)
+
+include_directories(${Boost_INCLUDE_DIRS})
+
+set(SOURCE_FILES
+        vadaptors.h
+        vcast.h
+        vchain.h
+        vconverter.h
+        vdefines.h
+        vfunctional.h
+        vfuture.h
+        vhash.h
+        vhex.h
+        vlazy.h
+        vlogger.h
+        vthread.h
+        vthreadpool.h
+        vtraits.h
+        vutil.h
+        vassert.h
+        vstd.h
+        vstring.h
+        vmeta.h
+        vneuro.h
+        vany.h
+        vtuple.h)
+
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    add_executable(vstd ${SOURCE_FILES} main.cpp)
+    target_link_libraries(vstd ${Boost_LIBRARIES})
+else ()
+    add_custom_target(vstd SOURCES ${SOURCE_FILES})
+endif ()

--- a/vstd/LICENSE.md
+++ b/vstd/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Andrzej Lis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vstd/README.md
+++ b/vstd/README.md
@@ -1,0 +1,42 @@
+# vstd
+c++ utility libraries
+## vstring
+string utilities
+## vany
+generic object type any utilities over boost:any
+## vfunctional
+functional programming utilities
+## vlazy
+lazy initialization template
+## vlogger
+simple logger for c++
+## vmeta
+meta object and reflection system for c++
+<pre>
+class CMetaExample {
+V_META(CMetaExample,
+       vstd::meta::empty,
+       V_PROPERTY(CMetaExample, std::string, text, getText, setText))
+public:
+    CMetaExample() = default;
+
+    std::string getText() {
+        return text;
+    }
+
+    void setText(std::string text) {
+        CMetaExample::text = text;
+    }
+
+private:
+    std::string text;
+};
+
+void vmeta_example() {
+    auto example = std::make_shared<CMetaExample>();
+    CMetaExample::static_meta()->set_property<CMetaExample, std::string>("text", example, "exampleText");
+    vstd::logger::info("Direct access:", example->getText());
+    vstd::logger::info("Meta access:",
+                       CMetaExample::static_meta()->get_property<CMetaExample, std::string>("text", example));
+}
+</pre>

--- a/vstd/main.cpp
+++ b/vstd/main.cpp
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "vstd.h"
+
+class CMetaExample {
+V_META(CMetaExample,
+       vstd::meta::empty,
+       V_PROPERTY(CMetaExample, std::string, text, getText, setText))
+public:
+    CMetaExample() = default;
+
+    std::string getText() {
+        return text;
+    }
+
+    void setText(std::string text) {
+        CMetaExample::text = text;
+    }
+
+private:
+    std::string text;
+};
+
+void vmeta_example() {
+    auto example = std::make_shared<CMetaExample>();
+    CMetaExample::static_meta()->set_property<CMetaExample, std::string>("text", example, "exampleText");
+    vstd::logger::info("Direct access:", example->getText());
+    vstd::logger::info("Meta access:",
+                       CMetaExample::static_meta()->get_property<CMetaExample, std::string>("text", example));
+}
+
+int main() {
+    vmeta_example();
+    return 0;
+}

--- a/vstd/vadaptors.h
+++ b/vstd/vadaptors.h
@@ -1,0 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <boost/range/adaptors.hpp>
+#include "vtraits.h"
+#include "vfuture.h"
+
+namespace vstd {
+    namespace adaptors {
+        template<typename F>
+        auto add_later(F f) {
+            return boost::adaptors::transformed([f](auto future) {
+                return future->thenLater(f);
+            });
+        }
+    }
+}

--- a/vstd/vany.h
+++ b/vstd/vany.h
@@ -1,0 +1,48 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "vcast.h"
+#include "vutil.h"
+#include <unordered_map>
+
+namespace vstd {
+    namespace detail {
+        template<typename T=void>
+        //left returned
+        //right taken
+        std::unordered_map<std::pair<boost::typeindex::type_index, boost::typeindex::type_index>, std::function<boost::any(
+                boost::any)>> &registry() {
+            static std::unordered_map<std::pair<boost::typeindex::type_index, boost::typeindex::type_index>, std::function<boost::any(
+                    boost::any)>> reg;
+            return reg;
+        };
+    }
+
+    template<typename T>
+    T any_cast(boost::any val) {
+        auto key = std::pair<boost::typeindex::type_index, boost::typeindex::type_index>(boost::typeindex::type_id<T>(),
+                                                                                         val.type());
+        if (vstd::ctn(detail::registry(), key)) {
+            return boost::any_cast<T>(detail::registry()[key](val));
+        }
+        return boost::any_cast<T>(val);
+    }
+
+    template<typename T, typename U>
+    void register_any_type() {
+        detail::registry()[vstd::type_pair<T, U>()] = [](
+                boost::any conv) {
+            return boost::any(vstd::cast<T>(boost::any_cast<U>(conv)));
+        };
+    };
+}

--- a/vstd/vassert.h
+++ b/vstd/vassert.h
@@ -1,0 +1,39 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "vdefines.h"
+#include "vlogger.h"
+
+namespace vstd {
+    template<typename T, typename... Args>
+    T fail_if(T arg, Args... args) {
+        if (arg) {
+            vstd::logger::fatal(args...);
+        }
+        return arg;
+    }
+
+    template<typename... Args>
+    void fail(Args... args) {
+        fail_if(true, args...);
+    }
+
+    template<typename T, typename... Args>
+    T not_null(T t, Args... args) {
+        if (t) {
+            return t;
+        }
+        fail(args...);
+        return t;
+    }
+}

--- a/vstd/vbind.h
+++ b/vstd/vbind.h
@@ -1,0 +1,74 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+namespace vstd {
+    namespace partial {
+        using namespace std;
+
+        struct pb_tag {
+        };
+
+        template<typename T> using result_of_t = typename result_of<T>::type;
+        template<typename T> using is_prebinder = is_base_of<pb_tag, typename remove_reference<T>::type>;
+
+        template<int N, int ...S>
+        struct seq : seq<N - 1, N, S...> {
+        };
+        template<int ...S>
+        struct seq<0, S...> {
+            typedef seq type;
+        };
+
+        template<typename T>
+        auto dispatchee(T t, false_type) -> decltype(t) {
+            return t;
+        }
+
+        template<typename T>
+        auto dispatchee(T t, true_type) -> decltype(t()) {
+            return t();
+        }
+
+        template<typename T>
+        auto expand(T t) -> decltype(dispatchee(t, is_prebinder<T>())) {
+            return dispatchee(t, is_prebinder<T>());
+        }
+
+        template<typename T> using expand_type = decltype(expand(declval<T>()));
+
+        template<typename f, typename ...ltypes>
+        struct prebinder : public pb_tag {
+            tuple<f, ltypes...> closure;
+            typedef typename seq<sizeof...(ltypes)>::type sequence;
+
+            prebinder(f F, ltypes... largs) : closure(F, largs...) {}
+
+            template<int ...S, typename ...rtypes>
+            result_of_t<f(expand_type<ltypes>..., rtypes...)>
+            apply(seq<0, S...>, rtypes ... rargs) {
+                return (get<0>(closure))(expand(get<S>(closure))..., rargs...);
+            }
+
+            template<typename ...rtypes>
+            result_of_t<f(expand_type<ltypes>..., rtypes...)>
+            operator()(rtypes ... rargs) {
+                return apply(sequence(), rargs...);
+            }
+        };
+
+        template<typename f, typename ...ltypes>
+        prebinder<f, ltypes...> bind(f F, ltypes ... largs) {
+            return prebinder<f, ltypes...>(F, largs...);
+        }
+    }
+}

--- a/vstd/vcache.h
+++ b/vstd/vcache.h
@@ -1,0 +1,52 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+namespace vstd {
+    template<typename key, typename val, val(*get_next)(), int(*get_ttl)()>
+    class cache {
+        std::unordered_map<key, std::pair<val, int>> _values;
+    public:
+        val get(key k, int time) {
+            auto it = _values.find(k);
+            if (it == _values.end()) {
+                val ret = get_next();
+                _values.insert(std::make_pair(k, std::make_pair(ret, time + get_ttl())));
+                return ret;
+            }
+            if ((*it).second.second < time) {
+                _values.erase(it);
+                return get(k, time);
+            }
+            return (*it).second.first;
+        }
+    };
+
+    template<typename key, typename val, int(*get_ttl)()>
+    class cache2 {
+        std::unordered_map<key, std::pair<val, int>> _values;
+    public:
+        val get(key k, int time, std::function<val()> cb) {
+            auto it = _values.find(k);
+            if (it == _values.end()) {
+                val ret = cb();
+                _values.insert(std::make_pair(k, std::make_pair(ret, time + get_ttl())));
+                return ret;
+            }
+            if ((*it).second.second < time) {
+                _values.erase(it);
+                return get(k, time, cb);
+            }
+            return (*it).second.first;
+        }
+    };
+}

--- a/vstd/vcast.h
+++ b/vstd/vcast.h
@@ -1,0 +1,60 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "vdefines.h"
+#include "vtraits.h"
+
+namespace vstd {
+    template<typename T, typename U>
+    T cast(U ptr,
+           typename vstd::disable_if<vstd::is_shared_ptr<T>::value>::type * = 0,
+           typename vstd::disable_if<vstd::is_shared_ptr<U>::value>::type * = 0,
+           typename vstd::disable_if<vstd::is_container<T>::value>::type * = 0,
+           typename vstd::disable_if<vstd::is_range<U>::value>::type * = 0,
+           typename vstd::disable_if<vstd::is_pair<T>::value>::type * = 0,
+           typename vstd::disable_if<vstd::is_pair<U>::value>::type * = 0) {
+        return ptr;
+    }
+
+    template<typename T, typename U>
+    std::shared_ptr<T> cast(U ptr,
+                            typename vstd::disable_if<vstd::is_shared_ptr<T>::value>::type * = 0,
+                            typename vstd::enable_if<vstd::is_shared_ptr<U>::value>::type * = 0) {
+        return std::dynamic_pointer_cast<T>(ptr);
+    }
+
+    template<typename T, typename U>
+    T cast(U ptr,
+           typename vstd::enable_if<vstd::is_shared_ptr<T>::value>::type * = 0,
+           typename vstd::enable_if<vstd::is_shared_ptr<U>::value>::type * = 0) {
+        return cast<typename T::element_type>(ptr);
+    }
+
+    template<typename T, typename U>
+    T cast(U ptr,
+           typename std::enable_if<vstd::is_pair<T>::value>::type * = 0,
+           typename std::enable_if<vstd::is_pair<U>::value>::type * = 0) {
+        return std::make_pair(cast<typename T::first_type>(ptr.first), cast<typename T::second_type>(ptr.second));
+    }
+
+    template<typename T, typename U>
+    T cast(U c,
+           typename std::enable_if<vstd::is_container<T>::value>::type * = 0,
+           typename std::enable_if<vstd::is_range<U>::value>::type * = 0) {
+        T t;
+        for (auto x:c) {
+            t.insert(cast<typename T::value_type>(x));
+        }
+        return t;
+    }
+}

--- a/vstd/vchain.h
+++ b/vstd/vchain.h
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <mutex>
+
+#include "vfuture.h"
+
+namespace vstd {
+    template<typename T>
+    class chain {
+        std::shared_ptr<vstd::future<void, void>> _future = vstd::async([]() {});
+        std::recursive_mutex _lock;
+        std::function<void(T)> _cb;
+    public:
+        chain(std::function<void(T)> cb) : _cb(cb) {}
+
+        void invoke_async(T t) {
+            std::unique_lock<std::recursive_mutex> lock(_lock);
+            _future = _future->thenAsync(vstd::bind(_cb, t));
+        }
+
+        void invoke_later(T t) {
+            std::unique_lock<std::recursive_mutex> lock(_lock);
+            _future = _future->thenLater(vstd::bind(_cb, t));
+        }
+
+        std::shared_ptr<vstd::future<void, void>> terminate() {
+            std::unique_lock<std::recursive_mutex> lock(_lock);
+            return _future;
+        };
+    };
+}

--- a/vstd/vconverter.h
+++ b/vstd/vconverter.h
@@ -1,0 +1,172 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <boost/python.hpp>
+#include "vcast.h"
+
+namespace vstd {
+    namespace detail {
+        template<typename Ret, typename... Args>
+        struct builder {
+            static void build(PyObject *obj_ptr, boost::python::converter::rvalue_from_python_stage1_data *data) {
+                help(obj_ptr, data);
+            }
+
+            template<typename R=Ret>
+            static void help(PyObject *obj_ptr,
+                             boost::python::converter::rvalue_from_python_stage1_data *data,
+                             typename vstd::disable_if<vstd::is_shared_ptr<R>::value>::type * = 0) {
+                void *storage = ((boost::python::converter::rvalue_from_python_storage
+                        <std::function<R(Args...) >> *) data)->storage.bytes;
+                boost::python::object func =
+                        boost::python::object(boost::python::handle<>(
+                                boost::python::borrowed(
+                                        boost::python::incref(obj_ptr))));
+                new(storage) std::function<R(Args...)>([func](Args... args) {
+                    return boost::python::extract<R>(
+                            boost::python::incref(func(args...).ptr()));
+                });
+                data->convertible = storage;
+            }
+
+            template<typename R=Ret>
+            static void help(PyObject *obj_ptr,
+                             boost::python::converter::rvalue_from_python_stage1_data *data,
+                             typename vstd::enable_if<vstd::is_shared_ptr<R>::value>::type * = 0) {
+                typedef typename R::element_type *ptr_type;
+                void *storage = ((boost::python::converter::rvalue_from_python_storage
+                        <std::function<R(Args...) >> *) data)->storage.bytes;
+                boost::python::object func = boost::python::object(
+                        boost::python::handle<>(boost::python::borrowed(
+                                boost::python::incref(obj_ptr))));
+                new(storage) std::function<R(Args...)>([func](Args... args) {
+                    return R(vstd::functional::call(
+                            boost::python::extract<ptr_type>(
+                                    boost::python::incref(func(args...).ptr()))));
+                });
+                data->convertible = storage;
+            }
+        };
+
+        template<typename... Args>
+        struct builder<void, Args...> {
+            static void build(PyObject *obj_ptr,
+                              boost::python::converter::rvalue_from_python_stage1_data *data) {
+                void *storage = ((boost::python::converter::rvalue_from_python_storage
+                        <std::function<void(Args...) >> *) data)->storage.bytes;
+                boost::python::object func = boost::python::object(
+                        boost::python::handle<>(
+                                boost::python::borrowed(
+                                        boost::python::incref(obj_ptr))));
+                new(storage) std::function<void(Args...)>([func](Args... args) {
+                    func(args...);
+                });
+                data->convertible = storage;
+            }
+        };
+
+        template<typename... Args>
+        struct builder<bool, Args...> {
+            static void build(PyObject *obj_ptr,
+                              boost::python::converter::rvalue_from_python_stage1_data *data) {
+                void *storage = ((boost::python::converter::rvalue_from_python_storage
+                        <std::function<bool(Args...) >> *) data)->storage.bytes;
+                boost::python::object func = boost::python::object(
+                        boost::python::handle<>(
+                                boost::python::borrowed(
+                                        boost::python::incref(obj_ptr))));
+                new(storage) std::function<bool(Args...)>([func](Args... args) {
+                    return func(args...).ptr() == Py_True;
+                });
+                data->convertible = storage;
+            }
+        };
+
+        template<class Source, class Target>
+        struct implicit_cast {
+
+            static void *convertible(PyObject *obj) {
+                return boost::python::converter::implicit_rvalue_convertible_from_python(obj,
+                                                                                         boost::python::converter::registered<Source>::converters)
+                       ? obj : 0;
+            }
+
+            static void construct(PyObject *obj,
+                                  boost::python::converter::rvalue_from_python_stage1_data *data) {
+                void *storage = ((boost::python::converter::rvalue_from_python_storage<Target> *) data)->storage.bytes;
+
+                boost::python::arg_from_python<Source> get_source(obj);
+                bool convertible = get_source.convertible();
+                BOOST_VERIFY (convertible);
+
+                new(storage) Target(vstd::cast<Target>(get_source()));
+
+                data->convertible = storage;
+            }
+        };
+    }
+
+    namespace detail {
+        template<typename Ret, typename... Args>
+        struct function_converter {
+            function_converter() {
+                boost::python::converter::registry::push_back(
+                        [](PyObject *obj_ptr) -> void * {
+                            if (PyCallable_Check(obj_ptr)) { return obj_ptr; }
+                            return nullptr;
+                        },
+                        detail::builder<Ret, Args...>::build,
+                        boost::python::type_id<std::function<Ret(Args...) >>());
+            }
+        };
+
+        template<typename T>
+        struct register_pointer {
+            register_pointer() {
+                boost::python::register_ptr_to_python<std::shared_ptr<T> >();
+            }
+        };
+
+    }
+
+    template<typename Ret, typename... Args>
+    struct function_converter {
+        function_converter() {
+            static detail::function_converter<Ret, Args...> _dummy;
+        }
+    };
+
+    template<typename T>
+    void register_pointer() {
+        static detail::register_pointer<T> _dummy;
+    }
+
+    namespace detail {
+
+        template<class Source, class Target>
+        struct implicitly_convertible_cast {
+            implicitly_convertible_cast(boost::type<Source> * = 0, boost::type<Target> * = 0) {
+                boost::python::converter::registry::push_back(
+                        &detail::implicit_cast<Source, Target>::convertible,
+                        &detail::implicit_cast<Source, Target>::construct,
+                        boost::python::type_id<Target>(),
+                        &boost::python::converter::expected_from_python_type_direct<Source>::get_pytype);
+            }
+        };
+    }
+
+    template<class Source, class Target>
+    void implicitly_convertible_cast() {
+        static detail::implicitly_convertible_cast<Source, Target> _dummy;
+    }
+}

--- a/vstd/vdefines.h
+++ b/vstd/vdefines.h
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+//TODO: this shoul be done via command line api
+#define PYTHON_LOGGING
+
+#ifdef PYTHON_LOGGING
+#define PYTHON_LOG vstd::logger::debug();PyErr_Print()
+#else
+#define PYTHON_LOG
+#endif
+
+#ifdef Py_PYTHON_H
+#define PY_SAFE(x) try{x;}catch(...){PYTHON_LOG;PyErr_Clear();}
+#define PY_UNSAFE(x) try{x;}catch(...){PYTHON_LOG;PyErr_Clear();throw;}
+#define PY_SAFE_RET(x) try{x;}catch(...){PYTHON_LOG;PyErr_Clear();return nullptr;}
+#define PY_SAFE_RET_VAL(x, r) try{x;}catch(...){PYTHON_LOG;PyErr_Clear();return r;}
+#endif
+
+#undef PYTHON_LOGGING

--- a/vstd/veventloop.h
+++ b/vstd/veventloop.h
@@ -1,0 +1,169 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "vfuture.h"
+
+namespace vstd {
+    template<typename T=void>
+    class event_loop {
+        struct DelayCompare {
+            bool operator()(const std::pair<int, std::function<void()>> &a, std::pair<int, std::function<void()>> b) {
+                return std::greater<int>()(a.first, b.first);
+            }
+        };
+
+        int lastFrameTime = SDL_GetTicks();
+        Uint32 _call_function_event = SDL_RegisterEvents(1);
+        std::thread::id _main_thread_id = std::this_thread::get_id();
+
+        std::priority_queue<std::pair<int, std::function<void()>>,
+                std::vector<std::pair<int, std::function<void()>>>,
+                DelayCompare> delayQueue;
+        std::list<std::pair<std::function<bool()>, std::function<void()>>> conditionalQueue;
+
+        std::list<std::function<void(int)>> frameCallbackList;
+        std::list<std::function<bool(SDL_Event *)>> eventCallbackList;
+    public:
+        static std::shared_ptr<event_loop> instance() {
+            static std::shared_ptr<vstd::event_loop<>> _loop = std::make_shared<vstd::event_loop<>>();
+            return _loop;
+        }
+
+        void invoke(const std::function<void()> &f) {
+            SDL_Event event;
+            SDL_zero(event);
+            event.type = _call_function_event;
+            event.user.data1 = new std::function<void()>(f);
+            SDL_PushEvent(&event);
+        }
+
+        void invoke_when(const std::function<bool()> &pred, const std::function<void()> &func) {
+            invoke([=, this]() {
+                conditionalQueue.emplace_back(pred, func);
+            });
+        }
+
+        void await(const std::function<void()> &f) {
+            if (std::this_thread::get_id() == _main_thread_id) {
+                f();
+            } else {
+                std::recursive_mutex _mutex;
+                std::unique_lock<std::recursive_mutex> _lock(_mutex);
+                bool completed = false;
+                std::condition_variable_any _condition;
+                invoke([&]() {
+                    std::unique_lock<std::recursive_mutex> __lock(_mutex);
+                    f();
+                    completed = true;
+                    _condition.notify_all();
+                });
+                _condition.wait(_lock, [&]() { return completed; });
+            }
+        }
+
+        void delay(int t, const std::function<void()> &f) {
+            if (std::this_thread::get_id() == _main_thread_id) {
+                delayQueue.push(std::make_pair(SDL_GetTicks() + t, f));
+            } else {
+                vstd::later([=, this]() {
+                    delayQueue.push(std::make_pair(SDL_GetTicks() + t, f));
+                });
+            }
+        }
+
+        void registerFrameCallback(const std::function<void(int)> &f) {
+            frameCallbackList.push_back(f);
+        }
+
+        void registerEventCallback(const std::function<bool(SDL_Event *)> &f) {
+            eventCallbackList.push_back(f);
+        }
+
+        bool run() {
+            int frameTime = SDL_GetTicks();
+
+            SDL_Event event;
+            while (SDL_PollEvent(&event)) {
+                if (event.type == SDL_QUIT) {
+                    return false;
+                }
+                for (const auto &cm:eventCallbackList) {
+                    if (cm(&event)) {
+                        break;
+                    }
+                }
+            }
+
+            auto it = conditionalQueue.begin();
+            while (it != conditionalQueue.end()) {
+                if (it->first()) {
+                    it->second();
+                    it = conditionalQueue.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+
+            while (!delayQueue.empty() && delayQueue.top().first < frameTime) {
+                delayQueue.top().second();
+                delayQueue.pop();
+            }
+
+            for (const auto &f:frameCallbackList) {
+                f(frameTime);
+            }
+
+            int endTime = SDL_GetTicks();
+            int actualFrameTime = endTime - lastFrameTime;
+            int desiredFrameTime = 1000 / fps;
+
+            int diffTime = desiredFrameTime - actualFrameTime;
+            if (diffTime < 0) {
+                //TODO: vstd::logger::warning("CEventLoop:", "cannot achieve specified fps!");
+            } else {
+                SDL_Delay(diffTime);
+            }
+
+            this->lastFrameTime = SDL_GetTicks();
+
+            return true;
+        }
+
+        event_loop() {
+            SDL_Init(SDL_INIT_EVENTS);
+            registerEventCallback([this](SDL_Event *event) {
+                if (event->type == _call_function_event) {
+                    static_cast<std::function<void()> *>(event->user.data1)->operator()();
+                    delete static_cast<std::function<void()> *>(event->user.data1);
+                    return true;
+                }
+                return false;
+            });
+        }
+
+        ~event_loop() {
+            SDL_Quit();
+        }
+
+    private:
+        int fps = 100;
+    public:
+        int getFps() {
+            return fps;
+        }
+
+        void setFps(int fps) {
+            this->fps = fps;
+        }
+    };
+}

--- a/vstd/vfunctional.h
+++ b/vstd/vfunctional.h
@@ -1,0 +1,82 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "vdefines.h"
+#include "vtraits.h"
+#include "vutil.h"
+
+namespace vstd {
+    namespace functional {
+        template<typename F, typename... Args>
+
+        typename disable_if<is_void<typename function_traits<F>::return_type>::value,
+                typename function_traits<F>::return_type>::type call(F f, Args... args) {
+            return f(args...);
+        }
+
+        template<typename F, typename... Args>
+
+        typename enable_if<is_void<typename function_traits<F>::return_type>::value,
+                typename function_traits<F>::return_type>::type call(F f, Args... args) {
+            f(args...);
+        }
+
+        template<typename Return, typename Container, typename Func>
+        Return map(Container &container, Func f) {
+            Return ret;
+            for (typename Container::value_type val:container) {
+                ret.insert(f(val));
+            }
+            return ret;
+        }
+
+        template<typename Container, typename Func>
+        void foreach(Container &container, Func f) {
+            for (auto val:container) {
+                f(val);
+            }
+        }
+
+        template<typename T, typename Container, typename Func>
+        T sum(Container &container, Func f) {
+            T s = 0;
+            for (auto val:container) {
+                s += f(val);
+            }
+            return s;
+        }
+
+
+        template<typename T, typename Container>
+        T sum(Container &container) {
+            T s = 0;
+            for (auto val:container) {
+                s += val;
+            }
+            return s;
+        }
+
+        template<typename Return, typename Container, typename Func>
+        auto map_reduce(Container &container, Func f) {
+            std::unordered_map<Return, std::set<typename Container::value_type>> ret;
+            for (auto val:container) {
+                auto bucket = f(val);
+                if (!ctn(ret, bucket)) {
+                    ret[bucket] = std::set<typename Container::value_type>();
+                }
+                ret[bucket].insert(val);
+            }
+            return ret;
+        }
+    }
+}

--- a/vstd/vfuture.h
+++ b/vstd/vfuture.h
@@ -1,0 +1,324 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <boost/range/adaptors.hpp>
+#include <mutex>
+#include <condition_variable>
+#include "vutil.h"
+#include "vthread.h"
+
+namespace vstd {
+    namespace detail {
+        template<typename G,
+                typename return_type=typename vstd::function_traits<G>::return_type,
+                typename argument_type=typename vstd::function_traits<G>::first_arg>
+        auto normalize(G f,
+                       typename vstd::enable_if<std::is_void<return_type>::value>::type * = 0,
+                       typename vstd::enable_if<std::is_void<argument_type>::value>::type * = 0) {
+            return [f](void *) -> void * {
+                f();
+                return nullptr;
+            };
+        }
+
+        template<typename G,
+                typename return_type=typename vstd::function_traits<G>::return_type,
+                typename argument_type=typename vstd::function_traits<G>::first_arg>
+        auto normalize(G f,
+                       typename vstd::disable_if<std::is_void<return_type>::value>::type * = 0,
+                       typename vstd::enable_if<std::is_void<argument_type>::value>::type * = 0) {
+            return [f](void *) {
+                return f();
+            };
+        }
+
+        template<typename G,
+                typename return_type=typename vstd::function_traits<G>::return_type,
+                typename argument_type=typename vstd::function_traits<G>::first_arg>
+        auto normalize(G f,
+                       typename vstd::enable_if<std::is_void<return_type>::value>::type * = 0,
+                       typename vstd::disable_if<std::is_void<argument_type>::value>::type * = 0) {
+            return [f](argument_type t) -> void * {
+                f(t);
+                return nullptr;
+            };
+        }
+
+        template<typename G,
+                typename return_type=typename vstd::function_traits<G>::return_type,
+                typename argument_type=typename vstd::function_traits<G>::first_arg>
+        auto normalize(G f,
+                       typename vstd::disable_if<std::is_void<return_type>::value>::type * = 0,
+                       typename vstd::disable_if<std::is_void<argument_type>::value>::type * = 0) {
+            return f;
+        }
+
+        template<typename sig>
+        struct normalized_function {
+            typedef std::function<typename function_traits<decltype(normalize(std::declval<sig>()))>::return_type(
+                    typename function_traits<decltype(normalize(std::declval<sig>()))>::first_arg)> type;
+        };
+
+        template<typename ret, typename arg>
+        struct function_type {
+            typedef std::function<ret(arg)> type;
+        };
+
+        template<typename ret>
+        struct function_type<ret, void> {
+            typedef std::function<ret()> type;
+        };
+
+        template<typename return_type,
+                typename argument_type>
+        class ccall : public std::enable_shared_from_this<ccall<return_type, argument_type>> {
+            typedef typename function_type<return_type, argument_type>::type function_target;
+            typedef typename normalized_function<function_target>::type normalized_target;
+            typedef std::function<void(typename function_traits<normalized_target>::return_type)> on_result;
+
+            volatile bool completed = false;
+            std::recursive_mutex mutex;
+            std::condition_variable_any _condition;
+            return_type *result = _new<return_type>();
+            argument_type *argument = _new<argument_type>();
+
+            template<typename X>
+            X *_new(typename vstd::disable_if<vstd::is_same<X, void>::value>::type * = 0) {
+                return new X();
+            }
+
+            template<typename X>
+            X *_new(typename vstd::enable_if<vstd::is_same<X, void>::value>::type * = 0) {
+                return nullptr;
+            }
+
+            template<typename X>
+            void _delete(typename vstd::disable_if<vstd::is_same<X, void>::value>::type * = 0) {
+                delete result;
+            }
+
+            template<typename X>
+            void _delete(typename vstd::enable_if<vstd::is_same<X, void>::value>::type * = 0) {
+
+            }
+
+        public:
+
+            template<typename F, typename G>
+            ccall(F func, G caller) :
+                    _target(normalize(func)),
+                    _caller(caller) {
+
+            }
+
+            ~ccall() {
+                std::unique_lock<std::recursive_mutex> lock(mutex);
+                _delete<return_type>();
+            }
+
+            template<typename X=argument_type>
+            argument_type getArgument(typename vstd::disable_if<vstd::is_same<X, void>::value>::type * = 0) {
+                std::unique_lock<std::recursive_mutex> lock(mutex);
+                return *argument;
+            }
+
+            template<typename X=argument_type>
+            void *getArgument(typename vstd::enable_if<vstd::is_same<X, void>::value>::type * = 0) {
+                std::unique_lock<std::recursive_mutex> lock(mutex);
+                return nullptr;
+            }
+
+            template<typename X=argument_type>
+            void setArgument(X x, typename vstd::disable_if<vstd::is_same<X, void>::value>::type * = 0) {
+                std::unique_lock<std::recursive_mutex> lock(mutex);
+                *argument = x;
+            }
+
+            template<typename X=argument_type>
+            void setArgument(void *, typename vstd::enable_if<vstd::is_same<X, void>::value>::type * = 0) {
+                std::unique_lock<std::recursive_mutex> lock(mutex);
+                argument = nullptr;
+            }
+
+            template<typename X=return_type>
+            void setResult(X t, typename vstd::disable_if<vstd::is_same<X, void>::value>::type * = 0) {
+                std::unique_lock<std::recursive_mutex> lock(mutex);
+                *result = t;
+                completed = true;
+                if (_on_result) {
+                    _on_result(t);
+                }
+                _condition.notify_all();
+            }
+
+            template<typename X=return_type>
+            X getResult(typename vstd::disable_if<vstd::is_same<X, void>::value>::type * = 0) {
+                std::unique_lock<std::recursive_mutex> lock(mutex);
+                _condition.wait(lock, [this]() { return completed; });
+                return *result;
+            }
+
+            template<typename X=return_type>
+            void setResult(typename vstd::enable_if<vstd::is_same<X, void>::value>::type * = 0) {
+                std::unique_lock<std::recursive_mutex> lock(mutex);
+                completed = true;
+                if (_on_result) {
+                    _on_result(nullptr);
+                }
+                _condition.notify_all();
+            }
+
+            template<typename X=return_type>
+            void *getResult(typename vstd::enable_if<vstd::is_same<X, void>::value>::type * = 0) {
+                std::unique_lock<std::recursive_mutex> lock(mutex);
+                _condition.wait(lock, [this]() { return completed; });
+                return nullptr;
+            }
+
+            void call() {
+                std::unique_lock<std::recursive_mutex> lock(mutex);
+                auto self = this->shared_from_this();
+                vstd::functional::call(_caller, [self]() {
+                    self->setResult(vstd::functional::call(self->_target, self->getArgument()));
+                });
+            }
+
+            void onResult(on_result cb) {
+                std::unique_lock<std::recursive_mutex> lock(mutex);
+                if (completed) {
+                    cb(getResult());
+                } else {
+                    _on_result = cb;
+                }
+            }
+
+        private:
+
+            normalized_target _target;
+
+            on_result _on_result;
+
+            std::function<void(std::function<void()>)> _caller;
+        };
+    }
+
+    namespace detail {
+        template<typename func>
+        auto make_async(func f) {
+            return std::make_shared<ccall<typename function_traits<func>::return_type,
+                    typename function_traits<func>::first_arg>>(
+                    f, call_async<std::function<void() >>);
+        }
+
+        template<typename func>
+        auto make_later(func f) {
+            return std::make_shared<ccall<typename function_traits<func>::return_type,
+                    typename function_traits<func>::first_arg>>(
+                    f, call_later<std::function<void() >>);
+        }
+
+        template<typename func>
+        auto make_now(func f) {
+            return std::make_shared<ccall<typename function_traits<func>::return_type,
+                    typename function_traits<func>::first_arg>>(
+                    f, call_now<std::function<void() >>);
+        }
+    }
+
+    template<typename return_type,
+            typename argument_type>
+    class future : public std::enable_shared_from_this<future<return_type, argument_type>> {
+    public:
+        typedef typename detail::function_type<return_type, argument_type>::type function;
+
+        explicit future(std::shared_ptr<detail::ccall<return_type, argument_type>> call, bool start = true) :
+                _call(call) {
+            if (start) {
+                _call->call();
+            }
+        }
+
+        auto get() {
+            return _call->getResult();
+        }
+
+        template<typename G>
+        auto thenLater(G g) {
+            return chain_call(detail::make_later(g));
+        }
+
+        template<typename G>
+        auto thenAsync(G g) {
+            return chain_call(detail::make_async(g));
+        }
+
+    private:
+        std::shared_ptr<detail::ccall<return_type, argument_type>> _call;
+
+        template<typename _return_type, typename _first_arg>
+        auto chain_call(std::shared_ptr<detail::ccall<_return_type, _first_arg>> _new_call) {
+            auto _self = this->shared_from_this();
+            _self->_call->onResult([_new_call](auto arg) {
+                _new_call->setArgument(arg);
+                _new_call->call();
+            });
+            return std::make_shared<future<_return_type, _first_arg>>(_new_call, false);
+        }
+    };
+
+    namespace detail {
+        template<typename return_type, typename first_arg>
+        auto make_future(std::shared_ptr<detail::ccall<return_type, first_arg>> call) {
+            return std::make_shared<vstd::future<return_type, first_arg>>(call);
+        }
+    }
+
+    template<typename Func>
+    auto later(Func f) {
+        return detail::make_future(detail::make_later(vstd::make_function(f)));
+    }
+
+    template<typename Func>
+    auto async(Func f) {
+        return detail::make_future(detail::make_async(vstd::make_function(f)));
+    }
+
+    template<typename Func>
+    auto now(Func f) {
+        return detail::make_future(detail::make_now(vstd::make_function(f)));
+    }
+
+    template<typename F, typename Arg=typename vstd::function_traits<F>::template arg<0>::type>
+    auto wrap_later(F f) {
+        return [f](Arg a) {
+            return later(vstd::bind(f, a));
+        };
+    }
+
+    template<typename F, typename Arg=typename vstd::function_traits<F>::template arg<0>::type>
+    auto wrap_async(F f) {
+        return [f](Arg a) {
+            return async(vstd::bind(f, a));
+        };
+    }
+
+    template<typename Range>
+    auto join(Range range) {
+        return async([range]() {
+            return collect(collect(range) |
+                           boost::adaptors::transformed([](auto future) {
+                               return future->get();
+                           }));
+        });
+    }
+}

--- a/vstd/vhash.h
+++ b/vstd/vhash.h
@@ -1,0 +1,99 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "vdefines.h"
+#include "vtraits.h"
+#include "vfunctional.h"
+
+namespace vstd {
+    template<int a, int x>
+    struct power {
+        enum {
+            value = a * power<a, x - 1>::value
+        };
+    };
+
+    template<int a>
+    struct power<a, 0> {
+        enum {
+            value = 1
+        };
+    };
+
+    template<typename T>
+    struct hasher {
+        template<typename U=T>
+        static std::size_t hash(U u,
+                                typename vstd::disable_if<vstd::is_pair<U>::value>::type * = 0,
+                                typename vstd::disable_if<vstd::is_enum<U>::value>::type * = 0) {
+            return std::hash<U>()(u);
+        }
+
+        template<typename U=T>
+        static std::size_t hash(U u,
+                                typename vstd::disable_if<vstd::is_pair<U>::value>::type * = 0,
+                                typename vstd::enable_if<vstd::is_enum<U>::value>::type * = 0) {
+            return hasher<int>::hash(static_cast<int> ( u ));
+        }
+    };
+
+    template<typename T>
+    std::size_t hash_combine(T t) {
+        return hasher<T>::hash(t);
+    }
+
+    template<typename F, typename G, typename ...T>
+    std::size_t hash_combine(F f, G g, T... args) {
+        return power<31, sizeof... (args) + 1>::value *
+               hash_combine(f) +
+               hash_combine(g, args...);
+    }
+}
+
+namespace std {
+    template<>
+    struct hash<std::pair<int, int>> {
+        std::size_t operator()(const std::pair<int, int> &pair) const {
+            return vstd::hash_combine(pair.first, pair.second);
+        }
+    };
+
+    template<>
+    struct hash<std::pair<std::string, int>> {
+        std::size_t operator()(const std::pair<std::string, int> &pair) const {
+            return vstd::hash_combine(pair.first, pair.second);
+        }
+    };
+
+    template<>
+    struct hash<std::pair<std::string, std::string>> {
+        std::size_t operator()(const std::pair<std::string, std::string> &pair) const {
+            return vstd::hash_combine(pair.first, pair.second);
+        }
+    };
+
+    template<>
+    struct hash<std::pair<boost::typeindex::type_index, boost::typeindex::type_index>> {
+        std::size_t operator()(
+                const std::pair<boost::typeindex::type_index, boost::typeindex::type_index> &pair) const {
+            return vstd::hash_combine(pair.first, pair.second);
+        }
+    };
+
+    template<>
+    struct hash<boost::typeindex::type_index> {
+        std::size_t operator()(const boost::typeindex::type_index &ind) const {
+            return ind.hash_code();
+        }
+    };
+}

--- a/vstd/vhex.h
+++ b/vstd/vhex.h
@@ -1,0 +1,39 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <boost/algorithm/string.hpp>
+#include "vdefines.h"
+
+namespace vstd {
+    template<typename U>
+    std::string to_hex(U object) {
+        std::stringstream stream;
+        stream << std::hex << object;
+        return boost::to_upper_copy<std::string>(stream.str());
+    }
+
+    template<typename U>
+    std::string to_hex(U *object) {
+        return to_hex(static_cast<std::size_t > ( object ));
+    }
+
+    template<typename U>
+    std::string to_hex(std::shared_ptr<U> object) {
+        return to_hex<U *>(object.get());
+    }
+
+    template<typename... Args>
+    std::string to_hex_hash(Args... args) {
+        return to_hex<std::size_t>(hash_combine(args...));
+    }
+}

--- a/vstd/vlazy.h
+++ b/vstd/vlazy.h
@@ -1,0 +1,57 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace vstd {
+    template<typename T, typename Owner = std::shared_ptr<T>>
+    class lazy {
+    public:
+        std::shared_ptr<T> get() {
+            if (ptr) {
+                return ptr;
+            }
+            return ptr = std::make_shared<T>();
+        }
+
+        template<typename F>
+        std::shared_ptr<T> get(F &&f) {
+            if (ptr) {
+                return ptr;
+            }
+            if constexpr (std::is_invocable_r_v<std::shared_ptr<T>, F>) {
+                return ptr = std::forward<F>(f)();
+            } else {
+                return ptr = std::make_shared<T>(std::forward<F>(f));
+            }
+        }
+
+        template<typename First, typename... Rest>
+        std::shared_ptr<T> get(First &&first, Rest &&... rest) {
+            if (ptr) {
+                return ptr;
+            }
+            return ptr = std::make_shared<T>(
+                std::forward<First>(first), std::forward<Rest>(rest)...);
+        }
+
+        void clear() {
+            ptr = nullptr;
+        }
+
+    private :
+        std::shared_ptr<T> ptr;
+    };
+}

--- a/vstd/vlogger.h
+++ b/vstd/vlogger.h
@@ -1,0 +1,121 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include "vdefines.h"
+#include "vstring.h"
+
+namespace vstd {
+    class logger {
+    public:
+        enum class sink {
+            stdout_sink,
+            stderr_sink,
+            file_sink,
+            disabled,
+        };
+
+        static void set_sink(sink target, const std::string &file_path = std::string()) {
+            std::lock_guard<std::mutex> guard(_mutex);
+            if (target == sink::file_sink) {
+                if (file_path.empty()) {
+                    target = sink::stderr_sink;
+                } else {
+                    auto stream = std::make_unique<std::ofstream>(file_path, std::ios::out | std::ios::app);
+                    if (!stream->is_open()) {
+                        std::cerr << "vstd::logger: failed to open log file " << file_path
+                                  << ", falling back to stderr" << std::endl;
+                        target = sink::stderr_sink;
+                    } else {
+                        _file_stream = std::move(stream);
+                        _current_sink = sink::file_sink;
+                        return;
+                    }
+                }
+            }
+            _file_stream.reset();
+            _current_sink = target;
+        }
+
+        template<typename ...Args>
+        static void fatal(Args... args) {
+            log("FATAL:", args...);
+            std::terminate();
+        }
+
+        template<typename ...Args>
+        static void error(Args... args) {
+            log("ERROR:", args...);
+        }
+
+        template<typename ...Args>
+        static void warning(Args... args) {
+            log("WARNING:", args...);
+        }
+
+        template<typename ...Args>
+        static void info(Args... args) {
+            log("INFO:", args...);
+        }
+
+        template<typename ...Args>
+        static void debug(Args... args) {
+            log("DEBUG:", args...);
+        }
+
+    private:
+        inline static sink _current_sink = sink::stdout_sink;
+        inline static std::unique_ptr<std::ofstream> _file_stream;
+        inline static std::mutex _mutex;
+
+        template<typename T, typename U, typename ...Args>
+        static void log(T t, U u, Args... args) {
+            std::stringstream stream;
+            stream << vstd::str(t) << " " << vstd::str(u);
+            log(stream.str(), args...);
+        }
+
+        template<typename T>
+        static void log(T t) {
+            std::stringstream stream;
+            stream << t;
+            write_line(stream.str());
+        }
+
+        static void write_line(const std::string &line) {
+            std::lock_guard<std::mutex> guard(_mutex);
+            switch (_current_sink) {
+            case sink::stdout_sink:
+                std::cout << line << std::endl;
+                break;
+            case sink::stderr_sink:
+                std::cerr << line << std::endl;
+                break;
+            case sink::file_sink:
+                if (_file_stream && _file_stream->is_open()) {
+                    (*_file_stream) << line << std::endl;
+                } else {
+                    std::cerr << line << std::endl;
+                }
+                break;
+            case sink::disabled:
+                break;
+            }
+        }
+    };
+}

--- a/vstd/vmeta.h
+++ b/vstd/vmeta.h
@@ -1,0 +1,489 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+//TODO: line 36 optimize, do not use map
+#pragma once
+
+#include <boost/any.hpp>
+#include <functional>
+#include <unordered_map>
+#include <memory>
+#include "vany.h"
+#include "vbind.h"
+
+#define V_VOID boost::typeindex::type_id<void>()
+
+#define V_STRING(X) #X
+
+#define V_META(CLASS, SUPER, ...) \
+private: \
+friend class vstd::meta; \
+std::unordered_map<std::string, std::shared_ptr<vstd::property>> _dynamic_props; \
+virtual std::unordered_map<std::string, std::shared_ptr<vstd::property>> &dynamic_props(){return _dynamic_props;} \
+std::unordered_map<std::string, std::shared_ptr<vstd::method>> _dynamic_methods; \
+virtual std::unordered_map<std::string, std::shared_ptr<vstd::method>> &dynamic_methods(){return _dynamic_methods;} \
+public: \
+static std::shared_ptr<vstd::meta> static_meta(){ \
+    static std::shared_ptr<vstd::meta> _static_meta=std::make_shared<vstd::meta>(V_STRING(CLASS),SUPER::static_meta(),__VA_ARGS__); \
+    if(!vstd::ctn(*vstd::meta::index(),_static_meta->name())){vstd::meta::index()->insert(std::make_pair(_static_meta->name(),_static_meta));} \
+    return _static_meta; \
+} \
+virtual std::shared_ptr<vstd::meta> meta() { \
+    return static_meta(); \
+} \
+private: \
+
+// get number of arguments with __NARG__
+#define __NARG__(...)  __NARG_I_(__VA_ARGS__,__RSEQ_N())
+#define __NARG_I_(...) __ARG_N(__VA_ARGS__)
+#define __ARG_N(\
+      _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, \
+     _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, \
+     _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, \
+     _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, \
+     _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, \
+     _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, \
+     _61, _62, _63, N, ...) N
+#define __RSEQ_N() \
+     63,62,61,60,                   \
+     59,58,57,56,55,54,53,52,51,50, \
+     49,48,47,46,45,44,43,42,41,40, \
+     39,38,37,36,35,34,33,32,31,30, \
+     29,28,27,26,25,24,23,22,21,20, \
+     19,18,17,16,15,14,13,12,11,10, \
+     9,8,7,6,5,4,3,2,1,0
+
+// general definition for any function name
+#define _VFUNC_(name, n) name##n
+#define _VFUNC(name, n) _VFUNC_(name, n)
+#define VFUNC(func, ...) _VFUNC(func, __NARG__(__VA_ARGS__)) (__VA_ARGS__)
+
+// definition for FOO
+#define V_METHOD(...) VFUNC(V_METHOD, __VA_ARGS__)
+
+#define V_PROPERTY(CLASS, TYPE, NAME, GETTER, SETTER) std::make_shared<vstd::detail::property_impl<CLASS,TYPE>>\
+                                                        (V_STRING(NAME),&CLASS::GETTER,&CLASS::SETTER),        \
+                                                        V_METHOD(CLASS,GETTER,TYPE),V_METHOD(CLASS,SETTER,void,TYPE)
+
+#define V_METHOD2(CLASS, NAME) std::make_shared<vstd::detail::method_impl<CLASS,void>>(V_STRING(NAME),&CLASS::NAME)
+#define V_METHOD3(CLASS, NAME, RET_TYPE) std::make_shared<vstd::detail::method_impl<CLASS,RET_TYPE>>(V_STRING(NAME),&CLASS::NAME)
+#define V_METHOD4(CLASS, NAME, RET_TYPE, ...) std::make_shared<vstd::detail::method_impl<CLASS,RET_TYPE,__VA_ARGS__>>(V_STRING(NAME),&CLASS::NAME)
+#define V_METHOD5(CLASS, NAME, RET_TYPE, ...) std::make_shared<vstd::detail::method_impl<CLASS,RET_TYPE,__VA_ARGS__>>(V_STRING(NAME),&CLASS::NAME)
+#define V_METHOD6(CLASS, NAME, RET_TYPE, ...) std::make_shared<vstd::detail::method_impl<CLASS,RET_TYPE,__VA_ARGS__>>(V_STRING(NAME),&CLASS::NAME)
+
+namespace vstd {
+    //TODO: allow method overrides, use composite key in _methods in meta
+    class method {
+    public:
+        virtual std::string name() = 0;
+
+        virtual boost::any invoke(std::vector<boost::any> args) = 0;
+
+        virtual boost::typeindex::type_index object_type() = 0;
+
+        virtual boost::typeindex::type_index return_type() = 0;
+
+        virtual std::list<boost::typeindex::type_index> argument_types() = 0;
+    };
+
+    class property {
+    public:
+        virtual std::string name() = 0;
+
+        virtual boost::any get(boost::any object) = 0;
+
+        virtual void set(boost::any object, boost::any value) = 0;
+
+        virtual boost::typeindex::type_index object_type() = 0;
+
+        virtual boost::typeindex::type_index value_type() = 0;
+    };
+
+    namespace detail {
+        template<typename ObjectType, typename ReturnType, typename ...ArgumentTypes>
+        class method_impl : public method {
+            std::string _name;
+            std::function<ReturnType(ObjectType *, ArgumentTypes...)> _func;
+
+        public:
+
+            template<typename Method>
+            method_impl(std::string name, Method method, bool external):
+                    _name(name), _func(method) {
+
+            }
+
+            template<typename Method>
+            method_impl(std::string name, Method method) :
+                    _name(name), _func(std::mem_fn(method)) {
+
+            }
+
+            template<typename T=ReturnType>
+            method_impl(std::string name,
+                        typename vstd::disable_if<vstd::is_same<T, void>::value>::type * = 0) :
+                    _name(name), _func([](ObjectType *, ArgumentTypes...) {
+                return ReturnType();
+            }) {
+            }
+
+            template<typename T=ReturnType>
+            method_impl(std::string name,
+                        typename vstd::enable_if<vstd::is_same<T, void>::value>::type * = 0) :
+                    _name(name), _func([](ObjectType *, ArgumentTypes...) {
+
+            }) {
+            }
+
+            //TODO: implement arguments and return type
+            boost::any invoke(std::vector<boost::any> args) override {
+                return _call(_bind<0>(_func, args));
+            }
+
+            template<typename F, typename T=ReturnType>
+            auto
+            _call(F function, typename vstd::enable_if<vstd::is_same<T, void>::value>::type * = 0) {
+                function();
+                return boost::any();
+            }
+
+            template<typename F, typename T=ReturnType>
+            auto
+            _call(F function, typename vstd::disable_if<vstd::is_same<T, void>::value>::type * = 0) {
+                return function();
+            }
+
+            template<int argNo, typename F>
+            auto _bind(F function, std::vector<boost::any> args,
+                       typename vstd::disable_if<
+                               argNo < vstd::tuple_size<ObjectType, ArgumentTypes...>::size - 1>::type * = 0) {
+                return _bind<argNo>(function, args[argNo]);
+            }
+
+            template<int argNo, typename F>
+            auto _bind(F function, std::vector<boost::any> args,
+                       typename vstd::enable_if<
+                               argNo < vstd::tuple_size<ObjectType, ArgumentTypes...>::size - 1>::type * = 0) {
+                return _bind<argNo + 1>(_bind<argNo>(function, args[argNo]), args);
+            }
+
+            template<int argNo, typename F>
+            auto _bind(F function, boost::any arg, typename vstd::disable_if<argNo == 0>::type * = 0) {
+                return vstd::partial::bind(function,
+                                           vstd::any_cast<typename vstd::tuple_element<argNo, ObjectType, ArgumentTypes...>::type>(
+                                                   arg));
+            }
+
+            template<int argNo, typename F>
+            auto _bind(F function, boost::any arg, typename vstd::enable_if<argNo == 0>::type * = 0) {
+                return vstd::partial::bind(function, vstd::any_cast<std::shared_ptr<ObjectType >>(arg).get());
+            }
+
+
+            std::string name() override {
+                return _name;
+            }
+
+            boost::typeindex::type_index object_type() override {
+                return boost::typeindex::type_id<ObjectType>();
+            }
+
+            boost::typeindex::type_index return_type() override {
+                return boost::typeindex::type_id<ReturnType>();
+            }
+
+            std::list<boost::typeindex::type_index> argument_types() override {
+                return _argument_types();
+            }
+
+            std::list<boost::typeindex::type_index> _argument_types() {
+                return std::list<boost::typeindex::type_index>();
+            }
+
+            template<typename Arg, typename... Args>
+            std::list<boost::typeindex::type_index> argument_types(Arg arg, Args... props) {
+                std::list<boost::typeindex::type_index> ret;
+                ret.insert(boost::typeindex::type_id<Arg>());
+                for (boost::typeindex::type_index ind:argument_types<Args...>()) {
+                    ret.push_back(ind);
+                }
+                return ret;
+            };
+        };
+
+        template<typename ObjectType, typename PropertyType>
+        class property_impl : public property {
+            std::string _name;
+            std::function<PropertyType(ObjectType *)> _getter;
+            std::function<void(ObjectType *, PropertyType)> _setter;
+
+        public:
+            template<typename Getter, typename Setter>
+            property_impl(std::string name, Getter getter, Setter setter) :
+                    _name(name), _getter(std::mem_fn(getter)), _setter(std::mem_fn(setter)) {
+
+            }
+
+            std::string name() override {
+                return _name;
+            }
+
+            boost::any get(boost::any object) override {
+                return _getter(vstd::any_cast<std::shared_ptr<ObjectType>>(object).get());
+            }
+
+            void set(boost::any object, boost::any value) override {
+                _setter(vstd::any_cast<std::shared_ptr<ObjectType>>(object).get(),
+                        vstd::any_cast<PropertyType>(value));
+            }
+
+            boost::typeindex::type_index object_type() override {
+                return boost::typeindex::type_id<ObjectType>();
+            }
+
+            boost::typeindex::type_index value_type() override {
+                return boost::typeindex::type_id<PropertyType>();
+            }
+        };
+
+        template<typename ObjectType, typename PropertyType>
+        class dynamic_property_impl : public property {
+            std::string _name;
+            PropertyType _value;
+        public:
+            dynamic_property_impl(std::string name) : _name(name) {
+
+            }
+
+            std::string name() override {
+                return _name;
+            }
+
+            boost::any get(boost::any object) override {
+                return boost::any(_value);
+            }
+
+            void set(boost::any object, boost::any value) override {
+                _value = vstd::any_cast<PropertyType>(value);
+            }
+
+            boost::typeindex::type_index object_type() override {
+                return boost::typeindex::type_id<ObjectType>();
+            }
+
+            boost::typeindex::type_index value_type() override {
+                return boost::typeindex::type_id<PropertyType>();
+            }
+        };
+    }
+
+    class meta {
+    public:
+        class empty {
+        public:
+            static std::shared_ptr<vstd::meta> static_meta() {
+                return nullptr;
+            }
+        };
+
+        static std::unordered_map<std::string, std::shared_ptr<meta>> *index() {
+            static std::unordered_map<std::string, std::shared_ptr<meta>> _index;
+            return &_index;
+        };
+    private:
+        std::string _name;
+        std::unordered_map<std::string, std::shared_ptr<property>> _props;
+        std::unordered_map<std::string, std::shared_ptr<method>> _methods;
+        std::shared_ptr<meta> _super;
+
+
+        void _add() {
+
+        }
+
+        template<typename... Args>
+        void _add(std::shared_ptr<property> prop, Args... props) {
+            _props[prop->name()] = prop;
+            _add(props...);
+        };
+
+        template<typename... Args>
+        void _add(std::shared_ptr<method> meth, Args... props) {
+            _methods[meth->name()] = meth;
+            _add(props...);
+        };
+
+        template<typename... Args>
+        void _add(vstd::meta::empty val, Args... props) {
+            _add(props...);
+        };
+
+        template<typename ObjectType, typename PropertyType>
+        std::shared_ptr<property> _get_property_object(std::shared_ptr<ObjectType> ob, std::string name) {
+            if (vstd::ctn(_props, name)) {
+                return _props[name];
+            } else if (vstd::ctn(ob->dynamic_props(), name)) {
+                return ob->dynamic_props()[name];
+            } else if (auto super_p = _super ? _super->_get_property_object<ObjectType, PropertyType>(ob, name)
+                                             : nullptr) {
+                return super_p;
+            }
+            ob->dynamic_props()[name] = std::make_shared<detail::dynamic_property_impl<ObjectType, PropertyType>>(
+                    name);
+            return _get_property_object<ObjectType, PropertyType>(ob, name);
+        }
+
+        template<typename ObjectType, typename ReturnType, typename ...ArgumentTypes>
+        std::shared_ptr<method> _get_method_object(std::shared_ptr<ObjectType> ob, std::string name) {
+            if (vstd::ctn(_methods, name)) {
+                return _methods[name];
+            } else if (vstd::ctn(ob->dynamic_methods(), name)) {
+                return ob->dynamic_methods()[name];
+            } else if (auto super_p = _super ? _super->_get_method_object<ObjectType,
+                    ReturnType, ArgumentTypes...>(ob, name) : nullptr) {
+                return super_p;
+            }
+            //TODO: handle differently
+            return std::make_shared<vstd::detail::method_impl<ObjectType, ReturnType, ArgumentTypes...>>(name);
+        }
+
+        template<typename ObjectType, typename ReturnType, typename ...ArgumentTypes, typename Function>
+        void _set_method_object(std::shared_ptr<ObjectType> ob, std::string name, Function function) {
+            ob->dynamic_methods()[name] = std::make_shared<vstd::detail::method_impl<ObjectType, ReturnType, ArgumentTypes...>>(
+                    name,
+                    function,
+                    true);
+        }
+
+        template<typename PropertyCallback>
+        void _for_properties(PropertyCallback propertyCallback) {
+            for (auto &[name, property]:_props) {
+                if (propertyCallback(property)) {
+                    return;
+                }
+            }
+            if (_super) {
+                _super->_for_properties(propertyCallback);
+            }
+        }
+
+    public:
+        template<typename... Args>
+        meta(std::string name, std::shared_ptr<meta> super, Args... props) : _name(name), _super(super) {
+            _add(props...);
+        }
+
+        std::shared_ptr<meta> super() {
+            return _super;
+        }
+
+        std::string name() {
+            return _name;
+        }
+
+        bool inherits(std::string clas) {
+            return name() == clas || (_super && _super->inherits(clas));
+        }
+
+        template<typename ObjectType, typename PropertyType>
+        void set_property(std::string prop, std::shared_ptr<ObjectType> t, PropertyType p) {
+            _get_property_object<ObjectType, PropertyType>(t, prop)->set(t, p);
+        }
+
+        template<typename ReturnType, typename ObjectType, typename ...ArgumentTypes>
+        void invoke_method(std::string name, std::shared_ptr<ObjectType> t, ArgumentTypes... args,
+                           typename vstd::enable_if<std::is_same<ReturnType, void>::value>::type * = 0) {
+            _get_method_object<ObjectType, ReturnType, ArgumentTypes...>(t, name)->invoke({t, args...});
+        }
+
+        template<typename ReturnType, typename ObjectType, typename ...ArgumentTypes>
+        ReturnType invoke_method(std::string name, std::shared_ptr<ObjectType> t, ArgumentTypes... args,
+                                 typename vstd::disable_if<std::is_same<ReturnType, void>::value>::type * = 0) {
+            return vstd::any_cast<ReturnType>(
+                    _get_method_object<ObjectType, ReturnType, ArgumentTypes...>(t, name)->invoke({t, args...}));
+        }
+
+        template<typename ObjectType, typename PropertyType>
+        PropertyType get_property(std::string prop, std::shared_ptr<ObjectType> t,
+                                  typename vstd::disable_if<std::is_same<PropertyType, boost::any>::value>::type * = 0) {
+            return vstd::any_cast<PropertyType>(
+                    _get_property_object<ObjectType, PropertyType>(t, prop)->get(t));
+        }
+
+        template<typename ObjectType, typename PropertyType>
+        PropertyType get_property(std::string prop, std::shared_ptr<ObjectType> t,
+                                  typename vstd::enable_if<std::is_same<PropertyType, boost::any>::value>::type * = 0) {
+            return _get_property_object<ObjectType, PropertyType>(t, prop)->get(t);
+        }
+
+        template<typename ObjectType, typename ReturnType, typename ...ArgumentTypes, typename Function>
+        void set_method(std::string method, std::shared_ptr<ObjectType> t, Function function) {
+            _set_method_object<ObjectType, ReturnType, ArgumentTypes...>(t, method, function);
+        }
+
+        template<typename ObjectType>
+        boost::typeindex::type_index get_property_type(std::shared_ptr<ObjectType> ob, std::string name) {
+            if (vstd::ctn(_props, name)) {
+                return _props[name]->value_type();
+            } else if (vstd::ctn(ob->dynamic_props(), name)) {
+                return ob->dynamic_props()[name]->value_type();
+            } else if (_super) {
+                return _super->get_property_type<ObjectType>(ob, name);
+            }
+            return boost::typeindex::type_id<void>();
+        }
+
+        template<typename ObjectType>
+        std::shared_ptr<std::set<std::shared_ptr<vstd::property>>> properties(std::shared_ptr<ObjectType> ob) {
+            std::shared_ptr<std::set<std::shared_ptr<vstd::property>>> props = std::make_shared<std::set<std::shared_ptr<vstd::property>>>();
+            auto vals = _props | boost::adaptors::map_values;
+            props->insert(vals.begin(), vals.end());
+            vals = ob->dynamic_props() | boost::adaptors::map_values;
+            props->insert(vals.begin(), vals.end());
+            if (_super) {
+                auto _props = _super->properties(ob);
+                props->insert(_props->begin(), _props->end());
+            }
+            return props;
+        }
+
+        template<typename ObjectType,
+                typename PropertyCallback>
+        void for_properties(std::shared_ptr<ObjectType> ob,
+                            PropertyCallback propertyCallback) {
+            _for_properties(propertyCallback);
+            for (auto &[name, property]:   ob->dynamic_props()) {
+                if (propertyCallback(property)) {
+                    return;
+                }
+            }
+        }
+
+        template<typename ObjectType,
+                typename PropertyCallback>
+        void for_all_properties(std::shared_ptr<ObjectType> ob,
+                                PropertyCallback propertyCallback) {
+            for_properties(ob, [&](auto prop) {
+                propertyCallback(prop);
+                return false;
+            });
+        }
+
+        template<typename ObjectType>
+        bool has_property(std::string name, std::shared_ptr<ObjectType> ob) {
+            bool result = false;
+            for_properties(ob, [&](auto &property) {
+                return result = result || property->name() == name;
+            });
+            return result;
+        }
+    };
+}

--- a/vstd/vneuro.h
+++ b/vstd/vneuro.h
@@ -1,0 +1,233 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "vutil.h"
+
+namespace vstd {
+    template<typename T=void>
+    class neuro {
+        std::vector<int> _str;
+        std::vector<int> _dim;
+        double _alfa, _beta, _eta;
+        int _nw;
+        std::vector<std::pair<double *, double *>> teachers;
+        std::vector<std::pair<double *, double *>> tests;
+        double ***_neuro, ***_prev, ***_diff;
+        double **_o, **_e;
+
+        double fcn(double x, double beta) {
+            return 1.0 / (1.0 + std::exp(-beta * x));
+        }
+
+        double dfcn(double x) {
+            return (1.0 - x) * x;
+        }
+
+        void o(double *t) {
+            for (int j = 0; j < _str[0]; j++) {
+                _o[0][j] = t[j];
+            }
+            for (int i = 1; i < _nw; i++) {
+                for (int j = 0; j < _str[i]; j++) {
+                    _o[i][j] = 0;
+                    for (int k = 0; k < _str[i - 1]; k++) {
+                        _o[i][j] += _o[i - 1][k] * _neuro[i - 1][j][k];
+                    }
+                    _o[i][j] = fcn(_o[i][j], _beta);
+                }
+            }
+        }
+
+        void e(double *in, double *out) {
+            o(in);
+            for (int i = 0; i < _str[_nw - 1]; i++) {
+                _e[_nw - 2][i] = dfcn(out[i] - _o[_nw - 1][i]);
+            }
+
+            for (int j = 3; _nw - j >= 0; j++) {
+                for (int k = 0; k < _str[_nw - j + 1]; k++) {
+                    _e[_nw - j][k] = 0;
+                }
+                for (int k = 0; k < _str[_nw - j + 1]; k++) {
+                    for (int l = 0; l < _str[_nw - j + 2]; l++) {
+                        _e[_nw - j][k] += _e[_nw - j + 1][l] * _neuro[_nw - j + 1][l][k];
+                    }
+                }
+                for (int k = 0; k < _str[_nw - j + 1]; k++) {
+                    _e[_nw - j][k] *= dfcn(_o[_nw - j + 1][k]);
+                }
+            }
+        }
+
+    public:
+        void add_teacher(std::vector<double> in, std::vector<double> out) {
+            teachers.push_back(std::make_pair(vstd::as_array(in), vstd::as_array(out)));
+        }
+
+        void add_test(std::vector<double> in, std::vector<double> out) {
+            tests.push_back(std::make_pair(vstd::as_array(in), vstd::as_array(out)));
+        }
+
+        int teach(double erms, int step = 1) {
+            int i = 0;
+            while (this->erms() > erms) {
+                teach(step);
+                i += step;
+            }
+            return i;
+        }
+
+        void teach(int ite) {
+            if (teachers.size() != 0) {
+                while (ite-- > 0) {
+                    for (int i = 0; i < _nw - 1; i++) {
+                        for (int j = 0; j < _str[i + 1]; j++) {
+                            for (int k = 0; k < _str[i]; k++) {
+                                _diff[i][j][k] = _neuro[i][j][k] - _prev[i][j][k];
+                                _prev[i][j][k] = _neuro[i][j][k];
+                            }
+                        }
+                    }
+
+                    std::shuffle(teachers.begin(), teachers.end(), vstd::rng());
+
+                    for (auto t:teachers) {
+                        o(t.first);
+                        e(t.first, t.second);
+
+                        for (int j = 0; j < _nw - 1; j++) {
+                            for (int k = 0; k < _str[j + 1]; k++) {
+                                for (int l = 0; l < _str[j]; l++) {
+                                    _neuro[j][k][l] += (_eta * _e[j][k] * _o[j][l]) / teachers.size();
+                                }
+                            }
+                        }
+                    }
+
+                    for (int i = 0; i < _nw - 1; i++) {
+                        for (int j = 0; j < _str[i + 1]; j++) {
+                            for (int k = 0; k < _str[i]; k++) {
+                                _neuro[i][j][k] += _alfa * _diff[i][j][k];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        double erms() {
+            double erms = 0;
+            double tmp;
+            double *out_t, *out_n;
+            for (auto teacher : teachers) {
+                tmp = 0;
+                out_t = teacher.second;
+                o(teacher.first);
+                for (int k = 0; k < _str[_nw - 1]; k++) {
+                    tmp += std::pow(out_t[k] - _o[_nw - 1][k], 2);
+                }
+                erms += std::sqrt(tmp / _str[_nw - 1]);
+            }
+            return erms / teachers.size();
+        }
+
+        double test() {
+            double erms = 0;
+            double tmp;
+            double *out_t, *out_n;
+            for (auto teacher : tests) {
+                tmp = 0;
+                out_t = teacher.second;
+                o(teacher.first);
+                for (int k = 0; k < _str[_nw - 1]; k++) {
+                    tmp += std::pow(out_t[k] - _o[_nw - 1][k], 2);
+                }
+                erms += std::sqrt(tmp / _str[_nw - 1]);
+            }
+            return erms / teachers.size();
+        }
+
+        neuro(std::vector<int> str,
+              double alfa,
+              double beta,
+              double eta
+        ) :
+
+                _str(str), _alfa(alfa),
+                _beta(beta),
+                _eta(eta),
+                _nw((unsigned int) str.size()) {
+            _neuro = vstd::allocate<double **>(_nw - 1);
+            _prev = vstd::allocate<double **>(_nw - 1);
+            _diff = vstd::allocate<double **>(_nw - 1);
+            for (int i = 0; i < _nw - 1; i++) {
+                _neuro[i] = vstd::allocate<double *>(_str[i + 1]);
+                _prev[i] = vstd::allocate<double *>(_str[i + 1]);
+                _diff[i] = vstd::allocate<double *>(_str[i + 1]);
+                for (int j = 0; j < _str[i + 1]; j++) {
+                    _neuro[i][j] = vstd::allocate<double>(_str[i]);
+                    _prev[i][j] = vstd::allocate<double>(_str[i]);
+                    _diff[i][j] = vstd::allocate<double>(_str[i]);
+                    for (int k = 0; k < _str[i]; k++) {
+                        _diff[i][j][k] = _neuro[i][j][k] = _prev[i][j][k] = vstd::rand();
+                    }
+                }
+            }
+
+            _e = vstd::allocate<double *>(_nw - 1);
+            for (int i = 0; i < _nw - 1; i++) {
+                _e[i] = vstd::allocate<double>(_str[i + 1]);
+            }
+
+            _o = vstd::allocate<double *>(_nw);
+            for (int i = 0; i < _nw; i++) {
+                _o[i] = vstd::allocate<double>(_str[i]);
+            }
+        };
+
+
+        ~neuro() {
+            for (int i = 0; i < _nw - 1; i++) {
+                for (int j = 0; j < _str[i + 1]; j++) {
+                    vstd::deallocate(_neuro[i][j], _str[i]);
+                    vstd::deallocate(_prev[i][j], _str[i]);
+                    vstd::deallocate(_diff[i][j], _str[i]);
+                }
+                vstd::deallocate(_neuro[i], _str[i + 1]);
+                vstd::deallocate(_prev[i], _str[i + 1]);
+                vstd::deallocate(_diff[i], _str[i + 1]);
+            }
+            vstd::deallocate(_neuro, _nw - 1);
+            vstd::deallocate(_prev, _nw - 1);
+            vstd::deallocate(_diff, _nw - 1);
+
+            for (int i = 0; i < _nw - 1; i++) {
+                vstd::deallocate(_e[i], _str[i + 1]);
+            }
+            vstd::deallocate(_e, _nw - 1);
+
+            for (int i = 0; i < _nw; i++) {
+                vstd::deallocate(_o[i], _str[i]);
+            }
+            vstd::deallocate(_o, _nw - 1);
+
+            for (auto teacher:teachers) {
+                vstd::deallocate(teacher.first, _str[0]);
+                vstd::deallocate(teacher.second, _str[_str.size() - 1]);
+            }
+
+            for (auto test:tests) {
+                vstd::deallocate(test.first, _str[0]);
+                vstd::deallocate(test.second, _str[_str.size() - 1]);
+            }
+        }
+    };
+}

--- a/vstd/vstd.h
+++ b/vstd/vstd.h
@@ -1,0 +1,41 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "vstring.h"
+#include "vadaptors.h"
+#include "vassert.h"
+#include "vcast.h"
+#include "vdefines.h"
+#include "vfunctional.h"
+#include "vfuture.h"
+#include "vhash.h"
+#include "vhex.h"
+#include "vlazy.h"
+#include "vthread.h"
+#include "vtraits.h"
+#include "vutil.h"
+#include "vchain.h"
+#include "vconverter.h"
+#include "vlogger.h"
+#include "vmeta.h"
+#include "vneuro.h"
+#include "vany.h"
+#include "vcache.h"
+#include "vtuple.h"
+#include "vbind.h"
+
+#ifdef SDL_h_
+
+#include "veventloop.h"
+
+#endif

--- a/vstd/vstring.h
+++ b/vstd/vstring.h
@@ -1,0 +1,197 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <cstdio>
+#include <cstring>
+#include <list>
+#include <string>
+#include <sstream>
+#include <algorithm>
+#include <functional>
+#include <cctype>
+#include <locale>
+#include <type_traits>
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <utility>
+#include "vdefines.h"
+#include "vutil.h"
+
+namespace vstd {
+    template<typename T, typename = void>
+    struct has_to_std_string : std::false_type {};
+
+    template<typename T>
+    struct has_to_std_string<T, std::void_t<decltype(std::declval<T>().toStdString())>> : std::true_type {};
+
+    class stringable {
+    public:
+        virtual std::string to_string() = 0;
+    };
+
+    template<typename T=void>
+    std::string replace(std::string str, const std::string &from, const std::string &to) {
+        size_t start_pos = str.find(from);
+        if (start_pos == std::string::npos) {
+            return str;
+        }
+        str.replace(start_pos, from.length(), to);
+        return replace(str, from, to);
+    }
+
+    template<typename T=void>
+    std::string ltrim(std::string s) {
+        s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not_fn<int(int)>(std::isspace)));
+        return s;
+    }
+
+    template<typename T=void>
+    std::string rtrim(std::string s) {
+        s.erase(std::find_if(s.rbegin(), s.rend(), std::not_fn<int(int)>(std::isspace)).base(), s.end());
+        return s;
+    }
+
+    template<typename T=void>
+    std::string trim(const std::string &s) {
+        return ltrim(rtrim(s));
+    }
+
+    template<typename T=void>
+    bool is_empty(const std::string &string) {
+        return trim(string).length() == 0;
+    }
+
+    template<typename T, typename std::enable_if<!has_to_std_string<T>::value, int>::type = 0>
+    std::string str(T c) {
+        std::stringstream st;
+        st << c;
+        return st.str();
+    }
+
+    template<typename T, typename std::enable_if<has_to_std_string<T>::value, int>::type = 0>
+    std::string str(const T &c) {
+        return c.toStdString();
+    }
+
+    template<typename T, typename... Args>
+    std::string str(T c, Args... args) {
+        std::stringstream st;
+        st << c;
+        return st.str() + vstd::str(args...);
+    }
+
+    template<typename T=void>
+    std::string str(const std::shared_ptr<stringable> &c) {
+        return c->to_string();
+    }
+
+    template<typename T=void>
+    std::pair<int, bool> to_int(const std::string &s) {
+        if (isdigit(s[0])) {
+            try {
+                size_t result;
+                int value = std::stoi(s, &result);
+                if (result != s.size()) {
+                    return std::make_pair(value, false);
+                }
+                return std::make_pair(value, true);
+            } catch (...) {
+            }
+        }
+        return std::make_pair(0, false);
+    }
+
+    template<typename T=void>
+    bool is_int(const std::string &s) {
+        return to_int(s).second;
+    }
+
+    template<typename Ctn=std::list<std::string> >
+    std::string join(Ctn list, const std::string &sep) {
+        std::stringstream stream;
+        unsigned int i = 0;
+        for (const std::string &str: list) {
+            stream << str;
+            if (i++ != list.size() - 1) {
+                stream << sep;
+            }
+        }
+        return stream.str();
+    }
+
+    template<typename T=void>
+    std::vector<std::string> split(const std::string &s, char delim) {
+        std::vector<std::string> elems;
+        std::stringstream ss(s);
+        std::string item;
+        while (std::getline(ss, item, delim)) {
+            elems.push_back(item);
+        }
+        return elems;
+    }
+
+    template<typename T, typename U>
+    bool string_equals(T a, U b) {
+        return str(a) == str(b);
+    }
+
+    template<typename T=void>
+    bool ends_with(const std::string &full_string, const std::string &ending) {
+        if (full_string.length() >= ending.length()) {
+            return (0 == full_string.compare(full_string.length() - ending.length(), ending.length(), ending));
+        } else {
+            return false;
+        }
+    }
+
+    template<typename T=void>
+    wchar_t *to_wchar(const char *text) {
+        size_t size = strlen(text) + 1;
+        auto *wa = new wchar_t[size];
+        mbstowcs(wa, text, size);
+        return wa;
+    }
+
+    template<typename T=void>
+    wchar_t **to_wchar(int size, const char **text) {
+        auto **wa = new wchar_t *[size];
+        for (int i = 0; i < size; i++) {
+            wa[i] = to_wchar(text[i]);
+        }
+        return wa;
+    }
+
+    template<typename T=void>
+    std::string stem(const std::string &script) {
+        return boost::filesystem::path(script).stem().string();
+    }
+
+    template<typename T=void>
+    void add_line(std::string &org, const std::string &_new) {
+        if (!_new.empty()) {
+            org += "\n" + _new;
+        }
+    }
+
+    template<typename T=void>
+    std::string camel(std::string org) {
+        if (ctn(org, ' ')) {
+            std::string ret;
+            for (const auto &str: split(org, ' ')) {
+                ret += (camel(str) + " ");
+            }
+            return ret;
+        }
+        return boost::to_upper_copy<std::string>(org.substr(0, 1)) + org.substr(1, org.length());
+    }
+}

--- a/vstd/vthread.h
+++ b/vstd/vthread.h
@@ -1,0 +1,76 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "vdefines.h"
+#include "vtraits.h"
+#include "vutil.h"
+#include "vthreadpool.h"
+
+namespace vstd {
+    extern std::function<void(std::function<void()>)> get_call_later_handler();
+
+    extern std::function<void(std::function<void()>)> get_call_async_handler();
+
+    extern std::function<void(std::function<void()>)> get_call_now_handler();
+
+    extern std::function<void(std::function<void()>)> get_call_later_block_handler();
+
+    extern std::function<void(std::function<bool()>)> get_wait_until_handler();
+
+    extern std::function<void(std::function<bool()>, std::function<void()>)> get_call_when_handler();
+
+    extern std::function<void(int, std::function<void()>)> get_call_delayed_async_handler();
+
+    extern std::function<void(int, std::function<void()>)> get_call_delayed_later_handler();
+
+    template<typename Function, typename... Arguments>
+    void call_later(Function target, Arguments... args) {
+        get_call_later_handler()(vstd::bind(target, args...));
+    }
+
+    template<typename Function, typename... Arguments>
+    void call_async(Function target, Arguments... args) {
+        get_call_async_handler()(vstd::bind(target, args...));
+    }
+
+    template<typename Function, typename... Arguments>
+    void call_now(Function target, Arguments... args) {
+        get_call_now_handler()(vstd::bind(target, args...));
+    }
+
+    template<typename Function, typename... Arguments>
+    void call_later_block(Function target, Arguments... args) {
+        get_call_later_block_handler()(vstd::bind(target, args...));
+    }
+
+
+    template<typename Predicate>
+    void wait_until(Predicate pred) {
+        get_wait_until_handler()(pred);
+    }
+
+    template<typename Predicate, typename Function, typename... Arguments>
+    void call_when(Predicate pred, Function func, Arguments... params) {
+        get_call_when_handler()(pred,vstd::bind(func, params...));
+    }
+
+    template<typename Function, typename... Arguments>
+    void call_delayed_async(int millis, Function target, Arguments... args) {
+        get_call_delayed_async_handler()(millis, vstd::bind(target, args...));
+    }
+
+    template<typename Function, typename... Arguments>
+    void call_delayed_later(int millis, Function target, Arguments... args) {
+        get_call_delayed_later_handler()(millis, vstd::bind(target, args...));
+    }
+}

--- a/vstd/vthreadpool.h
+++ b/vstd/vthreadpool.h
@@ -1,0 +1,63 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <thread>
+
+namespace vstd {
+    namespace detail {
+        class worker_thread {
+        public:
+            template<typename thread_pool>
+            void operator()(std::shared_ptr<thread_pool> pool, std::shared_ptr<worker_thread> self) {
+                do {
+                    pool->_queue.pop(vstd::functional::call<std::function<void() >>);
+                } while (self.use_count() > 1);
+            }
+        };
+    }
+
+    template<int _worker_count, typename worker_thread=detail::worker_thread>
+    class thread_pool : public std::enable_shared_from_this<thread_pool<_worker_count, worker_thread>> {
+        friend worker_thread;
+    public:
+        template<typename F, typename... Args>
+        void execute(F f, Args... args) {
+            _queue.push(vstd::bind(f, args...));
+        }
+
+        std::shared_ptr<thread_pool> start() {
+            std::unique_lock<std::recursive_mutex> lock(_worker_lock);
+            while (_workers.size() < _worker_count) {
+                add_worker();
+            }
+            return this->shared_from_this();
+        }
+
+    private:
+        void add_worker() {
+            std::unique_lock<std::recursive_mutex> lock(_worker_lock);
+            auto worker = std::make_shared<worker_thread>();
+            _workers.insert(worker);
+            std::thread(*worker, this->shared_from_this(), worker).detach();
+        }
+
+        void del_worker() {
+            std::unique_lock<std::recursive_mutex> lock(_worker_lock);
+            _workers.erase(_workers.begin());
+        }
+
+        vstd::blocking_queue<std::function<void() >> _queue;
+        std::set<std::shared_ptr<worker_thread>> _workers;
+        std::recursive_mutex _worker_lock;
+    };
+}

--- a/vstd/vtraits.h
+++ b/vstd/vtraits.h
@@ -1,0 +1,168 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <string>
+#include "vstd.h"
+#include "vtuple.h"
+
+namespace vstd {
+    template<bool B, typename T = void> using enable_if = std::enable_if<B, T>;
+    template<bool B, typename T = void> using disable_if = std::enable_if<!B, T>;
+
+    using std::is_enum;
+    using std::is_same;
+    using std::is_base_of;
+    using std::is_void;
+
+    namespace detail {
+        template<typename T>
+        struct return_type
+                : public return_type<decltype(&T::operator())> {
+        };
+
+        template<typename ClassType, typename ReturnType, typename... Args>
+        struct return_type<ReturnType (ClassType::*)(Args...) const> {
+            typedef ReturnType type;
+        };
+
+        template<size_t i>
+        void args(typename vstd::enable_if<i == 0>::type * = 0) {}
+
+        template<size_t i, typename... Args>
+        typename vstd::tuple_element<i, Args...>
+
+        ::type
+        args(typename vstd::disable_if<sizeof... (Args) == 0>::type * = 0) {
+            //return std::declval<typename std::tuple_element<i, std::tuple<Args...>>::type>() ;
+        }
+    }
+
+    template<typename T>
+    struct function_traits
+            : public function_traits<decltype(&T::operator())> {
+    };
+
+    template<typename ClassType, typename ReturnType, typename... Args>
+    struct function_traits<ReturnType (ClassType::*)(Args...) const> {
+
+        constexpr static size_t arity = sizeof... (Args);
+
+
+        typedef ReturnType return_type;
+
+        template<size_t i>
+        struct arg {
+            typedef decltype(detail::args<i, Args...>()) type;
+        };
+
+        typedef typename arg<0>::type first_arg;
+    };
+
+    template<typename T, typename... Args>
+    class has_insert {
+        template<typename C,
+                typename = decltype(std::declval<C>().insert(std::declval<Args>()...))>
+        static std::true_type test(int);
+
+        template<typename C>
+        static std::false_type test(...);
+
+    public:
+        static constexpr bool value = decltype(test<T>(0))
+        ::value;
+    };
+
+    template<typename Range>
+    struct range_traits {
+        typedef typename vstd::function_traits<decltype(&Range::begin)>::return_type iterator;
+        typedef typename vstd::function_traits<decltype(&iterator::operator*)>::return_type value_type;
+    };
+
+    template<typename T>
+    struct clear_type {
+        typedef typename std::remove_reference<typename std::remove_cv<T>::type>::type type;
+    };
+
+    template<typename T, typename U>
+    struct is_same_clear : public std::is_same<typename clear_type<T>::type, typename clear_type<U>::type> {
+
+    };
+
+    template<class T, class R = void>
+    struct enable_if_type {
+        typedef R type;
+    };
+
+    template<class T, class Enable = void>
+    struct is_shared_ptr : std::false_type {
+    };
+
+    template<class T>
+    struct is_shared_ptr<T, typename enable_if_type<typename T::element_type>::type> : std::true_type {
+    };
+
+    template<class T, class Enable = void>
+    struct is_set : std::false_type {
+    };
+
+    template<class T>
+    struct is_set<T, typename std::enable_if<std::is_same<typename T::key_type, typename T::value_type>::value>::type>
+            : std::true_type {
+    };
+
+    template<class T, class E1 = void, class E2 = void, class E3 = void>
+    struct is_map : std::false_type {
+    };
+
+    template<class T>
+    struct is_map<T, typename enable_if_type<typename T::key_type>::type, typename enable_if_type<typename T::value_type>::type, typename disable_if<is_set<T>::value>::type>
+            : std::true_type {
+    };
+
+    template<class T, class E1 = void, class E2 = void>
+    struct is_pair : std::false_type {
+    };
+
+    template<class T>
+    struct is_pair<T, typename enable_if_type<typename T::first_type>::type, typename enable_if_type<typename T::second_type>::type>
+            : std::true_type {
+    };
+
+    template<class T, class E1 = void, class E2=void>
+    struct is_range : std::false_type {
+    };
+
+    template<class T>
+    struct is_range<T, typename enable_if_type<typename T::value_type>::type,
+            typename disable_if<is_same_clear<T, std::string>::value>::type> : std::true_type {
+    };
+
+    template<class T, class E1 = void, class E2=void, class E3=void>
+    struct is_container : std::false_type {
+    };
+
+    template<class T>
+    struct is_container<T, typename enable_if_type<typename T::value_type>::type,
+            typename enable_if<has_insert<T, typename T::value_type>::value>::type,
+            typename disable_if<is_same_clear<T, std::string>::value>::type> : std::true_type {
+    };
+
+    template<class T, class E1 = void>
+    struct is_pure_range : std::false_type {
+    };
+
+    template<class T>
+    struct is_pure_range<T, typename std::enable_if<
+            is_range<T>::value && !is_container<T>::value>::type> : std::true_type {
+    };
+}

--- a/vstd/vtuple.h
+++ b/vstd/vtuple.h
@@ -1,0 +1,34 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+namespace vstd {
+
+    template<std::size_t __i, typename _Head, typename... _Tail>
+    struct tuple_element : tuple_element<__i - 1, _Tail...> {
+    };
+
+    template<typename _Head, typename... _Tail>
+    struct tuple_element<0, _Head, _Tail...> {
+        typedef _Head type;
+    };
+
+    template<typename _Head=void, typename... _Tail>
+    struct tuple_size {
+        static constexpr size_t size = tuple_size<_Tail...>::size + 1;
+    };
+
+    template<>
+    struct tuple_size<void> {
+        static constexpr size_t size = 0;
+    };
+}

--- a/vstd/vutil.h
+++ b/vstd/vutil.h
@@ -1,0 +1,352 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Andrzej Lis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include <list>
+#include <set>
+#include <random>
+#include <chrono>
+#include <mutex>
+#include <condition_variable>
+#include <boost/pool/pool_alloc.hpp>
+#include <boost/any.hpp>
+#include <queue>
+#include "vtraits.h"
+#include "vhash.h"
+#include "vcast.h"
+
+namespace vstd {
+    template<typename Container>
+    auto any(Container &container) {
+        return *std::find_if(container.begin(), container.end(), [](auto it) { return true; });
+    }
+
+    template<typename Container, typename Value>
+    bool ctn(Container &container, Value value) {
+        return container.find(value) != container.end();
+    }
+
+    template<typename Container=std::string, typename Value>
+    bool ctn(std::string &container, Value value) {
+        return container.find(value) != std::string::npos;
+    }
+
+    template<typename Container, typename Value, typename Comparator>
+    bool ctn(Container &container, Value value, Comparator cmp) {
+        for (auto x: container) {
+            if (cmp(value, x)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    template<typename Container, typename Predicate>
+    bool ctn_pred(Container &container, Predicate pred) {
+        return std::find_if(container.begin(), container.end(), pred) != container.end();
+    }
+
+    template<typename Container, typename Predicate>
+    auto find_if(Container &container, Predicate predicate) {
+        return *std::find_if(container.begin(), container.end(), predicate);
+    }
+
+    template<typename Container, typename Predicate, typename Callback>
+    auto execute_if(Container &container, Predicate predicate, Callback callback) {
+        if (std::find_if(container.begin(), container.end(), predicate) != container.end()) {
+            callback(*std::find_if(container.begin(), container.end(), predicate));
+        }
+    }
+
+
+    template<typename Container, typename Value, typename Comparator>
+    void erase(Container &container, Value value, Comparator cmp) {
+        for (auto it = container.begin(); it != container.end(); it++) {
+            if (cmp(value, *it)) {
+                container.erase(it);
+                break;
+            }
+        }
+    }
+
+    template<typename Container, typename Predicate>
+    void erase_if(Container &container, Predicate predicate) {
+        for (auto it = container.begin(); it != container.end(); it++) {
+            if (predicate(*it)) {
+                container.erase(it);
+                break;
+            }
+        }
+    }
+
+    template<typename Container>
+    auto get(Container &container, int index) {
+        return *std::next(container.begin(), index);
+    }
+
+
+    template<typename T, typename U>
+    bool castable(std::shared_ptr<U> ptr) {
+        return std::dynamic_pointer_cast<T>(ptr).operator bool();
+    }
+
+    template<typename A, typename B>
+    auto type_pair() {
+        return std::make_pair(boost::typeindex::type_id<A>(), boost::typeindex::type_id<B>());
+    }
+
+    template<typename F, typename... Args>
+    std::function<typename function_traits<F>::return_type()> bind(F f, Args... args) {
+        return std::bind(f, args...);
+    }
+
+    template<typename F, typename... Args>
+    std::function<typename function_traits<F>::return_type()> bind(F f) {
+        return f;
+    }
+
+    template<typename Range, typename Value=typename range_traits<Range>::value_type>
+    std::set<Value> collect(Range r) {
+        return cast<std::set<Value>>(r);
+    }
+
+    template<typename T>
+    typename T::value_type pop(T &t) {
+        auto x = t.front();
+        t.pop();
+        return x;
+    }
+
+    template<typename T>
+    typename T::value_type pop_p(T &t) {
+        auto x = t.top();
+        t.pop();
+        return x;
+    }
+
+    template<typename T>
+    class list : public std::list<T> {
+    public:
+        template<typename U>
+        void insert(U u) {
+            this->push_back(u);
+        }
+    };
+
+    template<typename F,
+            typename ret=typename vstd::function_traits<F>::return_type,
+            typename arg=typename vstd::function_traits<F>::template arg<0>::type>
+    std::function<ret(arg)> make_function(F f,
+                                          typename vstd::disable_if<std::is_void<arg>::value>::type * = 0) {
+        return std::function<ret(arg)>(f);
+    }
+
+    template<typename F,
+            typename ret=typename vstd::function_traits<F>::return_type,
+            typename arg=typename vstd::function_traits<F>::template arg<0>::type>
+    std::function<ret()> make_function(F f,
+                                       typename vstd::enable_if<std::is_void<arg>::value>::type * = 0) {
+        return std::function<ret()>(f);
+    }
+
+//TODO: use somewhere std::priority_queue<T,std::vector<T>,std::function<bool ( T,T ) >>
+    template<typename T, typename Queue=std::queue<T>>
+    class blocking_queue {
+    private:
+        std::recursive_mutex d_mutex;
+        std::condition_variable_any d_condition;
+        Queue d_queue;
+    public:
+        typedef T value_type;
+
+        void push(T value) {
+            std::unique_lock<std::recursive_mutex> lock(d_mutex);
+            d_queue.push(value);
+            d_condition.notify_one();
+        }
+
+        void pop(std::function<void(T)> callback) {
+            T value;
+            {
+                std::unique_lock<std::recursive_mutex> lock(d_mutex);
+                d_condition.wait(lock, [this]() {
+                    return !d_queue.empty();
+                });
+                value = vstd::pop(d_queue);
+            }
+            callback(value);
+        }
+    };
+
+    template<typename T=void>
+    std::mt19937_64 &rng() {
+        static std::mt19937_64 rng((unsigned long) std::time(nullptr));
+        return rng;
+    }
+
+    template<typename T=void>
+    std::uniform_real_distribution<double> &unif() {
+        static std::uniform_real_distribution<double> unif(-0.5, 0.5);
+        return unif;
+    }
+
+    template<typename T=void>
+    double rand() {
+        return unif()(rng());
+    };
+
+    template<typename T, typename U>
+    int rand(T min, U max) {
+        return round((unif()(rng()) + 0.5) * (max - min)) + min;
+    };
+
+    template<typename T>
+    int rand(T max) {
+        return rand(0, max);
+    };
+
+    template<typename Ctn>
+    auto random_element(Ctn ctn) {
+        auto iterator = ctn.begin();
+        std::advance(iterator, vstd::rand(boost::size(ctn) - 1));
+        return *iterator;
+    };
+
+    template<typename Ctn>
+    auto random_components(int value, Ctn possibleComponents) {
+        std::list<int> returnValue;
+        while (value > 0) {
+            std::set<int> possible_values;
+            for (const auto &it: possibleComponents) {
+                if (it <= value) {
+                    possible_values.insert(it);
+                }
+            }
+            if (possible_values.empty()) {
+                break;
+            }
+            int pow = vstd::random_element(possible_values);
+            returnValue.push_back(pow);
+            value -= pow;
+        }
+        return returnValue;
+    };
+
+    template<typename T>
+    static T *allocate(size_t size) {
+        static boost::pool_allocator<T> _pool;
+        return _pool.allocate(size);
+    }
+
+    template<typename T>
+    static void deallocate(T *t, size_t size) {
+        static boost::pool_allocator<T> _pool;
+        _pool.deallocate(t, size);
+    }
+
+    template<typename T>
+    typename T::value_type *as_array(T vec) {
+        auto ret = vstd::allocate<typename T::value_type>(vec.size());
+        std::copy(std::begin(vec), std::end(vec), ret);
+        return ret;
+    }
+
+//TODO: handle return types
+    template<typename T, typename C>
+    static void if_not_null(T object, C callback) {
+        if (object) {
+            callback(object);
+        }
+    }
+
+    template<typename T>
+    static double percent(T object, double percent) {
+        return object * (percent / 100.0);
+    }
+
+    template<typename R, typename T, typename F>
+    R with(T t, F f, typename vstd::enable_if<std::is_void<R>::value>::type * = 0) {
+        if (t) {
+            f(t);
+        }
+    };
+
+    template<typename R, typename T, typename F>
+    R with(T t, F f, typename vstd::disable_if<std::is_void<R>::value>::type * = 0) {
+        if (t) {
+            return f(t);
+        }
+        return R();
+    }
+
+    template<typename A>
+    bool all_equals(A) {
+        return true;
+    }
+
+    template<typename A, typename B, typename...Args>
+    bool all_equals(A a, B b, Args... args) {
+        return a == b && all_equals(a, args...) && all_equals(b, args...);
+    }
+
+    template<typename T, typename ...Args>
+    std::set<T> set(T arg, Args... args) {
+        std::set<T> ret = vstd::set(args...);
+        ret.insert(arg);
+        return ret;
+    }
+
+    template<typename T>
+    std::set<T> set(T arg) {
+        std::set<T> ret;
+        ret.insert(arg);
+        return ret;
+    }
+
+    template<typename T, typename ...Args>
+    std::list<T> as_list(T arg, Args... args) {
+        std::list<T> ret = vstd::as_list(args...);
+        ret.push_back(arg);
+        return ret;
+    }
+
+    template<typename T>
+    std::list<T> as_list(T arg) {
+        std::list<T> ret;
+        ret.push_back(arg);
+        return ret;
+    }
+
+    template<typename T, typename U, typename V=typename T::key_type>
+    auto set_difference(T &first, U &last) {
+        std::set<V> to_add;
+        std::set<V> to_remove;
+
+        for (auto elem: last) {
+            if (!vstd::ctn(first, elem)) {
+                to_add.insert(elem);
+            }
+        }
+        for (auto elem: first) {
+            if (!vstd::ctn(last, elem)) {
+                to_remove.insert(elem);
+            }
+        }
+
+        return std::make_pair(to_add, to_remove);
+    }
+
+    template<typename T=void>
+    auto square_ctn(auto w, auto h, auto x, auto y) {
+        return x < w && y < h && !(x < 0) && !(y < 0);
+    }
+}


### PR DESCRIPTION
## What changed
- modernized the historical Qt build to configure with current CMake, Qt6, Python3 development headers, and Boost.Python
- replaced removed Qt OpenGL APIs (`QGLWidget`/`QGLFormat`) with `QOpenGLWidget` and `QSurfaceFormat`
- fixed legacy compatibility issues in serialization, utility helpers, script handling, and delayed-call glue so the code builds on a modern toolchain
- vendored `vstd` into the branch and removed the old submodule wiring so the restored snapshot is self-contained
- added the missing copy-constructor definitions that the current Qt metatype/moc flow expects at link time

## Why
This branch restores the last Qt-based snapshot to a buildable state on a dedicated historical branch instead of trying to retrofit the current `main` branch.

## Validation performed
- `cmake -S . -B build-qt`
- `cmake --build build-qt -j$(nproc)`
- `ctest --test-dir build-qt --output-on-failure` (`No tests were found!!!` on this historical snapshot)
- `QT_QPA_PLATFORM=offscreen timeout 2s ./build-qt/game` (the process stayed alive until the timeout without an immediate crash)

## Known limitations / follow-up work
- this PR intentionally compares `codex/restore-qt-compilable` against `codex/qt-last-snapshot-base` (`aa73c084`) so the review shows only the restoration commit
- the historical snapshot predates the current repository test harness, so there is no `test.py` or C++ unit-test target to run here
- this is a restoration branch for archival or further porting work, not a proposed merge back into modern `main`
