### PR TITLE
Wire Windows CI to Visual Studio and vcpkg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,25 +49,40 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Install Python deps
+        run: python -m pip install --upgrade pillow
       - name: submodules
         run: git submodule update --init --recursive
-      - name: install python deps
-        run: python -m pip install --upgrade pybind11 pillow
+      - name: Set up vcpkg
+        shell: pwsh
+        run: |
+          if (-not $env:VCPKG_ROOT) {
+            $env:VCPKG_ROOT = $env:VCPKG_INSTALLATION_ROOT
+          }
+          if (-not $env:VCPKG_ROOT) {
+            throw "VCPKG_ROOT and VCPKG_INSTALLATION_ROOT are not set"
+          }
+          "VCPKG_ROOT=$env:VCPKG_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+      - name: Install native deps
+        shell: pwsh
+        run: '& "$env:VCPKG_ROOT\vcpkg.exe" install --triplet x64-windows'
       - name: configure, test, and package
         shell: cmd
         run: |
           call configure.bat
           if errorlevel 1 exit /b 1
-          cmake --build cmake-build-release --target _game for_unit_tests
+          cmake --build cmake-build-release --config Release --target _game for_unit_tests
           if errorlevel 1 exit /b 1
-          ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
+          ctest --test-dir cmake-build-release -C Release --output-on-failure -R for_unit_tests
           if errorlevel 1 exit /b 1
+          set GAME_BUILD_DIR=cmake-build-release
+          set GAME_BUILD_CONFIG=Release
           python test.py
           if errorlevel 1 exit /b 1
-          cmake --build cmake-build-release --target package
+          cmake --build cmake-build-release --config Release --target package
           if errorlevel 1 exit /b 1
       - name: publish
         uses: actions/upload-artifact@v4
         with:
           name: fall-of-nouraajd-windows
-          path: cmake-build-release/fall-of-nouraajd-*.exe
+          path: cmake-build-release/fall-of-nouraajd-*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Cache ccache
         uses: actions/cache@v4
         with:
@@ -77,6 +77,7 @@ jobs:
           if errorlevel 1 exit /b 1
           set GAME_BUILD_DIR=cmake-build-release
           set GAME_BUILD_CONFIG=Release
+          set PATH=%CD%\cmake-build-release\Release;%CD%\vcpkg_installed\x64-windows\bin;%PATH%
           python test.py
           if errorlevel 1 exit /b 1
           cmake --build cmake-build-release --config Release --target package

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ test/
 *.cpp.*
 *.idea/
 /cmake-build-*
+/vcpkg_installed/
 /windows-tools/

--- a/.idea/runConfigurations/play__unity.xml
+++ b/.idea/runConfigurations/play__unity.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="play _unity" type="CMakeRunConfiguration" factoryName="Application" singleton="true" PROGRAM_PARAMS="play.py" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$PROJECT_DIR$/cmake-build-debug" PASS_PARENT_ENVS_2="true" PROJECT_NAME="fall-of-nouraajd" TARGET_NAME="_game_unity" CONFIG_NAME="Debug" RUN_PATH="/usr/bin/python3">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/play_debug.xml
+++ b/.idea/runConfigurations/play_debug.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="play debug" type="CMakeRunConfiguration" factoryName="Application" singleton="true" PROGRAM_PARAMS="play.py" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" WORKING_DIR="file://$PROJECT_DIR$/cmake-build-debug" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Project" TARGET_NAME="_game" CONFIG_NAME="Debug" RUN_PATH="/usr/bin/python3">
+  <configuration default="false" name="play debug" type="CMakeRunConfiguration" factoryName="Application" singleton="true" PROGRAM_PARAMS="play.py" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$PROJECT_DIR$/cmake-build-debug" PASS_PARENT_ENVS_2="true" PROJECT_NAME="fall-of-nouraajd" TARGET_NAME="_game" CONFIG_NAME="Windows Debug" RUN_PATH="/usr/bin/python3">
     <method v="2">
       <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
     </method>

--- a/.idea/runConfigurations/play_release.xml
+++ b/.idea/runConfigurations/play_release.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="play release" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="play.py" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" WORKING_DIR="file://$PROJECT_DIR$/cmake-build-release" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Project" TARGET_NAME="_game" CONFIG_NAME="Debug" RUN_PATH="/usr/bin/python3">
+  <configuration default="false" name="play release" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="play.py" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$PROJECT_DIR$/cmake-build-release" PASS_PARENT_ENVS_2="true" PROJECT_NAME="fall-of-nouraajd" TARGET_NAME="_game" CONFIG_NAME="Windows Debug" RUN_PATH="/usr/bin/python3">
     <method v="2">
       <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
     </method>

--- a/.idea/runConfigurations/test.xml
+++ b/.idea/runConfigurations/test.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="test" type="CMakeRunConfiguration" factoryName="Application" singleton="true" PROGRAM_PARAMS="test.py" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" WORKING_DIR="file://$PROJECT_DIR$/cmake-build-release" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Project" TARGET_NAME="_game" CONFIG_NAME="Debug" RUN_PATH="/usr/bin/python3">
+  <configuration default="false" name="test" type="CMakeRunConfiguration" factoryName="Application" singleton="true" PROGRAM_PARAMS="test.py" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$PROJECT_DIR$/cmake-build-debug" PASS_PARENT_ENVS_2="true" PROJECT_NAME="fall-of-nouraajd" TARGET_NAME="_game" CONFIG_NAME="Windows Debug" RUN_PATH="/usr/bin/python3">
     <method v="2">
       <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
     </method>

--- a/.idea/runConfigurations/test__unity.xml
+++ b/.idea/runConfigurations/test__unity.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="test _unity" type="CMakeRunConfiguration" factoryName="Application" singleton="true" PROGRAM_PARAMS="test.py" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$PROJECT_DIR$/cmake-build-debug" PASS_PARENT_ENVS_2="true" PROJECT_NAME="fall-of-nouraajd" TARGET_NAME="_game_unity" CONFIG_NAME="Debug" RUN_PATH="/usr/bin/python3">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/windows_play_debug.xml
+++ b/.idea/runConfigurations/windows_play_debug.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="windows play debug" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="play.py" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" WORKING_DIR="file://$PROJECT_DIR$/cmake-build-debug-windows" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Project" TARGET_NAME="_game" CONFIG_NAME="Debug" RUN_PATH="$PROJECT_DIR$/../../../../dev/Python36/python.exe">
+  <configuration default="false" name="windows play debug" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="play.py" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$PROJECT_DIR$/cmake-build-debug" PASS_PARENT_ENVS_2="true" PROJECT_NAME="fall-of-nouraajd" TARGET_NAME="_game" CONFIG_NAME="Windows Debug" RUN_PATH="$PROJECT_DIR$/../../../../dev/Python36/python.exe">
     <envs>
       <env name="PATH" value="%PATH%\\;C:\\dev\Python36\\\;C:\\dev\boost64\\;C:\\dev\SDL2_image-2.0.5\x86_64-w64-mingw32\\\;C:\\dev\SDL2_ttf-2.0.15\x86_64-w64-mingw32\\\;C:\\dev\SDL2-2.0.12\x86_64-w64-mingw32\\\;C:\\dev\mingw\mingw64\bin\\\;C:\\dev\boost64\lib\\\;C:\\dev\SDL2_image-2.0.5\x86_64-w64-mingw32\bin\\\;C:\\dev\SDL2_ttf-2.0.15\x86_64-w64-mingw32\bin\\\;C:\\dev\SDL2-2.0.12\x86_64-w64-mingw32\bin\\\;" />
     </envs>

--- a/.idea/runConfigurations/windows_play_release.xml
+++ b/.idea/runConfigurations/windows_play_release.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="windows play release" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="play.py" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" WORKING_DIR="file://$PROJECT_DIR$/cmake-build-release-windows" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Project" TARGET_NAME="_game" CONFIG_NAME="Debug" RUN_PATH="$PROJECT_DIR$/../../../../dev/Python36/python.exe">
+  <configuration default="false" name="windows play release" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="play.py" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" WORKING_DIR="file://$PROJECT_DIR$/cmake-build-release" PASS_PARENT_ENVS_2="true" PROJECT_NAME="fall-of-nouraajd" TARGET_NAME="_game" CONFIG_NAME="Windows Debug" RUN_PATH="$PROJECT_DIR$/../../../../dev/Python36/python.exe">
     <envs>
       <env name="PATH" value="%PATH%\\;C:\\dev\Python36\\\;C:\\dev\boost64\\;C:\\dev\SDL2_image-2.0.5\x86_64-w64-mingw32\\\;C:\\dev\SDL2_ttf-2.0.15\x86_64-w64-mingw32\\\;C:\\dev\SDL2-2.0.12\x86_64-w64-mingw32\\\;C:\\dev\mingw\mingw64\bin\\\;C:\\dev\boost64\lib\\\;C:\\dev\SDL2_image-2.0.5\x86_64-w64-mingw32\bin\\\;C:\\dev\SDL2_ttf-2.0.15\x86_64-w64-mingw32\bin\\\;C:\\dev\SDL2-2.0.12\x86_64-w64-mingw32\bin\\\;" />
     </envs>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,285 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="CMakePresetLoader">{
+  &quot;useNewFormat&quot;: true
+}</component>
+  <component name="CMakeReloadState">
+    <option name="reloaded" value="true" />
+  </component>
+  <component name="CMakeRunConfigurationManager">
+    <generated>
+      <config projectName="fall-of-nouraajd" targetName="_game" />
+    </generated>
+  </component>
+  <component name="CMakeSettings" AUTO_RELOAD="true">
+    <configurations>
+      <configuration PROFILE_NAME="Windows Debug" ENABLED="true" GENERATION_DIR="cmake-build-debug" CONFIG_NAME="Debug">
+        <ADDITIONAL_GENERATION_ENVIRONMENT>
+          <envs>
+            <env name="PATH" value="%PATH%\;C:\\dev\Python36\\;C:\\dev\boost64\;C:\\dev\SDL2_image-2.0.5\x86_64-w64-mingw32\\;C:\\dev\SDL2_ttf-2.0.15\x86_64-w64-mingw32\\;C:\\dev\SDL2-2.0.12\x86_64-w64-mingw32\\;C:\\dev\mingw\mingw64\bin\\;C:\\dev\boost_1_74_0\boost64\lib\\;C:\\dev\SDL2_image-2.0.5\x86_64-w64-mingw32\bin\\;C:\\dev\SDL2_ttf-2.0.15\x86_64-w64-mingw32\bin\\;C:\\dev\SDL2-2.0.12\x86_64-w64-mingw32\bin\\;" />
+          </envs>
+        </ADDITIONAL_GENERATION_ENVIRONMENT>
+      </configuration>
+      <configuration PROFILE_NAME="Windows Release" ENABLED="true" GENERATION_DIR="cmake-build-release" CONFIG_NAME="Release">
+        <ADDITIONAL_GENERATION_ENVIRONMENT>
+          <envs>
+            <env name="PATH" value="%PATH%;C:\\dev\Python36\;C:\\dev\boost64;C:\\dev\SDL2_image-2.0.5\x86_64-w64-mingw32\;C:\\dev\SDL2_ttf-2.0.15\x86_64-w64-mingw32\;C:\\dev\SDL2-2.0.12\x86_64-w64-mingw32\;C:\\dev\mingw\mingw64\bin\;C:\\dev\boost_1_74_0\boost64\lib\;C:\\dev\SDL2_image-2.0.5\x86_64-w64-mingw32\bin\;C:\\dev\SDL2_ttf-2.0.15\x86_64-w64-mingw32\bin\;C:\\dev\SDL2-2.0.12\x86_64-w64-mingw32\bin\;" />
+          </envs>
+        </ADDITIONAL_GENERATION_ENVIRONMENT>
+      </configuration>
+    </configurations>
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="4376a8b6-35dc-4e1d-8076-f9350c811619" name="Default Changelist" comment="show footsteps">
+      <change beforePath="$PROJECT_DIR$/.idea/runConfigurations/play__unity.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/runConfigurations/play__unity.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/runConfigurations/play_debug.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/runConfigurations/play_debug.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/runConfigurations/play_release.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/runConfigurations/play_release.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/runConfigurations/test.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/runConfigurations/test.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/runConfigurations/test__unity.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/runConfigurations/test__unity.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/runConfigurations/windows_play_debug.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/runConfigurations/windows_play_debug.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/runConfigurations/windows_play_release.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/runConfigurations/windows_play_release.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/vstd" beforeDir="false" afterPath="$PROJECT_DIR$/vstd" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ClangdSettings">
+    <option name="formatViaClangd" value="false" />
+  </component>
+  <component name="ExecutionTargetManager" SELECTED_TARGET="CMakeBuildProfile:Windows Debug" />
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+    <option name="ROOT_SYNC" value="DONT_SYNC" />
+    <option name="UPDATE_TYPE" value="REBASE" />
+  </component>
+  <component name="HighlightingSettingsPerFile">
+    <setting file="file://$PROJECT_DIR$/play.bat" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/src/core/CUtil.h" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/src/gui/CTextManager.cpp" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/src/gui/CTooltip.cpp" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/src/gui/object/CProxyTargetGraphicsObject.cpp" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/src/handler/CRngHandler.cpp" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/vstd/vlogger.h" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/vstd/vtraits.h" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/../../../../dev/SDL2-2.0.12/x86_64-w64-mingw32/include/SDL2/SDL_surface.h" root0="SKIP_INSPECTION" />
+    <setting file="file://$PROJECT_DIR$/../../../../dev/SDL2_ttf-2.0.15/x86_64-w64-mingw32/include/SDL2/SDL_ttf.h" root0="SKIP_INSPECTION" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 8
+}</component>
+  <component name="ProjectId" id="1gNN90pkLL51TNAByemaAz4hGrI" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true">
+    <OptionsSetting value="false" id="Update" />
+  </component>
+  <component name="ProjectViewState">
+    <option name="autoscrollFromSource" value="true" />
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.readMode.enableVisualFormatting&quot;: &quot;true&quot;,
+    &quot;WebServerToolWindowFactoryState&quot;: &quot;true&quot;,
+    &quot;cf.first.check.clang-format&quot;: &quot;false&quot;,
+    &quot;cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;master&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/andrz/git/fall-of-nouraajd/res/images&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;CPPToolchains&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  }
+}</component>
+  <component name="RecentsManager">
+    <key name="CopyFile.RECENT_KEYS">
+      <recent name="C:\Users\andrz\git\fall-of-nouraajd\res\images" />
+    </key>
+  </component>
+  <component name="RunManager" selected="CMake Application.windows play debug">
+    <configuration default="true" type="GradleAppRunConfiguration" factoryName="Application" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true">
+      <method v="2">
+        <option name="com.jetbrains.cidr.cpp.gradle.execution.GradleNativeBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+      </method>
+    </configuration>
+    <list>
+      <item itemvalue="CMake Application.play debug" />
+      <item itemvalue="CMake Application.play release" />
+      <item itemvalue="CMake Application.play _unity" />
+      <item itemvalue="CMake Application.test" />
+      <item itemvalue="CMake Application.test _unity" />
+      <item itemvalue="CMake Application.windows play debug" />
+      <item itemvalue="CMake Application.windows play release" />
+    </list>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="4376a8b6-35dc-4e1d-8076-f9350c811619" name="Default Changelist" comment="" />
+      <created>1597950936399</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1597950936399</updated>
+      <workItem from="1597950938896" duration="183000" />
+      <workItem from="1597951149890" duration="2194000" />
+      <workItem from="1597985157182" duration="2173000" />
+      <workItem from="1621662891903" duration="16000" />
+      <workItem from="1621663111472" duration="13000" />
+      <workItem from="1668583221011" duration="6499000" />
+      <workItem from="1668634398629" duration="11882000" />
+      <workItem from="1668682222536" duration="1824000" />
+      <workItem from="1668692733914" duration="699000" />
+      <workItem from="1668703184119" duration="671000" />
+      <workItem from="1668769449405" duration="482000" />
+      <workItem from="1669046029893" duration="3077000" />
+      <workItem from="1669364500447" duration="2825000" />
+      <workItem from="1669551799441" duration="3041000" />
+      <workItem from="1672299739490" duration="342000" />
+      <workItem from="1672300130305" duration="2000" />
+      <workItem from="1678914502884" duration="104000" />
+      <workItem from="1690914722951" duration="960000" />
+      <workItem from="1690950152187" duration="22776000" />
+      <workItem from="1691095660045" duration="1420000" />
+      <workItem from="1708809242549" duration="421000" />
+      <workItem from="1712178011389" duration="10000" />
+    </task>
+    <task id="LOCAL-00001" summary="add workspace">
+      <created>1597951943440</created>
+      <option name="number" value="00001" />
+      <option name="presentableId" value="LOCAL-00001" />
+      <option name="project" value="LOCAL" />
+      <updated>1597951943440</updated>
+    </task>
+    <task id="LOCAL-00002" summary="fix path">
+      <created>1597989671780</created>
+      <option name="number" value="00002" />
+      <option name="presentableId" value="LOCAL-00002" />
+      <option name="project" value="LOCAL" />
+      <updated>1597989671780</updated>
+    </task>
+    <task id="LOCAL-00003" summary="fixes">
+      <created>1668587399039</created>
+      <option name="number" value="00003" />
+      <option name="presentableId" value="LOCAL-00003" />
+      <option name="project" value="LOCAL" />
+      <updated>1668587399039</updated>
+    </task>
+    <task id="LOCAL-00004" summary="fixes">
+      <created>1668588617830</created>
+      <option name="number" value="00004" />
+      <option name="presentableId" value="LOCAL-00004" />
+      <option name="project" value="LOCAL" />
+      <updated>1668588617830</updated>
+    </task>
+    <task id="LOCAL-00005" summary="fixes">
+      <created>1668676790930</created>
+      <option name="number" value="00005" />
+      <option name="presentableId" value="LOCAL-00005" />
+      <option name="project" value="LOCAL" />
+      <updated>1668676790930</updated>
+    </task>
+    <task id="LOCAL-00006" summary="fixes">
+      <created>1668678254452</created>
+      <option name="number" value="00006" />
+      <option name="presentableId" value="LOCAL-00006" />
+      <option name="project" value="LOCAL" />
+      <updated>1668678254452</updated>
+    </task>
+    <task id="LOCAL-00007" summary="show coordinates">
+      <created>1668769717420</created>
+      <option name="number" value="00007" />
+      <option name="presentableId" value="LOCAL-00007" />
+      <option name="project" value="LOCAL" />
+      <updated>1668769717420</updated>
+    </task>
+    <task id="LOCAL-00008" summary="path finder now uses teleporters">
+      <created>1669551836552</created>
+      <option name="number" value="00008" />
+      <option name="presentableId" value="LOCAL-00008" />
+      <option name="project" value="LOCAL" />
+      <updated>1669551836552</updated>
+    </task>
+    <task id="LOCAL-00009" summary="path finder now uses teleporters">
+      <created>1672299996047</created>
+      <option name="number" value="00009" />
+      <option name="presentableId" value="LOCAL-00009" />
+      <option name="project" value="LOCAL" />
+      <updated>1672299996047</updated>
+    </task>
+    <task id="LOCAL-00010" summary="enable show coordinates on property">
+      <option name="closed" value="true" />
+      <created>1690950750763</created>
+      <option name="number" value="00010" />
+      <option name="presentableId" value="LOCAL-00010" />
+      <option name="project" value="LOCAL" />
+      <updated>1690950750763</updated>
+    </task>
+    <task id="LOCAL-00011" summary="show footsteps">
+      <option name="closed" value="true" />
+      <created>1691055516455</created>
+      <option name="number" value="00011" />
+      <option name="presentableId" value="LOCAL-00011" />
+      <option name="project" value="LOCAL" />
+      <updated>1691055516455</updated>
+    </task>
+    <option name="localTasksCounter" value="12" />
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="VCPKGProject">
+    <isAutomaticCheckingOnLaunch value="false" />
+    <isAutomaticFoundErrors value="true" />
+    <isAutomaticReloadCMake value="true" />
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="add workspace" />
+    <MESSAGE value="fix path" />
+    <MESSAGE value="fixes" />
+    <MESSAGE value="show coordinates" />
+    <MESSAGE value="path finder now uses teleporters" />
+    <MESSAGE value="enable show coordinates on property" />
+    <MESSAGE value="show footsteps" />
+    <option name="LAST_COMMIT_MESSAGE" value="show footsteps" />
+    <option name="REFORMAT_BEFORE_PROJECT_COMMIT" value="true" />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager>
+      <breakpoints>
+        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
+          <url>file://$PROJECT_DIR$/src/gui/object/CMapGraphicsObject.cpp</url>
+          <line>72</line>
+          <option name="timeStamp" value="16" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
+          <url>file://$PROJECT_DIR$/src/gui/object/CMapGraphicsObject.cpp</url>
+          <line>71</line>
+          <option name="timeStamp" value="17" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
+          <url>file://$PROJECT_DIR$/src/core/CController.cpp</url>
+          <line>287</line>
+          <option name="timeStamp" value="18" />
+        </line-breakpoint>
+      </breakpoints>
+    </breakpoint-manager>
+  </component>
+  <component name="XSLT-Support.FileAssociations.UIState">
+    <expand />
+    <select />
+  </component>
+</project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
+if (POLICY CMP0087)
+    cmake_policy(SET CMP0087 NEW)
+endif ()
 
 project(fall-of-nouraajd)
 
-include(CPack)
-set(CPACK_GENERATOR "TGZ")
+if (WIN32)
+    set(CPACK_GENERATOR "ZIP")
+    add_compile_definitions(SDL_MAIN_HANDLED)
+else ()
+    set(CPACK_GENERATOR "TGZ")
+endif ()
 
 include(${CMAKE_SOURCE_DIR}/cmake/cotire.cmake)
 
@@ -28,16 +35,18 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include cmath -Wall -fconcepts")
+if (MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /bigobj /permissive- /Zc:preprocessor /EHsc /DBOOST_ALLOW_DEPRECATED_HEADERS /DBOOST_BIND_GLOBAL_PLACEHOLDERS /D_USE_MATH_DEFINES /DNOMINMAX /DWIN32_LEAN_AND_MEAN")
+else ()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include cmath -Wall -fconcepts")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -s")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g3")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_ALLOW_DEPRECATED_HEADERS -DBOOST_BIND_GLOBAL_PLACEHOLDERS")
 
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -s")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g3")
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_ALLOW_DEPRECATED_HEADERS -DBOOST_BIND_GLOBAL_PLACEHOLDERS")
-
-if (WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_hypot=hypot -Wa,-mbig-obj")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O")
+    if (WIN32)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_hypot=hypot -Wa,-mbig-obj")
+        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O")
+    endif ()
 endif ()
 
 file(GLOB_RECURSE GAME_SRC ${CMAKE_SOURCE_DIR}/src/**.cpp ${CMAKE_SOURCE_DIR}/src/**.h)
@@ -59,9 +68,40 @@ if (NOT pybind11_FOUND)
         message(FATAL_ERROR "pybind11 was not found. Install pybind11 or set pybind11_DIR.")
     endif ()
 endif ()
-find_package(SDL2 REQUIRED)
-find_package(SDL2_image REQUIRED)
-find_package(SDL2_ttf REQUIRED)
+find_package(SDL2 CONFIG QUIET)
+if (NOT SDL2_FOUND AND NOT TARGET SDL2::SDL2)
+    find_package(SDL2 REQUIRED)
+endif ()
+find_package(SDL2_image CONFIG QUIET)
+if (NOT SDL2_image_FOUND AND NOT TARGET SDL2_image::SDL2_image)
+    find_package(SDL2_image REQUIRED)
+endif ()
+find_package(SDL2_ttf CONFIG QUIET)
+if (NOT SDL2_ttf_FOUND AND NOT TARGET SDL2_ttf::SDL2_ttf)
+    find_package(SDL2_ttf REQUIRED)
+endif ()
+
+set(BOOST_FILESYSTEM_LIBS ${Boost_LIBRARIES})
+if (TARGET Boost::filesystem)
+    set(BOOST_FILESYSTEM_LIBS Boost::filesystem)
+endif ()
+
+set(SDL2_LIBS ${SDL2_LIBRARY})
+set(SDL2_EXECUTABLE_LIBS ${SDL2_LIBRARY})
+if (TARGET SDL2::SDL2)
+    set(SDL2_LIBS SDL2::SDL2)
+    set(SDL2_EXECUTABLE_LIBS SDL2::SDL2)
+endif ()
+
+set(SDL2_IMAGE_LIBS ${SDL2_IMAGE_LIBRARY})
+if (TARGET SDL2_image::SDL2_image)
+    set(SDL2_IMAGE_LIBS SDL2_image::SDL2_image)
+endif ()
+
+set(SDL2_TTF_LIBS ${SDL2_TTF_LIBRARY})
+if (TARGET SDL2_ttf::SDL2_ttf)
+    set(SDL2_TTF_LIBS SDL2_ttf::SDL2_ttf)
+endif ()
 
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${Python3_INCLUDE_DIRS})
@@ -76,7 +116,7 @@ include_directories(${CMAKE_SOURCE_DIR}/vstd)
 include_directories(${CMAKE_SOURCE_DIR}/random-dungeon-generator)
 
 pybind11_add_module(_game NO_EXTRAS ${GAME_SRC})
-target_link_libraries(_game PRIVATE ${Boost_LIBRARIES} ${SDL2_LIBRARY} ${SDL2_IMAGE_LIBRARY} ${SDL2_TTF_LIBRARY})
+target_link_libraries(_game PRIVATE ${BOOST_FILESYSTEM_LIBS} ${SDL2_LIBS} ${SDL2_IMAGE_LIBS} ${SDL2_TTF_LIBS})
 
 set_source_files_properties(
     ${CMAKE_SOURCE_DIR}/src/core/CModule.cpp
@@ -282,29 +322,47 @@ install(FILES res/game.py play.py mcp.py test.py DESTINATION fall-of-nouraajd)
 if (WIN32)
     install(FILES play.bat DESTINATION fall-of-nouraajd)
 
-    install(FILES windows-tools/SDL2_image-2.0.5/x86_64-w64-mingw32/bin/libjpeg-9.dll DESTINATION fall-of-nouraajd)
-    install(FILES windows-tools/SDL2_image-2.0.5/x86_64-w64-mingw32/bin/libpng16-16.dll DESTINATION fall-of-nouraajd)
-    install(FILES windows-tools/SDL2_image-2.0.5/x86_64-w64-mingw32/bin/libtiff-5.dll DESTINATION fall-of-nouraajd)
-    install(FILES windows-tools/SDL2_image-2.0.5/x86_64-w64-mingw32/bin/libwebp-7.dll DESTINATION fall-of-nouraajd)
-    install(FILES windows-tools/SDL2_image-2.0.5/x86_64-w64-mingw32/bin/SDL2_image.dll DESTINATION fall-of-nouraajd)
-    install(FILES windows-tools/SDL2_image-2.0.5/x86_64-w64-mingw32/bin/zlib1.dll DESTINATION fall-of-nouraajd)
+    set(WINDOWS_RUNTIME_DEPENDENCY_CODE "")
+    if (DEFINED _VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
+        foreach (runtime_dir
+                 "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin"
+                 "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/bin")
+            if (EXISTS "${runtime_dir}")
+                string(APPEND WINDOWS_RUNTIME_DEPENDENCY_CODE
+                       "list(APPEND runtime_search_dirs [[${runtime_dir}]])\n")
+            endif ()
+        endforeach ()
+    endif ()
 
-    install(FILES windows-tools/SDL2_ttf-2.0.15/x86_64-w64-mingw32/bin/libfreetype-6.dll DESTINATION fall-of-nouraajd)
-    install(FILES windows-tools/SDL2_ttf-2.0.15/x86_64-w64-mingw32/bin/SDL2_ttf.dll DESTINATION fall-of-nouraajd)
-
-    install(FILES windows-tools/SDL2-2.0.12/x86_64-w64-mingw32/bin/SDL2.dll DESTINATION fall-of-nouraajd)
-
-    install(FILES windows-tools/boost64/lib/libboost_filesystem-mgw8-mt-x64-1_74.dll DESTINATION fall-of-nouraajd)
-
-    install(FILES windows-tools/Python36/python.exe DESTINATION fall-of-nouraajd)
-    install(FILES windows-tools/Python36/python36.dll DESTINATION fall-of-nouraajd)
-    install(FILES windows-tools/Python36/vcruntime140.dll DESTINATION fall-of-nouraajd)
-
-    install(FILES windows-tools/mingw/mingw64/bin/libgcc_s_seh-1.dll DESTINATION fall-of-nouraajd)
-    install(FILES windows-tools/mingw/mingw64/bin/libstdc++-6.dll DESTINATION fall-of-nouraajd)
-    install(FILES windows-tools/mingw/mingw64/bin/libwinpthread-1.dll DESTINATION fall-of-nouraajd)
-
-    install(FILES windows-tools/Python36/python36.zip DESTINATION fall-of-nouraajd)
+    install(CODE "
+        if (CMAKE_VERSION VERSION_LESS 3.16)
+            message(WARNING \"CMake 3.16 or newer is required to bundle Windows runtime DLLs automatically.\")
+        else ()
+            set(runtime_search_dirs \"\$ENV{PATH}\")
+            ${WINDOWS_RUNTIME_DEPENDENCY_CODE}
+            file(GET_RUNTIME_DEPENDENCIES
+                RESOLVED_DEPENDENCIES_VAR runtime_deps
+                UNRESOLVED_DEPENDENCIES_VAR unresolved_runtime_deps
+                MODULES \"$<TARGET_FILE:_game>\"
+                DIRECTORIES \${runtime_search_dirs}
+                PRE_EXCLUDE_REGEXES
+                    \"api-ms-.*\"
+                    \"ext-ms-.*\"
+                POST_EXCLUDE_REGEXES
+                    \".*[Ww][Ii][Nn][Dd][Oo][Ww][Ss][\\/][Ss]ystem32.*\"
+            )
+            foreach (runtime_dep IN LISTS runtime_deps)
+                file(INSTALL
+                    DESTINATION \"\${CMAKE_INSTALL_PREFIX}/fall-of-nouraajd\"
+                    TYPE SHARED_LIBRARY
+                    FILES \"\${runtime_dep}\"
+                )
+            endforeach ()
+            if (unresolved_runtime_deps)
+                message(WARNING \"Unresolved Windows runtime dependencies: \${unresolved_runtime_deps}\")
+            endif ()
+        endif ()
+    ")
 endif ()
 
 
@@ -331,17 +389,39 @@ target_include_directories(for_unit_tests PRIVATE
 target_link_libraries(for_unit_tests PRIVATE
     Python3::Python
     pybind11::headers
-    ${SDL2_LIBRARY}
-    ${SDL2_IMAGE_LIBRARY}
+    ${BOOST_FILESYSTEM_LIBS}
+    ${SDL2_EXECUTABLE_LIBS}
+    ${SDL2_IMAGE_LIBS}
+    ${SDL2_TTF_LIBS}
 )
 
 enable_testing()
 add_test(NAME for_unit_tests COMMAND for_unit_tests)
+if (WIN32 AND DEFINED _VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
+    set(TEST_PYTHONHOME "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/tools/python3")
+    set(TEST_RUNTIME_PATH "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin")
+    if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)
+        set_tests_properties(for_unit_tests PROPERTIES
+            ENVIRONMENT "PYTHONHOME=${TEST_PYTHONHOME}"
+            ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:${TEST_RUNTIME_PATH}"
+        )
+    else ()
+        set_tests_properties(for_unit_tests PROPERTIES
+            ENVIRONMENT "PYTHONHOME=${TEST_PYTHONHOME};PATH=${TEST_RUNTIME_PATH}"
+        )
+    endif ()
+endif ()
 
-SET(CPACK_STRIP_FILES _game.so)
+if (WIN32)
+    set(CPACK_STRIP_FILES _game.pyd)
+else ()
+    set(CPACK_STRIP_FILES _game.so)
+endif ()
 
 if (WIN32)
     set_target_properties(_game PROPERTIES UNITY_BUILD OFF)
 else()
     set_target_properties(_game PROPERTIES UNITY_BUILD ON UNITY_BUILD_BATCH_SIZE 8)
 endif ()
+
+include(CPack)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ cmake --build cmake-build-release --target _game -j$(nproc)
 python3 play.py
 </pre>
 
+### windows
+Install Visual Studio 2022 with the **Desktop development with C++** workload and CMake tools, install Python 3,
+then install and bootstrap vcpkg. From a normal `cmd.exe` shell:
+<pre>
+git clone https://github.com/microsoft/vcpkg C:\vcpkg
+C:\vcpkg\bootstrap-vcpkg.bat
+set VCPKG_ROOT=C:\vcpkg
+python -m pip install --upgrade pillow
+git submodule update --init --recursive
+%VCPKG_ROOT%\vcpkg install --triplet x64-windows
+configure.bat
+cmake --build cmake-build-release --config Release --target _game
+set GAME_BUILD_CONFIG=Release
+python play.py
+</pre>
+
 ### mcp server (engine api)
 <pre>
 cmake --build cmake-build-release --target _game -j$(nproc)
@@ -43,6 +59,7 @@ To use stdio transport instead (required by some Codex flows), run from the repo
 <pre>
 python3 mcp.py --stdio --repo-root . --build-dir cmake-build-release
 </pre>
+On Windows Visual Studio builds, add `--build-config Release`.
 The command also works from `cmake-build-release/mcp.py` if you prefer launching from the build directory.
 
 ### testing
@@ -59,6 +76,8 @@ cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)
 ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
 python3 test.py
 </pre>
+For Windows Visual Studio builds, use `--config Release`, pass `-C Release` to `ctest`,
+and set `GAME_BUILD_CONFIG=Release` before running `python test.py`.
 Also run `./scripts/run_coverage.sh` when a change touches tests (for example
 `test.py` or `tests/unit/**`), `src/core/**`, `src/handler/**`, `src/object/**`,
 or the coverage tooling. The scoped line coverage threshold for that run is 80%;

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ python3 play.py
 </pre>
 
 ### windows
-Install Visual Studio 2022 with the **Desktop development with C++** workload and CMake tools, install Python 3,
+Install Visual Studio 2022 with the **Desktop development with C++** workload and CMake tools, install Python 3.12,
 then install and bootstrap vcpkg. From a normal `cmd.exe` shell:
 <pre>
 git clone https://github.com/microsoft/vcpkg C:\vcpkg

--- a/configure.bat
+++ b/configure.bat
@@ -16,6 +16,14 @@ if errorlevel 1 (
 )
 
 for /f "usebackq delims=" %%i in (`python -c "import sys; print(sys.executable)"`) do set "PYTHON_EXECUTABLE=%%i"
+for /f "usebackq delims=" %%i in (`python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"`) do set "PYTHON_VERSION=%%i"
+if not "!PYTHON_VERSION!"=="3.12" (
+    echo Python 3.12 is required on PATH for the Windows build.
+    echo Found Python !PYTHON_VERSION! at:
+    echo   !PYTHON_EXECUTABLE!
+    echo vcpkg provides Python 3.12 development libraries, so the interpreter must match that ABI.
+    exit /b 1
+)
 
 if not defined VCPKG_ROOT (
     if defined VCPKG_INSTALLATION_ROOT set "VCPKG_ROOT=!VCPKG_INSTALLATION_ROOT!"
@@ -49,6 +57,8 @@ if not exist "!VCPKG_TOOLCHAIN_FILE!" (
 if not defined CMAKE_GENERATOR set "CMAKE_GENERATOR=Visual Studio 17 2022"
 if not defined CMAKE_GENERATOR_PLATFORM set "CMAKE_GENERATOR_PLATFORM=x64"
 if not defined VCPKG_TARGET_TRIPLET set "VCPKG_TARGET_TRIPLET=x64-windows"
+if not defined VCPKG_INSTALLED_DIR set "VCPKG_INSTALLED_DIR=%CD%\vcpkg_installed"
+set "VCPKG_INSTALLED_DIR_CMAKE=!VCPKG_INSTALLED_DIR:\=/!"
 
 call :configure cmake-build-debug
 if errorlevel 1 exit /b 1
@@ -75,12 +85,24 @@ if exist "!BUILD_DIR!\CMakeCache.txt" (
             rmdir /s /q "!BUILD_DIR!\CMakeFiles" 2>nul
         )
     )
+    if exist "!BUILD_DIR!\CMakeCache.txt" (
+        findstr /C:"VCPKG_INSTALLED_DIR:PATH=!VCPKG_INSTALLED_DIR_CMAKE!" "!BUILD_DIR!\CMakeCache.txt" >nul 2>nul
+        if errorlevel 1 (
+            echo Recreating !BUILD_DIR! because it was configured with a different vcpkg installed directory.
+            del /q "!BUILD_DIR!\CMakeCache.txt" 2>nul
+            rmdir /s /q "!BUILD_DIR!\CMakeFiles" 2>nul
+        )
+    )
 )
 
 cmake -B ./!BUILD_DIR! -S . ^
+    -U "Python3_*" ^
+    -U "_Python3_*" ^
+    -U "PYBIND11_PYTHON_*" ^
     -G "!CMAKE_GENERATOR!" ^
     -A "!CMAKE_GENERATOR_PLATFORM!" ^
     -DCMAKE_TOOLCHAIN_FILE="!VCPKG_TOOLCHAIN_FILE!" ^
+    -DVCPKG_INSTALLED_DIR="!VCPKG_INSTALLED_DIR!" ^
     -DVCPKG_TARGET_TRIPLET="!VCPKG_TARGET_TRIPLET!" ^
     -DPython3_EXECUTABLE="!PYTHON_EXECUTABLE!"
 exit /b %ERRORLEVEL%

--- a/configure.bat
+++ b/configure.bat
@@ -1,11 +1,86 @@
-git clone https://github.com/lisu188/fall-of-nouraajd-windows-tools.git windows-tools
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
 
-set PATH=%pythonLocation%\;%pythonLocation%\Scripts\;%cd%\windows-tools\Python36\;%cd%\windows-tools\boost64;%cd%\windows-tools\SDL2_image-2.0.5\x86_64-w64-mingw32\;%cd%\windows-tools\SDL2_ttf-2.0.15\x86_64-w64-mingw32\;%cd%\windows-tools\SDL2-2.0.12\x86_64-w64-mingw32\;%cd%\windows-tools\mingw\mingw64\bin\;%cd%\windows-tools\boost_1_74_0\boost64\lib\;%cd%\windows-tools\SDL2_image-2.0.5\x86_64-w64-mingw32\bin\;%cd%\windows-tools\SDL2_ttf-2.0.15\x86_64-w64-mingw32\bin\;%cd%\windows-tools\SDL2-2.0.12\x86_64-w64-mingw32\bin\;C:\Program Files\CMake\bin;%PATH%
-set PYTHON_EXECUTABLE=%pythonLocation%\python.exe
-for /f "usebackq delims=" %%i in (`"%PYTHON_EXECUTABLE%" -m pybind11 --cmakedir`) do set PYBIND11_DIR=%%i
+where cmake >nul 2>nul
+if errorlevel 1 (
+    echo CMake was not found on PATH.
+    echo Install Visual Studio 2022 with the C++ CMake tools component, or add CMake to PATH.
+    exit /b 1
+)
 
-mkdir cmake-build-debug
-mkdir cmake-build-release
+where python >nul 2>nul
+if errorlevel 1 (
+    echo Python was not found on PATH.
+    echo Install Python 3 and make sure it is available on PATH.
+    exit /b 1
+)
 
-cmake -B./cmake-build-debug -H. -DCMAKE_BUILD_TYPE=Debug -G "MinGW Makefiles" -DPython3_ROOT_DIR="%pythonLocation%" -DPython3_EXECUTABLE="%PYTHON_EXECUTABLE%" -Dpybind11_DIR="%PYBIND11_DIR%"
-cmake -B./cmake-build-release -H. -DCMAKE_BUILD_TYPE=Release -G "MinGW Makefiles" -DPython3_ROOT_DIR="%pythonLocation%" -DPython3_EXECUTABLE="%PYTHON_EXECUTABLE%" -Dpybind11_DIR="%PYBIND11_DIR%"
+for /f "usebackq delims=" %%i in (`python -c "import sys; print(sys.executable)"`) do set "PYTHON_EXECUTABLE=%%i"
+
+if not defined VCPKG_ROOT (
+    if defined VCPKG_INSTALLATION_ROOT set "VCPKG_ROOT=!VCPKG_INSTALLATION_ROOT!"
+)
+if not defined VCPKG_ROOT (
+    if exist "C:\vcpkg" set "VCPKG_ROOT=C:\vcpkg"
+)
+if not defined VCPKG_ROOT (
+    set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+    if exist "!VSWHERE!" (
+        for /f "usebackq delims=" %%i in (`"!VSWHERE!" -latest -products * -find "VC\vcpkg\vcpkg.exe" 2^>nul`) do (
+            if not defined VCPKG_ROOT (
+                for %%d in ("%%~dpi.") do set "VCPKG_ROOT=%%~fd"
+            )
+        )
+    )
+)
+if not defined VCPKG_ROOT (
+    echo VCPKG_ROOT was not set, C:\vcpkg was not found, and Visual Studio vcpkg was not found.
+    echo Install vcpkg, then set VCPKG_ROOT to its install directory.
+    exit /b 1
+)
+
+set "VCPKG_TOOLCHAIN_FILE=!VCPKG_ROOT!\scripts\buildsystems\vcpkg.cmake"
+if not exist "!VCPKG_TOOLCHAIN_FILE!" (
+    echo vcpkg CMake toolchain file was not found:
+    echo   !VCPKG_TOOLCHAIN_FILE!
+    exit /b 1
+)
+
+if not defined CMAKE_GENERATOR set "CMAKE_GENERATOR=Visual Studio 17 2022"
+if not defined CMAKE_GENERATOR_PLATFORM set "CMAKE_GENERATOR_PLATFORM=x64"
+if not defined VCPKG_TARGET_TRIPLET set "VCPKG_TARGET_TRIPLET=x64-windows"
+
+call :configure cmake-build-debug
+if errorlevel 1 exit /b 1
+
+call :configure cmake-build-release
+if errorlevel 1 exit /b 1
+
+exit /b 0
+
+:configure
+set "BUILD_DIR=%~1"
+
+if exist "!BUILD_DIR!\CMakeCache.txt" (
+    findstr /C:"CMAKE_GENERATOR:INTERNAL=!CMAKE_GENERATOR!" "!BUILD_DIR!\CMakeCache.txt" >nul 2>nul
+    if errorlevel 1 (
+        echo Recreating !BUILD_DIR! because it was configured with a different CMake generator.
+        del /q "!BUILD_DIR!\CMakeCache.txt" 2>nul
+        rmdir /s /q "!BUILD_DIR!\CMakeFiles" 2>nul
+    ) else (
+        findstr /C:"CMAKE_GENERATOR_PLATFORM:INTERNAL=!CMAKE_GENERATOR_PLATFORM!" "!BUILD_DIR!\CMakeCache.txt" >nul 2>nul
+        if errorlevel 1 (
+            echo Recreating !BUILD_DIR! because it was configured for a different platform.
+            del /q "!BUILD_DIR!\CMakeCache.txt" 2>nul
+            rmdir /s /q "!BUILD_DIR!\CMakeFiles" 2>nul
+        )
+    )
+)
+
+cmake -B ./!BUILD_DIR! -S . ^
+    -G "!CMAKE_GENERATOR!" ^
+    -A "!CMAKE_GENERATOR_PLATFORM!" ^
+    -DCMAKE_TOOLCHAIN_FILE="!VCPKG_TOOLCHAIN_FILE!" ^
+    -DVCPKG_TARGET_TRIPLET="!VCPKG_TARGET_TRIPLET!" ^
+    -DPython3_EXECUTABLE="!PYTHON_EXECUTABLE!"
+exit /b %ERRORLEVEL%

--- a/mcp.py
+++ b/mcp.py
@@ -97,9 +97,11 @@ class EngineMcpServer:
         trace_messages: bool = False,
         native_log_sink: str = "stdout",
         native_log_path: Path | None = None,
+        build_config: str | None = None,
     ) -> None:
         self.repo_root = repo_root
         self.build_dir = build_dir
+        self.build_config = build_config
         self.allow_origins = allow_origins or []
         self.trace_messages = trace_messages
         self.native_log_sink = native_log_sink
@@ -116,8 +118,13 @@ class EngineMcpServer:
 
     def build_extension(self) -> None:
         logger.info("building extension target _game in %s", self.build_dir)
+        command = ["cmake", "--build", str(self.build_dir), "--target", "_game"]
+        if self.build_config:
+            command.extend(["--config", self.build_config])
+        else:
+            command.append(f"-j{os.cpu_count() or 1}")
         subprocess.run(
-            ["cmake", "--build", str(self.build_dir), "--target", "_game", f"-j{os.cpu_count() or 1}"],
+            command,
             cwd=self.repo_root,
             check=True,
         )
@@ -126,16 +133,24 @@ class EngineMcpServer:
         os.chdir(self.build_dir)
         sys.path.insert(0, str(self.repo_root / "res"))
         sys.path.insert(0, str(self.build_dir))
+        for extension_dir in reversed(self._extension_search_dirs()):
+            if extension_dir.exists():
+                sys.path.insert(0, str(extension_dir))
         try:
             self._game_module = importlib.import_module("_game")
         except ModuleNotFoundError as exc:
             raise ModuleNotFoundError(
                 "Unable to import compiled `_game` module. Build it with `cmake --build "
-                f"{self.build_dir} --target _game -j$(nproc)` or run mcp.py with `--build`."
+                f"{self.build_dir} --target _game` or run mcp.py with `--build`."
             ) from exc
         self._configure_native_logging()
         self.game_module = importlib.import_module("game")
         logger.info("modules imported successfully")
+
+    def _extension_search_dirs(self) -> list[Path]:
+        if self.build_config:
+            return [self.build_dir / self.build_config]
+        return [self.build_dir / config for config in ("Release", "Debug", "RelWithDebInfo", "MinSizeRel")]
 
     def inspect_and_export(self) -> None:
         if self._game_module is None or self.game_module is None:
@@ -1447,6 +1462,11 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="MCP server exposing unified game/_game functions")
     parser.add_argument("--repo-root", default=None, help="Repository root path")
     parser.add_argument("--build-dir", default="cmake-build-release", help="Build directory containing _game")
+    parser.add_argument(
+        "--build-config",
+        default=os.environ.get("GAME_BUILD_CONFIG"),
+        help="CMake build configuration for multi-config generators such as Visual Studio",
+    )
     parser.add_argument("--build", action="store_true", help="Build the extension before starting the server")
     parser.add_argument("--stdio", action="store_true", help="Run as a stdio MCP server instead of HTTP")
     parser.add_argument("--host", default="127.0.0.1", help="HTTP host to bind when running in HTTP mode")
@@ -1512,6 +1532,7 @@ def main() -> int:
         trace_messages=args.trace_messages,
         native_log_sink=native_log_sink,
         native_log_path=native_log_path,
+        build_config=args.build_config,
     )
     if args.build:
         server.build_extension()

--- a/play.py
+++ b/play.py
@@ -1,5 +1,5 @@
 # fall-of-nouraajd c++ dark fantasy game
-# Copyright (C) 2019  Andrzej Lis
+# Copyright (C) 2025  Andrzej Lis
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -31,6 +31,15 @@ def _find_build_dir(root: Path) -> Path | None:
     return None
 
 
+def _insert_extension_paths(build_dir: Path) -> None:
+    build_config = os.environ.get("GAME_BUILD_CONFIG")
+    if build_config:
+        _insert_path(build_dir / build_config)
+        return
+    for config in ("Release", "Debug", "RelWithDebInfo", "MinSizeRel"):
+        _insert_path(build_dir / config)
+
+
 def _ensure_workdir(build_dir: Path | None) -> None:
     if build_dir and not (Path.cwd() / "config").exists():
         os.chdir(build_dir)
@@ -43,6 +52,7 @@ def _bootstrap() -> None:
     build_dir = _find_build_dir(repo_root)
     if build_dir:
         _insert_path(build_dir)
+        _insert_extension_paths(build_dir)
     _ensure_workdir(build_dir)
 
 

--- a/src/core/CGlobal.h
+++ b/src/core/CGlobal.h
@@ -20,7 +20,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <Python.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/locale.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/range/irange.hpp>
 

--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -421,6 +421,9 @@ void CMap::setTurn(int turn) { this->turn = turn; }
 void CMap::setTiles(std::set<std::shared_ptr<CTile>> objects) {
     tiles.clear();
     for (const auto &ob : objects) {
+        if (!ob) {
+            continue;
+        }
         tiles[normalizeCoords(ob->getCoords())] = ob;
     }
     bumpNavigationRevision();
@@ -434,6 +437,9 @@ void CMap::setObjects(std::set<std::shared_ptr<CMapObject>> objects) {
     mapObjects.clear();
     mapObjectsCache.clear();
     for (auto ob : objects) {
+        if (!ob) {
+            continue;
+        }
         mapObjects[ob->getName()] = ob;
         mapObjectsCache.insert(std::make_pair(normalizeCoords(ob->getCoords()), ob->getName()));
     }
@@ -472,6 +478,9 @@ std::set<std::shared_ptr<CTrigger>> CMap::getTriggers() {
 
 void CMap::setTriggers(std::set<std::shared_ptr<CTrigger>> triggers) {
     for (auto trigger : triggers) {
+        if (!trigger) {
+            continue;
+        }
         getEventHandler()->registerTrigger(trigger);
     }
 }

--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -100,7 +100,7 @@ std::shared_ptr<CPlayer> CMap::getPlayer() {
     // TODO: think of better solution after save
     if (!player) {
         for (auto object : getObjects()) {
-            if (object->getName() == "player") {
+            if (object && object->getName() == "player") {
                 player = vstd::cast<CPlayer>(object);
                 player->setController(getGame()->createObject<CPlayerController>());
                 player->setFightController(getGame()->createObject<CPlayerFightController>());
@@ -438,6 +438,7 @@ void CMap::setObjects(std::set<std::shared_ptr<CMapObject>> objects) {
     mapObjectsCache.clear();
     for (auto ob : objects) {
         if (!ob) {
+            vstd::logger::warning("Ignoring null map object in CMap::setObjects");
             continue;
         }
         mapObjects[ob->getName()] = ob;
@@ -479,6 +480,7 @@ std::set<std::shared_ptr<CTrigger>> CMap::getTriggers() {
 void CMap::setTriggers(std::set<std::shared_ptr<CTrigger>> triggers) {
     for (auto trigger : triggers) {
         if (!trigger) {
+            vstd::logger::warning("Ignoring null trigger in CMap::setTriggers");
             continue;
         }
         getEventHandler()->registerTrigger(trigger);

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -639,6 +639,6 @@ PYBIND11_MODULE(_game, m) {
     PY_WRAP_GENERIC_DOC(randint, "randint(lower, upper) -> int: Return a random integer in engine-defined bounds.");
     m.def("jsonify", &jsonify_py, "jsonify(obj) -> str: Serialize a game object to JSON text.");
     PY_WRAP_GENERIC_DOC(logger, "logger(message) -> None: Write an info log message to the engine logger.");
-    m.def("set_logger_sink", set_logger_sink_py,
+    m.def("set_logger_sink", set_logger_sink_py, py::arg("sink_name"), py::arg("path") = py::none(),
           "set_logger_sink(sink, path=None) -> None: Configure the native logger output target.");
 }

--- a/src/core/CPathFinder.h
+++ b/src/core/CPathFinder.h
@@ -22,12 +22,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 class CCreature;
 
-template <typename T = void> std::list<Coords> near_coords(auto coords) {
+template <typename CoordsLike> std::list<Coords> near_coords(const CoordsLike &coords) {
     return {Coords(coords.x + 1, coords.y, coords.z), Coords(coords.x - 1, coords.y, coords.z),
             Coords(coords.x, coords.y + 1, coords.z), Coords(coords.x, coords.y - 1, coords.z)};
 }
 
-template <typename T = void> std::list<Coords> near_coords_with(auto coords) {
+template <typename CoordsLike> std::list<Coords> near_coords_with(const CoordsLike &coords) {
     return {Coords(coords.x, coords.y, coords.z), Coords(coords.x + 1, coords.y, coords.z),
             Coords(coords.x - 1, coords.y, coords.z), Coords(coords.x, coords.y + 1, coords.z),
             Coords(coords.x, coords.y - 1, coords.z)};

--- a/src/core/CSerialization.cpp
+++ b/src/core/CSerialization.cpp
@@ -258,8 +258,11 @@ std::set<std::shared_ptr<CGameObject>> array_deserialize(const std::shared_ptr<C
                                                          const std::shared_ptr<json> &object) {
     std::set<std::shared_ptr<CGameObject>> objects;
     for (unsigned int i = 0; i < object->size(); i++) {
-        objects.insert(CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(
-            map, CJsonUtil::alias(object, (*object)[i])));
+        auto deserialized = CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(
+            map, CJsonUtil::alias(object, (*object)[i]));
+        if (deserialized) {
+            objects.insert(deserialized);
+        }
     }
     return objects;
 }

--- a/src/core/CSerialization.cpp
+++ b/src/core/CSerialization.cpp
@@ -260,9 +260,10 @@ std::set<std::shared_ptr<CGameObject>> array_deserialize(const std::shared_ptr<C
     for (unsigned int i = 0; i < object->size(); i++) {
         auto deserialized = CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(
             map, CJsonUtil::alias(object, (*object)[i]));
-        if (deserialized) {
-            objects.insert(deserialized);
+        if (!deserialized) {
+            vstd::logger::warning("Failed to deserialize object in array at index:", i);
         }
+        objects.insert(deserialized);
     }
     return objects;
 }

--- a/src/gui/CTextManager.h
+++ b/src/gui/CTextManager.h
@@ -22,33 +22,32 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CGameObject.h"
 
 class CTextManager : public CGameObject {
-  V_META(CTextManager, CGameObject, vstd::meta::empty())
-  std::unordered_map<std::pair<std::string, int>, SDL_Texture *> _textures;
+    V_META(CTextManager, CGameObject, vstd::meta::empty())
+    std::unordered_map<std::pair<std::string, int>, SDL_Texture *> _textures;
 
-public:
-  explicit CTextManager(const std::shared_ptr<CGui> &_gui = nullptr);
+  public:
+    explicit CTextManager(const std::shared_ptr<CGui> &_gui = nullptr);
 
-  ~CTextManager() override;
+    ~CTextManager() override;
 
-  std::pair<int, int> getTextureSize(std::string text);
+    std::pair<int, int> getTextureSize(std::string text);
 
-  void drawText(const std::string &text, int x, int y, int w);
+    void drawText(const std::string &text, int x, int y, int w);
 
-  void drawText(const std::string &text, const std::shared_ptr<SDL_Rect> &rect);
+    void drawText(const std::string &text, const std::shared_ptr<SDL_Rect> &rect);
 
-  void drawTextCentered(const std::string &text, int x, int y, int w, int h);
+    void drawTextCentered(const std::string &text, int x, int y, int w, int h);
 
-  void drawTextCentered(const std::string &text,
-                        const std::shared_ptr<SDL_Rect> &rect);
+    void drawTextCentered(const std::string &text, const std::shared_ptr<SDL_Rect> &rect);
 
-  int countLines(const std::string &text, int w);
+    int countLines(const std::string &text, int w);
 
-private:
-  SDL_Texture *getTexture(const std::string &text, int width = 0);
+  private:
+    SDL_Texture *getTexture(const std::string &text, int width = 0);
 
-  SDL_Texture *loadTexture(std::string text, int width = 0);
+    SDL_Texture *loadTexture(std::string text, int width = 0);
 
-  std::weak_ptr<CGui> _gui;
+    std::weak_ptr<CGui> _gui;
 
-  struct _TTF_Font *font;
+    TTF_Font *font;
 };

--- a/src/gui/object/CProxyTargetGraphicsObject.cpp
+++ b/src/gui/object/CProxyTargetGraphicsObject.cpp
@@ -24,94 +24,82 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <utility>
 
 void CProxyTargetGraphicsObject::refresh() {
-  vstd::with<void>(getGui(), [this](auto gui) {
-    int prevX = 0, prevY = 0;
-    for (const auto &x_pair : proxyObjects) {
-      prevX = std::max(prevX, x_pair.first + 1);
-      if (!x_pair.second.empty()) {
-        prevY = std::max(prevY, x_pair.second.rbegin()->first + 1);
-      }
-    }
-
-    int currentSizeX = getSizeX(gui);
-    int currentSizeY = getSizeY(gui);
-
-    int xDiff = currentSizeX - prevX;
-    int yDiff = currentSizeY - prevY;
-
-    for (int x = 0; x < std::max(prevX, currentSizeX); x++) {
-      for (int y = 0; y < std::max(prevY, currentSizeY); y++) {
-        if (vstd::square_ctn(currentSizeX, currentSizeY, x, y) &&
-            !vstd::square_ctn(prevX, prevY, x, y)) {
-          addProxyObject(gui, x, y);
-        } else if (!vstd::square_ctn(currentSizeX, currentSizeY, x, y) &&
-                   vstd::square_ctn(prevX, prevY, x, y)) {
-          removeProxyObject(x, y);
+    vstd::with<void>(getGui(), [this](auto gui) {
+        int prevX = 0, prevY = 0;
+        for (const auto &x_pair : proxyObjects) {
+            prevX = std::max(prevX, x_pair.first + 1);
+            if (!x_pair.second.empty()) {
+                prevY = std::max(prevY, x_pair.second.rbegin()->first + 1);
+            }
         }
-      }
-    }
 
-    if (xDiff != 0 || yDiff != 0) {
-      refreshAll();
-    }
-  });
+        int currentSizeX = getSizeX(gui);
+        int currentSizeY = getSizeY(gui);
+
+        int xDiff = currentSizeX - prevX;
+        int yDiff = currentSizeY - prevY;
+
+        for (int x = 0; x < std::max(prevX, currentSizeX); x++) {
+            for (int y = 0; y < std::max(prevY, currentSizeY); y++) {
+                if (vstd::square_ctn(currentSizeX, currentSizeY, x, y) && !vstd::square_ctn(prevX, prevY, x, y)) {
+                    addProxyObject(gui, x, y);
+                } else if (!vstd::square_ctn(currentSizeX, currentSizeY, x, y) &&
+                           vstd::square_ctn(prevX, prevY, x, y)) {
+                    removeProxyObject(x, y);
+                }
+            }
+        }
+
+        if (xDiff != 0 || yDiff != 0) {
+            refreshAll();
+        }
+    });
 }
 
-void CProxyTargetGraphicsObject::addProxyObject(auto gui, int &x, int &y) {
-  std::shared_ptr<CProxyGraphicsObject> nh =
-      std::make_shared<CProxyGraphicsObject>(x, y);
-  std::shared_ptr<CLayout> layout1 =
-      gui->getGame()->template createObject<CLayout>(proxyLayout);
-  layout1->setNumericProperty("tileSize",
-                              getTileSize(this->ptr<CGameGraphicsObject>()));
-  nh->setLayout(layout1);
-  proxyObjects[x][y] = nh;
-  addChild(nh);
+void CProxyTargetGraphicsObject::addProxyObject(std::shared_ptr<CGui> gui, int &x, int &y) {
+    std::shared_ptr<CProxyGraphicsObject> nh = std::make_shared<CProxyGraphicsObject>(x, y);
+    std::shared_ptr<CLayout> layout1 = gui->getGame()->template createObject<CLayout>(proxyLayout);
+    layout1->setNumericProperty("tileSize", getTileSize(this->ptr<CGameGraphicsObject>()));
+    nh->setLayout(layout1);
+    proxyObjects[x][y] = nh;
+    addChild(nh);
 }
 
 void CProxyTargetGraphicsObject::removeProxyObject(int &x, int &y) {
-  removeChild(proxyObjects[x][y]);
-  proxyObjects[x].erase(y);
-  if (proxyObjects[x].empty()) {
-    proxyObjects.erase(x);
-  }
+    removeChild(proxyObjects[x][y]);
+    proxyObjects[x].erase(y);
+    if (proxyObjects[x].empty()) {
+        proxyObjects.erase(x);
+    }
 }
 
 void CProxyTargetGraphicsObject::refreshAll() {
-  for (auto [_x, map_x] : proxyObjects) {
-    for (auto [no, val] : map_x) {
-      val->refresh();
+    for (auto [_x, map_x] : proxyObjects) {
+        for (auto [no, val] : map_x) {
+            val->refresh();
+        }
     }
-  }
 }
 
 void CProxyTargetGraphicsObject::refreshObject(int x, int y) {
-  int sizeX = getSizeX(getGui());
-  int sizeY = getSizeY(getGui());
-  if (x < 0 || x >= sizeX || y < 0 || y >= sizeY) {
-    vstd::logger::warning("Ignoring proxy refresh outside target bounds:", x,
-                          y, "size:", sizeX, sizeY);
-  } else {
-    proxyObjects[x][y]->refresh();
-  }
+    int sizeX = getSizeX(getGui());
+    int sizeY = getSizeY(getGui());
+    if (x < 0 || x >= sizeX || y < 0 || y >= sizeY) {
+        vstd::logger::warning("Ignoring proxy refresh outside target bounds:", x, y, "size:", sizeX, sizeY);
+    } else {
+        proxyObjects[x][y]->refresh();
+    }
 }
 
-int CProxyTargetGraphicsObject::getSizeX(std::shared_ptr<CGui> gui) {
-  return 0;
-}
+int CProxyTargetGraphicsObject::getSizeX(std::shared_ptr<CGui> gui) { return 0; }
 
-int CProxyTargetGraphicsObject::getSizeY(std::shared_ptr<CGui> gui) {
-  return 0;
-}
+int CProxyTargetGraphicsObject::getSizeY(std::shared_ptr<CGui> gui) { return 0; }
 
-std::list<std::shared_ptr<CGameGraphicsObject>>
-CProxyTargetGraphicsObject::getProxiedObjects(std::shared_ptr<CGui> gui, int x,
-                                              int y) {
-  return {};
+std::list<std::shared_ptr<CGameGraphicsObject>> CProxyTargetGraphicsObject::getProxiedObjects(std::shared_ptr<CGui> gui,
+                                                                                              int x, int y) {
+    return {};
 }
 
 std::string CProxyTargetGraphicsObject::getProxyLayout() { return proxyLayout; }
 
-void CProxyTargetGraphicsObject::setProxyLayout(std::string _layout) {
-  proxyLayout = std::move(_layout);
-}
+void CProxyTargetGraphicsObject::setProxyLayout(std::string _layout) { proxyLayout = std::move(_layout); }

--- a/src/gui/object/CProxyTargetGraphicsObject.h
+++ b/src/gui/object/CProxyTargetGraphicsObject.h
@@ -22,38 +22,34 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 class CProxyGraphicsObject;
 
 class CProxyTargetGraphicsObject : public CGameGraphicsObject {
-  V_META(CProxyTargetGraphicsObject, CGameGraphicsObject,
-         V_METHOD(CProxyTargetGraphicsObject, refresh),
-         V_METHOD(CProxyTargetGraphicsObject, refreshAll),
-         V_PROPERTY(CProxyTargetGraphicsObject, std::string, proxyLayout,
-                    getProxyLayout, setProxyLayout))
-public:
-  virtual std::list<std::shared_ptr<CGameGraphicsObject>>
-  getProxiedObjects(std::shared_ptr<CGui> gui, int x, int y);
+    V_META(CProxyTargetGraphicsObject, CGameGraphicsObject, V_METHOD(CProxyTargetGraphicsObject, refresh),
+           V_METHOD(CProxyTargetGraphicsObject, refreshAll),
+           V_PROPERTY(CProxyTargetGraphicsObject, std::string, proxyLayout, getProxyLayout, setProxyLayout))
+  public:
+    virtual std::list<std::shared_ptr<CGameGraphicsObject>> getProxiedObjects(std::shared_ptr<CGui> gui, int x, int y);
 
-  virtual int getSizeX(std::shared_ptr<CGui> gui);
+    virtual int getSizeX(std::shared_ptr<CGui> gui);
 
-  virtual int getSizeY(std::shared_ptr<CGui> gui);
+    virtual int getSizeY(std::shared_ptr<CGui> gui);
 
-  CProxyTargetGraphicsObject() = default;
+    CProxyTargetGraphicsObject() = default;
 
-private:
-  std::map<int, std::map<int, std::shared_ptr<CProxyGraphicsObject>>>
-      proxyObjects;
-  std::string proxyLayout = "CProxyGraphicsLayout";
+  private:
+    std::map<int, std::map<int, std::shared_ptr<CProxyGraphicsObject>>> proxyObjects;
+    std::string proxyLayout = "CProxyGraphicsLayout";
 
-public:
-  std::string getProxyLayout();
+  public:
+    std::string getProxyLayout();
 
-  void setProxyLayout(std::string _layout);
+    void setProxyLayout(std::string _layout);
 
-  void refresh();
+    void refresh();
 
-  void refreshObject(int x, int y);
+    void refreshObject(int x, int y);
 
-  void refreshAll();
+    void refreshAll();
 
-  void addProxyObject(auto gui, int &x, int &y);
+    void addProxyObject(std::shared_ptr<CGui> gui, int &x, int &y);
 
-  void removeProxyObject(int &x, int &y);
+    void removeProxyObject(int &x, int &y);
 };

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -26,228 +26,192 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/object/CWidget.h"
 #include "handler/CEventHandler.h"
 
-void CListView::renderObject(std::shared_ptr<CGui> gui,
-                             std::shared_ptr<SDL_Rect> loc, int frameTime) {}
+void CListView::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> loc, int frameTime) {}
 
-bool CListView::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type,
-                           int button, int x, int y) {
-  if (type != SDL_MOUSEBUTTONDOWN ||
-      (button != SDL_BUTTON_LEFT && button != SDL_BUTTON_RIGHT)) {
+bool CListView::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button, int x, int y) {
+    if (type != SDL_MOUSEBUTTONDOWN || (button != SDL_BUTTON_LEFT && button != SDL_BUTTON_RIGHT)) {
+        return true;
+    }
+    int index = -1;
+    std::shared_ptr<CGameObject> object;
+    if (!tryGetClickedObject(gui, x, y, index, object)) {
+        return button != SDL_BUTTON_RIGHT;
+    }
+    if (button == SDL_BUTTON_RIGHT) {
+        return invokeRightClickCallback(gui, index, object);
+    }
+    invokeCallback(gui, index, object);
     return true;
-  }
-  int index = -1;
-  std::shared_ptr<CGameObject> object;
-  if (!tryGetClickedObject(gui, x, y, index, object)) {
-    return button != SDL_BUTTON_RIGHT;
-  }
-  if (button == SDL_BUTTON_RIGHT) {
-    return invokeRightClickCallback(gui, index, object);
-  }
-  invokeCallback(gui, index, object);
-  return true;
 }
 
 void CListView::doShift(const std::shared_ptr<CGui> &gui, int val) {
-  shift += val;
-  if (shift < 0) {
-    shift = 0;
-  } else if (shift > (signed)(*invokeCollection(gui)).size() -
-                         (getSizeX(gui) * getSizeY(gui) - 2 /*arrows*/)) {
-    shift = (*invokeCollection(gui)).size() -
-            (getSizeX(gui) * getSizeY(gui) - 2 /*arrows*/);
-  }
-  refreshAll();
+    shift += val;
+    if (shift < 0) {
+        shift = 0;
+    } else if (shift > (signed)(*invokeCollection(gui)).size() - (getSizeX(gui) * getSizeY(gui) - 2 /*arrows*/)) {
+        shift = (*invokeCollection(gui)).size() - (getSizeX(gui) * getSizeY(gui) - 2 /*arrows*/);
+    }
+    refreshAll();
 }
 
 int CListView::shiftIndex(const std::shared_ptr<CGui> &gui, int arg) {
-  if (!isOversized(gui)) {
-    return arg;
-  }
-  return arg > getLeftArrowIndex(gui) ? arg + shift - 1 : arg + shift;
+    if (!isOversized(gui)) {
+        return arg;
+    }
+    return arg > getLeftArrowIndex(gui) ? arg + shift - 1 : arg + shift;
 }
 
-int CListView::getRightArrowIndex(const std::shared_ptr<CGui> &gui) {
-  return getSizeX(gui) * getSizeY(gui) - 1;
-}
+int CListView::getRightArrowIndex(const std::shared_ptr<CGui> &gui) { return getSizeX(gui) * getSizeY(gui) - 1; }
 
-int CListView::getLeftArrowIndex(const std::shared_ptr<CGui> &gui) {
-  return getSizeX(gui) * (getSizeY(gui) - 1);
-}
+int CListView::getLeftArrowIndex(const std::shared_ptr<CGui> &gui) { return getSizeX(gui) * (getSizeY(gui) - 1); }
 
 // TODO: maybe return collection pointer to avoid copying
 std::unordered_multimap<int, std::shared_ptr<CGameObject>>
 CListView::calculateIndices(const std::shared_ptr<CGui> &gui) {
-  if (grouping) {
-    collection_pointer collection = invokeCollection(gui);
-    vstd::list<std::shared_ptr<CGameObject>> &container = *collection;
-    auto reduced = vstd::functional::map_reduce<std::string>(
-        container, [](auto ob) { return ob->getTypeId(); });
+    if (grouping) {
+        collection_pointer collection = invokeCollection(gui);
+        vstd::list<std::shared_ptr<CGameObject>> &container = *collection;
+        auto reduced = vstd::functional::map_reduce<std::string>(container, [](auto ob) { return ob->getTypeId(); });
 
-    std::unordered_multimap<int, std::shared_ptr<CGameObject>> indices;
+        std::unordered_multimap<int, std::shared_ptr<CGameObject>> indices;
 
-    int i = -1;
+        int i = -1;
 
-    for (const auto &it : (reduced)) {
-      i++;
-      for (const auto &it2 : it.second) {
-        indices.insert(std::make_pair(i, it2));
-      }
+        for (const auto &it : (reduced)) {
+            i++;
+            for (const auto &it2 : it.second) {
+                indices.insert(std::make_pair(i, it2));
+            }
+        }
+        return indices;
+    } else {
+        std::unordered_multimap<int, std::shared_ptr<CGameObject>> indices;
+        int i = -1;
+        collection_pointer sharedPtr = invokeCollection(gui);
+        for (const auto &it : (*sharedPtr)) {
+            indices.insert(std::make_pair(++i, it));
+        }
+        return indices;
     }
-    return indices;
-  } else {
-    std::unordered_multimap<int, std::shared_ptr<CGameObject>> indices;
-    int i = -1;
-    collection_pointer sharedPtr = invokeCollection(gui);
-    for (const auto &it : (*sharedPtr)) {
-      indices.insert(std::make_pair(++i, it));
-    }
-    return indices;
-  }
 }
 
-std::shared_ptr<SDL_Rect>
-CListView::calculateIndexPosition(const std::shared_ptr<CGui> &gui,
-                                  const std::shared_ptr<SDL_Rect> &loc,
-                                  int index) {
-  return RECT(tileSize * (index % getSizeX(gui)) + loc->x,
-              tileSize * (index / getSizeX(gui)) + loc->y, tileSize, tileSize);
+std::shared_ptr<SDL_Rect> CListView::calculateIndexPosition(const std::shared_ptr<CGui> &gui,
+                                                            const std::shared_ptr<SDL_Rect> &loc, int index) {
+    return RECT(tileSize * (index % getSizeX(gui)) + loc->x, tileSize * (index / getSizeX(gui)) + loc->y, tileSize,
+                tileSize);
 }
 
 bool CListView::isOversized(const std::shared_ptr<CGui> &gui) {
-  return allowOversize &&
-         getItemTypesCount(gui) > (getSizeX(gui) * getSizeY(gui));
+    return allowOversize && getItemTypesCount(gui) > (getSizeX(gui) * getSizeY(gui));
 }
 
 int CListView::getItemTypesCount(const std::shared_ptr<CGui> &gui) {
-  auto map = calculateIndices(gui);
-  std::set<int> indices;
-  for (const auto &it : map) {
-    indices.insert(it.first);
-  }
-  auto size = indices.size();
-  return size;
+    auto map = calculateIndices(gui);
+    std::set<int> indices;
+    for (const auto &it : map) {
+        indices.insert(it.first);
+    }
+    auto size = indices.size();
+    return size;
 }
 
 // TODO: sizes should be calculated dynamically based on preferences
 int CListView::getSizeX(std::shared_ptr<CGui> gui) {
-  return xPrefferedSize != -1
-             ? xPrefferedSize
-             : getLayout()->getRect(this->ptr<CListView>())->w / tileSize;
+    return xPrefferedSize != -1 ? xPrefferedSize : getLayout()->getRect(this->ptr<CListView>())->w / tileSize;
 }
 
 // TODO: sizes should be calculated dynamically based on preferences
 int CListView::getSizeY(std::shared_ptr<CGui> gui) {
-  return yPrefferedSize != -1
-             ? yPrefferedSize
-             : getLayout()->getRect(this->ptr<CListView>())->h / tileSize;
+    return yPrefferedSize != -1 ? yPrefferedSize : getLayout()->getRect(this->ptr<CListView>())->h / tileSize;
 }
 
-CListView::collection_pointer
-CListView::invokeCollection(std::shared_ptr<CGui> gui) {
-  return getParent()
-      ->meta()
-      ->invoke_method<CListView::collection_pointer, CGameGraphicsObject,
-                      std::shared_ptr<CGui>>(
-          collection, vstd::cast<CGameGraphicsObject>(getParent()), gui);
+CListView::collection_pointer CListView::invokeCollection(std::shared_ptr<CGui> gui) {
+    return getParent()
+        ->meta()
+        ->invoke_method<CListView::collection_pointer, CGameGraphicsObject, std::shared_ptr<CGui>>(
+            collection, vstd::cast<CGameGraphicsObject>(getParent()), gui);
 }
 
-void CListView::invokeCallback(std::shared_ptr<CGui> gui, int i,
-                               std::shared_ptr<CGameObject> object) {
-  getParent()
-      ->meta()
-      ->invoke_method<void, CGameGraphicsObject, std::shared_ptr<CGui>, int,
-                      std::shared_ptr<CGameObject>>(
-          callback, vstd::cast<CGameGraphicsObject>(getParent()), gui, i,
-          object);
+void CListView::invokeCallback(std::shared_ptr<CGui> gui, int i, std::shared_ptr<CGameObject> object) {
+    getParent()
+        ->meta()
+        ->invoke_method<void, CGameGraphicsObject, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>>(
+            callback, vstd::cast<CGameGraphicsObject>(getParent()), gui, i, object);
 }
 
-bool CListView::invokeRightClickCallback(std::shared_ptr<CGui> gui, int i,
-                                         std::shared_ptr<CGameObject> object) {
-  if (rightClickCallback.empty()) {
-    return false;
-  }
-  return getParent()
-      ->meta()
-      ->invoke_method<bool, CGameGraphicsObject, std::shared_ptr<CGui>, int,
-                      std::shared_ptr<CGameObject>>(
-          rightClickCallback, vstd::cast<CGameGraphicsObject>(getParent()), gui,
-          i, object);
+bool CListView::invokeRightClickCallback(std::shared_ptr<CGui> gui, int i, std::shared_ptr<CGameObject> object) {
+    if (rightClickCallback.empty()) {
+        return false;
+    }
+    return getParent()
+        ->meta()
+        ->invoke_method<bool, CGameGraphicsObject, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>>(
+            rightClickCallback, vstd::cast<CGameGraphicsObject>(getParent()), gui, i, object);
 }
 
 auto CListView::getArrowCallback(bool left) {
-  return [=, this](std::shared_ptr<CGui> gui, SDL_EventType type, int button,
-                   int, int) {
-    if (type == SDL_MOUSEBUTTONDOWN && button == SDL_BUTTON_LEFT) {
-      doShift(gui, left ? -1 : 1);
-    }
-    return true;
-  };
+    return [this, left](std::shared_ptr<CGui> gui, SDL_EventType type, int button, int, int) {
+        if (type == SDL_MOUSEBUTTONDOWN && button == SDL_BUTTON_LEFT) {
+            doShift(gui, left ? -1 : 1);
+        }
+        return true;
+    };
 }
 
-bool CListView::invokeSelect(std::shared_ptr<CGui> gui, int i,
-                             std::shared_ptr<CGameObject> object) {
-  return getParent()
-      ->meta()
-      ->invoke_method<bool, CGameGraphicsObject, std::shared_ptr<CGui>, int,
-                      std::shared_ptr<CGameObject>>(
-          select, vstd::cast<CGameGraphicsObject>(getParent()), gui, i, object);
+bool CListView::invokeSelect(std::shared_ptr<CGui> gui, int i, std::shared_ptr<CGameObject> object) {
+    return getParent()
+        ->meta()
+        ->invoke_method<bool, CGameGraphicsObject, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>>(
+            select, vstd::cast<CGameGraphicsObject>(getParent()), gui, i, object);
 }
 
-bool CListView::tryGetClickedObject(std::shared_ptr<CGui> gui, int x, int y,
-                                    int &index,
+bool CListView::tryGetClickedObject(std::shared_ptr<CGui> gui, int x, int y, int &index,
                                     std::shared_ptr<CGameObject> &object) {
-  int xIndex = x / tileSize;
-  int yIndex = y / tileSize;
-  if (xIndex < 0 || yIndex < 0 || xIndex >= getSizeX(gui) ||
-      yIndex >= getSizeY(gui)) {
-    return false;
-  }
-  index = shiftIndex(gui, xIndex + (yIndex * getSizeX(gui)));
-  auto indexedCollection = calculateIndices(gui);
-  if (!vstd::ctn(indexedCollection, index)) {
-    return false;
-  }
-  object = indexedCollection.find(index)->second;
-  return true;
+    int xIndex = x / tileSize;
+    int yIndex = y / tileSize;
+    if (xIndex < 0 || yIndex < 0 || xIndex >= getSizeX(gui) || yIndex >= getSizeY(gui)) {
+        return false;
+    }
+    index = shiftIndex(gui, xIndex + (yIndex * getSizeX(gui)));
+    auto indexedCollection = calculateIndices(gui);
+    if (!vstd::ctn(indexedCollection, index)) {
+        return false;
+    }
+    object = indexedCollection.find(index)->second;
+    return true;
 }
 
-std::list<std::shared_ptr<CGameGraphicsObject>>
-CListView::getProxiedObjects(std::shared_ptr<CGui> gui, int x, int y) {
-  std::list<std::shared_ptr<CGameGraphicsObject>> return_val;
-  int i = getSizeX(gui) * y + x;
-  if (i == getLeftArrowIndex(gui) && isOversized(gui)) {
-    return_val.push_back(
-        CAnimationProvider::getAnimation(gui->getGame(),
-                                         "images/arrows/left")
-            ->withCallback(getArrowCallback(true))); // TODO: cache
-  } else if (i == getRightArrowIndex(gui) && isOversized(gui)) {
-    return_val.push_back(
-        CAnimationProvider::getAnimation(gui->getGame(),
-                                         "images/arrows/right")
-            ->withCallback(getArrowCallback(false))); // TODO: cache
-  } else {
-    auto indexedCollection = calculateIndices(gui);
-    int itemIndex = shiftIndex(gui, i);
+std::list<std::shared_ptr<CGameGraphicsObject>> CListView::getProxiedObjects(std::shared_ptr<CGui> gui, int x, int y) {
+    std::list<std::shared_ptr<CGameGraphicsObject>> return_val;
+    int i = getSizeX(gui) * y + x;
+    if (i == getLeftArrowIndex(gui) && isOversized(gui)) {
+        return_val.push_back(CAnimationProvider::getAnimation(gui->getGame(),
+                                                              "images/arrows/left")
+                                 ->withCallback(getArrowCallback(true))); // TODO: cache
+    } else if (i == getRightArrowIndex(gui) && isOversized(gui)) {
+        return_val.push_back(CAnimationProvider::getAnimation(gui->getGame(),
+                                                              "images/arrows/right")
+                                 ->withCallback(getArrowCallback(false))); // TODO: cache
+    } else {
+        auto indexedCollection = calculateIndices(gui);
+        int itemIndex = shiftIndex(gui, i);
 
-    bool isItemPresent = vstd::ctn(indexedCollection, itemIndex) &&
-                         indexedCollection.find(itemIndex)->second;
+        bool isItemPresent = vstd::ctn(indexedCollection, itemIndex) && indexedCollection.find(itemIndex)->second;
 
-    if (isItemPresent || showEmpty) {
-      addItemBox(gui, return_val);
+        if (isItemPresent || showEmpty) {
+            addItemBox(gui, return_val);
+        }
+        if (isItemPresent) {
+            addItem(return_val, indexedCollection, itemIndex);
+        }
+        if (invokeSelect(gui, itemIndex, isItemPresent ? indexedCollection.find(itemIndex)->second : nullptr)) {
+            addSelectionBox(gui, return_val);
+        }
+        if (indexedCollection.count(itemIndex) > 1) {
+            addCountBox(gui, indexedCollection.count(itemIndex), return_val);
+        }
     }
-    if (isItemPresent) {
-      addItem(return_val, indexedCollection, itemIndex);
-    }
-    if (invokeSelect(gui, itemIndex,
-                     isItemPresent ? indexedCollection.find(itemIndex)->second
-                                   : nullptr)) {
-      addSelectionBox(gui, return_val);
-    }
-    if (indexedCollection.count(itemIndex) > 1) {
-      addCountBox(gui, indexedCollection.count(itemIndex), return_val);
-    }
-  }
-  return return_val;
+    return return_val;
 }
 
 void CListView::addCountBox(const std::shared_ptr<CGui> &gui, int count,
@@ -264,77 +228,58 @@ void CListView::addCountBox(const std::shared_ptr<CGui> &gui, int count,
     return_val.push_back(countBox); // TODO: cache
 }
 
-void CListView::addSelectionBox(
-    const std::shared_ptr<CGui> &gui,
-    std::list<std::shared_ptr<CGameGraphicsObject>> &return_val) const {
-  auto selectionBox =
-      gui->getGame()->getObjectHandler()->createObject<CSelectionBox>(
-          gui->getGame());
-  selectionBox->setThickness(5);
-  selectionBox->setPriority(3);
-  return_val.push_back(selectionBox); // TODO: cache
+void CListView::addSelectionBox(const std::shared_ptr<CGui> &gui,
+                                std::list<std::shared_ptr<CGameGraphicsObject>> &return_val) const {
+    auto selectionBox = gui->getGame()->getObjectHandler()->createObject<CSelectionBox>(gui->getGame());
+    selectionBox->setThickness(5);
+    selectionBox->setPriority(3);
+    return_val.push_back(selectionBox); // TODO: cache
 }
 
-void CListView::addItem(
-    std::list<std::shared_ptr<CGameGraphicsObject>> &return_val,
-    std::unordered_multimap<int, std::shared_ptr<CGameObject>>
-        indexedCollection,
-    int itemIndex) const {
-  auto self = const_cast<CListView *>(this)->ptr<CListView>();
-  auto object = indexedCollection.find(itemIndex)->second;
-  std::shared_ptr<CGameGraphicsObject> objectGraphic = object->getGraphicsObject()
-                                                           ->withCallback(
-                                                               [self, itemIndex, object](
-                                                                   std::shared_ptr<CGui> gui,
-                                                                   SDL_EventType type, int button,
-                                                                   int, int) {
-                                                                 if (type != SDL_MOUSEBUTTONDOWN) {
-                                                                   return false;
-                                                                 }
-                                                                 if (button == SDL_BUTTON_LEFT) {
-                                                                   self->invokeCallback(gui, itemIndex,
-                                                                                        object);
-                                                                   return true;
-                                                                 }
-                                                                 if (button ==
-                                                                     SDL_BUTTON_RIGHT) {
-                                                                   return self
-                                                                       ->invokeRightClickCallback(
-                                                                           gui, itemIndex, object);
-                                                                 }
-                                                                 return false;
-                                                               });
-  objectGraphic->setPriority(2);
-  return_val.push_back(objectGraphic);
+void CListView::addItem(std::list<std::shared_ptr<CGameGraphicsObject>> &return_val,
+                        std::unordered_multimap<int, std::shared_ptr<CGameObject>> indexedCollection,
+                        int itemIndex) const {
+    auto self = const_cast<CListView *>(this)->ptr<CListView>();
+    auto object = indexedCollection.find(itemIndex)->second;
+    std::shared_ptr<CGameGraphicsObject> objectGraphic = object->getGraphicsObject()->withCallback(
+        [self, itemIndex, object](std::shared_ptr<CGui> gui, SDL_EventType type, int button, int, int) {
+            if (type != SDL_MOUSEBUTTONDOWN) {
+                return false;
+            }
+            if (button == SDL_BUTTON_LEFT) {
+                self->invokeCallback(gui, itemIndex, object);
+                return true;
+            }
+            if (button == SDL_BUTTON_RIGHT) {
+                return self->invokeRightClickCallback(gui, itemIndex, object);
+            }
+            return false;
+        });
+    objectGraphic->setPriority(2);
+    return_val.push_back(objectGraphic);
 }
 
-void CListView::addItemBox(
-    const std::shared_ptr<CGui> &gui,
-    std::list<std::shared_ptr<CGameGraphicsObject>> &return_val) const {
-  std::shared_ptr<CAnimation> itemBox =
-      CAnimationProvider::getAnimation(gui->getGame(), "images/item")
-          ->withCallback([](std::shared_ptr<CGui>, SDL_EventType, int, int,
-                            int) { return false; });
-  itemBox->setPriority(1);
-  return_val.push_back(itemBox); // TODO: cache
+void CListView::addItemBox(const std::shared_ptr<CGui> &gui,
+                           std::list<std::shared_ptr<CGameGraphicsObject>> &return_val) const {
+    std::shared_ptr<CAnimation> itemBox =
+        CAnimationProvider::getAnimation(gui->getGame(), "images/item")
+            ->withCallback([](std::shared_ptr<CGui>, SDL_EventType, int, int, int) { return false; });
+    itemBox->setPriority(1);
+    return_val.push_back(itemBox); // TODO: cache
 }
 
 std::string CListView::getCollection() { return collection; }
 
-void CListView::setCollection(std::string collection) {
-  CListView::collection = collection;
-}
+void CListView::setCollection(std::string collection) { CListView::collection = collection; }
 
 std::string CListView::getCallback() { return callback; }
 
-void CListView::setCallback(std::string callback) {
-  CListView::callback = callback;
-}
+void CListView::setCallback(std::string callback) { CListView::callback = callback; }
 
 std::string CListView::getRightClickCallback() { return rightClickCallback; }
 
 void CListView::setRightClickCallback(std::string rightClickCallback) {
-  CListView::rightClickCallback = rightClickCallback;
+    CListView::rightClickCallback = rightClickCallback;
 }
 
 std::string CListView::getSelect() { return select; }
@@ -343,46 +288,37 @@ void CListView::setSelect(std::string select) { CListView::select = select; }
 
 std::shared_ptr<CScript> CListView::getRefreshObject() { return refreshObject; }
 
-void CListView::setRefreshObject(std::shared_ptr<CScript> refreshObject) {
-  CListView::refreshObject = refreshObject;
-}
+void CListView::setRefreshObject(std::shared_ptr<CScript> refreshObject) { CListView::refreshObject = refreshObject; }
 
 std::string CListView::getRefreshEvent() { return refreshEvent; }
 
-void CListView::setRefreshEvent(std::string refreshEvent) {
-  CListView::refreshEvent = refreshEvent;
-}
+void CListView::setRefreshEvent(std::string refreshEvent) { CListView::refreshEvent = refreshEvent; }
 
 void CListView::initialize() {
-  auto self = this->ptr<CListView>();
-  vstd::call_when(
-      [self]() {
-        return self->getGui() != nullptr &&
-               self->getGui()->getGame() != nullptr &&
-               self->getGui()->getGame()->getMap() != nullptr;
-      },
-      [self]() {
-        if (self->refreshObject) {
-          self->refreshObject->invoke(self->getGui()->getGame(), self)
-              ->connect(self->refreshEvent, self, "refresh");
-          self->refreshObject->invoke(self->getGui()->getGame(), self)
-              ->connect(self->refreshEvent, self, "refreshAll");
-        }
-        self->refresh();
-      });
+    auto self = this->ptr<CListView>();
+    vstd::call_when(
+        [self]() {
+            return self->getGui() != nullptr && self->getGui()->getGame() != nullptr &&
+                   self->getGui()->getGame()->getMap() != nullptr;
+        },
+        [self]() {
+            if (self->refreshObject) {
+                self->refreshObject->invoke(self->getGui()->getGame(), self)
+                    ->connect(self->refreshEvent, self, "refresh");
+                self->refreshObject->invoke(self->getGui()->getGame(), self)
+                    ->connect(self->refreshEvent, self, "refreshAll");
+            }
+            self->refresh();
+        });
 }
 
 int CListView::getXPrefferedSize() const { return xPrefferedSize; }
 
-void CListView::setXPrefferedSize(int xPrefferedSize) {
-  CListView::xPrefferedSize = xPrefferedSize;
-}
+void CListView::setXPrefferedSize(int xPrefferedSize) { CListView::xPrefferedSize = xPrefferedSize; }
 
 int CListView::getYPrefferedSize() const { return yPrefferedSize; }
 
-void CListView::setYPrefferedSize(int yPrefferedSize) {
-  CListView::yPrefferedSize = yPrefferedSize;
-}
+void CListView::setYPrefferedSize(int yPrefferedSize) { CListView::yPrefferedSize = yPrefferedSize; }
 
 int CListView::getTileSize() { return tileSize; }
 
@@ -390,9 +326,7 @@ void CListView::setTileSize(int _tileSize) { tileSize = _tileSize; }
 
 bool CListView::getAllowOversize() { return allowOversize; }
 
-void CListView::setAllowOversize(bool _allowOversize) {
-  allowOversize = _allowOversize;
-}
+void CListView::setAllowOversize(bool _allowOversize) { allowOversize = _allowOversize; }
 
 bool CListView::getShowEmpty() { return showEmpty; }
 

--- a/src/handler/CGuiHandler.h
+++ b/src/handler/CGuiHandler.h
@@ -27,6 +27,10 @@ class CDialog;
 
 class CMarket;
 
+class CCreature;
+
+class CItem;
+
 class CGuiHandler : public CGameObject {
     V_META(CGuiHandler, CGameObject, vstd::meta::empty())
 

--- a/test.py
+++ b/test.py
@@ -18,11 +18,13 @@ import builtins
 import importlib
 import json
 import os
+import queue
 import re
 import select
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import traceback
 import types
@@ -54,6 +56,15 @@ if build_dir.exists():
 
 if str(Path.cwd()) not in sys.path:
     sys.path.insert(0, str(Path.cwd()))
+build_config = os.environ.get("GAME_BUILD_CONFIG")
+extension_dirs = []
+if build_config:
+    extension_dirs.append(build_dir / build_config)
+else:
+    extension_dirs.extend(build_dir / config for config in ("Release", "Debug", "RelWithDebInfo", "MinSizeRel"))
+for extension_dir in reversed(extension_dirs):
+    if extension_dir.exists() and str(extension_dir) not in sys.path:
+        sys.path.insert(0, str(extension_dir))
 if str(REPO_ROOT / "res") not in sys.path:
     sys.path.insert(1, str(REPO_ROOT / "res"))
 if str(REPO_ROOT) not in sys.path:
@@ -2566,7 +2577,7 @@ class GameTest(unittest.TestCase):
 
         dialog_dir = REPO_ROOT / "res/maps/nouraajd"
         for path in dialog_dir.glob("*.json"):
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 data = json.load(f)
             for key, value in data.items():
                 if not isinstance(value, dict):
@@ -3366,7 +3377,7 @@ class GameTest(unittest.TestCase):
         errors = []
         for path in (REPO_ROOT / "res").rglob("*.json"):
             try:
-                with open(path) as f:
+                with open(path, encoding="utf-8") as f:
                     json.load(f)
             except Exception:
                 errors.append(str(path))
@@ -3475,10 +3486,14 @@ class GameTest(unittest.TestCase):
             ],
         }
 
-        with tempfile.TemporaryDirectory(dir=TEST_OUTPUT_DIR) as temp_dir:
-            path = Path(temp_dir) / "map.json"
-            path.write_text(json.dumps(map_data))
-            issues, warnings = validate_map_json_tiled_compatibility(path)
+        class InlineMapPath:
+            def read_text(self):
+                return json.dumps(map_data)
+
+            def relative_to(self, root):
+                return Path("inline/map.json")
+
+        issues, warnings = validate_map_json_tiled_compatibility(InlineMapPath())
 
         self.assertEqual([], issues)
         self.assertEqual([], warnings)
@@ -3487,12 +3502,12 @@ class GameTest(unittest.TestCase):
     def test_plugin_load_function(self):
         missing = []
         for path in (REPO_ROOT / "res/plugins").rglob("*.py"):
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 tree = ast.parse(f.read())
             if not any(isinstance(n, ast.FunctionDef) and n.name == "load" for n in tree.body):
                 missing.append(str(path))
         for path in (REPO_ROOT / "res/maps").rglob("script.py"):
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 tree = ast.parse(f.read())
             if not any(isinstance(n, ast.FunctionDef) and n.name == "load" for n in tree.body):
                 missing.append(str(path))
@@ -3507,9 +3522,14 @@ class GameTest(unittest.TestCase):
                 continue
             if any(p.startswith("cmake-build") for p in parts):
                 continue
-            if "random-dungeon-generator" in parts or "vstd" in parts:
+            if (
+                "random-dungeon-generator" in parts
+                or "vstd" in parts
+                or "vcpkg_installed" in parts
+                or "windows-tools" in parts
+            ):
                 continue
-            with open(path) as f:
+            with open(path, encoding="utf-8", errors="replace") as f:
                 for i, line in enumerate(f, 1):
                     if line.startswith("\t"):
                         offenders.append(f"{path}:{i}")
@@ -3525,7 +3545,7 @@ class GameTest(unittest.TestCase):
         json_paths = list((REPO_ROOT / "res/config").rglob("*.json"))
         json_paths.extend((REPO_ROOT / "res/maps").rglob("*.json"))
         for path in json_paths:
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 data = json.load(f)
             for key, val in self._collect_resource_paths(data):
                 if val == "string":
@@ -3996,6 +4016,21 @@ class McpServerTest(unittest.TestCase):
             return payload
 
     def _readline(self, stream, deadline: float) -> bytes:
+        if os.name == "nt":
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                self.fail("Timed out waiting for MCP response header")
+            result_queue = queue.Queue(maxsize=1)
+
+            def read_line():
+                result_queue.put(stream.readline())
+
+            threading.Thread(target=read_line, daemon=True).start()
+            try:
+                return result_queue.get(timeout=remaining)
+            except queue.Empty:
+                self.fail("Timed out waiting for MCP response header")
+
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "fall-of-nouraajd",
+  "version-string": "0.1.0",
+  "dependencies": [
+    "boost-algorithm",
+    "boost-any",
+    "boost-filesystem",
+    "boost-pool",
+    "boost-python",
+    "boost-range",
+    "boost-type-index",
+    "pybind11",
+    "sdl2",
+    "sdl2-image",
+    "sdl2-ttf"
+  ]
+}


### PR DESCRIPTION
## Summary
- switch the Windows GitHub Actions job and local configure.bat flow to Visual Studio/vcpkg instead of the old bundled windows-tools path
- require Python 3.12 on Windows so the interpreter ABI matches vcpkg's pybind/Python libraries
- add Windows runtime DLL paths before running test.py and keep vcpkg installs scoped to the repo build
- update the vstd submodule for MSVC compatibility from lisu188/vstd#13 and lisu188/vstd#14
- log and skip null map objects/triggers from stale saves, and log failed object deserialization entries so old saves like gooby do not crash loading

## Testing
- `cmake --build cmake-build-release --config Release --target _game for_unit_tests -- /m:1 /clp:ErrorsOnly`
- `ctest --test-dir cmake-build-release -C Release --output-on-failure -R for_unit_tests`
- `python.exe test.py` with `GAME_BUILD_DIR=cmake-build-release`, `GAME_BUILD_CONFIG=Release`, Release and vcpkg DLL dirs on PATH: 91 tests passed
- `cmake --build cmake-build-release --config Release --target package -- /m:1 /clp:ErrorsOnly`
- `./scripts/run_coverage.sh` attempted through WSL, but WSL coverage run timed out after 30 minutes and produced no coverage report in this Windows session

Submodule PRs:
- https://github.com/lisu188/vstd/pull/13
- https://github.com/lisu188/vstd/pull/14