### PR TITLE
Document Valgrind debugging tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,11 @@ Testing section. Import the optional `game` module inside each test that
 requires it so that tests which don't depend on the compiled module can still
 run.
 
+## Debugging
+- Use `valgrind` for native memory diagnostics and runtime error investigation.
+- Use `callgrind` through `valgrind --tool=callgrind` when profiling hot paths
+  or performance regressions.
+
 ### Resource-to-CMake checklist
 - Whenever files are added under `res/`, update the root `CMakeLists.txt` so each new file is covered by `configure_file(...)` entries or by an `install(DIRECTORY ...)` rule as appropriate.
 - Before committing, verify no `res/**` file is missing from CMake resource references.


### PR DESCRIPTION
## What changed
Added a Debugging section to AGENTS.md documenting Valgrind for native memory/runtime diagnostics and Callgrind via valgrind --tool=callgrind for hotspot/performance profiling.

## Why
This makes the available native debugging and profiling tools explicit for future agents.

## Validation
Reviewed the staged diff.
Ran git diff --check -- AGENTS.md.

## Known limitations
Compiled C++ and Python test suites were not run because this is documentation-only and does not change runtime behavior.