### PR TITLE
Modernize project for C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 if (POLICY CMP0087)
     cmake_policy(SET CMP0087 NEW)
 endif ()
@@ -31,14 +31,14 @@ include(${CMAKE_SOURCE_DIR}/cmake/cotire.cmake)
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_SOURCE_DIR}/cmake")
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /bigobj /permissive- /Zc:preprocessor /EHsc /DBOOST_ALLOW_DEPRECATED_HEADERS /DBOOST_BIND_GLOBAL_PLACEHOLDERS /D_USE_MATH_DEFINES /DNOMINMAX /DWIN32_LEAN_AND_MEAN")
 else ()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include cmath -Wall -fconcepts")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include cmath -Wall")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -s")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g3")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_ALLOW_DEPRECATED_HEADERS -DBOOST_BIND_GLOBAL_PLACEHOLDERS")
@@ -51,7 +51,6 @@ endif ()
 
 file(GLOB_RECURSE GAME_SRC ${CMAKE_SOURCE_DIR}/src/**.cpp ${CMAKE_SOURCE_DIR}/src/**.h)
 
-find_package(Boost COMPONENTS filesystem REQUIRED)
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 find_package(pybind11 CONFIG QUIET)
 if (NOT pybind11_FOUND)
@@ -81,11 +80,6 @@ if (NOT SDL2_ttf_FOUND AND NOT TARGET SDL2_ttf::SDL2_ttf)
     find_package(SDL2_ttf REQUIRED)
 endif ()
 
-set(BOOST_FILESYSTEM_LIBS ${Boost_LIBRARIES})
-if (TARGET Boost::filesystem)
-    set(BOOST_FILESYSTEM_LIBS Boost::filesystem)
-endif ()
-
 set(SDL2_LIBS ${SDL2_LIBRARY})
 set(SDL2_EXECUTABLE_LIBS ${SDL2_LIBRARY})
 if (TARGET SDL2::SDL2)
@@ -103,7 +97,6 @@ if (TARGET SDL2_ttf::SDL2_ttf)
     set(SDL2_TTF_LIBS SDL2_ttf::SDL2_ttf)
 endif ()
 
-include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${Python3_INCLUDE_DIRS})
 include_directories(${SDL2_INCLUDE_DIR})
 include_directories(${SDL2_IMAGE_INCLUDE_DIR})
@@ -116,7 +109,7 @@ include_directories(${CMAKE_SOURCE_DIR}/vstd)
 include_directories(${CMAKE_SOURCE_DIR}/random-dungeon-generator)
 
 pybind11_add_module(_game NO_EXTRAS ${GAME_SRC})
-target_link_libraries(_game PRIVATE ${BOOST_FILESYSTEM_LIBS} ${SDL2_LIBS} ${SDL2_IMAGE_LIBS} ${SDL2_TTF_LIBS})
+target_link_libraries(_game PRIVATE ${SDL2_LIBS} ${SDL2_IMAGE_LIBS} ${SDL2_TTF_LIBS})
 
 set_source_files_properties(
     ${CMAKE_SOURCE_DIR}/src/core/CModule.cpp
@@ -380,7 +373,6 @@ target_include_directories(for_unit_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/vstd
     json/single_include/nlohmann
     ${Python3_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
     ${SDL2_INCLUDE_DIR}
     ${SDL2_IMAGE_INCLUDE_DIR}
     ${SDL2_TTF_INCLUDE_DIR}
@@ -389,7 +381,6 @@ target_include_directories(for_unit_tests PRIVATE
 target_link_libraries(for_unit_tests PRIVATE
     Python3::Python
     pybind11::headers
-    ${BOOST_FILESYSTEM_LIBS}
     ${SDL2_EXECUTABLE_LIBS}
     ${SDL2_IMAGE_LIBS}
     ${SDL2_TTF_LIBS}

--- a/configure.sh
+++ b/configure.sh
@@ -3,7 +3,7 @@
 sudo apt update
 sudo apt install -y build-essential cmake ninja-build ccache \
     python3 python3-dev \
-    libboost-dev libboost-filesystem-dev \
+    libboost-dev \
     libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev
 
 git submodule update --init --recursive

--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -203,9 +203,9 @@ std::shared_ptr<CItem> CMonsterFightController::getLeastPowerfulItemWithTag(std:
         return it->hasTag(tag);
     };
     std::set<std::shared_ptr<CItem>> items = cr->getItems();
-    auto rng = items | boost::adaptors::filtered(pred);
-    auto max = boost::min_element(rng, cmp);
-    if (max != boost::end(rng)) {
+    auto rng = items | std::views::filter(pred);
+    auto max = std::ranges::min_element(rng, cmp);
+    if (max != std::ranges::end(rng)) {
         return *max;
     }
     return {};
@@ -226,10 +226,10 @@ std::shared_ptr<CInteraction> CMonsterFightController::selectInteraction(std::sh
         return a->getManaCost() < b->getManaCost();
     };
     std::set<std::shared_ptr<CInteraction>> interactions = cr->getInteractions();
-    auto rng = interactions | boost::adaptors::filtered(pFunction) | boost::adaptors::filtered(pFunction2) |
-               boost::adaptors::filtered(pFunction3);
-    auto max = boost::max_element(rng, pred);
-    if (max != boost::end(rng)) {
+    auto rng =
+        interactions | std::views::filter(pFunction) | std::views::filter(pFunction2) | std::views::filter(pFunction3);
+    auto max = std::ranges::max_element(rng, pred);
+    if (max != std::ranges::end(rng)) {
         return *max;
     }
     return {};
@@ -271,7 +271,7 @@ void CPlayerController::onTurnEnded(std::shared_ptr<CCreature>) {}
 // TODO: add stopping when obstacle found
 std::pair<bool, Coords::Direction> CPlayerController::isOnPath(std::shared_ptr<CPlayer> player, Coords coords) {
     if (!isCompleted(player)) {
-        for (auto it : path | boost::adaptors::filtered([this](auto it) { return it.first >= currentStep - 1; })) {
+        for (auto it : path | std::views::filter([this](auto it) { return it.first >= currentStep - 1; })) {
             if (it.second == coords) {
                 auto prev = it.first > 0 ? path[it.first - 1] : player->getCoords();
                 auto dir = player->getMap()->getShortestDelta(prev, coords);

--- a/src/core/CGlobal.h
+++ b/src/core/CGlobal.h
@@ -19,23 +19,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <Python.h>
 
-#include <boost/filesystem.hpp>
-#include <boost/range/algorithm.hpp>
-#include <boost/range/irange.hpp>
-
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 #include <pybind11/functional.h>
+#include <pybind11/stl.h>
 
 #include <SDL.h>
 #include <SDL_image.h>
 #include <SDL_ttf.h>
 
+#include <any>
 #include <condition_variable>
 #include <csignal>
 #include <cstdio>
 #include <ctime>
 #include <deque>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iomanip>
@@ -48,10 +46,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <mutex>
 #include <queue>
 #include <random>
+#include <ranges>
 #include <set>
 #include <sstream>
 #include <string>
 #include <thread>
+#include <typeindex>
+#include <typeinfo>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -304,7 +304,7 @@ std::shared_ptr<CMap> CRandomMapGenerator::loadRandomMap(const std::shared_ptr<C
 
 void CRandomMapGenerator::generateEncounters(const std::shared_ptr<CGame> &game, std::shared_ptr<CMap> &map,
                                              std::map<int, rdg<>::Room> &rooms) {
-    for (const auto &room : rooms | boost::adaptors::map_values) {
+    for (const auto &room : rooms | std::views::values) {
         auto roomCoords = Coords(room.row + room.width / 2, room.col + room.height / 2, 0);
         if (roomCoords.getDist(map->getEntry()) > 5) {
             for (const auto &creature : game->getRngHandler()->getRandomEncounter(5)) {

--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -283,8 +283,8 @@ bool CMap::isMoving() { return moving; }
 //         return vstd::castable<CCreature>(object);
 //     };
 //     for (std::shared_ptr<CMapObject> object:mapObjects |
-//                                             boost::adaptors::map_values |
-//                                             boost::adaptors::filtered(pred))
+//                                             std::views::values |
+//                                             std::views::filter(pred))
 //                                             {
 //         vstd::cast<CCreature>(object)->applyEffects();
 //     }
@@ -293,22 +293,21 @@ bool CMap::isMoving() { return moving; }
 void CMap::forObjects(std::function<void(std::shared_ptr<CMapObject>)> func,
                       std::function<bool(std::shared_ptr<CMapObject>)> predicate) {
     auto clone = mapObjects;
-    for (std::shared_ptr<CMapObject> object :
-         clone | boost::adaptors::map_values | boost::adaptors::filtered(predicate)) {
+    for (std::shared_ptr<CMapObject> object : clone | std::views::values | std::views::filter(predicate)) {
         func(object);
     }
 }
 
 void CMap::forTiles(std::function<void(std::shared_ptr<CTile>)> func,
                     std::function<bool(std::shared_ptr<CTile>)> predicate) {
-    for (std::shared_ptr<CTile> tile : (tiles | boost::adaptors::map_values | boost::adaptors::filtered(predicate))) {
+    for (std::shared_ptr<CTile> tile : tiles | std::views::values | std::views::filter(predicate)) {
         func(tile);
     }
 }
 
 void CMap::removeObjects(std::function<bool(std::shared_ptr<CMapObject>)> func) {
     auto clone = mapObjects;
-    for (std::shared_ptr<CMapObject> object : clone | boost::adaptors::map_values | boost::adaptors::filtered(func)) {
+    for (std::shared_ptr<CMapObject> object : clone | std::views::values | std::views::filter(func)) {
         removeObject(object);
     }
 }
@@ -352,7 +351,7 @@ void CMap::move() {
         std::make_shared<std::list<std::pair<std::shared_ptr<CCreature>, Coords>>>();
 
     std::vector<std::shared_ptr<CMapObject>> active_objects;
-    for (auto object : map->mapObjects | boost::adaptors::map_values | boost::adaptors::filtered(pred)) {
+    for (auto object : map->mapObjects | std::views::values | std::views::filter(pred)) {
         active_objects.push_back(object);
     }
 
@@ -362,7 +361,7 @@ void CMap::move() {
             [creature, coordinates](Coords coords) { coordinates->push_back(std::make_pair(creature, coords)); });
     };
 
-    auto pending = active_objects | boost::adaptors::transformed(controller);
+    auto pending = active_objects | std::views::transform(controller);
     auto joined = vstd::join(pending);
 
     bool round_complete = false;
@@ -430,7 +429,11 @@ void CMap::setTiles(std::set<std::shared_ptr<CTile>> objects) {
 }
 
 std::set<std::shared_ptr<CTile>> CMap::getTiles() {
-    return vstd::cast<std::set<std::shared_ptr<CTile>>>(tiles | boost::adaptors::map_values);
+    std::set<std::shared_ptr<CTile>> result;
+    for (const auto &[coords, tile] : tiles) {
+        result.insert(tile);
+    }
+    return result;
 }
 
 void CMap::setObjects(std::set<std::shared_ptr<CMapObject>> objects) {
@@ -448,7 +451,11 @@ void CMap::setObjects(std::set<std::shared_ptr<CMapObject>> objects) {
 }
 
 std::set<std::shared_ptr<CMapObject>> CMap::getObjects() {
-    return vstd::cast<std::set<std::shared_ptr<CMapObject>>>(mapObjects | boost::adaptors::map_values);
+    std::set<std::shared_ptr<CMapObject>> result;
+    for (const auto &[name, object] : mapObjects) {
+        result.insert(object);
+    }
+    return result;
 }
 
 void CMap::dumpPaths(std::string path) {

--- a/src/core/CProvider.cpp
+++ b/src/core/CProvider.cpp
@@ -23,8 +23,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 namespace {
 
 bool isConfigResourcePath(const std::string &path) {
-    const boost::filesystem::path resourcePath(path);
-    return !resourcePath.has_parent_path() || resourcePath.parent_path() == boost::filesystem::path("config");
+    const std::filesystem::path resourcePath(path);
+    return !resourcePath.has_parent_path() || resourcePath.parent_path() == std::filesystem::path("config");
 }
 
 } // namespace
@@ -78,8 +78,8 @@ std::shared_ptr<json> CResourcesProvider::loadJson(std::string path) {
 
 std::string CResourcesProvider::getPath(std::string path) {
     for (auto it : searchPath) {
-        if (boost::filesystem::exists(it / boost::filesystem::path(path))) {
-            boost::filesystem::path p = it / boost::filesystem::path(path);
+        auto p = std::filesystem::path(it) / std::filesystem::path(path);
+        if (std::filesystem::exists(p)) {
             return p.string();
         }
     }
@@ -106,7 +106,7 @@ std::vector<std::string> CResourcesProvider::getFiles(const std::string &type) {
         vstd::logger::fatal("Unknown resource type:", type);
     }
 
-    boost::filesystem::directory_iterator dir(folderName), end;
+    std::filesystem::directory_iterator dir(folderName), end;
     while (dir != end) {
         if (type == CResType::MAP || type == CResType::SAVE) {
             auto pt = dir->path().filename().stem().string();
@@ -124,10 +124,10 @@ std::vector<std::string> CResourcesProvider::getFiles(const std::string &type) {
 
 void CResourcesProvider::save(std::string file, const std::string &data) {
     vstd::logger::info("Saving map: " + file);
-    boost::filesystem::path path(file);
-    boost::filesystem::path dir = path.parent_path();
-    if (!boost::filesystem::exists(dir)) {
-        boost::filesystem::create_directory(dir);
+    std::filesystem::path path(file);
+    std::filesystem::path dir = path.parent_path();
+    if (!dir.empty() && !std::filesystem::exists(dir)) {
+        std::filesystem::create_directories(dir);
     }
     std::ofstream f(file);
     f << data;
@@ -141,9 +141,9 @@ std::shared_ptr<CAnimation> CAnimationProvider::getAnimation(const std::shared_p
                                                              const std::shared_ptr<CGameObject> &object, bool custom) {
     auto animation = game->createObject<CAnimation>("CAnimation");
     auto animationPath = object->getAnimation();
-    if (boost::filesystem::is_directory(animationPath)) {
+    if (std::filesystem::is_directory(animationPath)) {
         animation = game->createObject<CDynamicAnimation>("CDynamicAnimation");
-    } else if (boost::filesystem::is_regular_file(CResourcesProvider::getInstance()->getPath(animationPath + ".png"))) {
+    } else if (std::filesystem::is_regular_file(CResourcesProvider::getInstance()->getPath(animationPath + ".png"))) {
         animation = custom ? game->createObject<CAnimation>("CCustomAnimation")
                            : game->createObject<CStaticAnimation>("CStaticAnimation");
     } else {
@@ -175,8 +175,8 @@ const std::string &CResource::getPathSuffix() const { return pathSuffix; }
 void CResource::setPathSuffix(const std::string &pathSuffix) { CResource::pathSuffix = pathSuffix; }
 
 std::string CResource::getFilePath() const {
-    return (boost::filesystem::path(getPathPrefix()) /
-            boost::filesystem::path(getPath()).replace_extension(getPathSuffix()))
+    return (std::filesystem::path(getPathPrefix()) /
+            std::filesystem::path(getPath()).replace_extension(getPathSuffix()))
         .string();
 }
 

--- a/src/core/CProvider.h
+++ b/src/core/CProvider.h
@@ -21,79 +21,79 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CAnimation.h"
 
 struct CResType {
-  const static std::string CONFIG;
-  const static std::string MAP;
-  const static std::string PLUGIN;
-  const static std::string SAVE;
+    const static std::string CONFIG;
+    const static std::string MAP;
+    const static std::string PLUGIN;
+    const static std::string SAVE;
 };
 
 class CResource : public CGameObject {
-V_META(CResource, CGameObject, vstd::meta::empty())
-public:
-  virtual std::string type() = 0;
+    V_META(CResource, CGameObject, vstd::meta::empty())
+  public:
+    virtual std::string type() = 0;
 
-  const std::string &getPath() const;
+    const std::string &getPath() const;
 
-  void setPath(const std::string &path);
+    void setPath(const std::string &path);
 
-  const std::string &getPathPrefix() const;
+    const std::string &getPathPrefix() const;
 
-  void setPathPrefix(const std::string &pathPrefix);
+    void setPathPrefix(const std::string &pathPrefix);
 
-  const std::string &getPathSuffix() const;
+    const std::string &getPathSuffix() const;
 
-  void setPathSuffix(const std::string &pathSuffix);
+    void setPathSuffix(const std::string &pathSuffix);
 
-  std::string getFilePath() const;
+    std::string getFilePath() const;
 
-private:
-  std::string path;
-  std::string pathPrefix;
-  std::string pathSuffix;
+  private:
+    std::string path;
+    std::string pathPrefix;
+    std::string pathSuffix;
 };
 
 class CTextResource : public CResource {
-V_META(CTextResource, CResource, vstd::meta::empty())
-public:
-  std::string getText();
+    V_META(CTextResource, CResource, vstd::meta::empty())
+  public:
+    std::string getText();
 };
 
 class CConfigResource : public CResource {
-V_META(CConfigResource, CTextResource, vstd::meta::empty())
-public:
-  std::string type() override { return CResType::CONFIG; }
+    V_META(CConfigResource, CTextResource, vstd::meta::empty())
+  public:
+    std::string type() override { return CResType::CONFIG; }
 };
 
 class CResourceLoader : public CGameObject {
-V_META(CResourceLoader, CGameObject, vstd::meta::empty())
-public:
-  virtual std::shared_ptr<CResource> load(std::string path) = 0;
+    V_META(CResourceLoader, CGameObject, vstd::meta::empty())
+  public:
+    virtual std::shared_ptr<CResource> load(std::string path) = 0;
 };
 
 class CConfigResourceLoader : public CResourceLoader {
-V_META(CConfigResourceLoader, CResourceLoader, vstd::meta::empty())
-public:
-  std::shared_ptr<CResource> load(std::string path) override {
-    auto config = std::make_shared<CConfigResource>();
-    config->setPathPrefix("config");
-    config->setPath(normalizePath(std::move(path)));
-    config->setPathSuffix("json");
-    return config;
-  }
+    V_META(CConfigResourceLoader, CResourceLoader, vstd::meta::empty())
+  public:
+    std::shared_ptr<CResource> load(std::string path) override {
+        auto config = std::make_shared<CConfigResource>();
+        config->setPathPrefix("config");
+        config->setPath(normalizePath(std::move(path)));
+        config->setPathSuffix("json");
+        return config;
+    }
 
-private:
-  static std::string normalizePath(std::string path) {
-    boost::filesystem::path normalized(std::move(path));
-    if (normalized.extension() == ".json") {
-      normalized.replace_extension();
+  private:
+    static std::string normalizePath(std::string path) {
+        std::filesystem::path normalized(std::move(path));
+        if (normalized.extension() == ".json") {
+            normalized.replace_extension();
+        }
+        auto normalizedString = normalized.generic_string();
+        constexpr auto prefix = "config/";
+        if (normalizedString.rfind(prefix, 0) == 0) {
+            normalizedString.erase(0, sizeof(prefix) - 1);
+        }
+        return normalizedString;
     }
-    auto normalizedString = normalized.generic_string();
-    constexpr auto prefix = "config/";
-    if (normalizedString.rfind(prefix, 0) == 0) {
-      normalizedString.erase(0, sizeof(prefix) - 1);
-    }
-    return normalizedString;
-  }
 };
 
 class CAnimation;
@@ -103,49 +103,46 @@ class CGame;
 class CGameObject;
 
 class CResourcesProvider {
-public:
-  static std::shared_ptr<CResourcesProvider> getInstance();
+  public:
+    static std::shared_ptr<CResourcesProvider> getInstance();
 
-  std::string load(std::string path);
+    std::string load(std::string path);
 
-  std::shared_ptr<json> loadJson(std::string path);
+    std::shared_ptr<json> loadJson(std::string path);
 
-  std::string getPath(std::string path);
+    std::string getPath(std::string path);
 
-  std::vector<std::string> getFiles(const std::string &type);
+    std::vector<std::string> getFiles(const std::string &type);
 
-  void save(std::string file, const std::string &data);
+    void save(std::string file, const std::string &data);
 
-  void save(std::string file, std::shared_ptr<json> data);
+    void save(std::string file, std::shared_ptr<json> data);
 
-  CResourcesProvider() = default;
+    CResourcesProvider() = default;
 
-private:
-  static std::list<std::string> searchPath;
+  private:
+    static std::list<std::string> searchPath;
 };
 
-class CConfigurationProvider
-    : private std::map<std::string, std::shared_ptr<json>> {
-public:
-  static std::shared_ptr<json> getConfig(const std::string &path);
+class CConfigurationProvider : private std::map<std::string, std::shared_ptr<json>> {
+  public:
+    static std::shared_ptr<json> getConfig(const std::string &path);
 
-private:
-  CConfigurationProvider() = default;
+  private:
+    CConfigurationProvider() = default;
 
-  ~CConfigurationProvider();
+    ~CConfigurationProvider();
 
-  std::shared_ptr<json> getConfiguration(const std::string &path);
+    std::shared_ptr<json> getConfiguration(const std::string &path);
 
-  void loadConfig(const std::string &path);
+    void loadConfig(const std::string &path);
 };
 
 class CAnimationProvider {
-public:
-  static std::shared_ptr<CAnimation>
-  getAnimation(const std::shared_ptr<CGame> &game,
-               const std::shared_ptr<CGameObject> &object, bool custom = false);
+  public:
+    static std::shared_ptr<CAnimation> getAnimation(const std::shared_ptr<CGame> &game,
+                                                    const std::shared_ptr<CGameObject> &object, bool custom = false);
 
-  static std::shared_ptr<CAnimation>
-  getAnimation(const std::shared_ptr<CGame> &game, std::string path,
-               bool custom = false);
+    static std::shared_ptr<CAnimation> getAnimation(const std::shared_ptr<CGame> &game, std::string path,
+                                                    bool custom = false);
 };

--- a/src/core/CSerialization.cpp
+++ b/src/core/CSerialization.cpp
@@ -22,8 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <stdexcept>
 
-std::shared_ptr<CSerializerBase>
-CSerialization::serializer(std::pair<boost::typeindex::type_index, boost::typeindex::type_index> key) {
+std::shared_ptr<CSerializerBase> CSerialization::serializer(std::pair<std::type_index, std::type_index> key) {
     return (*CTypes::serializers())[key];
 }
 
@@ -42,24 +41,21 @@ void CSerialization::setProperty(const std::shared_ptr<CGameObject> &object, con
     }
 }
 
-boost::typeindex::type_index CSerialization::getProperty(const std::shared_ptr<CGameObject> &object,
-                                                         const std::string &name) {
+std::type_index CSerialization::getProperty(const std::shared_ptr<CGameObject> &object, const std::string &name) {
     return object->meta()->get_property_type(object, name);
 }
 
-void CSerialization::setArrayProperty(const std::shared_ptr<CGameObject> &object, boost::typeindex::type_index property,
+void CSerialization::setArrayProperty(const std::shared_ptr<CGameObject> &object, std::type_index property,
                                       const std::string &key, std::shared_ptr<json> value) {
-    setOtherProperty(boost::typeindex::type_id<std::shared_ptr<json>>(),
-                     property != V_VOID ? property
-                                        : boost::typeindex::type_id<std::set<std::shared_ptr<CGameObject>>>(),
-                     object, key, boost::any(value));
+    setOtherProperty(vstd::type_id<std::shared_ptr<json>>(),
+                     property != V_VOID ? property : vstd::type_id<std::set<std::shared_ptr<CGameObject>>>(), object,
+                     key, std::any(value));
 }
 
-void CSerialization::setObjectProperty(const std::shared_ptr<CGameObject> &object,
-                                       boost::typeindex::type_index property, const std::string &key,
-                                       std::shared_ptr<json> value) {
-    setOtherProperty(boost::typeindex::type_id<std::shared_ptr<json>>(),
-                     property != V_VOID ? property : getGenericPropertyType(value), object, key, boost::any(value));
+void CSerialization::setObjectProperty(const std::shared_ptr<CGameObject> &object, std::type_index property,
+                                       const std::string &key, std::shared_ptr<json> value) {
+    setOtherProperty(vstd::type_id<std::shared_ptr<json>>(),
+                     property != V_VOID ? property : getGenericPropertyType(value), object, key, std::any(value));
 }
 
 void CSerialization::setNumericProperty(const std::shared_ptr<CGameObject> &object, const std::string &key, int value) {
@@ -104,26 +100,26 @@ void CSerialization::setStringProperty(const std::shared_ptr<CGameObject> &objec
 }
 
 bool CSerialization::isString(const std::shared_ptr<CGameObject> &object, const std::string &key) {
-    return getProperty(object, key) == boost::typeindex::type_id<std::string>();
+    return getProperty(object, key) == vstd::type_id<std::string>();
 }
 
-void CSerialization::setOtherProperty(boost::typeindex::type_index serializedId,
-                                      boost::typeindex::type_index deserializedId,
+void CSerialization::setOtherProperty(std::type_index serializedId, std::type_index deserializedId,
                                       const std::shared_ptr<CGameObject> &object, const std::string &key,
-                                      const boost::any &value) {
+                                      const std::any &value) {
     std::shared_ptr<CSerializerBase> serializer =
         (*CTypes::serializers())[std::make_pair(serializedId, deserializedId)];
-    boost::any result;
+    std::any result;
     try {
         result = vstd::not_null(serializer, "No serializer!")->deserialize(object->getGame(), value);
     } catch (const std::exception &ex) {
         throw std::runtime_error("Failed to deserialize property '" + key + "': " + ex.what());
     }
-    if (CTypes::is_pointer_type(result.type())) {
+    const auto resultType = vstd::type_id(result.type());
+    if (CTypes::is_pointer_type(resultType)) {
         object->setProperty(key, vstd::any_cast<std::shared_ptr<CGameObject>>(result));
-    } else if (CTypes::is_array_type(result.type())) {
+    } else if (CTypes::is_array_type(resultType)) {
         object->setProperty(key, vstd::any_cast<std::set<std::shared_ptr<CGameObject>>>(result));
-    } else if (CTypes::is_map_type(result.type())) {
+    } else if (CTypes::is_map_type(resultType)) {
         object->setProperty(key, vstd::any_cast<std::map<std::string, std::shared_ptr<CGameObject>>>(result));
     } else {
         CTypes::set_custom_property(object, key, result);
@@ -155,18 +151,19 @@ void add_arr_member(const std::shared_ptr<json> &object, bool value) { (*object)
 void add_arr_member(const std::shared_ptr<json> &object, int value) { (*object)[object->size()] = value; }
 
 void CSerialization::setProperty(const std::shared_ptr<json> &conf, const std::string &propertyName,
-                                 const boost::any &propertyValue) {
-    if (propertyValue.type() == boost::typeindex::type_id<int>()) {
+                                 const std::any &propertyValue) {
+    const auto propertyType = vstd::type_id(propertyValue.type());
+    if (propertyType == vstd::type_id<int>()) {
         add_member(conf, propertyName, vstd::any_cast<int>(propertyValue));
-    } else if (propertyValue.type() == boost::typeindex::type_id<std::string>()) {
+    } else if (propertyType == vstd::type_id<std::string>()) {
         add_member(conf, propertyName, vstd::any_cast<std::string>(propertyValue));
-    } else if (propertyValue.type() == boost::typeindex::type_id<bool>()) {
+    } else if (propertyType == vstd::type_id<bool>()) {
         add_member(conf, propertyName, vstd::any_cast<bool>(propertyValue));
     } else {
         std::shared_ptr<CSerializerBase> serializer;
         for (const auto &entry : *CTypes::serializers()) {
             auto types = entry.first;
-            if (types.second == propertyValue.type()) {
+            if (types.second == propertyType) {
                 vstd::fail_if(serializer, "Ambiguous serializer!");
                 serializer = entry.second;
             }
@@ -187,7 +184,7 @@ std::shared_ptr<json> object_serialize(const std::shared_ptr<CGameObject> &objec
         object->meta()->for_all_properties(object, [&](auto property) {
             if (property->name() != "type") {
                 CSerialization::setProperty(properties, property->name(),
-                                            object->getProperty<boost::any>(property->name()));
+                                            object->getProperty<std::any>(property->name()));
             }
         });
         add_member(conf, "properties", properties);
@@ -268,14 +265,14 @@ std::set<std::shared_ptr<CGameObject>> array_deserialize(const std::shared_ptr<C
     return objects;
 }
 
-boost::typeindex::type_index CSerialization::getGenericPropertyType(const std::shared_ptr<json> &object) {
+std::type_index CSerialization::getGenericPropertyType(const std::shared_ptr<json> &object) {
     if (CJsonUtil::isObject(object)) {
-        return boost::typeindex::type_id<std::shared_ptr<CGameObject>>();
+        return vstd::type_id<std::shared_ptr<CGameObject>>();
     } else if (CJsonUtil::isMap(object)) {
-        return boost::typeindex::type_id<std::map<std::string, std::shared_ptr<CGameObject>>>();
+        return vstd::type_id<std::map<std::string, std::shared_ptr<CGameObject>>>();
     }
     vstd::fail("Unable to determine property type!");
-    return boost::typeindex::type_index();
+    return V_VOID;
 }
 
 std::shared_ptr<json> CSerializerFunction<std::shared_ptr<json>, std::set<std::shared_ptr<CGameObject>>>::serialize(

--- a/src/core/CSerialization.h
+++ b/src/core/CSerialization.h
@@ -26,267 +26,192 @@ class CGameObject;
 class CSerializerBase;
 
 class CSerializerBase {
-  friend class CSerialization;
+    friend class CSerialization;
 
-public:
-  virtual boost::any serialize(boost::any object) = 0;
+  public:
+    virtual std::any serialize(std::any object) = 0;
 
-  virtual boost::any deserialize(std::shared_ptr<CGame> map,
-                                 boost::any object) = 0;
+    virtual std::any deserialize(std::shared_ptr<CGame> map, std::any object) = 0;
 };
 
-template <typename Serialized, typename Deserialized>
-class CSerializerFunction {
-public:
-  template <typename T = Serialized, typename V = Deserialized>
-  static T serialize(
-      V deserialized,
-      typename std::enable_if<vstd::is_shared_ptr<V>::value>::type * = 0) {
-    return CSerializerFunction<T, std::shared_ptr<CGameObject>>::serialize(
-        deserialized);
-  }
+template <typename Serialized, typename Deserialized> class CSerializerFunction {
+  public:
+    template <typename T = Serialized, typename V = Deserialized>
+    static T serialize(V deserialized, typename std::enable_if<vstd::is_shared_ptr<V>::value>::type * = 0) {
+        return CSerializerFunction<T, std::shared_ptr<CGameObject>>::serialize(deserialized);
+    }
 
-  template <typename T = Serialized, typename V = Deserialized>
-  static V deserialize(
-      std::shared_ptr<CGame> map, T serialized,
-      typename std::enable_if<vstd::is_shared_ptr<V>::value>::type * = 0) {
-    return std::dynamic_pointer_cast<typename V::element_type>(
-        CSerializerFunction<T, std::shared_ptr<CGameObject>>::deserialize(
-            map, serialized));
-  }
+    template <typename T = Serialized, typename V = Deserialized>
+    static V deserialize(std::shared_ptr<CGame> map, T serialized,
+                         typename std::enable_if<vstd::is_shared_ptr<V>::value>::type * = 0) {
+        return std::dynamic_pointer_cast<typename V::element_type>(
+            CSerializerFunction<T, std::shared_ptr<CGameObject>>::deserialize(map, serialized));
+    }
 
-  template <typename T = Serialized, typename V = Deserialized>
-  static T
-  serialize(V deserialized,
-            typename std::enable_if<vstd::is_set<V>::value>::type * = 0) {
-    return CSerializerFunction<T, std::set<std::shared_ptr<CGameObject>>>::
-        serialize(
+    template <typename T = Serialized, typename V = Deserialized>
+    static T serialize(V deserialized, typename std::enable_if<vstd::is_set<V>::value>::type * = 0) {
+        return CSerializerFunction<T, std::set<std::shared_ptr<CGameObject>>>::serialize(
             vstd::cast<std::set<std::shared_ptr<CGameObject>>>(deserialized));
-  }
+    }
 
-  template <typename T = Serialized, typename V = Deserialized>
-  static V
-  deserialize(std::shared_ptr<CGame> map, T serialized,
-              typename std::enable_if<vstd::is_set<V>::value>::type * = 0) {
-    return vstd::cast<V>(
-        CSerializerFunction<T, std::set<std::shared_ptr<CGameObject>>>::
-            deserialize(map, serialized));
-  }
+    template <typename T = Serialized, typename V = Deserialized>
+    static V deserialize(std::shared_ptr<CGame> map, T serialized,
+                         typename std::enable_if<vstd::is_set<V>::value>::type * = 0) {
+        return vstd::cast<V>(
+            CSerializerFunction<T, std::set<std::shared_ptr<CGameObject>>>::deserialize(map, serialized));
+    }
 
-  template <typename T = Serialized, typename V = Deserialized>
-  static T
-  serialize(V deserialized,
-            typename std::enable_if<vstd::is_map<V>::value>::type * = 0) {
-    return CSerializerFunction<
-        T, std::map<std::string, std::shared_ptr<CGameObject>>>::
-        serialize(
-            vstd::cast<std::map<std::string, std::shared_ptr<CGameObject>>>(
-                deserialized));
-  }
+    template <typename T = Serialized, typename V = Deserialized>
+    static T serialize(V deserialized, typename std::enable_if<vstd::is_map<V>::value>::type * = 0) {
+        return CSerializerFunction<T, std::map<std::string, std::shared_ptr<CGameObject>>>::serialize(
+            vstd::cast<std::map<std::string, std::shared_ptr<CGameObject>>>(deserialized));
+    }
 
-  template <typename T = Serialized, typename V = Deserialized>
-  static V
-  deserialize(std::shared_ptr<CGame> map, T serialized,
-              typename std::enable_if<vstd::is_map<V>::value>::type * = 0) {
-    return vstd::cast<V>(
-        CSerializerFunction<
-            T, std::map<std::string, std::shared_ptr<CGameObject>>>::
-            deserialize(map, serialized));
-  }
+    template <typename T = Serialized, typename V = Deserialized>
+    static V deserialize(std::shared_ptr<CGame> map, T serialized,
+                         typename std::enable_if<vstd::is_map<V>::value>::type * = 0) {
+        return vstd::cast<V>(
+            CSerializerFunction<T, std::map<std::string, std::shared_ptr<CGameObject>>>::deserialize(map, serialized));
+    }
 };
 
 // inline this functions
-extern std::set<std::shared_ptr<CGameObject>>
-array_deserialize(const std::shared_ptr<CGame> &map,
-                  const std::shared_ptr<json> &object);
+extern std::set<std::shared_ptr<CGameObject>> array_deserialize(const std::shared_ptr<CGame> &map,
+                                                                const std::shared_ptr<json> &object);
 
-extern std::shared_ptr<json>
-array_serialize(const std::set<std::shared_ptr<CGameObject>> &set);
+extern std::shared_ptr<json> array_serialize(const std::set<std::shared_ptr<CGameObject>> &set);
 
-extern std::map<std::string, std::shared_ptr<CGameObject>>
-map_deserialize(const std::shared_ptr<CGame> &map,
-                const std::shared_ptr<json> &object);
+extern std::map<std::string, std::shared_ptr<CGameObject>> map_deserialize(const std::shared_ptr<CGame> &map,
+                                                                           const std::shared_ptr<json> &object);
 
-extern std::shared_ptr<json> map_serialize(
-    const std::map<std::string, std::shared_ptr<CGameObject>> &object);
+extern std::shared_ptr<json> map_serialize(const std::map<std::string, std::shared_ptr<CGameObject>> &object);
 
-extern std::shared_ptr<CGameObject>
-object_deserialize(const std::shared_ptr<CGame> &game,
-                   const std::shared_ptr<json> &config);
+extern std::shared_ptr<CGameObject> object_deserialize(const std::shared_ptr<CGame> &game,
+                                                       const std::shared_ptr<json> &config);
 
-extern std::shared_ptr<json>
-object_serialize(const std::shared_ptr<CGameObject> &object);
+extern std::shared_ptr<json> object_serialize(const std::shared_ptr<CGameObject> &object);
 
-extern std::set<std::string>
-array_string_deserialize(std::shared_ptr<CGame> map,
-                         std::shared_ptr<json> object);
+extern std::set<std::string> array_string_deserialize(std::shared_ptr<CGame> map, std::shared_ptr<json> object);
 
 extern std::shared_ptr<json> array_string_serialize(std::set<std::string> set);
 
-extern void add_member(const std::shared_ptr<json> &object,
-                       const std::string &key, const std::string &value);
+extern void add_member(const std::shared_ptr<json> &object, const std::string &key, const std::string &value);
 
-extern void add_member(const std::shared_ptr<json> &object,
-                       const std::string &key,
-                       const std::shared_ptr<json> &value);
+extern void add_member(const std::shared_ptr<json> &object, const std::string &key, const std::shared_ptr<json> &value);
 
-extern void add_member(const std::shared_ptr<json> &object,
-                       const std::string &key, bool value);
+extern void add_member(const std::shared_ptr<json> &object, const std::string &key, bool value);
 
-extern void add_member(const std::shared_ptr<json> &object,
-                       const std::string &key, int value);
+extern void add_member(const std::shared_ptr<json> &object, const std::string &key, int value);
 
-extern void add_arr_member(const std::shared_ptr<json> &object,
-                           const std::string &value);
+extern void add_arr_member(const std::shared_ptr<json> &object, const std::string &value);
 
-extern void add_arr_member(const std::shared_ptr<json> &object,
-                           const std::shared_ptr<json> &value);
+extern void add_arr_member(const std::shared_ptr<json> &object, const std::shared_ptr<json> &value);
 
 extern void add_arr_member(const std::shared_ptr<json> &object, bool value);
 
 extern void add_arr_member(const std::shared_ptr<json> &object, int value);
 
-template <>
-class CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>> {
-public:
-  static std::shared_ptr<json>
-  serialize(const std::shared_ptr<CGameObject> &object);
+template <> class CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>> {
+  public:
+    static std::shared_ptr<json> serialize(const std::shared_ptr<CGameObject> &object);
 
-  static std::shared_ptr<CGameObject>
-  deserialize(const std::shared_ptr<CGame> &map,
-              const std::shared_ptr<json> &config);
+    static std::shared_ptr<CGameObject> deserialize(const std::shared_ptr<CGame> &map,
+                                                    const std::shared_ptr<json> &config);
 };
 
-template <>
-class CSerializerFunction<std::shared_ptr<json>,
-                          std::map<std::string, std::shared_ptr<CGameObject>>> {
-public:
-  static std::shared_ptr<json>
-  serialize(const std::map<std::string, std::shared_ptr<CGameObject>> &object);
+template <> class CSerializerFunction<std::shared_ptr<json>, std::map<std::string, std::shared_ptr<CGameObject>>> {
+  public:
+    static std::shared_ptr<json> serialize(const std::map<std::string, std::shared_ptr<CGameObject>> &object);
 
-  static std::map<std::string, std::shared_ptr<CGameObject>>
-  deserialize(const std::shared_ptr<CGame> &map,
-              const std::shared_ptr<json> &object);
+    static std::map<std::string, std::shared_ptr<CGameObject>> deserialize(const std::shared_ptr<CGame> &map,
+                                                                           const std::shared_ptr<json> &object);
 };
 
-template <>
-class CSerializerFunction<std::shared_ptr<json>,
-                          std::set<std::shared_ptr<CGameObject>>> {
-public:
-  static std::shared_ptr<json>
-  serialize(const std::set<std::shared_ptr<CGameObject>> &set);
+template <> class CSerializerFunction<std::shared_ptr<json>, std::set<std::shared_ptr<CGameObject>>> {
+  public:
+    static std::shared_ptr<json> serialize(const std::set<std::shared_ptr<CGameObject>> &set);
 
-  static std::set<std::shared_ptr<CGameObject>>
-  deserialize(const std::shared_ptr<CGame> &map,
-              const std::shared_ptr<json> &object);
+    static std::set<std::shared_ptr<CGameObject>> deserialize(const std::shared_ptr<CGame> &map,
+                                                              const std::shared_ptr<json> &object);
 };
 
-template <typename Serialized, typename Deserialized>
-class CSerializer : public CSerializerBase {
-public:
-  boost::any serialize(boost::any object) final {
-    return boost::any(CSerializerFunction<Serialized, Deserialized>::serialize(
-        vstd::any_cast<Deserialized>(object)));
-  }
+template <typename Serialized, typename Deserialized> class CSerializer : public CSerializerBase {
+  public:
+    std::any serialize(std::any object) final {
+        return std::any(CSerializerFunction<Serialized, Deserialized>::serialize(vstd::any_cast<Deserialized>(object)));
+    }
 
-  boost::any deserialize(std::shared_ptr<CGame> map, boost::any object) final {
-    return boost::any(
-        CSerializerFunction<Serialized, Deserialized>::deserialize(
-            map, vstd::any_cast<Serialized>(object)));
-  }
+    std::any deserialize(std::shared_ptr<CGame> map, std::any object) final {
+        return std::any(
+            CSerializerFunction<Serialized, Deserialized>::deserialize(map, vstd::any_cast<Serialized>(object)));
+    }
 };
 
-template <typename Serialized, typename Deserialized>
-class CCustomSerializer : public CSerializerBase {
-private:
-  std::function<Serialized(Deserialized)> _serialize;
-  std::function<Deserialized(std::shared_ptr<CGame>, Serialized)> _deserialize;
+template <typename Serialized, typename Deserialized> class CCustomSerializer : public CSerializerBase {
+  private:
+    std::function<Serialized(Deserialized)> _serialize;
+    std::function<Deserialized(std::shared_ptr<CGame>, Serialized)> _deserialize;
 
-public:
-  CCustomSerializer(
-      std::function<Serialized(Deserialized)> _serialize,
-      std::function<Deserialized(std::shared_ptr<CGame>, Serialized)>
-          _deserialize)
-      : _serialize(_serialize), _deserialize(_deserialize) {}
+  public:
+    CCustomSerializer(std::function<Serialized(Deserialized)> _serialize,
+                      std::function<Deserialized(std::shared_ptr<CGame>, Serialized)> _deserialize)
+        : _serialize(_serialize), _deserialize(_deserialize) {}
 
-  boost::any serialize(boost::any object) final {
-    return boost::any(_serialize(vstd::any_cast<Deserialized>(object)));
-  }
+    std::any serialize(std::any object) final { return std::any(_serialize(vstd::any_cast<Deserialized>(object))); }
 
-  boost::any deserialize(std::shared_ptr<CGame> map, boost::any object) final {
-    return boost::any(_deserialize(map, vstd::any_cast<Serialized>(object)));
-  }
+    std::any deserialize(std::shared_ptr<CGame> map, std::any object) final {
+        return std::any(_deserialize(map, vstd::any_cast<Serialized>(object)));
+    }
 };
 
 class CSerialization {
-  static std::shared_ptr<CSerializerBase> serializer(
-      std::pair<boost::typeindex::type_index, boost::typeindex::type_index>
-          key);
+    static std::shared_ptr<CSerializerBase> serializer(std::pair<std::type_index, std::type_index> key);
 
-  template <typename Serialized, typename Deserialized>
-  static std::shared_ptr<CSerializerBase> serializer() {
-    return serializer(vstd::type_pair<Serialized, Deserialized>());
-  }
+    template <typename Serialized, typename Deserialized> static std::shared_ptr<CSerializerBase> serializer() {
+        return serializer(vstd::type_pair<Serialized, Deserialized>());
+    }
 
-public:
-  template <typename Serialized, typename Deserialized>
-  static Serialized serialize(Deserialized deserialized) {
-    boost::any variant = serializer<Serialized, Deserialized>()->serialize(
-        boost::any(deserialized));
-    return vstd::any_cast<Serialized>(variant);
-  }
+  public:
+    template <typename Serialized, typename Deserialized> static Serialized serialize(Deserialized deserialized) {
+        std::any variant = serializer<Serialized, Deserialized>()->serialize(std::any(deserialized));
+        return vstd::any_cast<Serialized>(variant);
+    }
 
-  template <typename Serialized, typename Deserialized>
-  static Deserialized deserialize(std::shared_ptr<CGame> map,
-                                  Serialized serialized) {
-    boost::any variant = serializer<Serialized, Deserialized>()->deserialize(
-        map, boost::any(serialized));
-    return vstd::any_cast<Deserialized>(variant);
-  }
+    template <typename Serialized, typename Deserialized>
+    static Deserialized deserialize(std::shared_ptr<CGame> map, Serialized serialized) {
+        std::any variant = serializer<Serialized, Deserialized>()->deserialize(map, std::any(serialized));
+        return vstd::any_cast<Deserialized>(variant);
+    }
 
-  static void setProperty(const std::shared_ptr<CGameObject> &object,
-                          const std::string &key,
-                          const std::shared_ptr<json> &value);
+    static void setProperty(const std::shared_ptr<CGameObject> &object, const std::string &key,
+                            const std::shared_ptr<json> &value);
 
-  static void setProperty(const std::shared_ptr<json> &conf,
-                          const std::string &propertyName,
-                          const boost::any &propertyValue);
+    static void setProperty(const std::shared_ptr<json> &conf, const std::string &propertyName,
+                            const std::any &propertyValue);
 
-  static std::string generateName(const std::shared_ptr<CGameObject> &object);
+    static std::string generateName(const std::shared_ptr<CGameObject> &object);
 
-private:
-  static boost::typeindex::type_index
-  getProperty(const std::shared_ptr<CGameObject> &object,
-              const std::string &name);
+  private:
+    static std::type_index getProperty(const std::shared_ptr<CGameObject> &object, const std::string &name);
 
-  static boost::typeindex::type_index
-  getGenericPropertyType(const std::shared_ptr<json> &object);
+    static std::type_index getGenericPropertyType(const std::shared_ptr<json> &object);
 
-  static void setArrayProperty(const std::shared_ptr<CGameObject> &object,
-                               boost::typeindex::type_index property,
-                               const std::string &key,
-                               std::shared_ptr<json> value);
+    static void setArrayProperty(const std::shared_ptr<CGameObject> &object, std::type_index property,
+                                 const std::string &key, std::shared_ptr<json> value);
 
-  static void setObjectProperty(const std::shared_ptr<CGameObject> &object,
-                                boost::typeindex::type_index property,
-                                const std::string &key,
-                                std::shared_ptr<json> value);
+    static void setObjectProperty(const std::shared_ptr<CGameObject> &object, std::type_index property,
+                                  const std::string &key, std::shared_ptr<json> value);
 
-  static void setStringProperty(const std::shared_ptr<CGameObject> &object,
-                                const std::string &key,
-                                const std::string &value);
+    static void setStringProperty(const std::shared_ptr<CGameObject> &object, const std::string &key,
+                                  const std::string &value);
 
-  static void setNumericProperty(const std::shared_ptr<CGameObject> &object,
-                                 const std::string &key, int value);
+    static void setNumericProperty(const std::shared_ptr<CGameObject> &object, const std::string &key, int value);
 
-  static void setBooleanProperty(const std::shared_ptr<CGameObject> &object,
-                                 const std::string &key, bool value);
+    static void setBooleanProperty(const std::shared_ptr<CGameObject> &object, const std::string &key, bool value);
 
-  static void setOtherProperty(boost::typeindex::type_index serializedId,
-                               boost::typeindex::type_index deserializedId,
-                               const std::shared_ptr<CGameObject> &object,
-                               const std::string &key, const boost::any &value);
+    static void setOtherProperty(std::type_index serializedId, std::type_index deserializedId,
+                                 const std::shared_ptr<CGameObject> &object, const std::string &key,
+                                 const std::any &value);
 
-  static bool isString(const std::shared_ptr<CGameObject> &object,
-                       const std::string &key);
+    static bool isString(const std::shared_ptr<CGameObject> &object, const std::string &key);
 };

--- a/src/core/CStats.cpp
+++ b/src/core/CStats.cpp
@@ -94,40 +94,34 @@ int Stats::getMainValue() { return this->getNumericProperty(mainStat); }
 Stats::Stats() {}
 
 void Stats::addBonus(std::shared_ptr<Stats> stats) {
-  stats->meta()->for_all_properties(stats, [&](auto property) {
-    if (property->value_type() == boost::typeindex::type_id<int>()) {
-      this->incProperty(property->name(),
-                        stats->getProperty<int>(property->name()));
-    }
-  });
+    stats->meta()->for_all_properties(stats, [&](auto property) {
+        if (property->value_type() == vstd::type_id<int>()) {
+            this->incProperty(property->name(), stats->getProperty<int>(property->name()));
+        }
+    });
 }
 
 void Stats::removeBonus(std::shared_ptr<Stats> stats) {
-  stats->meta()->for_all_properties(stats, [&](auto property) {
-    if (property->value_type() == boost::typeindex::type_id<int>()) {
-      this->incProperty(property->name(),
-                        -stats->getProperty<int>(property->name()));
-    }
-  });
+    stats->meta()->for_all_properties(stats, [&](auto property) {
+        if (property->value_type() == vstd::type_id<int>()) {
+            this->incProperty(property->name(), -stats->getProperty<int>(property->name()));
+        }
+    });
 }
 
 std::string Stats::getText(int level) {
-  std::ostringstream stream;
-  stream << "Level: " << level << "\n";
-  stream << "Strength: " << strength << "\n";
-  stream << "Agility: " << agility << "\n";
-  stream << "Intelligence: " << intelligence << "\n";
-  stream << "Stamina: " << stamina << "\n";
-  stream << "Damage: " << dmgMin + damage << "-" << dmgMax + damage << "\n";
-  stream << "Hit: " << hit + attack << "%"
-         << "\n";
-  stream << "Crit: " << crit << "%"
-         << "\n";
-  stream << "Armor: " << armor << "%"
-         << "\n";
-  stream << "Block: " << block << "%"
-         << "\n";
-  return stream.str();
+    std::ostringstream stream;
+    stream << "Level: " << level << "\n";
+    stream << "Strength: " << strength << "\n";
+    stream << "Agility: " << agility << "\n";
+    stream << "Intelligence: " << intelligence << "\n";
+    stream << "Stamina: " << stamina << "\n";
+    stream << "Damage: " << dmgMin + damage << "-" << dmgMax + damage << "\n";
+    stream << "Hit: " << hit + attack << "%" << "\n";
+    stream << "Crit: " << crit << "%" << "\n";
+    stream << "Armor: " << armor << "%" << "\n";
+    stream << "Block: " << block << "%" << "\n";
+    return stream.str();
 }
 
 Damage::Damage() {}

--- a/src/core/CTypes.cpp
+++ b/src/core/CTypes.cpp
@@ -47,452 +47,363 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CWrapper.h"
 #include "core/CGame.h"
 
-std::unordered_map<std::string, std::function<std::shared_ptr<CGameObject>()>> *
-CTypes::builders() {
-  static std::unordered_map<std::string,
-                            std::function<std::shared_ptr<CGameObject>()>>
-      reg;
-  return &reg;
+std::unordered_map<std::string, std::function<std::shared_ptr<CGameObject>()>> *CTypes::builders() {
+    static std::unordered_map<std::string, std::function<std::shared_ptr<CGameObject>()>> reg;
+    return &reg;
 }
 
-std::unordered_map<boost::typeindex::type_index,
-                   std::function<void(std::shared_ptr<CGameObject>, std::string,
-                                      boost::any)>> *
+std::unordered_map<std::type_index, std::function<void(std::shared_ptr<CGameObject>, std::string, std::any)>> *
 CTypes::setters() {
-  static std::unordered_map<boost::typeindex::type_index,
-                            std::function<void(std::shared_ptr<CGameObject>,
-                                               std::string, boost::any)>>
-      reg;
-  return &reg;
+    static std::unordered_map<std::type_index, std::function<void(std::shared_ptr<CGameObject>, std::string, std::any)>>
+        reg;
+    return &reg;
 }
 
-std::unordered_map<
-    std::pair<boost::typeindex::type_index, boost::typeindex::type_index>,
-    std::shared_ptr<CSerializerBase>> *
+std::unordered_map<std::pair<std::type_index, std::type_index>, std::shared_ptr<CSerializerBase>> *
 CTypes::serializers() {
-  static std::unordered_map<
-      std::pair<boost::typeindex::type_index, boost::typeindex::type_index>,
-      std::shared_ptr<CSerializerBase>>
-      reg;
-  return &reg;
+    static std::unordered_map<std::pair<std::type_index, std::type_index>, std::shared_ptr<CSerializerBase>> reg;
+    return &reg;
 }
 
-bool CTypes::is_map_type(boost::typeindex::type_index index) {
-  return vstd::ctn(*map_types(), index);
+bool CTypes::is_map_type(std::type_index index) { return vstd::ctn(*map_types(), index); }
+
+bool CTypes::is_pointer_type(std::type_index index) { return vstd::ctn(*pointer_types(), index); }
+
+bool CTypes::is_array_type(std::type_index index) { return vstd::ctn(*array_types(), index); }
+
+std::unordered_set<std::type_index> *CTypes::map_types() {
+    static std::unordered_set<std::type_index> _map_types;
+    return &_map_types;
 }
 
-bool CTypes::is_pointer_type(boost::typeindex::type_index index) {
-  return vstd::ctn(*pointer_types(), index);
+std::unordered_set<std::type_index> *CTypes::array_types() {
+    static std::unordered_set<std::type_index> _array_types;
+    return &_array_types;
 }
 
-bool CTypes::is_array_type(boost::typeindex::type_index index) {
-  return vstd::ctn(*array_types(), index);
-}
-
-std::unordered_set<boost::typeindex::type_index> *CTypes::map_types() {
-  static std::unordered_set<boost::typeindex::type_index> _map_types;
-  return &_map_types;
-}
-
-std::unordered_set<boost::typeindex::type_index> *CTypes::array_types() {
-  static std::unordered_set<boost::typeindex::type_index> _array_types;
-  return &_array_types;
-}
-
-std::unordered_set<boost::typeindex::type_index> *CTypes::pointer_types() {
-  static std::unordered_set<boost::typeindex::type_index> _pointer_types;
-  return &_pointer_types;
+std::unordered_set<std::type_index> *CTypes::pointer_types() {
+    static std::unordered_set<std::type_index> _pointer_types;
+    return &_pointer_types;
 }
 
 namespace {
 struct register_all_types {
-  register_all_types() {
-    // Original types1.cpp
-    CTypes::register_type<CGameObject>();
-    {
-      CTypes::register_type<CGame, CGameObject>();
-      CTypes::register_type<CMap, CGameObject>();
+    register_all_types() {
+        // Original types1.cpp
+        CTypes::register_type<CGameObject>();
+        {
+            CTypes::register_type<CGame, CGameObject>();
+            CTypes::register_type<CMap, CGameObject>();
 
-      CTypes::register_type<CFightController, CGameObject>();
-      {
-        CTypes::register_type<CPlayerFightController, CFightController,
-                              CGameObject>();
-        CTypes::register_type<CMonsterFightController, CFightController,
-                              CGameObject>();
-      }
-      CTypes::register_type<CGameEvent, CGameObject>();
-      {
-        CTypes::register_type<CGameEventCaused, CGameEvent, CGameObject>();
-      }
-      CTypes::register_type<CPlugin, CGameObject>();
-      {
-        CTypes::register_type<CWrapper<CPlugin>, CPlugin, CGameObject>();
-      }
-    }
-
-    // Original types2.cpp
-    CTypes::register_type<CGameObject>();
-    {
-      CTypes::register_type<CMapObject, CGameObject>();
-      {
-        CTypes::register_type<CBuilding, CMapObject, CGameObject>();
-        {
-          CTypes::register_type<CWrapper<CBuilding>, CBuilding, CMapObject,
-                                CGameObject>();
-        }
-        CTypes::register_type<CEvent, CMapObject, CGameObject>();
-        {
-          CTypes::register_type<CWrapper<CEvent>, CEvent, CMapObject,
-                                CGameObject>();
-        }
-        CTypes::register_type<CItem, CMapObject, CGameObject>();
-        {
-          CTypes::register_type<CWeapon, CItem, CMapObject, CGameObject>();
-          {
-            CTypes::register_type<CSmallWeapon, CWeapon, CItem, CMapObject,
-                                  CGameObject>();
-          }
-          CTypes::register_type<CArmor, CItem, CMapObject, CGameObject>();
-          CTypes::register_type<CPotion, CItem, CMapObject, CGameObject>();
-          {
-            CTypes::register_type<CWrapper<CPotion>, CPotion, CItem, CMapObject,
-                                  CGameObject>();
-          }
-          CTypes::register_type<CHelmet, CItem, CMapObject, CGameObject>();
-          CTypes::register_type<CBoots, CItem, CMapObject, CGameObject>();
-          CTypes::register_type<CBelt, CItem, CMapObject, CGameObject>();
-          CTypes::register_type<CGloves, CItem, CMapObject, CGameObject>();
-          CTypes::register_type<CScroll, CItem, CMapObject, CGameObject>();
-          {
-            CTypes::register_type<CWrapper<CScroll>, CScroll, CItem, CMapObject,
-                                  CGameObject>();
-          }
-        }
-        {
-          CTypes::register_type<CWrapper<CScroll>, CScroll, CItem, CMapObject,
-                                CGameObject>();
+            CTypes::register_type<CFightController, CGameObject>();
+            {
+                CTypes::register_type<CPlayerFightController, CFightController, CGameObject>();
+                CTypes::register_type<CMonsterFightController, CFightController, CGameObject>();
+            }
+            CTypes::register_type<CGameEvent, CGameObject>();
+            { CTypes::register_type<CGameEventCaused, CGameEvent, CGameObject>(); }
+            CTypes::register_type<CPlugin, CGameObject>();
+            { CTypes::register_type<CWrapper<CPlugin>, CPlugin, CGameObject>(); }
         }
 
-        CTypes::register_type<CCreature, CMapObject, CGameObject>();
+        // Original types2.cpp
+        CTypes::register_type<CGameObject>();
         {
-          CTypes::register_type<CPlayer, CCreature, CMapObject, CGameObject>();
+            CTypes::register_type<CMapObject, CGameObject>();
+            {
+                CTypes::register_type<CBuilding, CMapObject, CGameObject>();
+                { CTypes::register_type<CWrapper<CBuilding>, CBuilding, CMapObject, CGameObject>(); }
+                CTypes::register_type<CEvent, CMapObject, CGameObject>();
+                { CTypes::register_type<CWrapper<CEvent>, CEvent, CMapObject, CGameObject>(); }
+                CTypes::register_type<CItem, CMapObject, CGameObject>();
+                {
+                    CTypes::register_type<CWeapon, CItem, CMapObject, CGameObject>();
+                    { CTypes::register_type<CSmallWeapon, CWeapon, CItem, CMapObject, CGameObject>(); }
+                    CTypes::register_type<CArmor, CItem, CMapObject, CGameObject>();
+                    CTypes::register_type<CPotion, CItem, CMapObject, CGameObject>();
+                    { CTypes::register_type<CWrapper<CPotion>, CPotion, CItem, CMapObject, CGameObject>(); }
+                    CTypes::register_type<CHelmet, CItem, CMapObject, CGameObject>();
+                    CTypes::register_type<CBoots, CItem, CMapObject, CGameObject>();
+                    CTypes::register_type<CBelt, CItem, CMapObject, CGameObject>();
+                    CTypes::register_type<CGloves, CItem, CMapObject, CGameObject>();
+                    CTypes::register_type<CScroll, CItem, CMapObject, CGameObject>();
+                    { CTypes::register_type<CWrapper<CScroll>, CScroll, CItem, CMapObject, CGameObject>(); }
+                }
+                { CTypes::register_type<CWrapper<CScroll>, CScroll, CItem, CMapObject, CGameObject>(); }
+
+                CTypes::register_type<CCreature, CMapObject, CGameObject>();
+                { CTypes::register_type<CPlayer, CCreature, CMapObject, CGameObject>(); }
+            }
         }
-      }
-    }
 
-    // Original types3.cpp
-    CTypes::register_type<CGameObject>();
-    {
-      CTypes::register_type<CEffect, CGameObject>();
-      {
-        CTypes::register_type<CWrapper<CEffect>, CEffect, CGameObject>();
-      }
+        // Original types3.cpp
+        CTypes::register_type<CGameObject>();
+        {
+            CTypes::register_type<CEffect, CGameObject>();
+            { CTypes::register_type<CWrapper<CEffect>, CEffect, CGameObject>(); }
 
-      CTypes::register_type<CMarket, CGameObject>();
-      CTypes::register_type<CDialog, CGameObject>();
-      {
-        CTypes::register_type<CWrapper<CDialog>, CDialog, CGameObject>();
-      }
-      CTypes::register_type<CDialogOption, CGameObject>();
-      CTypes::register_type<CDialogState, CGameObject>();
+            CTypes::register_type<CMarket, CGameObject>();
+            CTypes::register_type<CDialog, CGameObject>();
+            { CTypes::register_type<CWrapper<CDialog>, CDialog, CGameObject>(); }
+            CTypes::register_type<CDialogOption, CGameObject>();
+            CTypes::register_type<CDialogState, CGameObject>();
 
-      CTypes::register_type<CTrigger, CGameObject>();
-      {
-        CTypes::register_type<CWrapper<CTrigger>, CTrigger, CGameObject>();
-      }
+            CTypes::register_type<CTrigger, CGameObject>();
+            { CTypes::register_type<CWrapper<CTrigger>, CTrigger, CGameObject>(); }
 
-      CTypes::register_type<CQuest, CGameObject>();
-      {
-        CTypes::register_type<CWrapper<CQuest>, CQuest, CGameObject>();
-      }
+            CTypes::register_type<CQuest, CGameObject>();
+            { CTypes::register_type<CWrapper<CQuest>, CQuest, CGameObject>(); }
 
-      CTypes::register_type<Stats, CGameObject>();
-      CTypes::register_type<Damage, CGameObject>();
+            CTypes::register_type<Stats, CGameObject>();
+            CTypes::register_type<Damage, CGameObject>();
 
-      CTypes::register_type<CTile, CGameObject>();
-      {
-        CTypes::register_type<CWrapper<CTile>, CTile, CGameObject>();
-      }
+            CTypes::register_type<CTile, CGameObject>();
+            { CTypes::register_type<CWrapper<CTile>, CTile, CGameObject>(); }
 
-      CTypes::register_type<CInteraction, CGameObject>();
-      {
-        CTypes::register_type<CWrapper<CInteraction>, CInteraction,
-                              CGameObject>();
-      }
+            CTypes::register_type<CInteraction, CGameObject>();
+            { CTypes::register_type<CWrapper<CInteraction>, CInteraction, CGameObject>(); }
 
-      CTypes::register_type<CController, CGameObject>();
-      {
-        CTypes::register_type<CTargetController, CController, CGameObject>();
-        CTypes::register_type<CRandomController, CController, CGameObject>();
-        CTypes::register_type<CGroundController, CController, CGameObject>();
-        CTypes::register_type<CRangeController, CController, CGameObject>();
-        CTypes::register_type<CNpcRandomController, CController, CGameObject>();
-        CTypes::register_type<CPlayerController, CController, CGameObject>();
-      }
+            CTypes::register_type<CController, CGameObject>();
+            {
+                CTypes::register_type<CTargetController, CController, CGameObject>();
+                CTypes::register_type<CRandomController, CController, CGameObject>();
+                CTypes::register_type<CGroundController, CController, CGameObject>();
+                CTypes::register_type<CRangeController, CController, CGameObject>();
+                CTypes::register_type<CNpcRandomController, CController, CGameObject>();
+                CTypes::register_type<CPlayerController, CController, CGameObject>();
+            }
 
-      CTypes::register_type<CTextureCache, CGameObject>();
-      CTypes::register_type<CTextManager, CGameObject>();
-    }
+            CTypes::register_type<CTextureCache, CGameObject>();
+            CTypes::register_type<CTextManager, CGameObject>();
+        }
 
-    // Original types4.cpp
-    CTypes::register_type<CGameObject>();
-    {
-      CTypes::register_type<CLayout, CGameObject>();
-      {
-        CTypes::register_type<CCenteredLayout, CLayout, CGameObject>();
-        CTypes::register_type<CParentLayout, CLayout, CGameObject>();
-        CTypes::register_type<CProxyGraphicsLayout, CLayout, CGameObject>();
-      }
-    }
+        // Original types4.cpp
+        CTypes::register_type<CGameObject>();
+        {
+            CTypes::register_type<CLayout, CGameObject>();
+            {
+                CTypes::register_type<CCenteredLayout, CLayout, CGameObject>();
+                CTypes::register_type<CParentLayout, CLayout, CGameObject>();
+                CTypes::register_type<CProxyGraphicsLayout, CLayout, CGameObject>();
+            }
+        }
 
-    // Original types5.cpp (custom types)
-    auto array_string_deserialize = [](std::shared_ptr<CGame> game,
-                                       std::shared_ptr<json> object) {
-      std::set<std::string> objects;
-      for (unsigned int i = 0; i < object->size(); i++) {
-        objects.insert((*object)[i].get<std::string>());
-      }
-      return objects;
-    };
-
-    auto array_string_serialize = [](std::set<std::string> set) {
-      std::shared_ptr<json> arr = std::make_shared<json>();
-      for (std::string ob : set) {
-        add_arr_member(arr, ob);
-      }
-      return arr;
-    };
-
-    auto tags_deserialize = [](std::shared_ptr<CGame> game,
-                               std::shared_ptr<json> object) {
-      (void)game;
-      CTags tags;
-      for (unsigned int i = 0; i < object->size(); i++) {
-        tags.insert(CTags::fromString((*object)[i].get<std::string>()));
-      }
-      return tags;
-    };
-
-    auto tags_serialize = [](CTags tags) {
-      std::shared_ptr<json> arr = std::make_shared<json>(json::array());
-      for (const auto &tag : tags) {
-        add_arr_member(arr, std::string(CTags::toString(tag)));
-      }
-      return arr;
-    };
-
-    auto array_int_deserialize = [](std::shared_ptr<CGame> game,
-                                    std::shared_ptr<json> object) {
-      std::set<int> objects;
-      for (unsigned int i = 0; i < object->size(); i++) {
-        objects.insert((*object)[i].get<int>());
-      }
-      return objects;
-    };
-
-    auto array_int_serialize = [](std::set<int> set) {
-      std::shared_ptr<json> arr = std::make_shared<json>();
-      for (int ob : set) {
-        add_arr_member(arr, ob);
-      }
-      return arr;
-    };
-
-    auto map_string_string_deserialize = [](std::shared_ptr<CGame> game,
-                                            std::shared_ptr<json> object) {
-      std::map<std::string, std::string> objects;
-      for (auto [key, value] : object->items()) {
-        objects[key] = value.get<std::string>();
-      }
-      return objects;
-    };
-
-    auto map_string_string_serialize =
-        [](std::map<std::string, std::string> map) {
-          std::shared_ptr<json> arr = std::make_shared<json>();
-          for (auto ob : map) {
-            add_member(arr, ob.first, ob.second);
-          }
-          return arr;
+        // Original types5.cpp (custom types)
+        auto array_string_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
+            std::set<std::string> objects;
+            for (unsigned int i = 0; i < object->size(); i++) {
+                objects.insert((*object)[i].get<std::string>());
+            }
+            return objects;
         };
 
-    auto map_string_int_deserialize = [](std::shared_ptr<CGame> game,
-                                         std::shared_ptr<json> object) {
-      std::map<std::string, int> objects;
-      for (auto [key, value] : object->items()) {
-        objects[key] = value.get<int>();
-      }
-      return objects;
-    };
+        auto array_string_serialize = [](std::set<std::string> set) {
+            std::shared_ptr<json> arr = std::make_shared<json>();
+            for (std::string ob : set) {
+                add_arr_member(arr, ob);
+            }
+            return arr;
+        };
 
-    auto map_string_int_serialize = [](std::map<std::string, int> map) {
-      std::shared_ptr<json> arr = std::make_shared<json>();
-      for (auto ob : map) {
-        add_member(arr, ob.first, ob.second);
-      }
-      return arr;
-    };
+        auto tags_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
+            (void)game;
+            CTags tags;
+            for (unsigned int i = 0; i < object->size(); i++) {
+                tags.insert(CTags::fromString((*object)[i].get<std::string>()));
+            }
+            return tags;
+        };
 
-    auto map_int_string_deserialize = [](std::shared_ptr<CGame> game,
-                                         std::shared_ptr<json> object) {
-      std::map<int, std::string> objects;
-      for (auto [key, value] : object->items()) {
-        objects[vstd::to_int(key).first] = value.get<std::string>();
-      }
-      return objects;
-    };
+        auto tags_serialize = [](CTags tags) {
+            std::shared_ptr<json> arr = std::make_shared<json>(json::array());
+            for (const auto &tag : tags) {
+                add_arr_member(arr, std::string(CTags::toString(tag)));
+            }
+            return arr;
+        };
 
-    auto map_int_string_serialize = [](std::map<int, std::string> map) {
-      std::shared_ptr<json> arr = std::make_shared<json>();
-      for (auto ob : map) {
-        add_member(arr, vstd::str(ob.first), ob.second);
-      }
-      return arr;
-    };
+        auto array_int_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
+            std::set<int> objects;
+            for (unsigned int i = 0; i < object->size(); i++) {
+                objects.insert((*object)[i].get<int>());
+            }
+            return objects;
+        };
 
-    auto map_int_int_deserialize = [](std::shared_ptr<CGame> game,
-                                      std::shared_ptr<json> object) {
-      std::map<int, int> objects;
-      for (auto [key, value] : object->items()) {
-        objects[vstd::to_int(key).first] = value.get<int>();
-      }
-      return objects;
-    };
+        auto array_int_serialize = [](std::set<int> set) {
+            std::shared_ptr<json> arr = std::make_shared<json>();
+            for (int ob : set) {
+                add_arr_member(arr, ob);
+            }
+            return arr;
+        };
 
-    auto map_int_int_serialize = [](std::map<int, int> map) {
-      std::shared_ptr<json> arr = std::make_shared<json>();
-      for (auto ob : map) {
-        add_member(arr, vstd::str(ob.first), ob.second);
-      }
-      return arr;
-    };
+        auto map_string_string_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
+            std::map<std::string, std::string> objects;
+            for (auto [key, value] : object->items()) {
+                objects[key] = value.get<std::string>();
+            }
+            return objects;
+        };
 
-    CTypes::register_custom_type<std::set<std::string>>(
-        array_string_serialize, array_string_deserialize);
-    CTypes::register_custom_type<CTags>(tags_serialize, tags_deserialize);
-    CTypes::register_custom_type<std::set<int>>(array_int_serialize,
-                                                array_int_deserialize);
-    CTypes::register_custom_type<std::map<std::string, std::string>>(
-        map_string_string_serialize, map_string_string_deserialize);
-    CTypes::register_custom_type<std::map<std::string, int>>(
-        map_string_int_serialize, map_string_int_deserialize);
-    CTypes::register_custom_type<std::map<int, std::string>>(
-        map_int_string_serialize, map_int_string_deserialize);
-    CTypes::register_custom_type<std::map<int, int>>(map_int_int_serialize,
-                                                     map_int_int_deserialize);
+        auto map_string_string_serialize = [](std::map<std::string, std::string> map) {
+            std::shared_ptr<json> arr = std::make_shared<json>();
+            for (auto ob : map) {
+                add_member(arr, ob.first, ob.second);
+            }
+            return arr;
+        };
 
-    // Original types6.cpp
-    CTypes::register_type<CGameObject>();
-    {
-      CTypes::register_type<CListInt, CGameObject>();
-      CTypes::register_type<CListString, CGameObject>();
-      CTypes::register_type<CMapStringString, CGameObject>();
-      CTypes::register_type<CMapStringInt, CGameObject>();
-      CTypes::register_type<CMapIntString, CGameObject>();
-      CTypes::register_type<CMapIntInt, CGameObject>();
-    }
+        auto map_string_int_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
+            std::map<std::string, int> objects;
+            for (auto [key, value] : object->items()) {
+                objects[key] = value.get<int>();
+            }
+            return objects;
+        };
 
-    // Original types7.cpp
-    CTypes::register_type<CGameObject>();
-    {
-      CTypes::register_type<CSlotConfig, CGameObject>();
-      CTypes::register_type<CSlot, CGameObject>();
-      CTypes::register_type<CScript, CGameObject>();
-    }
+        auto map_string_int_serialize = [](std::map<std::string, int> map) {
+            std::shared_ptr<json> arr = std::make_shared<json>();
+            for (auto ob : map) {
+                add_member(arr, ob.first, ob.second);
+            }
+            return arr;
+        };
 
-    // Original types8.cpp
-    CTypes::register_type<CGameObject>();
-    {
-      CTypes::register_type<CObjectHandler, CGameObject>();
-      CTypes::register_type<CEventHandler, CGameObject>();
-      CTypes::register_type<CRngHandler, CGameObject>();
-    }
+        auto map_int_string_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
+            std::map<int, std::string> objects;
+            for (auto [key, value] : object->items()) {
+                objects[vstd::to_int(key).first] = value.get<std::string>();
+            }
+            return objects;
+        };
 
-    // Original types9.cpp
-    CTypes::register_type<CGameObject>();
-    {
-      CTypes::register_type<CGameGraphicsObject, CGameObject>();
-      {
-        CTypes::register_type<CGui, CGameGraphicsObject, CGameObject>();
-        CTypes::register_type<CStatsGraphicsObject, CGameGraphicsObject,
-                              CGameObject>();
-        CTypes::register_type<CConsoleGraphicsObject, CGameGraphicsObject,
-                              CGameObject>();
-        CTypes::register_type<CProxyGraphicsObject, CGameGraphicsObject,
-                              CGameObject>();
-        CTypes::register_type<CSideBar, CGameGraphicsObject, CGameObject>();
-      }
-    }
+        auto map_int_string_serialize = [](std::map<int, std::string> map) {
+            std::shared_ptr<json> arr = std::make_shared<json>();
+            for (auto ob : map) {
+                add_member(arr, vstd::str(ob.first), ob.second);
+            }
+            return arr;
+        };
 
-    // Original types10.cpp
-    CTypes::register_type<CGameObject>();
-    {
-      CTypes::register_type<CGameGraphicsObject, CGameObject>();
-      {
-        CTypes::register_type<CGamePanel, CGameGraphicsObject, CGameObject>();
+        auto map_int_int_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
+            std::map<int, int> objects;
+            for (auto [key, value] : object->items()) {
+                objects[vstd::to_int(key).first] = value.get<int>();
+            }
+            return objects;
+        };
+
+        auto map_int_int_serialize = [](std::map<int, int> map) {
+            std::shared_ptr<json> arr = std::make_shared<json>();
+            for (auto ob : map) {
+                add_member(arr, vstd::str(ob.first), ob.second);
+            }
+            return arr;
+        };
+
+        CTypes::register_custom_type<std::set<std::string>>(array_string_serialize, array_string_deserialize);
+        CTypes::register_custom_type<CTags>(tags_serialize, tags_deserialize);
+        CTypes::register_custom_type<std::set<int>>(array_int_serialize, array_int_deserialize);
+        CTypes::register_custom_type<std::map<std::string, std::string>>(map_string_string_serialize,
+                                                                         map_string_string_deserialize);
+        CTypes::register_custom_type<std::map<std::string, int>>(map_string_int_serialize, map_string_int_deserialize);
+        CTypes::register_custom_type<std::map<int, std::string>>(map_int_string_serialize, map_int_string_deserialize);
+        CTypes::register_custom_type<std::map<int, int>>(map_int_int_serialize, map_int_int_deserialize);
+
+        // Original types6.cpp
+        CTypes::register_type<CGameObject>();
         {
-          CTypes::register_type<CGameTextPanel, CGamePanel, CGameGraphicsObject,
-                                CGameObject>();
-          CTypes::register_type<CGameInventoryPanel, CGamePanel,
-                                CGameGraphicsObject, CGameObject>();
-          CTypes::register_type<CGameTradePanel, CGamePanel,
-                                CGameGraphicsObject, CGameObject>();
-          CTypes::register_type<CGameFightPanel, CGamePanel,
-                                CGameGraphicsObject, CGameObject>();
-          CTypes::register_type<CGameQuestPanel, CGamePanel,
-                                CGameGraphicsObject, CGameObject>();
-          CTypes::register_type<CGameCharacterPanel, CGamePanel,
-                                CGameGraphicsObject, CGameObject>();
-          CTypes::register_type<CGameQuestionPanel, CGamePanel,
-                                CGameGraphicsObject, CGameObject>();
-          CTypes::register_type<CGameDialogPanel, CGamePanel,
-                                CGameGraphicsObject, CGameObject>();
-          CTypes::register_type<CGameLootPanel, CGamePanel, CGameGraphicsObject,
-                                CGameObject>();
+            CTypes::register_type<CListInt, CGameObject>();
+            CTypes::register_type<CListString, CGameObject>();
+            CTypes::register_type<CMapStringString, CGameObject>();
+            CTypes::register_type<CMapStringInt, CGameObject>();
+            CTypes::register_type<CMapIntString, CGameObject>();
+            CTypes::register_type<CMapIntInt, CGameObject>();
         }
-      }
-    }
 
-    // Original types11.cpp
-    CTypes::register_type<CGameObject>();
-    {
-      CTypes::register_type<CGameGraphicsObject, CGameObject>();
-      {
-        CTypes::register_type<CProxyTargetGraphicsObject, CGameGraphicsObject,
-                              CGameObject>();
+        // Original types7.cpp
+        CTypes::register_type<CGameObject>();
         {
-          CTypes::register_type<CMapGraphicsObject, CProxyTargetGraphicsObject,
-                                CGameGraphicsObject, CGameObject>();
-          CTypes::register_type<CListView, CProxyTargetGraphicsObject,
-                                CGameGraphicsObject, CGameObject>();
-          CTypes::register_type<CCreatureView, CProxyTargetGraphicsObject,
-                                CGameGraphicsObject, CGameObject>();
+            CTypes::register_type<CSlotConfig, CGameObject>();
+            CTypes::register_type<CSlot, CGameObject>();
+            CTypes::register_type<CScript, CGameObject>();
         }
-        CTypes::register_type<CWidget, CGameGraphicsObject, CGameObject>();
-        CTypes::register_type<CTextWidget, CWidget, CGameGraphicsObject,
-                              CGameObject>();
-        CTypes::register_type<CButton, CTextWidget, CWidget,
-                              CGameGraphicsObject, CGameObject>();
-      }
-    }
 
-    // Original types12.cpp
-    CTypes::register_type<CGameObject>();
-    {
-      CTypes::register_type<CGameGraphicsObject, CGameObject>();
-      {
-        CTypes::register_type<CAnimation, CGameGraphicsObject, CGameObject>();
+        // Original types8.cpp
+        CTypes::register_type<CGameObject>();
         {
-          CTypes::register_type<CStaticAnimation, CAnimation,
-                                CGameGraphicsObject, CGameObject>();
-          CTypes::register_type<CDynamicAnimation, CAnimation,
-                                CGameGraphicsObject, CGameObject>();
-          CTypes::register_type<CSelectionBox, CAnimation, CGameGraphicsObject,
-                                CGameObject>();
+            CTypes::register_type<CObjectHandler, CGameObject>();
+            CTypes::register_type<CEventHandler, CGameObject>();
+            CTypes::register_type<CRngHandler, CGameObject>();
         }
-        CTypes::register_type<CTooltip, CGameGraphicsObject, CGameObject>();
-      }
+
+        // Original types9.cpp
+        CTypes::register_type<CGameObject>();
+        {
+            CTypes::register_type<CGameGraphicsObject, CGameObject>();
+            {
+                CTypes::register_type<CGui, CGameGraphicsObject, CGameObject>();
+                CTypes::register_type<CStatsGraphicsObject, CGameGraphicsObject, CGameObject>();
+                CTypes::register_type<CConsoleGraphicsObject, CGameGraphicsObject, CGameObject>();
+                CTypes::register_type<CProxyGraphicsObject, CGameGraphicsObject, CGameObject>();
+                CTypes::register_type<CSideBar, CGameGraphicsObject, CGameObject>();
+            }
+        }
+
+        // Original types10.cpp
+        CTypes::register_type<CGameObject>();
+        {
+            CTypes::register_type<CGameGraphicsObject, CGameObject>();
+            {
+                CTypes::register_type<CGamePanel, CGameGraphicsObject, CGameObject>();
+                {
+                    CTypes::register_type<CGameTextPanel, CGamePanel, CGameGraphicsObject, CGameObject>();
+                    CTypes::register_type<CGameInventoryPanel, CGamePanel, CGameGraphicsObject, CGameObject>();
+                    CTypes::register_type<CGameTradePanel, CGamePanel, CGameGraphicsObject, CGameObject>();
+                    CTypes::register_type<CGameFightPanel, CGamePanel, CGameGraphicsObject, CGameObject>();
+                    CTypes::register_type<CGameQuestPanel, CGamePanel, CGameGraphicsObject, CGameObject>();
+                    CTypes::register_type<CGameCharacterPanel, CGamePanel, CGameGraphicsObject, CGameObject>();
+                    CTypes::register_type<CGameQuestionPanel, CGamePanel, CGameGraphicsObject, CGameObject>();
+                    CTypes::register_type<CGameDialogPanel, CGamePanel, CGameGraphicsObject, CGameObject>();
+                    CTypes::register_type<CGameLootPanel, CGamePanel, CGameGraphicsObject, CGameObject>();
+                }
+            }
+        }
+
+        // Original types11.cpp
+        CTypes::register_type<CGameObject>();
+        {
+            CTypes::register_type<CGameGraphicsObject, CGameObject>();
+            {
+                CTypes::register_type<CProxyTargetGraphicsObject, CGameGraphicsObject, CGameObject>();
+                {
+                    CTypes::register_type<CMapGraphicsObject, CProxyTargetGraphicsObject, CGameGraphicsObject,
+                                          CGameObject>();
+                    CTypes::register_type<CListView, CProxyTargetGraphicsObject, CGameGraphicsObject, CGameObject>();
+                    CTypes::register_type<CCreatureView, CProxyTargetGraphicsObject, CGameGraphicsObject,
+                                          CGameObject>();
+                }
+                CTypes::register_type<CWidget, CGameGraphicsObject, CGameObject>();
+                CTypes::register_type<CTextWidget, CWidget, CGameGraphicsObject, CGameObject>();
+                CTypes::register_type<CButton, CTextWidget, CWidget, CGameGraphicsObject, CGameObject>();
+            }
+        }
+
+        // Original types12.cpp
+        CTypes::register_type<CGameObject>();
+        {
+            CTypes::register_type<CGameGraphicsObject, CGameObject>();
+            {
+                CTypes::register_type<CAnimation, CGameGraphicsObject, CGameObject>();
+                {
+                    CTypes::register_type<CStaticAnimation, CAnimation, CGameGraphicsObject, CGameObject>();
+                    CTypes::register_type<CDynamicAnimation, CAnimation, CGameGraphicsObject, CGameObject>();
+                    CTypes::register_type<CSelectionBox, CAnimation, CGameGraphicsObject, CGameObject>();
+                }
+                CTypes::register_type<CTooltip, CGameGraphicsObject, CGameObject>();
+            }
+        }
     }
-  }
 } _register_all_types;
 } // namespace

--- a/src/core/CTypes.h
+++ b/src/core/CTypes.h
@@ -24,147 +24,118 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CObject.h"
 
 class CTypes {
-public:
-  static std::unordered_map<std::string,
-                            std::function<std::shared_ptr<CGameObject>()>> *
-  builders();
+  public:
+    static std::unordered_map<std::string, std::function<std::shared_ptr<CGameObject>()>> *builders();
 
-  static std::unordered_map<
-      std::pair<boost::typeindex::type_index, boost::typeindex::type_index>,
-      std::shared_ptr<CSerializerBase>> *
-  serializers();
+    static std::unordered_map<std::pair<std::type_index, std::type_index>, std::shared_ptr<CSerializerBase>> *
+    serializers();
 
-  static std::unordered_set<boost::typeindex::type_index> *pointer_types();
+    static std::unordered_set<std::type_index> *pointer_types();
 
-  static std::unordered_set<boost::typeindex::type_index> *array_types();
+    static std::unordered_set<std::type_index> *array_types();
 
-  static std::unordered_set<boost::typeindex::type_index> *map_types();
+    static std::unordered_set<std::type_index> *map_types();
 
-  static std::unordered_map<boost::typeindex::type_index,
-                            std::function<void(std::shared_ptr<CGameObject>,
-                                               std::string, boost::any)>> *
-  setters();
+    static std::unordered_map<std::type_index,
+                              std::function<void(std::shared_ptr<CGameObject>, std::string, std::any)>> *
+    setters();
 
-  static bool is_map_type(boost::typeindex::type_index index);
+    static bool is_map_type(std::type_index index);
 
-  static bool is_pointer_type(boost::typeindex::type_index index);
+    static bool is_pointer_type(std::type_index index);
 
-  static bool is_array_type(boost::typeindex::type_index index);
+    static bool is_array_type(std::type_index index);
 
-  template <typename T> static bool is_map_type() {
-    return is_map_type(boost::typeindex::type_id<T>());
-  }
+    template <typename T> static bool is_map_type() { return is_map_type(vstd::type_id<T>()); }
 
-  template <typename T> static bool is_pointer_type() {
-    return is_pointer_type(boost::typeindex::type_id<T>());
-  }
+    template <typename T> static bool is_pointer_type() { return is_pointer_type(vstd::type_id<T>()); }
 
-  template <typename T> static bool is_array_type() {
-    return is_array_type(boost::typeindex::type_id<T>());
-  }
+    template <typename T> static bool is_array_type() { return is_array_type(vstd::type_id<T>()); }
 
-  template <typename Serialized, typename Deserialized>
-  static void register_serializer() {
-    (*serializers())[vstd::type_pair<Serialized, Deserialized>()] =
-        std::make_shared<CSerializer<Serialized, Deserialized>>();
-  }
-
-  template <typename T> static void register_custom_setter() {
-    (*setters())[boost::typeindex::type_id<T>()] =
-        [](std::shared_ptr<CGameObject> object, std::string key,
-           boost::any value) {
-          object->setProperty(key, vstd::any_cast<T>(value));
-        };
-  }
-
-  template <typename Serialized, typename Deserialized>
-  static void register_custom_serializer(
-      std::function<Serialized(Deserialized)> serialize,
-      std::function<Deserialized(std::shared_ptr<CGame>, Serialized)>
-          deserialize) {
-    (*serializers())[vstd::type_pair<Serialized, Deserialized>()] =
-        std::make_shared<CCustomSerializer<Serialized, Deserialized>>(
-            serialize, deserialize);
-  }
-
-  template <typename T> static void register_builder() {
-    (*builders())[T::static_meta()->name()] = []() {
-      return std::make_shared<T>();
-    };
-  }
-
-  template <typename T> static void register_predicate() {}
-
-  template <typename T> static void register_supplier() {}
-
-  template <typename T> static void register_consumer() {}
-
-  template <typename T> static void register_pointer() {}
-
-  template <typename T> static void register_serializer() {
-    register_serializer<std::shared_ptr<json>, std::shared_ptr<T>>();
-    register_serializer<std::shared_ptr<json>, std::set<std::shared_ptr<T>>>();
-    register_serializer<std::shared_ptr<json>,
-                        std::map<std::string, std::shared_ptr<T>>>();
-  }
-
-  template <typename T, typename U> static void register_cast() {}
-
-  template <typename T, typename U> static void register_any_cast() {
-    vstd::register_any_type<std::shared_ptr<T>, std::shared_ptr<U>>();
-    vstd::register_any_type<std::set<std::shared_ptr<T>>,
-                            std::set<std::shared_ptr<U>>>();
-    vstd::register_any_type<std::map<std::string, std::shared_ptr<T>>,
-                            std::map<std::string, std::shared_ptr<U>>>();
-  }
-
-  template <typename T> static void register_derived_types() {
-    pointer_types()->insert(boost::typeindex::type_id<std::shared_ptr<T>>());
-    array_types()->insert(
-        boost::typeindex::type_id<std::set<std::shared_ptr<T>>>());
-    map_types()->insert(
-        boost::typeindex::type_id<std::map<std::string, std::shared_ptr<T>>>());
-  }
-
-  template <typename T, typename U, typename... Args>
-  static void register_type() {
-    static_assert(vstd::is_base_of<U, T>::value && !vstd::is_same<T, U>::value,
-                  "invalid base class");
-    register_type<T>();
-    register_any_cast<T, U>();
-    register_any_cast<U, T>();
-    register_cast<U, T>();
-    register_type<T, Args...>();
-  }
-
-  template <typename T> static void register_type() {
-    register_serializer<T>();
-    register_builder<T>();
-    register_consumer<T>();
-    register_supplier<T>();
-    register_predicate<T>();
-    register_derived_types<T>();
-    register_any_cast<T, T>();
-  }
-
-  template <typename T>
-  static void register_custom_type(
-      std::function<std::shared_ptr<json>(T)> serialize,
-      std::function<T(std::shared_ptr<CGame>, std::shared_ptr<json>)>
-          deserialize) {
-    register_custom_serializer(serialize, deserialize);
-    register_custom_setter<T>();
-  }
-
-  static void set_custom_property(std::shared_ptr<CGameObject> object,
-                                  std::string key, boost::any property) {
-    auto setter = setters()->find(property.type());
-    if (setter == setters()->end() || !setter->second) {
-      throw std::runtime_error(
-          "No custom setter registered for property '" + key +
-          "' of type '" +
-          boost::typeindex::type_index(property.type()).pretty_name() + "'");
+    template <typename Serialized, typename Deserialized> static void register_serializer() {
+        (*serializers())[vstd::type_pair<Serialized, Deserialized>()] =
+            std::make_shared<CSerializer<Serialized, Deserialized>>();
     }
-    setter->second(object, key, property);
-  }
+
+    template <typename T> static void register_custom_setter() {
+        (*setters())[vstd::type_id<T>()] = [](std::shared_ptr<CGameObject> object, std::string key, std::any value) {
+            object->setProperty(key, vstd::any_cast<T>(value));
+        };
+    }
+
+    template <typename Serialized, typename Deserialized>
+    static void
+    register_custom_serializer(std::function<Serialized(Deserialized)> serialize,
+                               std::function<Deserialized(std::shared_ptr<CGame>, Serialized)> deserialize) {
+        (*serializers())[vstd::type_pair<Serialized, Deserialized>()] =
+            std::make_shared<CCustomSerializer<Serialized, Deserialized>>(serialize, deserialize);
+    }
+
+    template <typename T> static void register_builder() {
+        (*builders())[T::static_meta()->name()] = []() { return std::make_shared<T>(); };
+    }
+
+    template <typename T> static void register_predicate() {}
+
+    template <typename T> static void register_supplier() {}
+
+    template <typename T> static void register_consumer() {}
+
+    template <typename T> static void register_pointer() {}
+
+    template <typename T> static void register_serializer() {
+        register_serializer<std::shared_ptr<json>, std::shared_ptr<T>>();
+        register_serializer<std::shared_ptr<json>, std::set<std::shared_ptr<T>>>();
+        register_serializer<std::shared_ptr<json>, std::map<std::string, std::shared_ptr<T>>>();
+    }
+
+    template <typename T, typename U> static void register_cast() {}
+
+    template <typename T, typename U> static void register_any_cast() {
+        vstd::register_any_type<std::shared_ptr<T>, std::shared_ptr<U>>();
+        vstd::register_any_type<std::set<std::shared_ptr<T>>, std::set<std::shared_ptr<U>>>();
+        vstd::register_any_type<std::map<std::string, std::shared_ptr<T>>, std::map<std::string, std::shared_ptr<U>>>();
+    }
+
+    template <typename T> static void register_derived_types() {
+        pointer_types()->insert(vstd::type_id<std::shared_ptr<T>>());
+        array_types()->insert(vstd::type_id<std::set<std::shared_ptr<T>>>());
+        map_types()->insert(vstd::type_id<std::map<std::string, std::shared_ptr<T>>>());
+    }
+
+    template <typename T, typename U, typename... Args> static void register_type() {
+        static_assert(vstd::is_base_of<U, T>::value && !vstd::is_same<T, U>::value, "invalid base class");
+        register_type<T>();
+        register_any_cast<T, U>();
+        register_any_cast<U, T>();
+        register_cast<U, T>();
+        register_type<T, Args...>();
+    }
+
+    template <typename T> static void register_type() {
+        register_serializer<T>();
+        register_builder<T>();
+        register_consumer<T>();
+        register_supplier<T>();
+        register_predicate<T>();
+        register_derived_types<T>();
+        register_any_cast<T, T>();
+    }
+
+    template <typename T>
+    static void register_custom_type(std::function<std::shared_ptr<json>(T)> serialize,
+                                     std::function<T(std::shared_ptr<CGame>, std::shared_ptr<json>)> deserialize) {
+        register_custom_serializer(serialize, deserialize);
+        register_custom_setter<T>();
+    }
+
+    static void set_custom_property(std::shared_ptr<CGameObject> object, std::string key, std::any property) {
+        auto propertyType = vstd::type_id(property.type());
+        auto setter = setters()->find(propertyType);
+        if (setter == setters()->end() || !setter->second) {
+            throw std::runtime_error("No custom setter registered for property '" + key + "' of type '" +
+                                     vstd::type_name(propertyType) + "'");
+        }
+        setter->second(object, key, property);
+    }
 };

--- a/src/core/CUtil.h
+++ b/src/core/CUtil.h
@@ -24,84 +24,77 @@ class CGameObject;
 class CMapObject;
 
 struct Coords {
-  Coords();
+    Coords();
 
-  Coords(int x, int y, int z);
+    Coords(int x, int y, int z);
 
-  int x, y, z;
+    int x, y, z;
 
-  bool operator==(const Coords &other) const;
+    bool operator==(const Coords &other) const;
 
-  bool operator!=(const Coords &other) const;
+    bool operator!=(const Coords &other) const;
 
-  bool operator<(const Coords &other) const;
+    bool operator<(const Coords &other) const;
 
-  bool operator>(const Coords &other) const;
+    bool operator>(const Coords &other) const;
 
-  Coords operator-(const Coords &other) const;
+    Coords operator-(const Coords &other) const;
 
-  Coords operator+(const Coords &other) const;
+    Coords operator+(const Coords &other) const;
 
-  Coords operator*() const;
+    Coords operator*() const;
 
-  double getDist(const Coords &a) const;
+    double getDist(const Coords &a) const;
 
-  bool adjacent(const Coords &a) const;
+    bool adjacent(const Coords &a) const;
 
-  bool same(const Coords &a) const;
+    bool same(const Coords &a) const;
 
-  bool adjacentOrSame(const Coords &a) const;
+    bool adjacentOrSame(const Coords &a) const;
 
-  enum Direction { UNDEFINED, ZERO, EAST, WEST, NORTH, SOUTH, UP, DOWN };
+    enum Direction { UNDEFINED, ZERO, EAST, WEST, NORTH, SOUTH, UP, DOWN };
 } extern ZERO, EAST, WEST, NORTH, SOUTH, UP, DOWN;
 
 class CUtil {
-public:
-  static std::shared_ptr<SDL_Rect>
-  boxInBox(const std::shared_ptr<SDL_Rect> &out,
-           const std::shared_ptr<SDL_Rect> &in);
+  public:
+    static std::shared_ptr<SDL_Rect> boxInBox(const std::shared_ptr<SDL_Rect> &out,
+                                              const std::shared_ptr<SDL_Rect> &in);
 
-  static std::shared_ptr<SDL_Rect> rect(int x, int y, int w, int h);
+    static std::shared_ptr<SDL_Rect> rect(int x, int y, int w, int h);
 
-  static std::shared_ptr<SDL_Rect> centeredRect(int centerX, int centerY,
-                                                int w, int h);
+    static std::shared_ptr<SDL_Rect> centeredRect(int centerX, int centerY, int w, int h);
 
-  static std::shared_ptr<SDL_Rect>
-  bounds(const std::shared_ptr<SDL_Rect> &rect);
+    static std::shared_ptr<SDL_Rect> bounds(const std::shared_ptr<SDL_Rect> &rect);
 
-  static bool isIn(const std::shared_ptr<SDL_Rect> &rect, int x, int y);
+    static bool isIn(const std::shared_ptr<SDL_Rect> &rect, int x, int y);
 
-  static int parseKey(SDL_Keycode i);
+    static int parseKey(SDL_Keycode i);
 
-  static Coords::Direction getDirection(Coords coords);
+    static Coords::Direction getDirection(Coords coords);
 
-  template <typename Predicate>
-  static std::set<std::string> findFiles(std::string dir, Predicate pred) {
-    std::set<std::string> retValue;
-    boost::filesystem::directory_iterator iterator(dir), end;
-    while (iterator != end) {
-      auto path = iterator->path().string();
-      if (pred(path)) {
-        retValue.insert(path);
-      }
-      iterator++;
+    template <typename Predicate> static std::set<std::string> findFiles(std::string dir, Predicate pred) {
+        std::set<std::string> retValue;
+        std::filesystem::directory_iterator iterator(dir), end;
+        while (iterator != end) {
+            auto path = iterator->path().string();
+            if (pred(path)) {
+                retValue.insert(path);
+            }
+            iterator++;
+        }
+        return retValue;
     }
-    return retValue;
-  }
 };
 
 namespace std {
 template <> struct hash<Coords> {
-  std::size_t operator()(const Coords &coords) const {
-    return vstd::hash_combine(coords.x, coords.y, coords.z);
-  }
+    std::size_t operator()(const Coords &coords) const { return vstd::hash_combine(coords.x, coords.y, coords.z); }
 };
 
 template <> struct less<std::weak_ptr<CMapObject>> {
-  bool operator()(const std::weak_ptr<CMapObject> &a,
-                  const std::weak_ptr<CMapObject> &b) const {
-    return a.lock() < b.lock();
-  }
+    bool operator()(const std::weak_ptr<CMapObject> &a, const std::weak_ptr<CMapObject> &b) const {
+        return a.lock() < b.lock();
+    }
 };
 
 } // namespace std
@@ -113,51 +106,37 @@ template <> std::string str(Coords coords);
 template <typename F>
 auto sdl_safe(
     F f,
-    typename vstd::disable_if<vstd::is_same<
-        typename vstd::function_traits<F>::return_type, int>::value>::type * =
-        0,
-    typename vstd::disable_if<vstd::is_same<
-        typename vstd::function_traits<F>::return_type, void>::value>::type * =
-        0) {
-  auto return_value = f();
-  if (!return_value) {
-    vstd::logger::error(SDL_GetError());
-  }
-  return return_value;
+    typename vstd::disable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, int>::value>::type * = 0,
+    typename vstd::disable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, void>::value>::type * = 0) {
+    auto return_value = f();
+    if (!return_value) {
+        vstd::logger::error(SDL_GetError());
+    }
+    return return_value;
 }
 
 template <typename F>
 auto sdl_safe(
     F f,
-    typename vstd::enable_if<vstd::is_same<
-        typename vstd::function_traits<F>::return_type, int>::value>::type * =
-        0,
-    typename vstd::disable_if<vstd::is_same<
-        typename vstd::function_traits<F>::return_type, void>::value>::type * =
-        0) {
-  auto return_value = f();
-  if (return_value == -1) {
-    vstd::logger::error(SDL_GetError());
-  }
-  return return_value;
+    typename vstd::enable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, int>::value>::type * = 0,
+    typename vstd::disable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, void>::value>::type * = 0) {
+    auto return_value = f();
+    if (return_value == -1) {
+        vstd::logger::error(SDL_GetError());
+    }
+    return return_value;
 }
 
 template <typename F>
 void sdl_safe(
     F f,
-    typename vstd::disable_if<vstd::is_same<
-        typename vstd::function_traits<F>::return_type, int>::value>::type * =
-        0,
-    typename vstd::enable_if<vstd::is_same<
-        typename vstd::function_traits<F>::return_type, void>::value>::type * =
-        0) {
-  f();
+    typename vstd::disable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, int>::value>::type * = 0,
+    typename vstd::enable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, void>::value>::type * = 0) {
+    f();
 }
 
 #define SDL_SAFE(x) sdl_safe([&]() { return x; })
 
-#define JSONIFY(x)                                                             \
-  CJsonUtil::to_string(CSerialization::serialize<std::shared_ptr<json>>(x))
-#define JSONIFY_STYLED(x)                                                      \
-  CJsonUtil::to_string(CSerialization::serialize<std::shared_ptr<json>>(x), -1)
+#define JSONIFY(x) CJsonUtil::to_string(CSerialization::serialize<std::shared_ptr<json>>(x))
+#define JSONIFY_STYLED(x) CJsonUtil::to_string(CSerialization::serialize<std::shared_ptr<json>>(x), -1)
 #define RECT(x, y, w, h) CUtil::rect(x, y, w, h)

--- a/src/gui/object/CGameGraphicsObject.cpp
+++ b/src/gui/object/CGameGraphicsObject.cpp
@@ -23,237 +23,198 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/object/CProxyGraphicsObject.h"
 #include "gui/panel/CGamePanel.h"
 
-void CGameGraphicsObject::renderObject(std::shared_ptr<CGui> reneder,
-                                       std::shared_ptr<SDL_Rect> rect,
-                                       int frameTime) {}
+void CGameGraphicsObject::renderObject(std::shared_ptr<CGui> reneder, std::shared_ptr<SDL_Rect> rect, int frameTime) {}
 
 void CGameGraphicsObject::render(std::shared_ptr<CGui> reneder, int frameTime) {
-  if (isVisible()) {
-    renderBackground(reneder, getRect(), frameTime);
-    renderObject(reneder, getRect(), frameTime);
-    for (const auto &child : children) {
-      child->render(reneder, frameTime);
+    if (isVisible()) {
+        renderBackground(reneder, getRect(), frameTime);
+        renderObject(reneder, getRect(), frameTime);
+        for (const auto &child : children) {
+            child->render(reneder, frameTime);
+        }
     }
-  }
 }
 
 bool CGameGraphicsObject::event(std::shared_ptr<CGui> gui, SDL_Event *event) {
-  if (isVisible()) {
-    for (const auto &child : children | boost::adaptors::reversed) {
-      if (child->event(gui, event)) {
-        return true;
-      }
+    if (isVisible()) {
+        for (auto it = children.rbegin(); it != children.rend(); ++it) {
+            const auto &child = *it;
+            if (child->event(gui, event)) {
+                return true;
+            }
+        }
+        for (const auto &callback : eventCallbackList) { // TODO:remove, replace with other event
+            if (callback.first(gui, this->ptr<CGameGraphicsObject>(), event) &&
+                callback.second(gui, this->ptr<CGameGraphicsObject>(), event)) {
+                return true;
+            }
+        }
+        if (event->type == SDL_KEYDOWN || event->type == SDL_KEYUP) {
+            return this->keyboardEvent(gui, (SDL_EventType)event->type, event->key.keysym.sym);
+        } else if (event->type == SDL_MOUSEBUTTONDOWN || event->type == SDL_MOUSEBUTTONUP) {
+            std::shared_ptr<SDL_Rect> transPos = getRect();
+            if (CUtil::isIn(transPos, event->button.x, event->button.y) || modal) {
+                return this->mouseEvent(gui, (SDL_EventType)event->type, event->button.button,
+                                        event->button.x - transPos->x, event->button.y - transPos->y);
+            }
+        }
+        // TODO: check if we are not consuming too many events
+        return modal;
     }
-    for (const auto &callback :
-         eventCallbackList) { // TODO:remove, replace with other event
-      if (callback.first(gui, this->ptr<CGameGraphicsObject>(), event) &&
-          callback.second(gui, this->ptr<CGameGraphicsObject>(), event)) {
-        return true;
-      }
-    }
-    if (event->type == SDL_KEYDOWN || event->type == SDL_KEYUP) {
-      return this->keyboardEvent(gui, (SDL_EventType)event->type,
-                                 event->key.keysym.sym);
-    } else if (event->type == SDL_MOUSEBUTTONDOWN ||
-               event->type == SDL_MOUSEBUTTONUP) {
-      std::shared_ptr<SDL_Rect> transPos = getRect();
-      if (CUtil::isIn(transPos, event->button.x, event->button.y) || modal) {
-        return this->mouseEvent(
-            gui, (SDL_EventType)event->type, event->button.button,
-            event->button.x - transPos->x, event->button.y - transPos->y);
-      }
-    }
-    // TODO: check if we are not consuming too many events
-    return modal;
-  }
-  return false;
+    return false;
 }
 
-bool CGameGraphicsObject::keyboardEvent(std::shared_ptr<CGui> sharedPtr,
-                                        SDL_EventType type, SDL_Keycode i) {
-  return false;
+bool CGameGraphicsObject::keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i) {
+    return false;
 }
 
-bool CGameGraphicsObject::mouseEvent(std::shared_ptr<CGui> sharedPtr,
-                                     SDL_EventType type, int button, int x,
-                                     int y) {
-  return false;
+bool CGameGraphicsObject::mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int button, int x, int y) {
+    return false;
 }
 
 void CGameGraphicsObject::registerEventCallback(
-    std::function<bool(std::shared_ptr<CGui>,
-                       std::shared_ptr<CGameGraphicsObject>, SDL_Event *)>
-        pred,
-    std::function<bool(std::shared_ptr<CGui>,
-                       std::shared_ptr<CGameGraphicsObject>, SDL_Event *)>
-        func) {
-  eventCallbackList.emplace_back(pred, func);
+    std::function<bool(std::shared_ptr<CGui>, std::shared_ptr<CGameGraphicsObject>, SDL_Event *)> pred,
+    std::function<bool(std::shared_ptr<CGui>, std::shared_ptr<CGameGraphicsObject>, SDL_Event *)> func) {
+    eventCallbackList.emplace_back(pred, func);
 }
 
 std::shared_ptr<CLayout> CGameGraphicsObject::getLayout() { return layout; }
 
-void CGameGraphicsObject::setLayout(std::shared_ptr<CLayout> layout) {
-  CGameGraphicsObject::layout = layout;
+void CGameGraphicsObject::setLayout(std::shared_ptr<CLayout> layout) { CGameGraphicsObject::layout = layout; }
+
+std::shared_ptr<SDL_Rect> CGameGraphicsObject::getRect() { return layout->getRect(this->ptr<CGameGraphicsObject>()); }
+
+void CGameGraphicsObject::setParent(std::shared_ptr<CGameGraphicsObject> _parent) {
+    if (parent.lock() != _parent) {
+        this->parent = _parent;
+        _parent->addChild(this->ptr<CGameGraphicsObject>());
+    }
 }
 
-std::shared_ptr<SDL_Rect> CGameGraphicsObject::getRect() {
-  return layout->getRect(this->ptr<CGameGraphicsObject>());
+std::shared_ptr<CGameGraphicsObject> CGameGraphicsObject::getParent() { return parent.lock(); }
+
+void CGameGraphicsObject::addChild(const std::shared_ptr<CGameGraphicsObject> &child) {
+    if (children.insert(child).second) {
+        child->setParent(this->ptr<CGameGraphicsObject>());
+    }
 }
 
-void CGameGraphicsObject::setParent(
-    std::shared_ptr<CGameGraphicsObject> _parent) {
-  if (parent.lock() != _parent) {
-    this->parent = _parent;
-    _parent->addChild(this->ptr<CGameGraphicsObject>());
-  }
-}
-
-std::shared_ptr<CGameGraphicsObject> CGameGraphicsObject::getParent() {
-  return parent.lock();
-}
-
-void CGameGraphicsObject::addChild(
-    const std::shared_ptr<CGameGraphicsObject> &child) {
-  if (children.insert(child).second) {
-    child->setParent(this->ptr<CGameGraphicsObject>());
-  }
-}
-
-void CGameGraphicsObject::removeChild(
-    const std::shared_ptr<CGameGraphicsObject> &child) {
-  if (children.erase(child)) {
-    child->removeParent();
-  }
+void CGameGraphicsObject::removeChild(const std::shared_ptr<CGameGraphicsObject> &child) {
+    if (children.erase(child)) {
+        child->removeParent();
+    }
 }
 
 void CGameGraphicsObject::removeParent() {
-  if (parent.lock()) {
-    parent.lock()->removeChild(this->ptr<CGameGraphicsObject>());
-    parent.reset();
-  }
+    if (parent.lock()) {
+        parent.lock()->removeChild(this->ptr<CGameGraphicsObject>());
+        parent.reset();
+    }
 }
 
 std::shared_ptr<CGameGraphicsObject> CGameGraphicsObject::getTopParent() {
-  if (auto _parent = getParent()) {
-    return _parent->getTopParent();
-  }
-  return this->ptr<CGameGraphicsObject>();
+    if (auto _parent = getParent()) {
+        return _parent->getTopParent();
+    }
+    return this->ptr<CGameGraphicsObject>();
 }
 
-std::set<std::shared_ptr<CGameGraphicsObject>>
-CGameGraphicsObject::getChildren() {
-  return vstd::cast<std::set<std::shared_ptr<CGameGraphicsObject>>>(children);
+std::set<std::shared_ptr<CGameGraphicsObject>> CGameGraphicsObject::getChildren() {
+    return vstd::cast<std::set<std::shared_ptr<CGameGraphicsObject>>>(children);
 }
 
-void CGameGraphicsObject::setChildren(
-    std::set<std::shared_ptr<CGameGraphicsObject>> _children) {
-  auto [to_add, to_remove] = vstd::set_difference(children, _children);
-  for (const auto &child : to_remove) {
-    removeChild(child);
-  }
-  for (const auto &child : to_add) {
-    addChild(child);
-  }
+void CGameGraphicsObject::setChildren(std::set<std::shared_ptr<CGameGraphicsObject>> _children) {
+    auto [to_add, to_remove] = vstd::set_difference(children, _children);
+    for (const auto &child : to_remove) {
+        removeChild(child);
+    }
+    for (const auto &child : to_add) {
+        addChild(child);
+    }
 }
 
 int CGameGraphicsObject::getPriority() { return priority; }
 
-void CGameGraphicsObject::setPriority(int _priority) {
-  this->priority = _priority;
-}
+void CGameGraphicsObject::setPriority(int _priority) { this->priority = _priority; }
 
 int CGameGraphicsObject::getTopPriority() {
-  auto iterator = std::max_element(children.begin(), children.end());
-  if (iterator != children.end()) {
-    return (*iterator)->getPriority();
-  }
-  return -1;
+    auto iterator = std::max_element(children.begin(), children.end());
+    if (iterator != children.end()) {
+        return (*iterator)->getPriority();
+    }
+    return -1;
 }
 
-void CGameGraphicsObject::pushChild(
-    const std::shared_ptr<CGameGraphicsObject> &child) {
-  child->setPriority(getTopPriority() + 1);
-  addChild(child);
+void CGameGraphicsObject::pushChild(const std::shared_ptr<CGameGraphicsObject> &child) {
+    child->setPriority(getTopPriority() + 1);
+    addChild(child);
 }
 
-std::shared_ptr<CGui> CGameGraphicsObject::getGui() {
-  return vstd::cast<CGui>(getTopParent());
-}
+std::shared_ptr<CGui> CGameGraphicsObject::getGui() { return vstd::cast<CGui>(getTopParent()); }
 
 bool CGameGraphicsObject::getModal() { return modal; }
 
 void CGameGraphicsObject::setModal(bool _modal) { modal = _modal; }
 
-std::shared_ptr<CGameGraphicsObject>
-CGameGraphicsObject::findChild(const std::string &type) {
-  for (auto child : getChildren()) {
-    if (auto found = child->findChild(type)) {
-      return found;
+std::shared_ptr<CGameGraphicsObject> CGameGraphicsObject::findChild(const std::string &type) {
+    for (auto child : getChildren()) {
+        if (auto found = child->findChild(type)) {
+            return found;
+        }
+        if (child->getType() == type) {
+            return child;
+        }
     }
-    if (child->getType() == type) {
-      return child;
-    }
-  }
-  return nullptr;
+    return nullptr;
 }
 
-std::shared_ptr<CGameGraphicsObject> CGameGraphicsObject::findChild(
-    const std::shared_ptr<CGameGraphicsObject> &toFind) {
-  for (auto child : getChildren()) {
-    if (auto found = child->findChild(toFind)) {
-      return found;
+std::shared_ptr<CGameGraphicsObject>
+CGameGraphicsObject::findChild(const std::shared_ptr<CGameGraphicsObject> &toFind) {
+    for (auto child : getChildren()) {
+        if (auto found = child->findChild(toFind)) {
+            return found;
+        }
+        if (child == toFind) {
+            return child;
+        }
     }
-    if (child == toFind) {
-      return child;
-    }
-  }
-  return nullptr;
+    return nullptr;
 }
 
 std::shared_ptr<CScript> CGameGraphicsObject::getVisible() { return visible; }
 
-void CGameGraphicsObject::setVisible(std::shared_ptr<CScript> _visible) {
-  CGameGraphicsObject::visible = _visible;
-}
+void CGameGraphicsObject::setVisible(std::shared_ptr<CScript> _visible) { CGameGraphicsObject::visible = _visible; }
 
 bool CGameGraphicsObject::isVisible() {
-  return !visible || visible->invoke<CGameObject>(
-                         getGame(), this->ptr<CGameObject>()) != nullptr;
+    return !visible || visible->invoke<CGameObject>(getGame(), this->ptr<CGameObject>()) != nullptr;
 }
 
-void CGameGraphicsObject::renderBackground(std::shared_ptr<CGui> gui,
-                                           std::shared_ptr<SDL_Rect> rect,
-                                           int time) {
-  if (!background.empty()) {
-    auto texture = gui->getTextureCache()->getTexture(background);
-    if (!texture) {
-      vstd::logger::error("CGameGraphicsObject: missing background",
-                          background);
-      return;
+void CGameGraphicsObject::renderBackground(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int time) {
+    if (!background.empty()) {
+        auto texture = gui->getTextureCache()->getTexture(background);
+        if (!texture) {
+            vstd::logger::error("CGameGraphicsObject: missing background", background);
+            return;
+        }
+        SDL_SAFE(SDL_RenderCopy(gui->getRenderer(), texture, nullptr, rect.get()));
     }
-    SDL_SAFE(SDL_RenderCopy(gui->getRenderer(), texture, nullptr, rect.get()));
-  }
 }
 
 std::string CGameGraphicsObject::getBackground() { return background; }
 
-void CGameGraphicsObject::setBackground(std::string _background) {
-  background = std::move(_background);
+void CGameGraphicsObject::setBackground(std::string _background) { background = std::move(_background); }
+
+bool priority_comparator::operator()(const std::shared_ptr<CGameGraphicsObject> &a,
+                                     const std::shared_ptr<CGameGraphicsObject> &b) const {
+    if (a->getPriority() == b->getPriority()) {
+        return a < b;
+    }
+    return a->getPriority() < b->getPriority();
 }
 
-bool priority_comparator::operator()(
-    const std::shared_ptr<CGameGraphicsObject> &a,
-    const std::shared_ptr<CGameGraphicsObject> &b) const {
-  if (a->getPriority() == b->getPriority()) {
-    return a < b;
-  }
-  return a->getPriority() < b->getPriority();
-}
-
-int CGameGraphicsObject::getTileSize(
-    const std::shared_ptr<CGameGraphicsObject> &object) {
-  if (object->hasProperty("tileSize")) {
-    return object->getNumericProperty("tileSize");
-  }
-  return getTileSize(object->getParent());
+int CGameGraphicsObject::getTileSize(const std::shared_ptr<CGameGraphicsObject> &object) {
+    if (object->hasProperty("tileSize")) {
+        return object->getNumericProperty("tileSize");
+    }
+    return getTileSize(object->getParent());
 }

--- a/src/gui/panel/CGameDialogPanel.cpp
+++ b/src/gui/panel/CGameDialogPanel.cpp
@@ -22,131 +22,110 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/object/CWidget.h"
 #include "object/CDialog.h"
 
-const std::shared_ptr<CDialog> &CGameDialogPanel::getDialog() const {
-  return dialog;
-}
+const std::shared_ptr<CDialog> &CGameDialogPanel::getDialog() const { return dialog; }
 
-void CGameDialogPanel::setDialog(const std::shared_ptr<CDialog> &_dialog) {
-  dialog = _dialog;
-}
+void CGameDialogPanel::setDialog(const std::shared_ptr<CDialog> &_dialog) { dialog = _dialog; }
 
 // TODO: unify with CGuiHandler
 void CGameDialogPanel::reload() {
-  auto self = this->ptr<CGameDialogPanel>();
-  if (currentStateId != "EXIT") {
-    std::shared_ptr<CDialogState> state = dialog->getState(currentStateId);
+    auto self = this->ptr<CGameDialogPanel>();
+    if (currentStateId != "EXIT") {
+        std::shared_ptr<CDialogState> state = dialog->getState(currentStateId);
 
-    std::set<std::shared_ptr<CGameGraphicsObject>> widgets;
+        std::set<std::shared_ptr<CGameGraphicsObject>> widgets;
 
-    std::shared_ptr<CTextWidget> mainWidget =
-        getGame()->createObject<CTextWidget>("CTextWidget");
-    mainWidget->setCentered(false);
-    mainWidget->setText(state->getText());
+        std::shared_ptr<CTextWidget> mainWidget = getGame()->createObject<CTextWidget>("CTextWidget");
+        mainWidget->setCentered(false);
+        mainWidget->setText(state->getText());
 
-    int percentSize = 5;
+        int percentSize = 5;
 
-    int totalLines = 0;
-    for (const auto &[index, option] : getCurrentOptions()) {
-      std::string clickName = vstd::to_hex_hash(option);
+        int totalLines = 0;
+        for (const auto &[index, option] : getCurrentOptions()) {
+            std::string clickName = vstd::to_hex_hash(option);
 
-      auto _option = option;
-      self->meta()
-          ->set_method<CGameGraphicsObject, void, std::shared_ptr<CGui>>(
-              clickName, self,
-              [self, _option](CGameGraphicsObject *_self,
-                              std::shared_ptr<CGui> gui) {
-                self->selectOption(_option);
-              });
+            auto _option = option;
+            self->meta()->set_method<CGameGraphicsObject, void, std::shared_ptr<CGui>>(
+                clickName, self, [self, _option](CGameGraphicsObject *_self, std::shared_ptr<CGui> gui) {
+                    self->selectOption(_option);
+                });
 
-      std::shared_ptr<CTextWidget> optionWidget =
-          getGame()->createObject<CTextWidget>("CTextWidget");
-      optionWidget->setClick(clickName);
-      auto optionText = vstd::str(index + 1) + ": " + option->getText();
-      optionWidget->setText(optionText);
-      optionWidget->setCentered(false);
+            std::shared_ptr<CTextWidget> optionWidget = getGame()->createObject<CTextWidget>("CTextWidget");
+            optionWidget->setClick(clickName);
+            auto optionText = vstd::str(index + 1) + ": " + option->getText();
+            optionWidget->setText(optionText);
+            optionWidget->setCentered(false);
 
-      std::shared_ptr<CLayout> optionWidgetLayout =
-          getGame()->createObject<CLayout>("CLayout");
+            std::shared_ptr<CLayout> optionWidgetLayout = getGame()->createObject<CLayout>("CLayout");
 
-      auto lines = getGame()->getGui()->getTextManager()->countLines(
-          optionText, getLayout()->getRect(self)->w);
-      totalLines += lines;
+            auto lines = getGame()->getGui()->getTextManager()->countLines(optionText, getLayout()->getRect(self)->w);
+            totalLines += lines;
 
-      optionWidgetLayout->setY(vstd::str(100 - (totalLines * percentSize)) +
-                               "%");
-      optionWidgetLayout->setW(vstd::str(100) + "%");
-      optionWidgetLayout->setH(vstd::str(percentSize * lines) + "%");
-      optionWidget->setLayout(optionWidgetLayout);
+            optionWidgetLayout->setY(vstd::str(100 - (totalLines * percentSize)) + "%");
+            optionWidgetLayout->setW(vstd::str(100) + "%");
+            optionWidgetLayout->setH(vstd::str(percentSize * lines) + "%");
+            optionWidget->setLayout(optionWidgetLayout);
 
-      widgets.insert(optionWidget);
+            widgets.insert(optionWidget);
+        }
+
+        std::shared_ptr<CLayout> mainWidgetLayout = getGame()->createObject<CLayout>("CLayout");
+        mainWidgetLayout->setW(vstd::str(100) + "%");
+        int textSize = 100 - totalLines * percentSize;
+        mainWidgetLayout->setH(vstd::str(textSize) + "%");
+        mainWidget->setLayout(mainWidgetLayout);
+
+        widgets.insert(mainWidget);
+
+        setChildren(widgets);
+    } else {
+        self->close();
+    }
+}
+
+std::shared_ptr<CDialogOption> CGameDialogPanel::getOption(int option) { return getCurrentOptions()[option]; }
+
+std::map<int, std::shared_ptr<CDialogOption>, std::greater<>> CGameDialogPanel::getCurrentOptions() {
+    // TODO: make this generic and in vstd
+    struct OptionComparator {
+        bool operator()(const std::shared_ptr<CDialogOption> &a, const std::shared_ptr<CDialogOption> &b) const {
+            return a->getNumber() < b->getNumber();
+        }
+    };
+
+    std::set<std::shared_ptr<CDialogOption>, OptionComparator> options;
+    for (const auto &option : dialog->getState(currentStateId)->getOptions()) {
+        if (option->getCondition().empty() || dialog->invokeCondition(option->getCondition())) {
+            options.insert(option);
+        }
     }
 
-    std::shared_ptr<CLayout> mainWidgetLayout =
-        getGame()->createObject<CLayout>("CLayout");
-    mainWidgetLayout->setW(vstd::str(100) + "%");
-    int textSize = 100 - totalLines * percentSize;
-    mainWidgetLayout->setH(vstd::str(textSize) + "%");
-    mainWidget->setLayout(mainWidgetLayout);
-
-    widgets.insert(mainWidget);
-
-    setChildren(widgets);
-  } else {
-    self->close();
-  }
-}
-
-std::shared_ptr<CDialogOption> CGameDialogPanel::getOption(int option) {
-  return getCurrentOptions()[option];
-}
-
-std::map<int, std::shared_ptr<CDialogOption>, std::greater<>>
-CGameDialogPanel::getCurrentOptions() {
-  // TODO: make this generic and in vstd
-  struct OptionComparator {
-    bool operator()(const std::shared_ptr<CDialogOption> &a,
-                    const std::shared_ptr<CDialogOption> &b) const {
-      return a->getNumber() < b->getNumber();
+    std::map<int, std::shared_ptr<CDialogOption>, std::greater<>> return_value;
+    int index = 0;
+    for (const auto &option : options) {
+        return_value[index++] = option;
     }
-  };
-
-  auto options =
-      vstd::cast<std::set<std::shared_ptr<CDialogOption>, OptionComparator>>(
-          dialog->getState(currentStateId)->getOptions() |
-          boost::adaptors::filtered([this](auto option) {
-            return option->getCondition().empty() ||
-                   dialog->invokeCondition(option->getCondition());
-          }));
-
-  std::map<int, std::shared_ptr<CDialogOption>, std::greater<>> return_value;
-  for (const auto &it : options | boost::adaptors::indexed(0)) {
-    return_value[it.index()] = it.value();
-  }
-  return return_value;
+    return return_value;
 }
 
-void CGameDialogPanel::selectOption(int option) {
-  selectOption(getOption(option));
-}
+void CGameDialogPanel::selectOption(int option) { selectOption(getOption(option)); }
 
-void CGameDialogPanel::selectOption(
-    const std::shared_ptr<CDialogOption> &option) {
-  if (!option->getAction().empty()) {
-    dialog->invokeAction(option->getAction());
-  }
-  currentStateId = option->getNextStateId();
-  reload();
-}
-
-bool CGameDialogPanel::keyboardEvent(std::shared_ptr<CGui> sharedPtr,
-                                     SDL_EventType type, SDL_Keycode i) {
-  // TODO: util function to transalte number keys to int
-  if (type == SDL_KEYDOWN) {
-    if (const auto opt = CUtil::parseKey(i) - 1;
-        opt > -1 && static_cast<size_t>(opt) < getCurrentOptions().size()) {
-      selectOption(opt);
-      return true;
+void CGameDialogPanel::selectOption(const std::shared_ptr<CDialogOption> &option) {
+    if (!option->getAction().empty()) {
+        dialog->invokeAction(option->getAction());
     }
-  }
-  return false;
+    currentStateId = option->getNextStateId();
+    reload();
+}
+
+bool CGameDialogPanel::keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i) {
+    // TODO: util function to transalte number keys to int
+    if (type == SDL_KEYDOWN) {
+        if (const auto opt = CUtil::parseKey(i) - 1;
+            opt > -1 && static_cast<size_t>(opt) < getCurrentOptions().size()) {
+            selectOption(opt);
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/handler/CEventHandler.cpp
+++ b/src/handler/CEventHandler.cpp
@@ -26,76 +26,68 @@ std::string CGameEvent::Type::onUse = "onUse";
 std::string CGameEvent::Type::onEquip = "onEquip";
 std::string CGameEvent::Type::onUnequip = "onUnequip";
 
-void CEventHandler::gameEvent(std::shared_ptr<CMapObject> object,
-                              std::shared_ptr<CGameEvent> event) const {
-  // TODO: maybe add reflection
-  if (event->getType() == CGameEvent::Type::onEnter) {
-    if (auto visitable = vstd::cast<Visitable>(object)) {
-      visitable->onEnter(event);
+void CEventHandler::gameEvent(std::shared_ptr<CMapObject> object, std::shared_ptr<CGameEvent> event) const {
+    // TODO: maybe add reflection
+    if (event->getType() == CGameEvent::Type::onEnter) {
+        if (auto visitable = vstd::cast<Visitable>(object)) {
+            visitable->onEnter(event);
+        }
+    } else if (event->getType() == CGameEvent::Type::onLeave) {
+        if (auto visitable = vstd::cast<Visitable>(object)) {
+            visitable->onLeave(event);
+        }
+    } else if (event->getType() == CGameEvent::Type::onTurn) {
+        if (auto turnable = vstd::cast<Turnable>(object)) {
+            turnable->onTurn(event);
+        }
+    } else if (event->getType() == CGameEvent::Type::onDestroy) {
+        if (auto creatable = vstd::cast<Creatable>(object)) {
+            creatable->onDestroy(event);
+        }
+    } else if (event->getType() == CGameEvent::Type::onCreate) {
+        if (auto creatable = vstd::cast<Creatable>(object)) {
+            creatable->onCreate(event);
+        }
+    } else if (event->getType() == CGameEvent::Type::onUse) {
+        if (auto usable = vstd::cast<Usable>(object)) {
+            usable->onUse(event);
+        }
+    } else if (event->getType() == CGameEvent::Type::onEquip) {
+        if (auto wearable = vstd::cast<Wearable>(object)) {
+            wearable->onEquip(event);
+        }
+    } else if (event->getType() == CGameEvent::Type::onUnequip) {
+        if (auto wearable = vstd::cast<Wearable>(object)) {
+            wearable->onUnequip(event);
+        }
+    } else {
+        vstd::logger::fatal("Unrecognized event type:", event->getType());
     }
-  } else if (event->getType() == CGameEvent::Type::onLeave) {
-    if (auto visitable = vstd::cast<Visitable>(object)) {
-      visitable->onLeave(event);
-    }
-  } else if (event->getType() == CGameEvent::Type::onTurn) {
-    if (auto turnable = vstd::cast<Turnable>(object)) {
-      turnable->onTurn(event);
-    }
-  } else if (event->getType() == CGameEvent::Type::onDestroy) {
-    if (auto creatable = vstd::cast<Creatable>(object)) {
-      creatable->onDestroy(event);
-    }
-  } else if (event->getType() == CGameEvent::Type::onCreate) {
-    if (auto creatable = vstd::cast<Creatable>(object)) {
-      creatable->onCreate(event);
-    }
-  } else if (event->getType() == CGameEvent::Type::onUse) {
-    if (auto usable = vstd::cast<Usable>(object)) {
-      usable->onUse(event);
-    }
-  } else if (event->getType() == CGameEvent::Type::onEquip) {
-    if (auto wearable = vstd::cast<Wearable>(object)) {
-      wearable->onEquip(event);
-    }
-  } else if (event->getType() == CGameEvent::Type::onUnequip) {
-    if (auto wearable = vstd::cast<Wearable>(object)) {
-      wearable->onUnequip(event);
-    }
-  } else {
-    vstd::logger::fatal("Unrecognized event type:", event->getType());
-  }
 
-  auto range =
-      triggers.equal_range(std::make_pair(object->getName(), event->getType()));
-  std::for_each(range.first, range.second,
-                [object, event](TriggerMap::value_type x) {
-                  x.second->trigger(object, event);
-                });
+    auto range = triggers.equal_range(std::make_pair(object->getName(), event->getType()));
+    std::for_each(range.first, range.second,
+                  [object, event](TriggerMap::value_type x) { x.second->trigger(object, event); });
 }
 
 void CEventHandler::registerTrigger(std::shared_ptr<CTrigger> trigger) {
-  triggers.insert(std::make_pair(
-      std::make_pair(trigger->getObject(), trigger->getEvent()), trigger));
+    triggers.insert(std::make_pair(std::make_pair(trigger->getObject(), trigger->getEvent()), trigger));
 }
 
 std::set<std::shared_ptr<CTrigger>> CEventHandler::getTriggers() {
-  std::set<std::shared_ptr<CTrigger>> triggers;
-  for (auto trigger : this->triggers | boost::adaptors::map_values) {
-    triggers.insert(trigger);
-  }
-  return triggers;
+    std::set<std::shared_ptr<CTrigger>> triggers;
+    for (auto trigger : this->triggers | std::views::values) {
+        triggers.insert(trigger);
+    }
+    return triggers;
 }
 
 CGameEvent::CGameEvent(std::string type) : type(type) {}
 
 std::string CGameEvent::getType() const { return type; }
 
-std::shared_ptr<CGameObject> CGameEventCaused::getCause() const {
-  return cause;
-}
+std::shared_ptr<CGameObject> CGameEventCaused::getCause() const { return cause; }
 
-CGameEventCaused::CGameEventCaused(std::string type,
-                                   std::shared_ptr<CGameObject> cause)
+CGameEventCaused::CGameEventCaused(std::string type, std::shared_ptr<CGameObject> cause)
     : CGameEvent(type), cause(cause) {}
 
 CGameEvent::CGameEvent() {}

--- a/src/handler/CObjectHandler.cpp
+++ b/src/handler/CObjectHandler.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<json> CObjectHandler::getConfig(const std::string &type) {
 
 std::vector<std::string> CObjectHandler::getAllTypes() {
     std::vector<std::string> types;
-    for (auto val : objectConfig | boost::adaptors::map_keys) {
+    for (auto val : objectConfig | std::views::keys) {
         types.push_back(val);
     }
     return types;

--- a/src/handler/CRngHandler.cpp
+++ b/src/handler/CRngHandler.cpp
@@ -22,112 +22,97 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CUtil.h"
 #include "object/CObject.h"
 
-std::set<std::shared_ptr<CItem>> CRngHandler::getRandomLoot(int value) const {
-  return calculateRandomLoot(value);
-}
+std::set<std::shared_ptr<CItem>> CRngHandler::getRandomLoot(int value) const { return calculateRandomLoot(value); }
 
-std::set<std::shared_ptr<CCreature>>
-CRngHandler::getRandomEncounter(int value) const {
-  auto randomEncounter = calculateRandomEncounter(value);
-  // TODO: make generic hashing of collections
-  std::size_t hash = vstd::rand(256);
-  for (const auto &creature : randomEncounter) {
-    hash = vstd::hash_combine(hash, creature);
-  }
-  for (const auto &creature : randomEncounter) {
-    creature->setAffiliation(vstd::str(hash));
-    // TODO: make this customizable
-    creature->setController(
-        game.lock()->createObject<CController>("CRandomController"));
-  }
-  return randomEncounter;
+std::set<std::shared_ptr<CCreature>> CRngHandler::getRandomEncounter(int value) const {
+    auto randomEncounter = calculateRandomEncounter(value);
+    // TODO: make generic hashing of collections
+    std::size_t hash = vstd::rand(256);
+    for (const auto &creature : randomEncounter) {
+        hash = vstd::hash_combine(hash, creature);
+    }
+    for (const auto &creature : randomEncounter) {
+        creature->setAffiliation(vstd::str(hash));
+        // TODO: make this customizable
+        creature->setController(game.lock()->createObject<CController>("CRandomController"));
+    }
+    return randomEncounter;
 }
 
 CRngHandler::CRngHandler(const std::shared_ptr<CGame> &game) : game(game) {
-  for (const std::string &type :
-       game->getObjectHandler()->getAllSubTypes("CItem")) {
-    std::shared_ptr<CItem> item = game->createObject<CItem>(type);
-    if (item) {
-      int power = item->getPower();
-      if (power > 0 && !item->hasTag(CTag::Quest)) {
-        itemPowerTable.insert(std::make_pair(power, type));
-      }
+    for (const std::string &type : game->getObjectHandler()->getAllSubTypes("CItem")) {
+        std::shared_ptr<CItem> item = game->createObject<CItem>(type);
+        if (item) {
+            int power = item->getPower();
+            if (power > 0 && !item->hasTag(CTag::Quest)) {
+                itemPowerTable.insert(std::make_pair(power, type));
+            }
+        }
     }
-  }
 
-  for (const std::string &type :
-       game->getObjectHandler()->getAllSubTypes("CCreature")) {
-    std::shared_ptr<CCreature> creature = game->createObject<CCreature>(type);
-    if (creature) {
-      int power = creature->getSw();
-      creaturePowerTable.insert(std::make_pair(power, type));
+    for (const std::string &type : game->getObjectHandler()->getAllSubTypes("CCreature")) {
+        std::shared_ptr<CCreature> creature = game->createObject<CCreature>(type);
+        if (creature) {
+            int power = creature->getSw();
+            creaturePowerTable.insert(std::make_pair(power, type));
+        }
     }
-  }
 }
 
-std::set<std::shared_ptr<CItem>>
-CRngHandler::calculateRandomLoot(int value) const {
-  std::set<std::shared_ptr<CItem>> loot;
-  for (auto pow : vstd::random_components(
-           value, itemPowerTable | boost::adaptors::map_keys)) {
-    std::set<std::string> possible_names;
-    auto range = itemPowerTable.equal_range(pow);
-    for (auto it = range.first; it != range.second; it++) {
-      possible_names.insert(it->second);
+std::set<std::shared_ptr<CItem>> CRngHandler::calculateRandomLoot(int value) const {
+    std::set<std::shared_ptr<CItem>> loot;
+    for (auto pow : vstd::random_components(value, itemPowerTable | std::views::keys)) {
+        std::set<std::string> possible_names;
+        auto range = itemPowerTable.equal_range(pow);
+        for (auto it = range.first; it != range.second; it++) {
+            possible_names.insert(it->second);
+        }
+        if (!possible_names.empty()) {
+            loot.insert(game.lock()->createObject<CItem>(vstd::random_element(possible_names)));
+        }
+        value -= pow;
     }
-    if (!possible_names.empty()) {
-      loot.insert(game.lock()->createObject<CItem>(
-          vstd::random_element(possible_names)));
-    }
-    value -= pow;
-  }
-  return loot;
+    return loot;
 }
 
 void CRngHandler::addRandomLoot(const std::shared_ptr<CCreature> &creature,
                                 const std::set<std::shared_ptr<CItem>> &items) {
-  // TODO: polymorphic
-  if (creature->isPlayer()) {
-    creature->getGame()->getGuiHandler()->showLoot(creature, items);
-  }
-  creature->addItems(items);
-}
-
-void CRngHandler::addRandomLoot(const std::shared_ptr<CCreature> &creature,
-                                int value) {
-  addRandomLoot(creature, getRandomLoot(value));
-}
-
-std::set<std::shared_ptr<CCreature>>
-CRngHandler::calculateRandomEncounter(int value) const {
-  std::set<std::shared_ptr<CCreature>> encounter;
-  for (int pow : vstd::random_components(value, boost::irange(1, value + 1))) {
-    auto possiblePowersRange =
-        creaturePowerTable | boost::adaptors::map_keys |
-        boost::adaptors::filtered([pow](int it) { return it <= pow; });
-    // TODO: util for range copy
-    std::set<int> possiblePowers(possiblePowersRange.begin(),
-                                 possiblePowersRange.end());
-    auto sw = vstd::random_element(possiblePowers);
-    std::set<std::string> possible_names;
-    auto range = creaturePowerTable.equal_range(sw);
-    for (auto it = range.first; it != range.second; it++) {
-      possible_names.insert(it->second);
+    // TODO: polymorphic
+    if (creature->isPlayer()) {
+        creature->getGame()->getGuiHandler()->showLoot(creature, items);
     }
-    if (!possible_names.empty()) {
-      auto creature = game.lock()->createObject<CCreature>(
-          vstd::random_element(possible_names));
-      creature->addExp(creature->getExpForLevel(pow - sw));
-      encounter.insert(creature);
-    }
-    value -= pow;
-  }
-  return encounter;
+    creature->addItems(items);
 }
 
-void CRngHandler::addRandomEncounter(const std::shared_ptr<CMap> &map, int x,
-                                     int y, int z, int value) {
-  for (const auto &creature : getRandomEncounter(value)) {
-    map->addObject(creature, Coords(x, y, z));
-  }
+void CRngHandler::addRandomLoot(const std::shared_ptr<CCreature> &creature, int value) {
+    addRandomLoot(creature, getRandomLoot(value));
+}
+
+std::set<std::shared_ptr<CCreature>> CRngHandler::calculateRandomEncounter(int value) const {
+    std::set<std::shared_ptr<CCreature>> encounter;
+    for (int pow : vstd::random_components(value, std::views::iota(1, value + 1))) {
+        auto possiblePowersRange =
+            creaturePowerTable | std::views::keys | std::views::filter([pow](int it) { return it <= pow; });
+        // TODO: util for range copy
+        std::set<int> possiblePowers(possiblePowersRange.begin(), possiblePowersRange.end());
+        auto sw = vstd::random_element(possiblePowers);
+        std::set<std::string> possible_names;
+        auto range = creaturePowerTable.equal_range(sw);
+        for (auto it = range.first; it != range.second; it++) {
+            possible_names.insert(it->second);
+        }
+        if (!possible_names.empty()) {
+            auto creature = game.lock()->createObject<CCreature>(vstd::random_element(possible_names));
+            creature->addExp(creature->getExpForLevel(pow - sw));
+            encounter.insert(creature);
+        }
+        value -= pow;
+    }
+    return encounter;
+}
+
+void CRngHandler::addRandomEncounter(const std::shared_ptr<CMap> &map, int x, int y, int z, int value) {
+    for (const auto &creature : getRandomEncounter(value)) {
+        map->addObject(creature, Coords(x, y, z));
+    }
 }

--- a/src/handler/CTooltipHandler.cpp
+++ b/src/handler/CTooltipHandler.cpp
@@ -19,21 +19,20 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CItem.h"
 
 std::string CTooltipHandler::buildTooltip(std::shared_ptr<CGameObject> object) {
-  std::string tooltip = object->getLabel();
-  vstd::add_line(tooltip, object->getDescription());
-  if (object->meta()->inherits("CItem")) {
+    std::string tooltip = object->getLabel();
     vstd::add_line(tooltip, object->getDescription());
-    auto bonus = vstd::cast<CItem>(object)->getBonus();
-    bonus->meta()->for_all_properties(bonus, [&](auto prop) {
-      // TODO: move to meta
-      if (prop->value_type() == boost::typeindex::type_id<int>()) {
-        auto value = bonus->getNumericProperty(prop->name());
-        if (value > 0) {
-          vstd::add_line(tooltip,
-                         vstd::camel(prop->name()) + ": " + vstd::str(value));
-        }
-      }
-    });
-  }
-  return tooltip;
+    if (object->meta()->inherits("CItem")) {
+        vstd::add_line(tooltip, object->getDescription());
+        auto bonus = vstd::cast<CItem>(object)->getBonus();
+        bonus->meta()->for_all_properties(bonus, [&](auto prop) {
+            // TODO: move to meta
+            if (prop->value_type() == vstd::type_id<int>()) {
+                auto value = bonus->getNumericProperty(prop->name());
+                if (value > 0) {
+                    vstd::add_line(tooltip, vstd::camel(prop->name()) + ": " + vstd::str(value));
+                }
+            }
+        });
+    }
+    return tooltip;
 }

--- a/src/object/CGameObject.h
+++ b/src/object/CGameObject.h
@@ -29,208 +29,192 @@ class CGame;
 
 class CAnimation;
 
-class CGameObject : public vstd::stringable,
-                    public std::enable_shared_from_this<CGameObject> {
-  V_META(CGameObject, vstd::meta::empty,
-         V_PROPERTY(CGameObject, std::string, name, getName, setName),
-         V_PROPERTY(CGameObject, std::string, type, getType, setType),
-         V_PROPERTY(CGameObject, std::string, typeId, getTypeId, setTypeId),
-         V_PROPERTY(CGameObject, std::string, animation, getAnimation,
-                    setAnimation),
-         V_PROPERTY(CGameObject, std::string, label, getLabel, setLabel),
-         V_PROPERTY(CGameObject, std::string, description, getDescription,
-                    setDescription),
-         V_PROPERTY(CGameObject, CTags, tags, getTags, setTags))
+class CGameObject : public vstd::stringable, public std::enable_shared_from_this<CGameObject> {
+    V_META(CGameObject, vstd::meta::empty, V_PROPERTY(CGameObject, std::string, name, getName, setName),
+           V_PROPERTY(CGameObject, std::string, type, getType, setType),
+           V_PROPERTY(CGameObject, std::string, typeId, getTypeId, setTypeId),
+           V_PROPERTY(CGameObject, std::string, animation, getAnimation, setAnimation),
+           V_PROPERTY(CGameObject, std::string, label, getLabel, setLabel),
+           V_PROPERTY(CGameObject, std::string, description, getDescription, setDescription),
+           V_PROPERTY(CGameObject, CTags, tags, getTags, setTags))
 
-public:
-  static std::function<bool(std::shared_ptr<CGameObject>,
-                            std::shared_ptr<CGameObject>)>
-      name_comparator;
+  public:
+    static std::function<bool(std::shared_ptr<CGameObject>, std::shared_ptr<CGameObject>)> name_comparator;
 
-  CGameObject();
+    CGameObject();
 
-  virtual ~CGameObject();
+    virtual ~CGameObject();
 
-  std::shared_ptr<CMap> getMap();
+    std::shared_ptr<CMap> getMap();
 
-  // TODO: get rid of game as a property!
-  std::shared_ptr<CGame> getGame();
+    // TODO: get rid of game as a property!
+    std::shared_ptr<CGame> getGame();
 
-  void setGame(std::shared_ptr<CGame> game);
+    void setGame(std::shared_ptr<CGame> game);
 
-  template <typename T = CGameObject> std::shared_ptr<T> ptr() {
-    //_cast purposedly
-    return vstd::cast<T>(const_cast<CGameObject *>(this)->shared_from_this());
-  }
-
-  template <typename T> void setProperty(std::string name, T property) {
-    this->meta()->set_property<CGameObject, T>(name, this->ptr(), property);
-  }
-
-  template <typename T> T getProperty(std::string name) {
-    return this->meta()->get_property<CGameObject, T>(name, this->ptr());
-  }
-
-  bool hasProperty(std::string name);
-
-  void setStringProperty(std::string name, std::string value);
-
-  void setBoolProperty(std::string name, bool value);
-
-  void setNumericProperty(std::string name, int value);
-
-  std::string getStringProperty(std::string name);
-
-  bool getBoolProperty(std::string name);
-
-  int getNumericProperty(std::string name);
-
-  template <typename T = CGameObject>
-  void setObjectProperty(std::string name, std::shared_ptr<T> object) {
-    setProperty(name, boost::any(object));
-  }
-
-  template <typename T = CGameObject>
-  std::shared_ptr<T> getObjectProperty(std::string name) {
-    return getProperty<std::shared_ptr<T>>(name);
-  }
-
-  template <typename T = CGameObject> std::shared_ptr<T> clone() {
-    return vstd::cast<T>(_clone());
-  }
-
-  void incProperty(std::string name, int value);
-
-  bool hasTag(CTag tag);
-
-  bool hasTag(const std::string &tag);
-
-  void addTag(CTag tag);
-
-  void addTag(const std::string &tag);
-
-  void removeTag(CTag tag);
-
-  void removeTag(const std::string &tag);
-
-public:
-  std::string getType();
-
-  void setType(std::string type);
-
-  std::string getTypeId();
-
-  void setTypeId(std::string _typeId);
-
-  std::string getName();
-
-  void setName(std::string name);
-
-  virtual std::string to_string() override;
-
-  CTags getTags();
-
-  void setTags(CTags tags);
-
-  std::string getAnimation();
-
-  void setAnimation(std::string animation);
-
-  std::string getLabel();
-
-  void setLabel(std::string _label);
-
-  std::string getDescription();
-
-  void setDescription(std::string _description);
-
-  std::shared_ptr<CAnimation> getGraphicsObject();
-
-  void connect(std::string signal, std::shared_ptr<CGameObject> object,
-               std::string slot);
-
-  template <bool now = false, typename... Args>
-  void signal(std::string signal, Args... args) {
-    // vstd::logger::debug(signal, args...);
-    auto it = connections.begin();
-    while (it != connections.end()) {
-      auto [_signal, object, slot] = *it;
-      auto ob = object.lock();
-      if (ob) {
-        if (signal == _signal) {
-          auto _slot = slot;
-          auto task = [=]() {
-            ob->meta()->invoke_method<void, CGameObject, Args...>(_slot, ob,
-                                                                  args...);
-          };
-          if constexpr (now) {
-            vstd::now(task);
-          } else {
-            vstd::later(task);
-          }
-        }
-        ++it;
-      } else {
-        it = connections.erase(it);
-      }
+    template <typename T = CGameObject> std::shared_ptr<T> ptr() {
+        //_cast purposedly
+        return vstd::cast<T>(const_cast<CGameObject *>(this)->shared_from_this());
     }
-  }
 
-private:
-  std::list<std::tuple<std::string, std::weak_ptr<CGameObject>, std::string>>
-      connections;
+    template <typename T> void setProperty(std::string name, T property) {
+        this->meta()->set_property<CGameObject, T>(name, this->ptr(), property);
+    }
 
-  std::shared_ptr<CGameObject> _clone();
+    template <typename T> T getProperty(std::string name) {
+        return this->meta()->get_property<CGameObject, T>(name, this->ptr());
+    }
 
-  vstd::lazy<CAnimation> graphicsObject;
+    bool hasProperty(std::string name);
 
-  std::string type;
-  std::string typeId;
-  std::string name;
-  std::string animation;
-  std::string label;
-  std::string description;
+    void setStringProperty(std::string name, std::string value);
 
-  CTags tags;
+    void setBoolProperty(std::string name, bool value);
 
-  // TODO: this creates cyclic dependencies
-  std::shared_ptr<CGame> game;
+    void setNumericProperty(std::string name, int value);
+
+    std::string getStringProperty(std::string name);
+
+    bool getBoolProperty(std::string name);
+
+    int getNumericProperty(std::string name);
+
+    template <typename T = CGameObject> void setObjectProperty(std::string name, std::shared_ptr<T> object) {
+        setProperty(name, std::any(object));
+    }
+
+    template <typename T = CGameObject> std::shared_ptr<T> getObjectProperty(std::string name) {
+        return getProperty<std::shared_ptr<T>>(name);
+    }
+
+    template <typename T = CGameObject> std::shared_ptr<T> clone() { return vstd::cast<T>(_clone()); }
+
+    void incProperty(std::string name, int value);
+
+    bool hasTag(CTag tag);
+
+    bool hasTag(const std::string &tag);
+
+    void addTag(CTag tag);
+
+    void addTag(const std::string &tag);
+
+    void removeTag(CTag tag);
+
+    void removeTag(const std::string &tag);
+
+  public:
+    std::string getType();
+
+    void setType(std::string type);
+
+    std::string getTypeId();
+
+    void setTypeId(std::string _typeId);
+
+    std::string getName();
+
+    void setName(std::string name);
+
+    virtual std::string to_string() override;
+
+    CTags getTags();
+
+    void setTags(CTags tags);
+
+    std::string getAnimation();
+
+    void setAnimation(std::string animation);
+
+    std::string getLabel();
+
+    void setLabel(std::string _label);
+
+    std::string getDescription();
+
+    void setDescription(std::string _description);
+
+    std::shared_ptr<CAnimation> getGraphicsObject();
+
+    void connect(std::string signal, std::shared_ptr<CGameObject> object, std::string slot);
+
+    template <bool now = false, typename... Args> void signal(std::string signal, Args... args) {
+        // vstd::logger::debug(signal, args...);
+        auto it = connections.begin();
+        while (it != connections.end()) {
+            auto [_signal, object, slot] = *it;
+            auto ob = object.lock();
+            if (ob) {
+                if (signal == _signal) {
+                    auto _slot = slot;
+                    auto task = [=]() { ob->meta()->invoke_method<void, CGameObject, Args...>(_slot, ob, args...); };
+                    if constexpr (now) {
+                        vstd::now(task);
+                    } else {
+                        vstd::later(task);
+                    }
+                }
+                ++it;
+            } else {
+                it = connections.erase(it);
+            }
+        }
+    }
+
+  private:
+    std::list<std::tuple<std::string, std::weak_ptr<CGameObject>, std::string>> connections;
+
+    std::shared_ptr<CGameObject> _clone();
+
+    vstd::lazy<CAnimation> graphicsObject;
+
+    std::string type;
+    std::string typeId;
+    std::string name;
+    std::string animation;
+    std::string label;
+    std::string description;
+
+    CTags tags;
+
+    // TODO: this creates cyclic dependencies
+    std::shared_ptr<CGame> game;
 };
 
 class Visitable {
-public:
-  virtual void onEnter(std::shared_ptr<CGameEvent>) = 0;
+  public:
+    virtual void onEnter(std::shared_ptr<CGameEvent>) = 0;
 
-  virtual void onLeave(std::shared_ptr<CGameEvent>) = 0;
+    virtual void onLeave(std::shared_ptr<CGameEvent>) = 0;
 };
 
 class Moveable {
-public:
-  virtual void beforeMove() = 0;
+  public:
+    virtual void beforeMove() = 0;
 
-  virtual void afterMove() = 0;
+    virtual void afterMove() = 0;
 };
 
 class Wearable {
-public:
-  virtual void onEquip(std::shared_ptr<CGameEvent>) = 0;
+  public:
+    virtual void onEquip(std::shared_ptr<CGameEvent>) = 0;
 
-  virtual void onUnequip(std::shared_ptr<CGameEvent>) = 0;
+    virtual void onUnequip(std::shared_ptr<CGameEvent>) = 0;
 };
 
 class Usable {
-public:
-  virtual void onUse(std::shared_ptr<CGameEvent>) = 0;
+  public:
+    virtual void onUse(std::shared_ptr<CGameEvent>) = 0;
 };
 
 class Turnable {
-public:
-  virtual void onTurn(std::shared_ptr<CGameEvent>) = 0;
+  public:
+    virtual void onTurn(std::shared_ptr<CGameEvent>) = 0;
 };
 
 class Creatable {
-public:
-  virtual void onCreate(std::shared_ptr<CGameEvent>) = 0;
+  public:
+    virtual void onCreate(std::shared_ptr<CGameEvent>) = 0;
 
-  virtual void onDestroy(std::shared_ptr<CGameEvent>) = 0;
+    virtual void onDestroy(std::shared_ptr<CGameEvent>) = 0;
 };

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,11 +3,7 @@
   "version-string": "0.1.0",
   "dependencies": [
     "boost-algorithm",
-    "boost-any",
-    "boost-filesystem",
     "boost-pool",
-    "boost-range",
-    "boost-type-index",
     "sdl2",
     "sdl2-image",
     "sdl2-ttf"


### PR DESCRIPTION
Summary: Updates the project, vstd, and random-dungeon-generator to C++20; migrates Boost.Filesystem, Boost.Any, Boost.TypeIndex, and Boost.Range usages to standard library equivalents; removes obsolete Boost dependencies. Testing: cmake configure/build, ctest for_unit_tests, python3 test.py, standalone vstd build, and standalone random-dungeon-generator build passed. Coverage: not included, forced by user request.