### PR TITLE
[codex] Remove json submodule dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "vstd"]
 	path = vstd
 	url = https://github.com/lisu188/vstd.git
-[submodule "json"]
-	path = json
-	url = https://github.com/nlohmann/json.git
 [submodule "random-dungeon-generator"]
 	path = random-dungeon-generator
 	url = https://github.com/lisu188/random-dungeon-generator.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,10 @@ find_package(SDL2_ttf CONFIG QUIET)
 if (NOT SDL2_ttf_FOUND AND NOT TARGET SDL2_ttf::SDL2_ttf)
     find_package(SDL2_ttf REQUIRED)
 endif ()
+find_path(NLOHMANN_JSON_INCLUDE_DIR nlohmann/json.hpp)
+if (NOT NLOHMANN_JSON_INCLUDE_DIR)
+    message(FATAL_ERROR "nlohmann/json.hpp was not found. On Debian/Ubuntu, run: sudo apt-get install nlohmann-json3-dev.")
+endif ()
 
 set(SDL2_LIBS ${SDL2_LIBRARY})
 set(SDL2_EXECUTABLE_LIBS ${SDL2_LIBRARY})
@@ -101,7 +105,7 @@ include_directories(${Python3_INCLUDE_DIRS})
 include_directories(${SDL2_INCLUDE_DIR})
 include_directories(${SDL2_IMAGE_INCLUDE_DIR})
 include_directories(${SDL2_TTF_INCLUDE_DIR})
-include_directories(json/single_include/nlohmann)
+include_directories(${NLOHMANN_JSON_INCLUDE_DIR})
 
 include_directories(${CMAKE_SOURCE_DIR}/src)
 
@@ -371,7 +375,7 @@ add_executable(for_unit_tests
 target_include_directories(for_unit_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_SOURCE_DIR}/vstd
-    json/single_include/nlohmann
+    ${NLOHMANN_JSON_INCLUDE_DIR}
     ${Python3_INCLUDE_DIRS}
     ${SDL2_INCLUDE_DIR}
     ${SDL2_IMAGE_INCLUDE_DIR}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ tab - open/close python console
 ## running
 ### ubuntu
 <pre>
-sudo apt install python3.11 python3.11-dev pybind11-dev
+sudo apt-get install python3.11 python3.11-dev pybind11-dev nlohmann-json3-dev
 ./configure.sh
 cmake --build cmake-build-release --target _game -j$(nproc)
 python3 play.py

--- a/configure.sh
+++ b/configure.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-sudo apt update
-sudo apt install -y build-essential cmake ninja-build ccache \
+sudo apt-get update
+sudo apt-get install -y build-essential cmake ninja-build ccache \
     python3 python3-dev \
     libboost-dev \
-    libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev
+    libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
+    nlohmann-json3-dev
 
 git submodule update --init --recursive
 mkdir -p cmake-build-debug

--- a/src/core/CGlobal.h
+++ b/src/core/CGlobal.h
@@ -38,7 +38,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <functional>
 #include <iomanip>
 #include <iostream>
-#include <json.hpp>
+#include <nlohmann/json.hpp>
 #include <limits>
 #include <list>
 #include <map>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,7 @@
   "dependencies": [
     "boost-algorithm",
     "boost-pool",
+    "nlohmann-json",
     "sdl2",
     "sdl2-image",
     "sdl2-ttf"


### PR DESCRIPTION
## What changed
- Removed the `json` submodule from `.gitmodules` and the repository tree.
- Switched the project include from `<json.hpp>` to `<nlohmann/json.hpp>`.
- Updated CMake to find `nlohmann/json.hpp` from the system/package include path and emit an explicit Debian/Ubuntu install hint when missing.
- Updated `configure.sh` to use `sudo apt-get` and install `nlohmann-json3-dev`.
- Added `nlohmann-json` to `vcpkg.json` so Windows/vcpkg builds still have the dependency after the submodule removal.
- Updated the README Ubuntu setup line to include `nlohmann-json3-dev`.

## Why
The project previously depended on nlohmann/json through a checked-out `json` submodule and CMake included `json/single_include/nlohmann`. This makes a fresh build depend on an extra submodule checkout for a package that is available directly from Debian/Ubuntu package repositories.

## Validation
- Verified via Ubuntu/Debian package metadata that the development package is `nlohmann-json3-dev` and provides `/usr/include/nlohmann/json.hpp`.
- `clang-format -i src/core/CGlobal.h`
- `git diff --cached --check` before commit and `git diff --check` during final review
- `cmake -S . -B /tmp/fon-json-config-check` passed after the apt package became available locally
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` passed after rebase
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` passed after rebase
- `python3 test.py` passed after rebase: 97 tests OK
- `./scripts/run_coverage.sh` passed its C++ and Python test portions after rebase: 97 tests OK

## Known limitations
- The coverage script still fails the repository line coverage gate: 53.5% line coverage versus the required 80.0%.
- Existing untracked local directories were not included: `.codex/` and `coverage/`.