### PR TITLE
[codex] Fix addTile tile cache update

### DIFF
--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -143,14 +143,19 @@ void CMap::moveTile(std::shared_ptr<CTile> tile, int x, int y, int z) {
 }
 
 bool CMap::addTile(std::shared_ptr<CTile> tile, int x, int y, int z) {
+    if (!tile) {
+        return false;
+    }
     Coords coords = normalizeCoords(Coords(x, y, z));
     if (this->contains(coords.x, coords.y, coords.z)) {
         return false;
     }
+    tile->setPosx(coords.x);
+    tile->setPosy(coords.y);
+    tile->setPosz(coords.z);
     tiles.insert(std::make_pair(coords, tile));
     bumpNavigationRevision();
-    tile->moveTo(coords.x, coords.y, coords.z);
-    //    signal("tileChanged", Coords(x, y, z)); //moveTo already sends signal
+    signal("tileChanged", coords);
     return true;
 }
 

--- a/test.py
+++ b/test.py
@@ -1497,6 +1497,31 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_replacing_non_origin_tile_preserves_origin_tile(self):
+        game = load_game_module()
+        _g, game_map, player = load_game_map_with_player("test", "Warrior")
+        game_map.removeAll(lambda obj: obj.getName() != "player")
+
+        origin = game.Coords(0, 0, 0)
+        adjacent = game.Coords(1, 0, 0)
+
+        game_map.replaceTile("WaterTile", origin)
+        self.assertFalse(game_map.canStep(origin))
+
+        game_map.replaceTile("GroundTile", adjacent)
+
+        self.assertFalse(game_map.canStep(origin))
+        self.assertTrue(game_map.canStep(adjacent))
+
+        return True, json.dumps(
+            {
+                "origin_walkable": game_map.canStep(origin),
+                "adjacent_walkable": game_map.canStep(adjacent),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_road_tile_heals_only_on_successful_step(self):
         game = load_game_module()
         g, game_map, player = load_game_map_with_player("test", "Warrior")


### PR DESCRIPTION
## What changed
- Updated `CMap::addTile` to seed a new tile's coordinates directly before inserting it into the tile map.
- Stopped using `tile->moveTo(...)` during insertion, because that path calls back into `CMap::moveTile` and can erase another tile at the new tile's previous default position.
- Added a regression test that replaces the origin tile, then replaces an adjacent tile, and verifies the origin tile remains intact.

## Why
Fresh tile instances start at `(0, 0, 0)`. When adding or replacing a non-origin tile, `addTile` inserted the tile at the requested coordinate and then called `moveTo`. The move callback attempted to remove the tile from its old coordinate, which could erase the real origin tile from the map cache.

## Validation
- `clang-format -i src/core/CMap.cpp`
- `black -l 120 test.py`
- `git diff --check origin/main...HEAD -- src/core/CMap.cpp test.py`
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` passed
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` passed
- `python3 test.py` initially hit the known flaky `test_inventory_panel_refreshes_only_after_event_loop_drains` assertion, the isolated rerun passed, and the subsequent full rerun passed: 97 tests OK
- `./scripts/run_coverage.sh` was run before the final rebase. The test portion passed on the second run, but the coverage gate failed at 53.6% line coverage versus the required 80.0%.

## Known limitations
- The repository's scoped coverage remains below the required threshold; this PR does not attempt to raise coverage outside the targeted `addTile` regression.
- Existing unrelated local worktree entries were not included: `vstd`, `.codex/`, and `coverage/`.