### PR TITLE
docs: require rdg and vstd to be kept on latest main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ possible.
 Regularly merge the repository's main branch (`main`) into your feature branch to
 stay up to date:
 Resolve any conflicts and rerun `python3 test.py`.
+Always update both `rdg` and `vstd` to the latest `main` branch before finishing your work.
 
 ## Adding Item Types
 Follow these steps whenever you introduce a new building, potion, effect, tile or other item type:


### PR DESCRIPTION
### Motivation
- Ensure both `rdg` and `vstd` feature branches are synchronized with `main` before finishing work to reduce merge conflicts and stale dependency issues.

### Description
- Add a single guideline line to `AGENTS.md` under the **Merging Main** section requiring: "Always update both `rdg` and `vstd` to the latest `main` branch before finishing your work."

### Testing
- Ran `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` which built the `_game` module successfully.
- Ran `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` which passed.
- Ran `python3 test.py`; an initial run produced one transient failure (`test_inventory_panel_refreshes_only_after_event_loop_drains`), and a subsequent re-run passed all 94 tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6335f8a08326997008643481ed94)