### PR TITLE
Use Python 3.12 for Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install Python deps
         run: python -m pip install --upgrade pillow
       - name: submodules


### PR DESCRIPTION
## Summary
- update the Windows GitHub Actions setup-python step to Python 3.12 so it matches configure.bat and the vcpkg Python ABI

## Testing
- Not run locally; workflow-only follow-up to the failing main Actions run 24885223545.

Context: the previous main run failed in Windows configure because CI still provided Python 3.11 while configure.bat now requires Python 3.12.