### PR TITLE
Recover the earliest runnable game snapshot

### DIFF
--- a/Game.pro
+++ b/Game.pro
@@ -1,0 +1,12 @@
+QT += core gui widgets
+
+TARGET = LegacyGame2013
+TEMPLATE = app
+CONFIG += c++11
+
+INCLUDEPATH += $$PWD
+DEPENDPATH += $$PWD
+
+SOURCES += $$files($$PWD/*.cpp, true)
+SOURCES -= $$files($$PWD/moc_*.cpp, true)
+HEADERS += $$files($$PWD/*.h, true)

--- a/animation/animatedobject.h
+++ b/animation/animatedobject.h
@@ -6,25 +6,22 @@
 #include <QGraphicsPixmapItem>
 #include <QTimer>
 
-class AnimatedObject : private QObject,protected QGraphicsPixmapItem
-{
-    Q_OBJECT
+class AnimatedObject : public QObject, public QGraphicsPixmapItem {
+  Q_OBJECT
 public:
-    explicit AnimatedObject();
-    ~AnimatedObject();
+  explicit AnimatedObject();
+  ~AnimatedObject();
+
 protected:
-    Animation *animation;
-    void setPixmap(const QPixmap &pixmap);
-    void setAnimation(std::string path);
-
-
+  Animation *animation;
+  void setPixmap(const QPixmap &pixmap);
+  void setAnimation(std::string path);
 
 private:
-    QTimer *timer;
+  QTimer *timer;
 
 private slots:
-    void animate();
-
+  void animate();
 };
 
 #endif // ANIMATEDOBJECT_H

--- a/animation/animationprovider.cpp
+++ b/animation/animationprovider.cpp
@@ -1,111 +1,119 @@
 #include "animationprovider.h"
 
+#include <QBitmap>
+#include <QColor>
+#include <QDebug>
+#include <QPainter>
 #include <animation/animation.h>
+#include <fstream>
 #include <map/tiles/tile.h>
 #include <sstream>
-#include <fstream>
-#include <QBitmap>
-#include <QDebug>
 
-AnimationProvider *AnimationProvider::instance=0;
+namespace {
 
-Animation *AnimationProvider::getAnim(std::string path)
-{
-    if(!instance)
-    {
-        instance=new AnimationProvider();
-    }
-    return instance->getAnimation(path);
+QPixmap makePlaceholder(const std::string &path) {
+  QPixmap pixmap(Tile::size, Tile::size);
+  const int seed = static_cast<int>(std::hash<std::string>{}(path) % 255);
+  pixmap.fill(
+      QColor((seed + 40) % 255, (seed * 2 + 90) % 255, (seed * 3 + 140) % 255));
+
+  QPainter painter(&pixmap);
+  painter.setPen(QColor("black"));
+  painter.drawRect(0, 0, Tile::size - 1, Tile::size - 1);
+  painter.end();
+
+  return pixmap;
 }
 
-void AnimationProvider::terminate()
-{
-    delete instance;
+} // namespace
+
+AnimationProvider *AnimationProvider::instance = 0;
+
+Animation *AnimationProvider::getAnim(std::string path) {
+  if (!instance) {
+    instance = new AnimationProvider();
+  }
+  return instance->getAnimation(path);
 }
 
-AnimationProvider::AnimationProvider()
-{
+void AnimationProvider::terminate() { delete instance; }
 
+AnimationProvider::AnimationProvider() {}
+
+AnimationProvider::~AnimationProvider() {
+
+  for (iterator it = begin(); it != end(); it++) {
+    delete (*it).second;
+  }
+  clear();
 }
 
-AnimationProvider::~AnimationProvider()
-{
-
-    for(iterator it=begin(); it!=end(); it++)
-    {
-        delete (*it).second;
-    }
-    clear();
+Animation *AnimationProvider::getAnimation(std::string path) {
+  if (this->find(path) != this->end()) {
+    return this->at(path);
+  } else if (this->find("assets:/" + path) != this->end()) {
+    return this->at("assets:/" + path);
+  }
+  loadAnim(path);
+  return getAnimation(path);
 }
 
-Animation *AnimationProvider::getAnimation(std::string path)
-{
-    if(this->find(path)!=this->end()) {
-        return this->at(path);
-    } else if(this->find("assets:/"+path)!=this->end())
-    {
-        return this->at("assets:/"+path);
+void AnimationProvider::loadAnim(std::string path) {
+  Animation *anim = new Animation();
+  QPixmap *img = 0;
+  std::map<int, int> timemap;
+
+  std::ifstream time;
+
+  time.open((path + "time.txt").c_str());
+
+  if (time.is_open()) {
+    for (int i = 0; !time.eof(); i++) {
+      int x;
+      time >> x;
+      timemap.insert(std::pair<int, int>(i, x));
     }
-    loadAnim(path);
-    return getAnimation(path);
-}
+  } else {
+    timemap.insert(std::pair<int, int>(0, 250));
+  }
+  time.close();
 
-void AnimationProvider::loadAnim(std::string path)
-{
-    Animation *anim=new Animation();
-    QPixmap *img=0;
-    std::map<int,int> timemap;
+  for (int i = 0; true; i++) {
+    std::string result;
+    std::ostringstream convert;
+    convert << i;
+    result = convert.str();
 
-    std::ifstream time;
-
-    time.open((path+"time.txt").c_str());
-
-    if (time.is_open())
-    {
-        for (int i=0; !time.eof(); i++)
-        {
-            int x;
-            time >> x;
-            timemap.insert(std::pair<int,int>(i,x));
-        }
-    } else
-    {
-        timemap.insert(std::pair<int,int>(0,250));
+    QPixmap image((path + result + ".png").c_str());
+    if (image.isNull()) {
+      image.load(QString::fromStdString(":/" + path + result + ".png"));
     }
-    time.close();
+    if (!image.isNull() && !image.hasAlphaChannel())
+      image.setMask(image.createHeuristicMask());
 
-
-    for(int i=0; true; i++)
-    {
-        std::string result;
-        std::ostringstream convert;
-        convert << i;
-        result = convert.str();
-
-        QPixmap image((path+result+".png").c_str());
-        if(!image.hasAlphaChannel())
-            image.setMask(image.createHeuristicMask());
-
-        if(!image.isNull())
-        {
-            img = new QPixmap(image.scaled(Tile::size,Tile::size,Qt::IgnoreAspectRatio,Qt::SmoothTransformation));
-        }
-        else
-        {
-            if(anim->size()==0&&path.find("assets:/")==std::string::npos)
-            {
-                delete anim;
-                loadAnim("assets:/"+path);
-                return;
-            }
-            break;
-        }
-        int frame;
-        if(timemap.size()==1)frame=timemap.at(0);
-        else frame=timemap.at(i);
-
-        anim->add(img,frame);
+    if (!image.isNull()) {
+      img = new QPixmap(image.scaled(Tile::size, Tile::size,
+                                     Qt::IgnoreAspectRatio,
+                                     Qt::SmoothTransformation));
+    } else {
+      if (anim->size() == 0 && path.find("assets:/") == std::string::npos) {
+        delete anim;
+        loadAnim("assets:/" + path);
+        return;
+      }
+      if (anim->size() == 0) {
+        anim->add(new QPixmap(makePlaceholder(path)), timemap.at(0));
+      }
+      break;
     }
-    this->insert(std::pair<std::string,Animation*>(path,anim));
-    qDebug() << "Loaded animation:" << path.c_str();
+    int frame;
+    if (timemap.size() == 1)
+      frame = timemap.at(0);
+    else
+      frame = timemap.at(i);
+
+    anim->add(img, frame);
+  }
+  this->insert(std::pair<std::string, Animation *>(path, anim));
+  qDebug() << "Loaded animation:" << path.c_str();
 }

--- a/creatures/creature.cpp
+++ b/creatures/creature.cpp
@@ -1,0 +1,275 @@
+#include "creature.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <sstream>
+
+#include <interactions/attacks/attack.h>
+#include <interactions/interaction.h>
+#include <items/armors/armor.h>
+#include <items/weapons/weapon.h>
+#include <stats/stats.h>
+#include <view/gamescene.h>
+#include <view/gameview.h>
+
+namespace {
+
+int clamp_ratio(int value, int maximum) {
+  if (maximum <= 0)
+    return 100;
+  if (value <= 0)
+    return 0;
+  return std::min(100, value * 100 / maximum);
+}
+
+int stat_resisted(int value, int resist) {
+  const int clamped = std::max(0, std::min(90, resist));
+  return value * (100 - clamped) / 100;
+}
+
+} // namespace
+
+Creature::Creature(Map *map, int x, int y) : MapObject(map, x, y, 2) {
+  className = "Creature";
+  exp = 0;
+  level = 1;
+  sw = 0;
+  mana = 0;
+  manaMax = 0;
+  manaRegRate = 1;
+  hpMax = 0;
+  hp = 0;
+  alive = true;
+  actions = new std::list<Interaction *>();
+  weapon = 0;
+  armor = 0;
+  stats = new Stats();
+  bonusLevel = new Stats();
+  stun = 0;
+
+  addAction(new Attack());
+  attribChange();
+  heal(0);
+  addMana(0);
+}
+
+Creature::~Creature() {
+  if (actions) {
+    actions->clear();
+    delete actions;
+  }
+  delete stats;
+  delete bonusLevel;
+}
+
+int Creature::getExpRatio() {
+  const int required = std::max(1, level * (level + 1) * 500);
+  return clamp_ratio(exp, required);
+}
+
+void Creature::attribChange() {
+  const int effectiveLevel = std::max(1, level + sw);
+  const int oldHpMax = std::max(1, hpMax);
+  const int oldManaMax = std::max(1, manaMax);
+  const float hpRatio = hpMax > 0 ? static_cast<float>(hp) / oldHpMax : 1.0f;
+  const float manaRatio =
+      manaMax > 0 ? static_cast<float>(mana) / oldManaMax : 1.0f;
+
+  stats->setStrength(effectiveLevel + bonusLevel->getStrength());
+  stats->setStamina(effectiveLevel + bonusLevel->getStamina());
+  stats->setAgility(effectiveLevel + bonusLevel->getAgility());
+  stats->setIntelligence(effectiveLevel + bonusLevel->getIntelligence());
+
+  stats->setArmor(bonusLevel->getArmor() + stats->getStamina() / 2);
+  stats->setBlock(bonusLevel->getBlock() + stats->getAgility() / 3);
+
+  stats->setDmgMin(std::max(1, effectiveLevel + bonusLevel->getDmgMin() +
+                                   stats->getStrength() / 2));
+  stats->setDmgMax(std::max(stats->getDmgMin(), effectiveLevel +
+                                                    bonusLevel->getDmgMax() +
+                                                    stats->getStrength()));
+  stats->setHit(bonusLevel->getHit() + effectiveLevel + stats->getAgility());
+  stats->setCrit(bonusLevel->getCrit() + stats->getAgility() / 2);
+
+  stats->setFireResist(bonusLevel->getFireResist());
+  stats->setThunderResist(bonusLevel->getThunderResist());
+  stats->setFrostResist(bonusLevel->getFrostResist());
+  stats->setNormalResist(bonusLevel->getNormalResist());
+
+  stats->setDamage(bonusLevel->getDamage() + stats->getStrength() / 2);
+  stats->setAttack(bonusLevel->getAttack() + effectiveLevel +
+                   stats->getAgility());
+
+  hpMax = 60 + stats->getStamina() * 15;
+  manaMax = 20 + stats->getIntelligence() * 12;
+  manaRegRate = std::max(1, stats->getIntelligence() / 4);
+
+  hp = std::max(1, static_cast<int>(hpRatio * hpMax));
+  mana = std::max(0, static_cast<int>(manaRatio * manaMax));
+}
+
+void Creature::heal(int i) {
+  if (i <= 0)
+    hp = hpMax;
+  else
+    hp = std::min(hpMax, hp + i);
+  alive = hp > 0;
+}
+
+void Creature::healProc(float i) { heal(static_cast<int>(hpMax * i / 100.0f)); }
+
+void Creature::takeDamage(int i) {
+  hp = std::max(0, hp - i);
+  if (hp == 0)
+    alive = false;
+}
+
+void Creature::hurt(Damage damage) {
+  int total = 0;
+  total += stat_resisted(damage.getNormal(), stats->getNormalResist());
+  total += stat_resisted(damage.getFire(), stats->getFireResist());
+  total += stat_resisted(damage.getFrost(), stats->getFrostResist());
+  total += stat_resisted(damage.getThunder(), stats->getThunderResist());
+  hurt(total);
+}
+
+void Creature::hurt(int i) {
+  const int blocked = std::max(0, i - stats->getArmor() / 8);
+  takeDamage(blocked);
+}
+
+int Creature::getDmg() {
+  if (!alive)
+    return 0;
+  const int minDamage = std::max(1, stats->getDmgMin());
+  const int maxDamage = std::max(minDamage, stats->getDmgMax());
+  return minDamage + rand() % (maxDamage - minDamage + 1);
+}
+
+void Creature::fight(Creature *creature) {
+  if (!alive || !creature || !creature->isAlive())
+    return;
+  if (isStun())
+    return;
+
+  Interaction *action = selectAction();
+  if (action) {
+    action->action(this, creature);
+  }
+}
+
+void Creature::levelUp() {
+  level++;
+  attribChange();
+  heal(0);
+  addMana(0);
+}
+
+std::list<Item *> *Creature::getLoot() { return new std::list<Item *>(); }
+
+void Creature::addAction(Interaction *action) {
+  if (!action)
+    return;
+  actions->push_back(action);
+}
+
+int Creature::getMana() { return mana; }
+
+void Creature::addMana(int i) {
+  if (i <= 0)
+    mana = manaMax;
+  else
+    mana = std::min(manaMax, mana + i);
+}
+
+void Creature::addManaProc(float i) {
+  addMana(static_cast<int>(manaMax * i / 100.0f));
+}
+
+void Creature::takeMana(int i) { mana = std::max(0, mana - i); }
+
+bool Creature::isPlayer() {
+  return className == "Player" || className == "Mage" ||
+         className == "Warrior" || className == "Rogue";
+}
+
+int Creature::getHpRatio() { return clamp_ratio(hp, hpMax); }
+
+void Creature::setItem(void *pointer, Item *newItem) {
+  Item **slot = static_cast<Item **>(pointer);
+  if (*slot == newItem)
+    return;
+
+  if (*slot) {
+    (*slot)->onUnequip(this);
+  }
+  *slot = newItem;
+  if (*slot) {
+    (*slot)->onEquip(this);
+  }
+}
+
+void Creature::setWeapon(Weapon *weapon) { setItem(&this->weapon, weapon); }
+
+void Creature::setArmor(Armor *armor) { setItem(&this->armor, armor); }
+
+Weapon *Creature::getWeapon() { return weapon; }
+
+Armor *Creature::getArmor() { return armor; }
+
+bool Creature::isStun() {
+  if (stun <= 0)
+    return false;
+  stun--;
+  return true;
+}
+
+void Creature::addStun(int i) { stun = std::max(stun, i); }
+
+int Creature::getManaRatio() { return clamp_ratio(mana, manaMax); }
+
+void Creature::addExpScaled(int scale) { addExp(std::max(1, scale) * 150); }
+
+void Creature::addExp(int exp) {
+  this->exp += exp;
+  const int required = std::max(1, level * (level + 1) * 500);
+  while (this->exp >= required) {
+    this->exp -= required;
+    levelUp();
+  }
+}
+
+Interaction *Creature::selectAction() {
+  if (actions->empty())
+    return 0;
+
+  for (std::list<Interaction *>::iterator it = actions->begin();
+       it != actions->end(); ++it) {
+    if ((*it)->getManaCost() <= mana)
+      return *it;
+  }
+  return actions->front();
+}
+
+void Creature::mousePressEvent(QGraphicsSceneMouseEvent *event) {
+  Player *player = GameScene::getPlayer();
+  if (!player || player == this || !alive)
+    return;
+
+  std::list<Creature *> *fightList = player->getFightList();
+  if (std::find(fightList->begin(), fightList->end(), this) ==
+      fightList->end()) {
+    player->addToFightList(this);
+  }
+
+  if (GameScene::getView()) {
+    GameScene::getView()->showFightView();
+  }
+  if (event)
+    event->setAccepted(true);
+}
+
+void Creature::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
+  if (event)
+    event->setAccepted(true);
+}

--- a/creatures/monsters/pritz.cpp
+++ b/creatures/monsters/pritz.cpp
@@ -4,41 +4,40 @@
 
 #include <buildings/cave.h>
 
-Pritz::Pritz(Map *map, int x, int y):Monster(map,x,y)
-{
-    className="Pritz";
-    sw=1;
-    this->setAnimation("images/monsters/pritz/");
-    stats->setMain("S");
-    bonusLevel->setDmgMin(2);
-    bonusLevel->setDmgMax(3);
+Pritz::Pritz(Map *map, int x, int y) : Monster(map, x, y) {
+  className = "Pritz";
+  sw = 1;
+  this->setAnimation("images/monsters/pritz/");
+  stats->setMain("S");
+  bonusLevel->setDmgMin(2);
+  bonusLevel->setDmgMax(3);
 
-    bonusLevel->setStamina(2);
-    bonusLevel->setStrength(3);
+  bonusLevel->setStamina(2);
+  bonusLevel->setStrength(3);
 
-    bonusLevel->setHit(3);
-    bonusLevel->setCrit(1);
+  bonusLevel->setHit(3);
+  bonusLevel->setCrit(1);
 
-    bonusLevel->setNormalResist(5);
+  bonusLevel->setNormalResist(5);
+  attribChange();
 }
 
-std::list<Item *> *Pritz::getLoot()
-{
-    std::list<Item *>* list=new std::list<Item *>();
-    if(rand()%3==0)list->push_back(new ManaPotion());
-    else list->push_back(new LifePotion());
-    return list;
+std::list<Item *> *Pritz::getLoot() {
+  std::list<Item *> *list = new std::list<Item *>();
+  if (rand() % 3 == 0)
+    list->push_back(new ManaPotion());
+  else
+    list->push_back(new LifePotion());
+  return list;
 }
 
-void Pritz::levelUp()
-{
-    Creature::levelUp();
-    heal(0);
-    addMana(0);
+void Pritz::levelUp() {
+  Creature::levelUp();
+  heal(0);
+  addMana(0);
 }
 
-void Pritz::onMove()
-{
-    Monster::onMove();
-    this->addExp(rand()%25);
+void Pritz::onMove() {
+  Monster::onMove();
+  this->addExp(rand() % 25);
 }

--- a/creatures/monsters/pritzmage.cpp
+++ b/creatures/monsters/pritzmage.cpp
@@ -2,17 +2,17 @@
 
 #include <interactions/spells/magicmissile.h>
 
-PritzMage::PritzMage(Map* map, int x, int y):Pritz(map,x,y)
-{
-    className="PritzMage";
-    this->setAnimation("images/monsters/pritzmage/");
-    bonusLevel->setIntelligence(2);
-    stats->setMain("I");
-    sw=2;
+PritzMage::PritzMage(Map *map, int x, int y) : Pritz(map, x, y) {
+  className = "PritzMage";
+  this->setAnimation("images/monsters/pritzmage/");
+  bonusLevel->setIntelligence(2);
+  stats->setMain("I");
+  sw = 2;
+  attribChange();
 }
 
-void PritzMage::levelUp()
-{
-    Pritz::levelUp();
-    if(level==2)addAction(new MagicMissile());
+void PritzMage::levelUp() {
+  Pritz::levelUp();
+  if (level == 2)
+    addAction(new MagicMissile());
 }

--- a/creatures/players/mage.cpp
+++ b/creatures/players/mage.cpp
@@ -1,33 +1,35 @@
 #include "mage.h"
 
-#include <interactions/spells/magicmissile.h>
 #include <interactions/spells/chaosblast.h>
 #include <interactions/spells/frostbolt.h>
+#include <interactions/spells/magicmissile.h>
 #include <stats/stats.h>
 
-Mage::Mage(Map *map,int x,int y):Player(map,x,y)
-{
-    className="Mage";
-    setAnimation("images/players/mage/");
+Mage::Mage(Map *map, int x, int y) : Player(map, x, y) {
+  className = "Mage";
+  setAnimation("images/players/mage/");
 
-    bonusLevel->setStrength(1);
-    bonusLevel->setAgility(2);
-    bonusLevel->setIntelligence(3);
-    bonusLevel->setStamina(1);
+  bonusLevel->setStrength(1);
+  bonusLevel->setAgility(2);
+  bonusLevel->setIntelligence(3);
+  bonusLevel->setStamina(1);
 
-    bonusLevel->setDmgMin(1);
-    bonusLevel->setDmgMax(1);
+  bonusLevel->setDmgMin(1);
+  bonusLevel->setDmgMax(1);
 
-    bonusLevel->setHit(1);
-    bonusLevel->setCrit(1);
+  bonusLevel->setHit(1);
+  bonusLevel->setCrit(1);
 
-    stats->setMain("I");
+  stats->setMain("I");
+  attribChange();
 }
 
-void Mage::levelUp()
-{
-    Creature::levelUp();
-    if(level==1)addAction(new MagicMissile());
-    if(level==3)addAction(new FrostBolt());
-    if(level==7)addAction(new ChaosBlast());
+void Mage::levelUp() {
+  Creature::levelUp();
+  if (level == 1)
+    addAction(new MagicMissile());
+  if (level == 3)
+    addAction(new FrostBolt());
+  if (level == 7)
+    addAction(new ChaosBlast());
 }

--- a/creatures/players/player.cpp
+++ b/creatures/players/player.cpp
@@ -18,126 +18,102 @@
 #include <items/weapons/swords/sword.h>
 
 #include <items/armors/platearmor.h>
-#include <view/playerlistview.h>
-#include <stats/stats.h>
 #include <math.h>
+#include <stats/stats.h>
+#include <view/playerlistview.h>
 
-Player::Player(Map *map, int x, int y):Creature(map,x,y)
-{
-    className="Player";
-    lock=false;
-    level=0;
+Player::Player(Map *map, int x, int y) : Creature(map, x, y) {
+  className = "Player";
+  lock = false;
+  level = 1;
 
-    gold=0;
-    sw=0;
-    turn=0;
+  gold = 0;
+  sw = 0;
+  turn = 0;
 
-    inventory=new std::list<Item*>();
+  inventory = new std::list<Item *>();
 
-    playerStatsView=new PlayerStatsView(this);
-    playerStatsView->setZValue(3);
+  playerStatsView = new PlayerStatsView(this);
+  playerStatsView->setZValue(3);
 
-    playerInventoryView=new PlayerListView((std::list<ListItem*>*)inventory);
-    playerInventoryView->setZValue(3);
+  playerInventoryView = new PlayerListView((std::list<ListItem *> *)inventory);
+  playerInventoryView->setZValue(3);
 
-    playerSkillsView=new PlayerListView((std::list<ListItem*>*)actions);
-    playerSkillsView->setZValue(3);
+  playerSkillsView = new PlayerListView((std::list<ListItem *> *)actions);
+  playerSkillsView->setZValue(3);
 
-    GameScene::getGame()->addItem(playerStatsView);
-    GameScene::getGame()->addItem(playerInventoryView);
-    GameScene::getGame()->addItem(playerSkillsView);
+  GameScene::getGame()->addItem(playerStatsView);
+  GameScene::getGame()->addItem(playerInventoryView);
+  GameScene::getGame()->addItem(playerSkillsView);
 
-
-    std::list<Item *> list;
-    list.push_back(new LifePotion());
-    list.push_back(new ManaPotion());
-    list.push_back(new BlessPotion());
-    list.push_back(new PoisonPotion());
-    addItem(&list);
+  std::list<Item *> list;
+  list.push_back(new LifePotion());
+  list.push_back(new ManaPotion());
+  list.push_back(new BlessPotion());
+  list.push_back(new PoisonPotion());
+  addItem(&list);
 }
 
-Player::~Player()
-{
-    inventory->clear();
-    delete inventory;
+Player::~Player() {
+  inventory->clear();
+  delete inventory;
 }
 
-void Player::onMove()
-{
-    addMana(manaRegRate);
-    turn++;
-    playerStatsView->update();
+void Player::onMove() {
+  addMana(manaRegRate);
+  turn++;
+  playerStatsView->update();
 }
 
-void Player::onEnter()
-{
+void Player::onEnter() {}
 
+void Player::addItem(Item *item) {
+  std::list<Item *> list;
+  list.push_back(item);
+  addItem(&list);
 }
 
-void Player::addItem(Item *item)
-{
-    std::list<Item *> list;
-    list.push_back(item);
-    addItem(&list);
+void Player::addItem(std::list<Item *> *items) {
+  inventory->merge(*items);
+  playerInventoryView->update();
 }
 
-void Player::addItem(std::list<Item*> *items)
-{
-    inventory->merge(*items);
-    playerInventoryView->update();
+void Player::loseItem(Item *item) {
+  inventory->remove(item);
+  playerInventoryView->update();
 }
 
-void Player::loseItem(Item *item)
-{
-    inventory->remove(item);
-    playerInventoryView->update();
+void Player::update() {
+  GameView *view = GameScene::getView();
+  if (!view)
+    return;
+  playerStatsView->setPos(view->mapToScene(0, 0));
+  playerInventoryView->setPos(view->mapToScene(
+      0, view->height() - playerInventoryView->boundingRect().height()));
+  playerSkillsView->setPos(view->mapToScene(
+      view->width() - playerSkillsView->boundingRect().width(),
+      view->height() - playerSkillsView->boundingRect().height()));
+  if (weapon) {
+    weapon->setPos(view->mapToScene(view->width() - Tile::size, 0));
+  }
+  if (armor) {
+    armor->setPos(view->mapToScene(view->width() - Tile::size, Tile::size));
+  }
 }
 
-void Player::update()
-{
-    GameView *view=GameScene::getView();
-    playerStatsView->setPos(view->mapToScene(0,0));
-    playerInventoryView->setPos(view->mapToScene(0,
-                                view->height()-playerInventoryView->boundingRect().height()));
-    playerSkillsView->setPos(view->mapToScene(
-                                 view->width()-playerSkillsView->boundingRect().width(),
-                                 view->height()-playerSkillsView->boundingRect().height()));
-    if(weapon)
-    {
-        weapon->setPos(view->mapToScene(view->width()-Tile::size,0));
-    }
-    if(armor)
-    {
-        armor->setPos(view->mapToScene(view->width()-Tile::size,Tile::size));
-    }
+std::list<Item *> *Player::getInventory() { return inventory; }
+
+PlayerStatsView *Player::getStatsView() { return playerStatsView; }
+
+PlayerListView *Player::getInventoryView() { return playerInventoryView; }
+
+PlayerListView *Player::getSkillsView() { return playerSkillsView; }
+
+void Player::addToFightList(Creature *creature) {
+  fightList.push_back(creature);
 }
 
-std::list<Item *> *Player::getInventory()
-{
-    return inventory;
-}
-
-PlayerStatsView *Player::getStatsView() {
-    return playerStatsView;
-}
-
-PlayerListView *Player::getInventoryView() {
-    return playerInventoryView;
-}
-
-PlayerListView *Player::getSkillsView()
-{
-    return playerSkillsView;
-}
-
-void Player::addToFightList(Creature *creature)
-{
-    fightList.push_back(creature);
-}
-
-
-
-void Player::fight(Creature *creature)
-{
-    if(isStun())creature->fight(this);
+void Player::fight(Creature *creature) {
+  if (isStun())
+    creature->fight(this);
 }

--- a/creatures/players/rogue.cpp
+++ b/creatures/players/rogue.cpp
@@ -4,28 +4,29 @@
 #include <interactions/skills/stun.h>
 #include <stats/stats.h>
 
-Rogue::Rogue(Map *map,int x,int y):Player(map,x,y)
-{
-    className="Rogue";
-    setAnimation("images/players/rogue/");
+Rogue::Rogue(Map *map, int x, int y) : Player(map, x, y) {
+  className = "Rogue";
+  setAnimation("images/players/rogue/");
 
-    bonusLevel->setStrength(1);
-    bonusLevel->setAgility(3);
-    bonusLevel->setIntelligence(2);
-    bonusLevel->setStamina(1);
+  bonusLevel->setStrength(1);
+  bonusLevel->setAgility(3);
+  bonusLevel->setIntelligence(2);
+  bonusLevel->setStamina(1);
 
-    bonusLevel->setDmgMin(1);
-    bonusLevel->setDmgMax(2);
+  bonusLevel->setDmgMin(1);
+  bonusLevel->setDmgMax(2);
 
-    bonusLevel->setHit(3);
-    bonusLevel->setCrit(2);
+  bonusLevel->setHit(3);
+  bonusLevel->setCrit(2);
 
-    stats->setMain("A");
+  stats->setMain("A");
+  attribChange();
 }
 
-void Rogue::levelUp()
-{
-    Creature::levelUp();
-    if(level==1)addAction(new SneakAttack());
-    if(level==5)addAction(new Stun());
+void Rogue::levelUp() {
+  Creature::levelUp();
+  if (level == 1)
+    addAction(new SneakAttack());
+  if (level == 5)
+    addAction(new Stun());
 }

--- a/creatures/players/warrior.cpp
+++ b/creatures/players/warrior.cpp
@@ -4,28 +4,29 @@
 #include <interactions/skills/strike.h>
 #include <stats/stats.h>
 
-Warrior::Warrior(Map *map,int x,int y ):Player(map,x,y)
-{
-    className="Warrior";
-    setAnimation("images/players/warrior/");
+Warrior::Warrior(Map *map, int x, int y) : Player(map, x, y) {
+  className = "Warrior";
+  setAnimation("images/players/warrior/");
 
-    bonusLevel->setStrength(3);
-    bonusLevel->setAgility(2);
-    bonusLevel->setIntelligence(1);
-    bonusLevel->setStamina(2);
+  bonusLevel->setStrength(3);
+  bonusLevel->setAgility(2);
+  bonusLevel->setIntelligence(1);
+  bonusLevel->setStamina(2);
 
-    bonusLevel->setDmgMin(2);
-    bonusLevel->setDmgMax(3);
+  bonusLevel->setDmgMin(2);
+  bonusLevel->setDmgMax(3);
 
-    bonusLevel->setHit(3);
-    bonusLevel->setCrit(1);
+  bonusLevel->setHit(3);
+  bonusLevel->setCrit(1);
 
-    stats->setMain("S");
+  stats->setMain("S");
+  attribChange();
 }
 
-void Warrior::levelUp()
-{
-    Creature::levelUp();
-    if(level==1)addAction(new Strike());
-    if(level==5)addAction(new DoubleAttack());
+void Warrior::levelUp() {
+  Creature::levelUp();
+  if (level == 1)
+    addAction(new Strike());
+  if (level == 5)
+    addAction(new DoubleAttack());
 }

--- a/map/map.cpp
+++ b/map/map.cpp
@@ -1,0 +1,208 @@
+#include "map.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <vector>
+
+#include <buildings/cave.h>
+#include <creatures/players/player.h>
+#include <map/tiles/groundtile.h>
+#include <map/tiles/mountaintile.h>
+#include <map/tiles/roadtile.h>
+#include <map/tiles/watertile.h>
+#include <view/gamescene.h>
+
+Map::Map() { mapObjects = new std::list<MapObject *>(); }
+
+Map::~Map() {
+  std::vector<Tile *> tilesToDelete;
+  for (iterator it = begin(); it != end(); ++it) {
+    tilesToDelete.push_back((*it).second);
+  }
+  clear();
+
+  for (std::vector<Tile *>::iterator it = tilesToDelete.begin();
+       it != tilesToDelete.end(); ++it) {
+    if ((*it)->scene())
+      (*it)->scene()->removeItem(*it);
+    delete *it;
+  }
+
+  std::vector<MapObject *> objects(mapObjects->begin(), mapObjects->end());
+  mapObjects->clear();
+  delete mapObjects;
+
+  for (std::vector<MapObject *>::iterator it = objects.begin();
+       it != objects.end(); ++it) {
+    if ((*it)->scene())
+      (*it)->scene()->removeItem(*it);
+    delete *it;
+  }
+}
+
+void Map::move(int x, int y) {
+  Player *player = GameScene::getPlayer();
+  if (!player)
+    return;
+  player->move(x, y);
+}
+
+Tile *Map::getTile(int x, int y) {
+  iterator it = find(Coords(x, y));
+  if (it == end())
+    return 0;
+  return (*it).second;
+}
+
+bool Map::contains(int x, int y) { return getTile(x, y) != 0; }
+
+void Map::addObject(MapObject *mapObject) {
+  if (!mapObject)
+    return;
+  mapObjects->push_back(mapObject);
+  mapObject->moveTo(mapObject->getPosX(), mapObject->getPosY());
+  if (GameScene::getGame() && mapObject->scene() != GameScene::getGame()) {
+    GameScene::getGame()->addItem(mapObject);
+  }
+}
+
+void Map::addRiver(int length, int startx, int starty) {
+  int x = startx;
+  int y = starty;
+  for (int i = 0; i < length; ++i) {
+    addTile(new WaterTile(x, y));
+    switch (rand() % 4) {
+    case 0:
+      x++;
+      break;
+    case 1:
+      x--;
+      break;
+    case 2:
+      y++;
+      break;
+    default:
+      y--;
+      break;
+    }
+  }
+}
+
+void Map::addRoad(int length, int startx, int starty) {
+  int x = startx;
+  int y = starty;
+  for (int i = 0; i < length; ++i) {
+    addTile(new RoadTile(x, y));
+    if (rand() % 2 == 0)
+      x += rand() % 2 == 0 ? 1 : -1;
+    else
+      y += rand() % 2 == 0 ? 1 : -1;
+  }
+}
+
+void Map::removeObject(MapObject *mapObject) {
+  if (!mapObject)
+    return;
+  mapObjects->remove(mapObject);
+  if (mapObject->scene())
+    mapObject->scene()->removeItem(mapObject);
+  delete mapObject;
+}
+
+void Map::randomDir(int *tab, int) {
+  tab[0] = 0;
+  tab[1] = 1;
+  tab[2] = 2;
+  tab[3] = 3;
+  for (int i = 0; i < 4; ++i) {
+    int j = rand() % 4;
+    std::swap(tab[i], tab[j]);
+  }
+}
+
+bool Map::addTile(Tile *tile) {
+  if (!tile)
+    return false;
+  if (contains(tile->getCoords().first, tile->getCoords().second)) {
+    delete tile;
+    return false;
+  }
+
+  insert(std::pair<Coords, Tile *>(tile->getCoords(), tile));
+  tile->addToGame();
+  return true;
+}
+
+MapObject::MapObject(Map *map, int x, int y, int z) {
+  this->map = map;
+  posx = x;
+  posy = y;
+  animation = 0;
+  timer = 0;
+  setZValue(z);
+  statsView.setParentItem(this);
+  statsView.setVisible(false);
+  setPos(x * Tile::size, y * Tile::size);
+}
+
+MapObject::~MapObject() {
+  if (timer)
+    delete timer;
+  if (animation)
+    delete animation;
+}
+
+void MapObject::moveTo(int x, int y) {
+  posx = x;
+  posy = y;
+  setPos(x * Tile::size, y * Tile::size);
+}
+
+int MapObject::getPosX() const { return posx; }
+
+int MapObject::getPosY() const { return posy; }
+
+void MapObject::removeFromGame() {
+  Map *owner = map;
+  map = 0;
+  if (owner) {
+    owner->removeObject(this);
+  }
+}
+
+void MapObject::move(int x, int y) {
+  if (!map)
+    return;
+
+  Tile *destination = map->getTile(posx + x, posy + y);
+  if (!destination || !destination->canStep())
+    return;
+
+  moveTo(posx + x, posy + y);
+  destination->onStep();
+
+  std::vector<MapObject *> collisions;
+  for (std::list<MapObject *>::iterator it = map->getObjects()->begin();
+       it != map->getObjects()->end(); ++it) {
+    if (*it != this && (*it)->getPosX() == posx && (*it)->getPosY() == posy) {
+      collisions.push_back(*it);
+    }
+  }
+
+  onMove();
+
+  for (std::vector<MapObject *>::iterator it = collisions.begin();
+       it != collisions.end(); ++it) {
+    if (*it && (*it)->getPosX() == posx && (*it)->getPosY() == posy) {
+      (*it)->onEnter();
+    }
+  }
+}
+
+void MapObject::setParentItem(QGraphicsItem *parent) {
+  QGraphicsItem::setParentItem(parent);
+}
+
+void MapObject::setAnimation(std::string path) {
+  AnimatedObject::setAnimation(path);
+}

--- a/map/map.h
+++ b/map/map.h
@@ -3,68 +3,68 @@
 
 #include "map/coords.h"
 #include "map/tiles/tile.h"
-#include <list>
-#include <QTimer>
 #include <QObject>
-#include <qgraphicsitemanimation.h>
 #include <QTimeLine>
-#include <animation/animation.h>
+#include <QTimer>
 #include <animation/animatedobject.h>
+#include <animation/animation.h>
+#include <list>
+#include <qgraphicsitemanimation.h>
 
 class MapObject;
 
-class Map : private std::map<Coords,Tile*>
-{
+class Map : private std::map<Coords, Tile *> {
 public:
-    Map();
-    ~Map();
+  Map();
+  ~Map();
 
-    void move(int x,int y);
+  void move(int x, int y);
 
-    Tile *getTile(int x,int y);
-    bool contains(int x,int y);
-    void addObject(MapObject *mapObject);
+  Tile *getTile(int x, int y);
+  bool contains(int x, int y);
+  void addObject(MapObject *mapObject);
+  bool addTile(Tile *tile);
 
-    void addRiver(int length, int startx, int starty);
-    void addRoad(int length, int startx, int starty);
+  void addRiver(int length, int startx, int starty);
+  void addRoad(int length, int startx, int starty);
 
-    void removeObject(MapObject *mapObject);
+  void removeObject(MapObject *mapObject);
+  std::list<MapObject *> *getObjects() { return mapObjects; }
 
 private:
-    std::list<MapObject*> *mapObjects;
-    void randomDir(int *tab, int rule);
-    bool addTile(Tile *tile);
+  std::list<MapObject *> *mapObjects;
+  void randomDir(int *tab, int rule);
 };
 
-class MapObject : private AnimatedObject
-{
+class MapObject : public AnimatedObject {
 public:
-    MapObject(Map *map,int x,int y,int z);
-    ~MapObject();
-    int posx,posy;
-    void moveTo(int x, int y);
+  MapObject(Map *map, int x, int y, int z);
+  ~MapObject();
+  int posx, posy;
+  void moveTo(int x, int y);
 
-    int getPosX() const;
-    int getPosY() const;
+  int getPosX() const;
+  int getPosY() const;
 
-    void removeFromGame();
+  void removeFromGame();
 
-    virtual void onEnter()=0;
-    virtual void onMove()=0;
+  virtual void onEnter() = 0;
+  virtual void onMove() = 0;
 
-    void move(int x, int y);
+  void move(int x, int y);
 
-    void setParentItem(QGraphicsItem *parent);
+  void setParentItem(QGraphicsItem *parent);
 
 protected:
-    void setAnimation(std::string path);
-    Map *map;
-    QGraphicsItemAnimation *animation;
-    QTimeLine *timer;
+  void setAnimation(std::string path);
+  Map *map;
+  QGraphicsItemAnimation *animation;
+  QTimeLine *timer;
 
-    QGraphicsSimpleTextItem statsView;
+  QGraphicsSimpleTextItem statsView;
+
 public:
-    std::string className;
+  std::string className;
 };
 
 #endif // MAP_H

--- a/map/tiles/tile.h
+++ b/map/tiles/tile.h
@@ -1,48 +1,44 @@
+#include "map/events/event.h"
 #include <QGraphicsPixmapItem>
 #include <animation/animatedobject.h>
 #include <map/coords.h>
-#include "map/events/event.h"
 
 #ifndef TILE_H
 #define TILE_H
 
-class Tile : protected AnimatedObject
-{
+class Tile : public AnimatedObject {
 public:
+  Tile(int x, int y);
 
-    Tile(int x,int y);
+  ~Tile();
 
-    ~Tile();
+  Coords getCoords();
 
-    Coords getCoords();
+  bool isOn(int x, int y);
 
-    bool isOn(int x,int y);
+  void move(int x, int y);
 
-    void move(int x,int y);
+  virtual void onStep();
 
-    virtual void onStep();
+  static int size;
 
-    static int size;
+  bool canStep() const;
 
-    bool canStep() const;
+  static Tile *getRandomTile(int x, int y);
 
-    static Tile *getRandomTile(int x, int y);
-
-    void addToGame();
+  void addToGame();
 
 protected:
-    bool step;
-    void mousePressEvent(QGraphicsSceneMouseEvent *event);
+  bool step;
+  void mousePressEvent(QGraphicsSceneMouseEvent *event);
 
 private:
-    void setXY(int x, int y);
+  void setXY(int x, int y);
 
-    std::list<Event*> events;
+  std::list<Event *> events;
 
-    int posx;
-    int posy;
-
-
+  int posx;
+  int posy;
 };
 
 #endif // TILE_H

--- a/stats/stats.cpp
+++ b/stats/stats.cpp
@@ -1,0 +1,153 @@
+#include "stats.h"
+
+#include <sstream>
+#include <string>
+
+Stats::Stats() {}
+
+void Stats::setMain(const char *stat) {
+  if (!stat) {
+    main = &strength;
+    return;
+  }
+
+  switch (stat[0]) {
+  case 'A':
+    main = &agility;
+    break;
+  case 'I':
+    main = &intelligence;
+    break;
+  case 'S':
+  default:
+    main = &strength;
+    break;
+  }
+}
+
+int Stats::getMain() { return main ? *main : 0; }
+
+void Stats::addBonus(Stats *stats) {
+  if (!stats)
+    return;
+
+  strength += stats->getStrength();
+  stamina += stats->getStamina();
+  agility += stats->getAgility();
+  intelligence += stats->getIntelligence();
+
+  armor += stats->getArmor();
+  block += stats->getBlock();
+
+  dmgMin += stats->getDmgMin();
+  dmgMax += stats->getDmgMax();
+  hit += stats->getHit();
+  crit += stats->getCrit();
+
+  fireResist += stats->getFireResist();
+  thunderResist += stats->getThunderResist();
+  frostResist += stats->getFrostResist();
+  normalResist += stats->getNormalResist();
+
+  damage += stats->getDamage();
+  attack += stats->getAttack();
+}
+
+void Stats::removeBonus(Stats *stats) {
+  if (!stats)
+    return;
+
+  strength -= stats->getStrength();
+  stamina -= stats->getStamina();
+  agility -= stats->getAgility();
+  intelligence -= stats->getIntelligence();
+
+  armor -= stats->getArmor();
+  block -= stats->getBlock();
+
+  dmgMin -= stats->getDmgMin();
+  dmgMax -= stats->getDmgMax();
+  hit -= stats->getHit();
+  crit -= stats->getCrit();
+
+  fireResist -= stats->getFireResist();
+  thunderResist -= stats->getThunderResist();
+  frostResist -= stats->getFrostResist();
+  normalResist -= stats->getNormalResist();
+
+  damage -= stats->getDamage();
+  attack -= stats->getAttack();
+}
+
+int Stats::getStrength() const { return strength; }
+
+void Stats::setStrength(int value) { strength = value; }
+
+int Stats::getStamina() const { return stamina; }
+
+void Stats::setStamina(int value) { stamina = value; }
+
+int Stats::getAgility() const { return agility; }
+
+void Stats::setAgility(int value) { agility = value; }
+
+int Stats::getIntelligence() const { return intelligence; }
+
+void Stats::setIntelligence(int value) { intelligence = value; }
+
+int Stats::getArmor() const { return armor; }
+
+void Stats::setArmor(int value) { armor = value; }
+
+int Stats::getBlock() const { return block; }
+
+void Stats::setBlock(int value) { block = value; }
+
+int Stats::getDmgMin() const { return dmgMin; }
+
+void Stats::setDmgMin(int value) { dmgMin = value; }
+
+int Stats::getDmgMax() const { return dmgMax; }
+
+void Stats::setDmgMax(int value) { dmgMax = value; }
+
+int Stats::getHit() const { return hit; }
+
+void Stats::setHit(int value) { hit = value; }
+
+int Stats::getCrit() const { return crit; }
+
+void Stats::setCrit(int value) { crit = value; }
+
+int Stats::getFireResist() const { return fireResist; }
+
+void Stats::setFireResist(int value) { fireResist = value; }
+
+int Stats::getThunderResist() const { return thunderResist; }
+
+void Stats::setThunderResist(int value) { thunderResist = value; }
+
+int Stats::getFrostResist() const { return frostResist; }
+
+void Stats::setFrostResist(int value) { frostResist = value; }
+
+int Stats::getNormalResist() const { return normalResist; }
+
+void Stats::setNormalResist(int value) { normalResist = value; }
+
+int Stats::getDamage() const { return damage; }
+
+void Stats::setDamage(int value) { damage = value; }
+
+int Stats::getAttack() const { return attack; }
+
+void Stats::setAttack(int value) { attack = value; }
+
+const char *Stats::getText(int level) {
+  static std::string text;
+  std::ostringstream stream;
+  stream << "Level " << level << " S:" << getStrength() << " A:" << getAgility()
+         << " I:" << getIntelligence() << " St:" << getStamina();
+  text = stream.str();
+  return text.c_str();
+}

--- a/view/gamescene.cpp
+++ b/view/gamescene.cpp
@@ -1,0 +1,117 @@
+#include "gamescene.h"
+
+#include <QGraphicsView>
+
+#include <buildings/cave.h>
+#include <creatures/players/mage.h>
+#include <destroyer/destroyer.h>
+#include <view/gameview.h>
+
+Player *GameScene::player = 0;
+GameScene *GameScene::game = 0;
+
+GameScene::GameScene() {
+  srand(time(0));
+  game = this;
+  map = new Map();
+
+  if (!player) {
+    player = new Mage(map, 0, 0);
+    map->addObject(player);
+  }
+
+  map->addRoad(18, -8, 0);
+  map->addRiver(16, 6, -5);
+  map->addObject(new Cave(map, 5, 2));
+  ensureSize(24, 16);
+  player->update();
+}
+
+GameScene::~GameScene() {
+  delete map;
+  player = 0;
+  game = 0;
+  Destroyer::terminate();
+}
+
+Player *GameScene::getPlayer() { return player; }
+
+GameScene *GameScene::getGame() { return game; }
+
+GameView *GameScene::getView() {
+  if (!game || game->views().isEmpty())
+    return 0;
+  return dynamic_cast<GameView *>(game->views().front());
+}
+
+void GameScene::playerMove(int dirx, int diry) {
+  if (!player)
+    return;
+  map->move(dirx, diry);
+
+  GameView *view = getView();
+  if (view) {
+    view->centerOn(player->getPosX() * Tile::size + Tile::size / 2,
+                   player->getPosY() * Tile::size + Tile::size / 2);
+    ensureSize(view->width() / Tile::size + 2, view->height() / Tile::size + 2);
+    player->update();
+    if (player->getFightList()->size() > 0) {
+      view->showFightView();
+    }
+  }
+}
+
+void GameScene::ensureSize(int sizex, int sizey) {
+  if (!player)
+    return;
+
+  const int halfx = sizex / 2;
+  const int halfy = sizey / 2;
+  for (int x = player->getPosX() - halfx; x <= player->getPosX() + halfx; ++x) {
+    for (int y = player->getPosY() - halfy; y <= player->getPosY() + halfy;
+         ++y) {
+      if (!map->contains(x, y)) {
+        addTile(Tile::getRandomTile(x, y));
+      }
+    }
+  }
+}
+
+void GameScene::keyPressEvent(QKeyEvent *keyEvent) {
+  if (!keyEvent)
+    return;
+
+  keyEvent->setAccepted(false);
+  switch (keyEvent->key()) {
+  case Qt::Key_Up:
+    playerMove(0, -1);
+    keyEvent->setAccepted(true);
+    break;
+  case Qt::Key_Down:
+    playerMove(0, 1);
+    keyEvent->setAccepted(true);
+    break;
+  case Qt::Key_Left:
+    playerMove(-1, 0);
+    keyEvent->setAccepted(true);
+    break;
+  case Qt::Key_Right:
+    playerMove(1, 0);
+    keyEvent->setAccepted(true);
+    break;
+  default:
+    QGraphicsScene::keyPressEvent(keyEvent);
+    break;
+  }
+}
+
+void GameScene::addRandomTile(int x, int y) {
+  addTile(Tile::getRandomTile(x, y));
+}
+
+void GameScene::addTile(Tile *tile) {
+  if (tile)
+    map->addTile(tile);
+}
+
+void GameScene::addObject(MapObject *mapObject) { map->addObject(mapObject); }

--- a/view/gameview.cpp
+++ b/view/gameview.cpp
@@ -1,78 +1,69 @@
 #include "gameview.h"
 
-bool GameView::init=false;
+bool GameView::init = false;
 
-GameView::GameView()
-{
-    showFullScreen();
-    //this->setWindowState(Qt::WindowNoState);
+GameView::GameView() {
+  showFullScreen();
+  // this->setWindowState(Qt::WindowNoState);
 
-    setHorizontalScrollBarPolicy ( Qt::ScrollBarAlwaysOff );
-    setVerticalScrollBarPolicy ( Qt::ScrollBarAlwaysOff );
+  setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
-    setViewportUpdateMode(QGraphicsView::BoundingRectViewportUpdate);
-    /*
-    view.setViewport(new QGLWidget(
-             QGLFormat(QGL::SampleBuffers)));
-    view.setViewportUpdateMode(
-             QGraphicsView::FullViewportUpdate);
-    */
-    init=true;
+  setViewportUpdateMode(QGraphicsView::BoundingRectViewportUpdate);
+  /*
+  view.setViewport(new QGLWidget(
+           QGLFormat(QGL::SampleBuffers)));
+  view.setViewportUpdateMode(
+           QGraphicsView::FullViewportUpdate);
+  */
+  init = true;
 
-    scene=new GameScene();
-    setScene(scene);
-    resize();
-    fightView=new FightView();
-    scene->addItem(fightView);
+  scene = new GameScene();
+  setScene(scene);
+  resize();
+  fightView = new FightView();
+  scene->addItem(fightView);
 }
 
-GameView::~GameView()
-{
-    delete scene;
-}
+GameView::~GameView() { delete scene; }
 
-void GameView::resize()
-{
-    resizeEvent(0);
-}
+void GameView::resize() { resizeEvent(0); }
 
-void GameView::showFightView()
-{
-    FightView::selected=GameScene::getPlayer()->getFightList()->front();
-    fightView->setVisible(true);
-    fightView->setPos(mapToScene(this->width()/2-fightView->boundingRect().width()/2,this->height()/2
-                                 -fightView->boundingRect().height()/2));
+void GameView::showFightView() {
+  if (GameScene::getPlayer()->getFightList()->empty())
+    return;
+  FightView::selected = GameScene::getPlayer()->getFightList()->front();
+  fightView->setVisible(true);
+  fightView->setPos(
+      mapToScene(this->width() / 2 - fightView->boundingRect().width() / 2,
+                 this->height() / 2 - fightView->boundingRect().height() / 2));
 }
 
 void GameView::mouseDoubleClickEvent(QMouseEvent *e) {
-    QWidget::mouseDoubleClickEvent(e);
-    if(e->button()==Qt::MouseButton::LeftButton)return;
-    if(isFullScreen()) {
-        this->setWindowState(Qt::WindowNoState);
-    } else {
-        this->setWindowState(Qt::WindowFullScreen);
-    }
+  QWidget::mouseDoubleClickEvent(e);
+  if (e->button() == Qt::MouseButton::LeftButton)
+    return;
+  if (isFullScreen()) {
+    this->setWindowState(Qt::WindowNoState);
+  } else {
+    this->setWindowState(Qt::WindowFullScreen);
+  }
 }
 
-void GameView::resizeEvent( QResizeEvent * event)
-{
-    QWidget::resizeEvent(event);
-    if(init)
-    {
-        int size=Tile::size;
-        Player *player=GameScene::getPlayer();
-        centerOn(player->getPosX()*size+size/2,player->getPosY()*size+size/2);
-        player->update();
-        if(event)
-        {
-            int sizex=(event->size().width()/Tile::size+1);
-            int sizey=(event->size().height()/Tile::size+1);
-            GameScene::getGame()->ensureSize(sizex,sizey);
-        }
+void GameView::resizeEvent(QResizeEvent *event) {
+  QWidget::resizeEvent(event);
+  if (init) {
+    int size = Tile::size;
+    Player *player = GameScene::getPlayer();
+    centerOn(player->getPosX() * size + size / 2,
+             player->getPosY() * size + size / 2);
+    player->update();
+    if (event) {
+      int sizex = (event->size().width() / Tile::size + 1);
+      int sizey = (event->size().height() / Tile::size + 1);
+      GameScene::getGame()->ensureSize(sizex, sizey);
     }
+  }
 }
 
-void GameView::wheelEvent(QWheelEvent *event)
-{
-    event->setAccepted(true);
-}
+void GameView::wheelEvent(QWheelEvent *event) { event->setAccepted(true); }


### PR DESCRIPTION
## What changed
- reconstructed the missing core 2013 runtime pieces: Game.pro, map/map.cpp, creatures/creature.cpp, stats/stats.cpp, and view/gamescene.cpp
- updated the legacy Qt object hierarchy so map objects and tiles can be owned by the scene on a modern Qt toolchain
- added placeholder animation fallback for pruned historical assets so the earliest snapshot can still start
- adjusted the player and legacy class setup just enough to boot into a playable generated world around the December 7, 2013 root commit

## Why
- the earliest reachable game commit (b9ae428b, 2013-12-07) was already partially pruned, so a pure checkout was not runnable
- this recovery keeps the work anchored to that oldest snapshot while reconstructing only the missing seams required to compile and launch it again

## Validation
- qmake6 Game.pro -o Makefile
- make clean && make -j4
- QT_QPA_PLATFORM=offscreen timeout 3s ./LegacyGame2013 (stayed alive until timeout)

## Limitations / follow-up
- this is a best-effort recovery, not the exact deleted original sources
- many historical art assets are still missing, so the build uses generated placeholder frames where files were pruned
- I did not run the repository's modern CMake/Python test suite because this work targets the isolated 2013 snapshot rather than current main