### PR TITLE
[codex] Add C++20 concept constraints

### DIFF
--- a/src/core/CConcepts.h
+++ b/src/core/CConcepts.h
@@ -1,0 +1,108 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2025  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "core/CGlobal.h"
+
+class CGameEvent;
+
+class CGameObject;
+
+class CGui;
+
+enum class CTag;
+
+namespace fn {
+template <typename T> using clean_t = std::remove_cvref_t<T>;
+
+template <typename T>
+concept SharedPtr = vstd::is_shared_ptr<clean_t<T>>::value;
+
+template <typename T>
+concept SetLike = vstd::is_set<clean_t<T>>::value;
+
+template <typename T>
+concept MapLike = vstd::is_map<clean_t<T>>::value;
+
+template <typename T>
+concept GameObjectDerived = std::derived_from<clean_t<T>, CGameObject>;
+
+template <typename T>
+concept MetaRegisteredGameObject = GameObjectDerived<T> && requires {
+    { clean_t<T>::static_meta()->name() } -> std::convertible_to<std::string>;
+};
+
+template <typename T>
+concept CoordsLike = requires(const clean_t<T> &coords) {
+    { coords.x } -> std::convertible_to<int>;
+    { coords.y } -> std::convertible_to<int>;
+    { coords.z } -> std::convertible_to<int>;
+};
+
+template <typename T>
+concept PriorityCostNode = requires(const clean_t<T> &node) {
+    { node.priority } -> std::convertible_to<int>;
+    { node.cost } -> std::convertible_to<int>;
+};
+
+template <typename T>
+concept JsonObjectPointer = requires(T object, const std::string &property) {
+    { object->count(property) } -> std::convertible_to<std::size_t>;
+    { object->size() } -> std::convertible_to<std::size_t>;
+    { (*object)[property].is_string() } -> std::convertible_to<bool>;
+    { (*object)[property].is_object() } -> std::convertible_to<bool>;
+};
+
+template <typename T>
+concept JsonMapPointer = JsonObjectPointer<T> && requires(T object) { object->items(); };
+
+template <typename T>
+concept JsonDumpPointer = requires(T value, int indent) {
+    { value->dump(indent) } -> std::convertible_to<std::string>;
+};
+
+template <typename Range>
+concept TaggablePointerRange =
+    std::ranges::input_range<Range> && requires(std::ranges::range_reference_t<Range> value, CTag tag) {
+        { value->hasTag(tag) } -> std::convertible_to<bool>;
+    };
+
+template <typename F>
+concept FilePredicate = std::predicate<F, std::string>;
+
+template <typename F>
+concept SdlStatusCallable = std::invocable<F &> && std::same_as<std::invoke_result_t<F &>, int>;
+
+template <typename F>
+concept SdlVoidCallable = std::invocable<F &> && std::same_as<std::invoke_result_t<F &>, void>;
+
+template <typename F>
+concept SdlNullableCallable = std::invocable<F &> && !SdlStatusCallable<F> && !SdlVoidCallable<F>;
+
+template <typename F>
+concept AnimationCallback = std::is_invocable_r_v<bool, F, std::shared_ptr<CGui>, SDL_EventType, int, int, int>;
+
+template <typename F>
+concept TriggerCallback = std::is_invocable_r_v<void, F, std::shared_ptr<CGameObject>, std::shared_ptr<CGameEvent>>;
+
+template <typename T>
+concept PythonWrapperBase = GameObjectDerived<T>;
+
+template <typename T>
+concept PythonReturn = std::same_as<T, void> || std::default_initializable<T>;
+} // namespace fn

--- a/src/core/CGame.h
+++ b/src/core/CGame.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 
 #include "CSlotConfig.h"
+#include "core/CConcepts.h"
 #include "core/CGlobal.h"
 #include "core/CPlugin.h"
 #include "core/CUtil.h"
@@ -40,50 +41,50 @@ class CGuiHandler;
 class CScriptHandler;
 
 class CGame : public CGameObject {
-  V_META(CGame, CGameObject, vstd::meta::empty())
-public:
-  CGame();
+    V_META(CGame, CGameObject, vstd::meta::empty())
+  public:
+    CGame();
 
-  ~CGame();
+    ~CGame();
 
-  void changeMap(std::string file);
+    void changeMap(std::string file);
 
-  std::shared_ptr<CMap> getMap() const;
+    std::shared_ptr<CMap> getMap() const;
 
-  void setMap(std::shared_ptr<CMap> map);
+    void setMap(std::shared_ptr<CMap> map);
 
-  std::shared_ptr<CGuiHandler> getGuiHandler();
+    std::shared_ptr<CGuiHandler> getGuiHandler();
 
-  std::shared_ptr<CScriptHandler> getScriptHandler();
+    std::shared_ptr<CScriptHandler> getScriptHandler();
 
-  std::shared_ptr<CObjectHandler> getObjectHandler();
+    std::shared_ptr<CObjectHandler> getObjectHandler();
 
-  void loadPlugin(std::function<std::shared_ptr<CPlugin>()> plugin);
+    void loadPlugin(std::function<std::shared_ptr<CPlugin>()> plugin);
 
-  std::shared_ptr<CRngHandler> getRngHandler();
+    std::shared_ptr<CRngHandler> getRngHandler();
 
-  template <typename T> std::shared_ptr<T> createObject(std::string name) {
-    return getObjectHandler()->createObject<T>(this->ptr<CGame>(), name);
-  }
+    template <fn::GameObjectDerived T> std::shared_ptr<T> createObject(std::string name) {
+        return getObjectHandler()->createObject<T>(this->ptr<CGame>(), name);
+    }
 
-  template <typename T> std::shared_ptr<T> createObject() {
-    return getObjectHandler()->createObject<T>(this->ptr<CGame>());
-  }
+    template <fn::MetaRegisteredGameObject T> std::shared_ptr<T> createObject() {
+        return getObjectHandler()->createObject<T>(this->ptr<CGame>());
+    }
 
-  std::shared_ptr<CSlotConfig> getSlotConfiguration();
+    std::shared_ptr<CSlotConfig> getSlotConfiguration();
 
-private:
-  vstd::lazy<CGuiHandler> guiHandler;
-  vstd::lazy<CScriptHandler> scriptHandler;
-  vstd::lazy<CSlotConfig> slotConfiguration;
-  vstd::lazy<CRngHandler> rngHandler;
+  private:
+    vstd::lazy<CGuiHandler> guiHandler;
+    vstd::lazy<CScriptHandler> scriptHandler;
+    vstd::lazy<CSlotConfig> slotConfiguration;
+    vstd::lazy<CRngHandler> rngHandler;
 
-  vstd::lazy<CObjectHandler> objectHandler;
-  std::shared_ptr<CMap> map;
-  std::shared_ptr<CGui> _gui;
+    vstd::lazy<CObjectHandler> objectHandler;
+    std::shared_ptr<CMap> map;
+    std::shared_ptr<CGui> _gui;
 
-public:
-  std::shared_ptr<CGui> getGui() const;
+  public:
+    std::shared_ptr<CGui> getGui() const;
 
-  void setGui(std::shared_ptr<CGui> _gui);
+    void setGui(std::shared_ptr<CGui> _gui);
 };

--- a/src/core/CGlobal.h
+++ b/src/core/CGlobal.h
@@ -19,8 +19,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <Python.h>
 
-#include <pybind11/pybind11.h>
 #include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include <SDL.h>
@@ -28,6 +28,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <SDL_ttf.h>
 
 #include <any>
+#include <concepts>
 #include <condition_variable>
 #include <csignal>
 #include <cstdio>
@@ -51,10 +52,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <sstream>
 #include <string>
 #include <thread>
+#include <type_traits>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 #include <vstd.h>
 

--- a/src/core/CJsonUtil.h
+++ b/src/core/CJsonUtil.h
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 
+#include "core/CConcepts.h"
 #include "core/CGlobal.h"
 
 namespace CJsonUtil {
@@ -39,15 +40,15 @@ inline std::string preview_json(std::string text, size_t limit = 120) {
     return text.substr(0, limit) + "...";
 }
 
-template <typename T> bool hasStringProp(T object, std::string prop) {
+template <fn::JsonObjectPointer T> bool hasStringProp(T object, std::string prop) {
     return object->count(prop) && (*object)[prop].is_string();
 }
 
-template <typename T> bool hasObjectProp(T object, std::string prop) {
+template <fn::JsonObjectPointer T> bool hasObjectProp(T object, std::string prop) {
     return object->count(prop) && (*object)[prop].is_object();
 }
 
-template <typename T> bool isRef(T object) {
+template <fn::JsonObjectPointer T> bool isRef(T object) {
     if (object->size() == 1) {
         return hasStringProp(object, "ref");
     } else if (object->size() == 2) {
@@ -56,7 +57,7 @@ template <typename T> bool isRef(T object) {
     return false;
 }
 
-template <typename T> bool isType(T object) {
+template <fn::JsonObjectPointer T> bool isType(T object) {
     if (object->size() == 1) {
         return hasStringProp(object, "class");
     } else if (object->size() == 2) {
@@ -65,9 +66,9 @@ template <typename T> bool isType(T object) {
     return false;
 }
 
-template <typename T> bool isObject(T object) { return isRef(object) || isType(object); }
+template <fn::JsonObjectPointer T> bool isObject(T object) { return isRef(object) || isType(object); }
 
-template <typename T> bool isMap(T object) {
+template <fn::JsonMapPointer T> bool isMap(T object) {
     for (auto [key, value] : object->items()) {
         (void)key; // to silence compiler
         if (!value.is_object() || !isObject(&value)) {
@@ -89,7 +90,7 @@ std::shared_ptr<json> from_string(std::string json_string, const std::string &so
     //        vstd::logger::debug(json,reader.getFormatedErrorMessages());
 }
 
-template <typename T> std::string to_string(T value, int indent = -1) { return value->dump(indent); }
+template <fn::JsonDumpPointer T> std::string to_string(T value, int indent = -1) { return value->dump(indent); }
 
 inline std::shared_ptr<json> clone(const json &value) { return std::make_shared<json>(value); }
 

--- a/src/core/CPathFinder.cpp
+++ b/src/core/CPathFinder.cpp
@@ -50,7 +50,7 @@ struct NextStepNode {
 };
 
 struct AStarCompare {
-    template <typename Node> bool operator()(const Node &a, const Node &b) const {
+    template <fn::PriorityCostNode Node> bool operator()(const Node &a, const Node &b) const {
         if (a.priority == b.priority) {
             return a.cost > b.cost;
         }

--- a/src/core/CPathFinder.h
+++ b/src/core/CPathFinder.h
@@ -17,17 +17,18 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 
+#include "core/CConcepts.h"
 #include "core/CGlobal.h"
 #include "core/CUtil.h"
 
 class CCreature;
 
-template <typename CoordsLike> std::list<Coords> near_coords(const CoordsLike &coords) {
+template <fn::CoordsLike CoordsLike> std::list<Coords> near_coords(const CoordsLike &coords) {
     return {Coords(coords.x + 1, coords.y, coords.z), Coords(coords.x - 1, coords.y, coords.z),
             Coords(coords.x, coords.y + 1, coords.z), Coords(coords.x, coords.y - 1, coords.z)};
 }
 
-template <typename CoordsLike> std::list<Coords> near_coords_with(const CoordsLike &coords) {
+template <fn::CoordsLike CoordsLike> std::list<Coords> near_coords_with(const CoordsLike &coords) {
     return {Coords(coords.x, coords.y, coords.z), Coords(coords.x + 1, coords.y, coords.z),
             Coords(coords.x - 1, coords.y, coords.z), Coords(coords.x, coords.y + 1, coords.z),
             Coords(coords.x, coords.y - 1, coords.z)};

--- a/src/core/CScript.h
+++ b/src/core/CScript.h
@@ -20,22 +20,19 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CGameObject.h"
 
 class CScript : public CGameObject {
-  V_META(CScript, CGameObject,
-         V_PROPERTY(CScript, std::string, script, getScript, setScript))
-public:
-  template <typename T>
-  std::shared_ptr<T> invoke(std::shared_ptr<CGame> game,
-                            std::shared_ptr<CGameObject> self) {
-    return vstd::cast<T>(invoke(game, self));
-  }
+    V_META(CScript, CGameObject, V_PROPERTY(CScript, std::string, script, getScript, setScript))
+  public:
+    template <fn::GameObjectDerived T>
+    std::shared_ptr<T> invoke(std::shared_ptr<CGame> game, std::shared_ptr<CGameObject> self) {
+        return vstd::cast<T>(invoke(game, self));
+    }
 
-  std::shared_ptr<CGameObject> invoke(std::shared_ptr<CGame> game,
-                                      std::shared_ptr<CGameObject> self);
+    std::shared_ptr<CGameObject> invoke(std::shared_ptr<CGame> game, std::shared_ptr<CGameObject> self);
 
-  std::string getScript();
+    std::string getScript();
 
-  void setScript(std::string script);
+    void setScript(std::string script);
 
-private:
-  std::string script;
+  private:
+    std::string script;
 };

--- a/src/core/CSerialization.h
+++ b/src/core/CSerialization.h
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 
+#include "core/CConcepts.h"
 #include "core/CGlobal.h"
 
 class CGame;
@@ -37,39 +38,42 @@ class CSerializerBase {
 template <typename Serialized, typename Deserialized> class CSerializerFunction {
   public:
     template <typename T = Serialized, typename V = Deserialized>
-    static T serialize(V deserialized, typename std::enable_if<vstd::is_shared_ptr<V>::value>::type * = 0) {
+        requires fn::SharedPtr<V>
+    static T serialize(V deserialized) {
         return CSerializerFunction<T, std::shared_ptr<CGameObject>>::serialize(deserialized);
     }
 
     template <typename T = Serialized, typename V = Deserialized>
-    static V deserialize(std::shared_ptr<CGame> map, T serialized,
-                         typename std::enable_if<vstd::is_shared_ptr<V>::value>::type * = 0) {
+        requires fn::SharedPtr<V>
+    static V deserialize(std::shared_ptr<CGame> map, T serialized) {
         return std::dynamic_pointer_cast<typename V::element_type>(
             CSerializerFunction<T, std::shared_ptr<CGameObject>>::deserialize(map, serialized));
     }
 
     template <typename T = Serialized, typename V = Deserialized>
-    static T serialize(V deserialized, typename std::enable_if<vstd::is_set<V>::value>::type * = 0) {
+        requires fn::SetLike<V>
+    static T serialize(V deserialized) {
         return CSerializerFunction<T, std::set<std::shared_ptr<CGameObject>>>::serialize(
             vstd::cast<std::set<std::shared_ptr<CGameObject>>>(deserialized));
     }
 
     template <typename T = Serialized, typename V = Deserialized>
-    static V deserialize(std::shared_ptr<CGame> map, T serialized,
-                         typename std::enable_if<vstd::is_set<V>::value>::type * = 0) {
+        requires fn::SetLike<V>
+    static V deserialize(std::shared_ptr<CGame> map, T serialized) {
         return vstd::cast<V>(
             CSerializerFunction<T, std::set<std::shared_ptr<CGameObject>>>::deserialize(map, serialized));
     }
 
     template <typename T = Serialized, typename V = Deserialized>
-    static T serialize(V deserialized, typename std::enable_if<vstd::is_map<V>::value>::type * = 0) {
+        requires fn::MapLike<V>
+    static T serialize(V deserialized) {
         return CSerializerFunction<T, std::map<std::string, std::shared_ptr<CGameObject>>>::serialize(
             vstd::cast<std::map<std::string, std::shared_ptr<CGameObject>>>(deserialized));
     }
 
     template <typename T = Serialized, typename V = Deserialized>
-    static V deserialize(std::shared_ptr<CGame> map, T serialized,
-                         typename std::enable_if<vstd::is_map<V>::value>::type * = 0) {
+        requires fn::MapLike<V>
+    static V deserialize(std::shared_ptr<CGame> map, T serialized) {
         return vstd::cast<V>(
             CSerializerFunction<T, std::map<std::string, std::shared_ptr<CGameObject>>>::deserialize(map, serialized));
     }

--- a/src/core/CTags.h
+++ b/src/core/CTags.h
@@ -24,6 +24,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <string_view>
 #include <vector>
 
+#include "core/CConcepts.h"
+
 enum class CTag {
     Buff,
     Heal,
@@ -65,7 +67,7 @@ class CTags {
 
     static std::string_view toString(CTag tag);
 
-    template <typename Range> static bool isTagPresent(const Range &range, CTag tag) {
+    template <fn::TaggablePointerRange Range> static bool isTagPresent(const Range &range, CTag tag) {
         for (const auto &value : range) {
             if (value->hasTag(tag)) {
                 return true;

--- a/src/core/CTypes.h
+++ b/src/core/CTypes.h
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <stdexcept>
 
+#include "core/CConcepts.h"
 #include "core/CGlobal.h"
 #include "core/CSerialization.h"
 #include "object/CObject.h"
@@ -71,40 +72,41 @@ class CTypes {
             std::make_shared<CCustomSerializer<Serialized, Deserialized>>(serialize, deserialize);
     }
 
-    template <typename T> static void register_builder() {
+    template <fn::MetaRegisteredGameObject T> static void register_builder() {
         (*builders())[T::static_meta()->name()] = []() { return std::make_shared<T>(); };
     }
 
-    template <typename T> static void register_predicate() {}
+    template <fn::GameObjectDerived T> static void register_predicate() {}
 
-    template <typename T> static void register_supplier() {}
+    template <fn::GameObjectDerived T> static void register_supplier() {}
 
-    template <typename T> static void register_consumer() {}
+    template <fn::GameObjectDerived T> static void register_consumer() {}
 
-    template <typename T> static void register_pointer() {}
+    template <fn::GameObjectDerived T> static void register_pointer() {}
 
-    template <typename T> static void register_serializer() {
+    template <fn::GameObjectDerived T> static void register_serializer() {
         register_serializer<std::shared_ptr<json>, std::shared_ptr<T>>();
         register_serializer<std::shared_ptr<json>, std::set<std::shared_ptr<T>>>();
         register_serializer<std::shared_ptr<json>, std::map<std::string, std::shared_ptr<T>>>();
     }
 
-    template <typename T, typename U> static void register_cast() {}
+    template <fn::GameObjectDerived T, fn::GameObjectDerived U> static void register_cast() {}
 
-    template <typename T, typename U> static void register_any_cast() {
+    template <fn::GameObjectDerived T, fn::GameObjectDerived U> static void register_any_cast() {
         vstd::register_any_type<std::shared_ptr<T>, std::shared_ptr<U>>();
         vstd::register_any_type<std::set<std::shared_ptr<T>>, std::set<std::shared_ptr<U>>>();
         vstd::register_any_type<std::map<std::string, std::shared_ptr<T>>, std::map<std::string, std::shared_ptr<U>>>();
     }
 
-    template <typename T> static void register_derived_types() {
+    template <fn::GameObjectDerived T> static void register_derived_types() {
         pointer_types()->insert(vstd::type_id<std::shared_ptr<T>>());
         array_types()->insert(vstd::type_id<std::set<std::shared_ptr<T>>>());
         map_types()->insert(vstd::type_id<std::map<std::string, std::shared_ptr<T>>>());
     }
 
-    template <typename T, typename U, typename... Args> static void register_type() {
-        static_assert(vstd::is_base_of<U, T>::value && !vstd::is_same<T, U>::value, "invalid base class");
+    template <fn::MetaRegisteredGameObject T, fn::GameObjectDerived U, fn::GameObjectDerived... Args>
+    static void register_type() {
+        static_assert(std::derived_from<T, U> && !std::same_as<T, U>, "invalid base class");
         register_type<T>();
         register_any_cast<T, U>();
         register_any_cast<U, T>();
@@ -112,7 +114,7 @@ class CTypes {
         register_type<T, Args...>();
     }
 
-    template <typename T> static void register_type() {
+    template <fn::MetaRegisteredGameObject T> static void register_type() {
         register_serializer<T>();
         register_builder<T>();
         register_consumer<T>();

--- a/src/core/CUtil.h
+++ b/src/core/CUtil.h
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 
+#include "core/CConcepts.h"
 #include "core/CGlobal.h"
 
 class CGameObject;
@@ -72,7 +73,7 @@ class CUtil {
 
     static Coords::Direction getDirection(Coords coords);
 
-    template <typename Predicate> static std::set<std::string> findFiles(std::string dir, Predicate pred) {
+    template <fn::FilePredicate Predicate> static std::set<std::string> findFiles(std::string dir, Predicate pred) {
         std::set<std::string> retValue;
         std::filesystem::directory_iterator iterator(dir), end;
         while (iterator != end) {
@@ -103,11 +104,7 @@ namespace vstd {
 template <> std::string str(Coords coords);
 }
 
-template <typename F>
-auto sdl_safe(
-    F f,
-    typename vstd::disable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, int>::value>::type * = 0,
-    typename vstd::disable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, void>::value>::type * = 0) {
+template <fn::SdlNullableCallable F> auto sdl_safe(F f) {
     auto return_value = f();
     if (!return_value) {
         vstd::logger::error(SDL_GetError());
@@ -115,11 +112,7 @@ auto sdl_safe(
     return return_value;
 }
 
-template <typename F>
-auto sdl_safe(
-    F f,
-    typename vstd::enable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, int>::value>::type * = 0,
-    typename vstd::disable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, void>::value>::type * = 0) {
+template <fn::SdlStatusCallable F> auto sdl_safe(F f) {
     auto return_value = f();
     if (return_value == -1) {
         vstd::logger::error(SDL_GetError());
@@ -127,13 +120,7 @@ auto sdl_safe(
     return return_value;
 }
 
-template <typename F>
-void sdl_safe(
-    F f,
-    typename vstd::disable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, int>::value>::type * = 0,
-    typename vstd::enable_if<vstd::is_same<typename vstd::function_traits<F>::return_type, void>::value>::type * = 0) {
-    f();
-}
+template <fn::SdlVoidCallable F> void sdl_safe(F f) { f(); }
 
 #define SDL_SAFE(x) sdl_safe([&]() { return x; })
 

--- a/src/core/CWrapper.h
+++ b/src/core/CWrapper.h
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 
+#include "core/CConcepts.h"
 #include "core/CGlobal.h"
 #include "core/CPlugin.h"
 #include "object/CDialog.h"
@@ -24,240 +25,238 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace py = pybind11;
 
-template <class T> class CWrapper : public T {
-  V_META(CWrapper<T>, T, vstd::meta::empty())
+template <fn::PythonWrapperBase T> class CWrapper : public T {
+    V_META(CWrapper<T>, T, vstd::meta::empty())
 
-public:
-  using T::T;
+  public:
+    using T::T;
 
-  void onEnter(std::shared_ptr<CGameEvent> event) override final {
-    try {
-      PYBIND11_OVERRIDE(void, T, onEnter, event);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void onEnter(std::shared_ptr<CGameEvent> event) override final {
+        try {
+            PYBIND11_OVERRIDE(void, T, onEnter, event);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 
-  void onTurn(std::shared_ptr<CGameEvent> event) override final {
-    try {
-      PYBIND11_OVERRIDE(void, T, onTurn, event);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void onTurn(std::shared_ptr<CGameEvent> event) override final {
+        try {
+            PYBIND11_OVERRIDE(void, T, onTurn, event);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 
-  void onCreate(std::shared_ptr<CGameEvent> event) override final {
-    try {
-      PYBIND11_OVERRIDE(void, T, onCreate, event);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void onCreate(std::shared_ptr<CGameEvent> event) override final {
+        try {
+            PYBIND11_OVERRIDE(void, T, onCreate, event);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 
-  void onDestroy(std::shared_ptr<CGameEvent> event) override final {
-    try {
-      PYBIND11_OVERRIDE(void, T, onDestroy, event);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void onDestroy(std::shared_ptr<CGameEvent> event) override final {
+        try {
+            PYBIND11_OVERRIDE(void, T, onDestroy, event);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 
-  void onLeave(std::shared_ptr<CGameEvent> event) override final {
-    try {
-      PYBIND11_OVERRIDE(void, T, onLeave, event);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void onLeave(std::shared_ptr<CGameEvent> event) override final {
+        try {
+            PYBIND11_OVERRIDE(void, T, onLeave, event);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 };
 
 template <> class CWrapper<CInteraction> : public CInteraction {
-  V_META(CWrapper<T>, CInteraction, vstd::meta::empty())
+    V_META(CWrapper<T>, CInteraction, vstd::meta::empty())
 
-public:
-  using CInteraction::CInteraction;
+  public:
+    using CInteraction::CInteraction;
 
-  void performAction(std::shared_ptr<CCreature> first,
-                     std::shared_ptr<CCreature> second) override final {
-    try {
-      PYBIND11_OVERRIDE(void, CInteraction, performAction, first, second);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void performAction(std::shared_ptr<CCreature> first, std::shared_ptr<CCreature> second) override final {
+        try {
+            PYBIND11_OVERRIDE(void, CInteraction, performAction, first, second);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 
-  bool configureEffect(std::shared_ptr<CEffect> effect) override final {
-    try {
-      PYBIND11_OVERRIDE(bool, CInteraction, configureEffect, effect);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
-      return false;
+    bool configureEffect(std::shared_ptr<CEffect> effect) override final {
+        try {
+            PYBIND11_OVERRIDE(bool, CInteraction, configureEffect, effect);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+            return false;
+        }
     }
-  }
 };
 
 template <> class CWrapper<CEffect> : public CEffect {
-  V_META(CWrapper<T>, CEffect, vstd::meta::empty())
+    V_META(CWrapper<T>, CEffect, vstd::meta::empty())
 
-public:
-  using CEffect::CEffect;
+  public:
+    using CEffect::CEffect;
 
-  void onEffect() override final {
-    try {
-      PYBIND11_OVERRIDE(void, CEffect, onEffect);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void onEffect() override final {
+        try {
+            PYBIND11_OVERRIDE(void, CEffect, onEffect);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 };
 
 template <> class CWrapper<CTile> : public CTile {
-  V_META(CWrapper<T>, CTile, vstd::meta::empty())
+    V_META(CWrapper<T>, CTile, vstd::meta::empty())
 
-public:
-  using CTile::CTile;
+  public:
+    using CTile::CTile;
 
-  void onStep(std::shared_ptr<CCreature> creature) override final {
-    try {
-      PYBIND11_OVERRIDE(void, CTile, onStep, creature);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void onStep(std::shared_ptr<CCreature> creature) override final {
+        try {
+            PYBIND11_OVERRIDE(void, CTile, onStep, creature);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 };
 
 template <> class CWrapper<CPotion> : public CPotion {
-  V_META(CWrapper<T>, CPotion, vstd::meta::empty())
+    V_META(CWrapper<T>, CPotion, vstd::meta::empty())
 
-public:
-  using CPotion::CPotion;
+  public:
+    using CPotion::CPotion;
 
-  void onUse(std::shared_ptr<CGameEvent> event) override final {
-    try {
-      PYBIND11_OVERRIDE(void, CPotion, onUse, event);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void onUse(std::shared_ptr<CGameEvent> event) override final {
+        try {
+            PYBIND11_OVERRIDE(void, CPotion, onUse, event);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 };
 
 template <> class CWrapper<CScroll> : public CScroll {
-  V_META(CWrapper<T>, CScroll, vstd::meta::empty())
+    V_META(CWrapper<T>, CScroll, vstd::meta::empty())
 
-public:
-  using CScroll::CScroll;
+  public:
+    using CScroll::CScroll;
 
-  void onUse(std::shared_ptr<CGameEvent> event) override final {
-    try {
-      PYBIND11_OVERRIDE(void, CScroll, onUse, event);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void onUse(std::shared_ptr<CGameEvent> event) override final {
+        try {
+            PYBIND11_OVERRIDE(void, CScroll, onUse, event);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 
-  bool isDisposable() override final {
-    try {
-      PYBIND11_OVERRIDE(bool, CScroll, isDisposable);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
-      return false;
+    bool isDisposable() override final {
+        try {
+            PYBIND11_OVERRIDE(bool, CScroll, isDisposable);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+            return false;
+        }
     }
-  }
 };
 
 template <> class CWrapper<CTrigger> : public CTrigger {
-  V_META(CWrapper<T>, CTrigger, vstd::meta::empty())
+    V_META(CWrapper<T>, CTrigger, vstd::meta::empty())
 
-public:
-  using CTrigger::CTrigger;
+  public:
+    using CTrigger::CTrigger;
 
-  void trigger(std::shared_ptr<CGameObject> object,
-               std::shared_ptr<CGameEvent> event) override final {
-    try {
-      PYBIND11_OVERRIDE(void, CTrigger, trigger, object, event);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void trigger(std::shared_ptr<CGameObject> object, std::shared_ptr<CGameEvent> event) override final {
+        try {
+            PYBIND11_OVERRIDE(void, CTrigger, trigger, object, event);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 };
 
 template <> class CWrapper<CQuest> : public CQuest {
-  V_META(CWrapper<T>, CQuest, vstd::meta::empty())
+    V_META(CWrapper<T>, CQuest, vstd::meta::empty())
 
-public:
-  using CQuest::CQuest;
+  public:
+    using CQuest::CQuest;
 
-  bool isCompleted() override final {
-    try {
-      PYBIND11_OVERRIDE(bool, CQuest, isCompleted);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
-      return false;
+    bool isCompleted() override final {
+        try {
+            PYBIND11_OVERRIDE(bool, CQuest, isCompleted);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+            return false;
+        }
     }
-  }
 
-  void onComplete() override final {
-    try {
-      PYBIND11_OVERRIDE(void, CQuest, onComplete);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void onComplete() override final {
+        try {
+            PYBIND11_OVERRIDE(void, CQuest, onComplete);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 };
 
 template <> class CWrapper<CPlugin> : public CPlugin {
-  V_META(CWrapper<T>, CPlugin, vstd::meta::empty())
+    V_META(CWrapper<T>, CPlugin, vstd::meta::empty())
 
-public:
-  using CPlugin::CPlugin;
+  public:
+    using CPlugin::CPlugin;
 
-  void load(std::shared_ptr<CGame> game) override final {
-    try {
-      PYBIND11_OVERRIDE(void, CPlugin, load, game);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void load(std::shared_ptr<CGame> game) override final {
+        try {
+            PYBIND11_OVERRIDE(void, CPlugin, load, game);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 };
 
 template <> class CWrapper<CDialog> : public CDialog {
-  V_META(CWrapper<T>, CDialog, vstd::meta::empty())
+    V_META(CWrapper<T>, CDialog, vstd::meta::empty())
 
-public:
-  using CDialog::CDialog;
+  public:
+    using CDialog::CDialog;
 
-  void invokeAction(std::string action) override final {
-    try {
-      PYBIND11_OVERRIDE(void, CDialog, invokeAction, action);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
+    void invokeAction(std::string action) override final {
+        try {
+            PYBIND11_OVERRIDE(void, CDialog, invokeAction, action);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+        }
     }
-  }
 
-  bool invokeCondition(std::string condition) override final {
-    try {
-      PYBIND11_OVERRIDE(bool, CDialog, invokeCondition, condition);
-    } catch (const py::error_already_set &) {
-      PYTHON_LOG;
-      PyErr_Clear();
-      return true;
+    bool invokeCondition(std::string condition) override final {
+        try {
+            PYBIND11_OVERRIDE(bool, CDialog, invokeCondition, condition);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+            return true;
+        }
     }
-  }
 };

--- a/src/gui/CAnimation.h
+++ b/src/gui/CAnimation.h
@@ -36,7 +36,7 @@ class CAnimation : public CGameGraphicsObject {
 
     bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int button, int x, int y) override;
 
-    template <typename F> auto withCallback(F f) {
+    template <fn::AnimationCallback F> auto withCallback(F f) {
         callback = f;
         hasCallback = true;
         return this->ptr<CAnimation>();

--- a/src/handler/CObjectHandler.h
+++ b/src/handler/CObjectHandler.h
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 
+#include "core/CConcepts.h"
 #include "core/CGlobal.h"
 #include "core/CUtil.h"
 
@@ -26,52 +27,47 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 class CMap;
 
 class CObjectHandler : public CGameObject {
-public:
-  CObjectHandler();
+  public:
+    CObjectHandler();
 
-  template <typename T = CGameObject>
-  std::shared_ptr<T> createObject(std::shared_ptr<CGame> game,
-                                  std::string type) {
-    return vstd::cast<T>(_createObject(game, type));
-  }
+    template <fn::GameObjectDerived T = CGameObject>
+    std::shared_ptr<T> createObject(std::shared_ptr<CGame> game, std::string type) {
+        return vstd::cast<T>(_createObject(game, type));
+    }
 
-  template <typename T = CGameObject>
-  std::shared_ptr<T> createObject(std::shared_ptr<CGame> game) {
-    return vstd::cast<T>(_createObject(game, T::static_meta()->name()));
-  }
+    template <fn::MetaRegisteredGameObject T = CGameObject>
+    std::shared_ptr<T> createObject(std::shared_ptr<CGame> game) {
+        return vstd::cast<T>(_createObject(game, T::static_meta()->name()));
+    }
 
-  template <typename T> std::shared_ptr<T> clone(std::shared_ptr<T> object) {
-    return vstd::cast<T>(_clone(object));
-  }
+    template <fn::GameObjectDerived T> std::shared_ptr<T> clone(std::shared_ptr<T> object) {
+        return vstd::cast<T>(_clone(object));
+    }
 
-  std::vector<std::string> getAllTypes();
+    std::vector<std::string> getAllTypes();
 
-  std::vector<std::string> getAllSubTypes(const std::string &claz);
+    std::vector<std::string> getAllSubTypes(const std::string &claz);
 
-  void registerConfig(const std::string &path);
+    void registerConfig(const std::string &path);
 
-  void registerConfig(const std::string &name, std::shared_ptr<json> value);
+    void registerConfig(const std::string &name, std::shared_ptr<json> value);
 
-  void registerConfig(const std::set<std::string> &paths);
+    void registerConfig(const std::set<std::string> &paths);
 
-  void registerType(std::string name,
-                    std::function<std::shared_ptr<CGameObject>()> constructor);
+    void registerType(std::string name, std::function<std::shared_ptr<CGameObject>()> constructor);
 
-  std::shared_ptr<CGameObject> getType(const std::string &name);
+    std::shared_ptr<CGameObject> getType(const std::string &name);
 
-  std::shared_ptr<json> getConfig(const std::string &type);
+    std::shared_ptr<json> getConfig(const std::string &type);
 
-  std::string getClass(const std::string &type);
+    std::string getClass(const std::string &type);
 
-private:
-  std::shared_ptr<CGameObject> _createObject(std::shared_ptr<CGame> map,
-                                             const std::string &type);
+  private:
+    std::shared_ptr<CGameObject> _createObject(std::shared_ptr<CGame> map, const std::string &type);
 
-  std::shared_ptr<CGameObject>
-  _clone(const std::shared_ptr<CGameObject> &object);
+    std::shared_ptr<CGameObject> _clone(const std::shared_ptr<CGameObject> &object);
 
-  std::unordered_map<std::string, std::function<std::shared_ptr<CGameObject>()>>
-      constructors;
+    std::unordered_map<std::string, std::function<std::shared_ptr<CGameObject>()>> constructors;
 
-  std::unordered_map<std::string, std::shared_ptr<json>> objectConfig;
+    std::unordered_map<std::string, std::shared_ptr<json>> objectConfig;
 };

--- a/src/handler/CScriptHandler.h
+++ b/src/handler/CScriptHandler.h
@@ -17,106 +17,98 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 
+#include "core/CConcepts.h"
 #include "core/CGlobal.h"
 #include "core/CUtil.h"
 #include <utility>
 
-template <typename Ret, typename... Args> struct wrap {
-  static std::function<Ret(Args...)> call(pybind11::object func) {
-    return [func](Args... args) -> Ret {
-      try {
-        pybind11::object ret = func(std::forward<Args>(args)...);
-        return ret.cast<Ret>();
-      } catch (...) {
-        PYTHON_LOG;
-        PyErr_Clear();
-        return Ret();
-      }
-    };
-  }
+template <fn::PythonReturn Ret, typename... Args> struct wrap {
+    static std::function<Ret(Args...)> call(pybind11::object func) {
+        return [func](Args... args) -> Ret {
+            try {
+                pybind11::object ret = func(std::forward<Args>(args)...);
+                return ret.cast<Ret>();
+            } catch (...) {
+                PYTHON_LOG;
+                PyErr_Clear();
+                return Ret();
+            }
+        };
+    }
 };
 
 template <typename... Args> struct wrap<void, Args...> {
-  static std::function<void(Args...)> call(pybind11::object func) {
-    return [func](Args... args) {
-      PY_SAFE(func(std::forward<Args>(args)...));
-    };
-  }
+    static std::function<void(Args...)> call(pybind11::object func) {
+        return [func](Args... args) { PY_SAFE(func(std::forward<Args>(args)...)); };
+    }
 };
 
 class CScriptHandler {
-public:
-  CScriptHandler();
+  public:
+    CScriptHandler();
 
-  ~CScriptHandler();
+    ~CScriptHandler();
 
-  void
-  execute_script(std::string script,
-                 pybind11::object name_space = pybind11::none());
+    void execute_script(std::string script, pybind11::object name_space = pybind11::none());
 
-  void execute_command(std::initializer_list<std::string> list);
+    void execute_command(std::initializer_list<std::string> list);
 
-  std::string build_command(std::initializer_list<std::string> list);
+    std::string build_command(std::initializer_list<std::string> list);
 
-  void add_function(std::string function_name, std::string function_code,
-                    std::initializer_list<std::string> args);
+    void add_function(std::string function_name, std::string function_code, std::initializer_list<std::string> args);
 
-  void add_class(std::string class_name, std::string function_code,
-                 std::initializer_list<std::string> args);
+    void add_class(std::string class_name, std::string function_code, std::initializer_list<std::string> args);
 
-  std::string add_class(std::string function_code,
-                        std::initializer_list<std::string> args);
+    std::string add_class(std::string function_code, std::initializer_list<std::string> args);
 
-  void import(std::string name);
+    void import(std::string name);
 
-  template <typename Ret = void, typename... Args>
-  std::function<Ret(Args...)> get_function(std::string functionName) {
-    return wrap<Ret, Args...>::call(get_object(functionName));
-  }
+    template <typename Ret = void, typename... Args>
+        requires fn::PythonReturn<Ret>
+    std::function<Ret(Args...)> get_function(std::string functionName) {
+        return wrap<Ret, Args...>::call(get_object(functionName));
+    }
 
-  template <typename Ret = void, typename... Args>
-  std::function<Ret(Args...)>
-  create_function(std::string functionName, std::string functionCode,
-                  std::initializer_list<std::string> args) {
-    vstd::fail_if(sizeof...(Args) != args.size(), "Wrong argument list!");
-    add_function(functionName, functionCode, args);
-    return get_function<Ret, Args...>(functionName);
-  }
+    template <typename Ret = void, typename... Args>
+        requires fn::PythonReturn<Ret>
+    std::function<Ret(Args...)> create_function(std::string functionName, std::string functionCode,
+                                                std::initializer_list<std::string> args) {
+        vstd::fail_if(sizeof...(Args) != args.size(), "Wrong argument list!");
+        add_function(functionName, functionCode, args);
+        return get_function<Ret, Args...>(functionName);
+    }
 
-  template <typename Ret = void, typename... Args>
-  Ret call_function(std::string name, Args... params) {
-    return get_function<Ret, Args...>(name)(params...);
-  }
+    template <typename Ret = void, typename... Args>
+        requires fn::PythonReturn<Ret>
+    Ret call_function(std::string name, Args... params) {
+        return get_function<Ret, Args...>(name)(params...);
+    }
 
-  template <typename Ret, typename... Args>
-  Ret call_created_function(std::string function_code,
-                            std::initializer_list<std::string> args,
-                            Args... params) {
-    std::string name = "FUNC" + vstd::to_hex_hash<std::string>(function_code);
-    Ret res =
-        create_function<Ret, Args...>(name, function_code, args)(params...);
-    execute_script("del " + name);
-    return res;
-  }
+    template <typename Ret, typename... Args>
+        requires(!std::same_as<Ret, void> && fn::PythonReturn<Ret>)
+    Ret call_created_function(std::string function_code, std::initializer_list<std::string> args, Args... params) {
+        std::string name = "FUNC" + vstd::to_hex_hash<std::string>(function_code);
+        Ret res = create_function<Ret, Args...>(name, function_code, args)(params...);
+        execute_script("del " + name);
+        return res;
+    }
 
-  template <typename... Args>
-  void call_created_function(std::string function_code,
-                             std::initializer_list<std::string> args,
-                             Args... params) {
-    std::string name = "FUNC" + vstd::to_hex_hash<std::string>(function_code);
-    create_function<void, Args...>(name, function_code, args)(params...);
-    execute_script("del " + name);
-  }
+    template <typename... Args>
+    void call_created_function(std::string function_code, std::initializer_list<std::string> args, Args... params) {
+        std::string name = "FUNC" + vstd::to_hex_hash<std::string>(function_code);
+        create_function<void, Args...>(name, function_code, args)(params...);
+        execute_script("del " + name);
+    }
 
-  template <typename T = pybind11::object> T get_object(std::string name) {
-    execute_script(vstd::join({"__tmp__", name}, "="));
-    pybind11::object object = main_namespace["__tmp__"];
-    T t = object.cast<T>();
-    execute_script("del __tmp__");
-    return t;
-  }
+    template <typename T = pybind11::object> T get_object(std::string name) {
+        execute_script(vstd::join({"__tmp__", name}, "="));
+        pybind11::object object = main_namespace["__tmp__"];
+        T t = object.cast<T>();
+        execute_script("del __tmp__");
+        return t;
+    }
 
-private:
-  pybind11::object main_module;
-  pybind11::dict main_namespace;
+  private:
+    pybind11::object main_module;
+    pybind11::dict main_namespace;
 };

--- a/src/object/CGameObject.h
+++ b/src/object/CGameObject.h
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 
+#include "core/CConcepts.h"
 #include "core/CTags.h"
 #include "core/CGlobal.h"
 #include "core/CUtil.h"
@@ -52,7 +53,7 @@ class CGameObject : public vstd::stringable, public std::enable_shared_from_this
 
     void setGame(std::shared_ptr<CGame> game);
 
-    template <typename T = CGameObject> std::shared_ptr<T> ptr() {
+    template <fn::GameObjectDerived T = CGameObject> std::shared_ptr<T> ptr() {
         //_cast purposedly
         return vstd::cast<T>(const_cast<CGameObject *>(this)->shared_from_this());
     }
@@ -79,15 +80,16 @@ class CGameObject : public vstd::stringable, public std::enable_shared_from_this
 
     int getNumericProperty(std::string name);
 
-    template <typename T = CGameObject> void setObjectProperty(std::string name, std::shared_ptr<T> object) {
+    template <fn::GameObjectDerived T = CGameObject>
+    void setObjectProperty(std::string name, std::shared_ptr<T> object) {
         setProperty(name, std::any(object));
     }
 
-    template <typename T = CGameObject> std::shared_ptr<T> getObjectProperty(std::string name) {
+    template <fn::GameObjectDerived T = CGameObject> std::shared_ptr<T> getObjectProperty(std::string name) {
         return getProperty<std::shared_ptr<T>>(name);
     }
 
-    template <typename T = CGameObject> std::shared_ptr<T> clone() { return vstd::cast<T>(_clone()); }
+    template <fn::GameObjectDerived T = CGameObject> std::shared_ptr<T> clone() { return vstd::cast<T>(_clone()); }
 
     void incProperty(std::string name, int value);
 

--- a/src/object/CTrigger.h
+++ b/src/object/CTrigger.h
@@ -20,43 +20,38 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CGameObject.h"
 
 class CTrigger : public CGameObject {
-  V_META(CTrigger, CGameObject,
-         V_PROPERTY(CTrigger, std::string, object, getObject, setObject),
-         V_PROPERTY(CTrigger, std::string, event, getEvent, setEvent))
-public:
-  CTrigger();
+    V_META(CTrigger, CGameObject, V_PROPERTY(CTrigger, std::string, object, getObject, setObject),
+           V_PROPERTY(CTrigger, std::string, event, getEvent, setEvent))
+  public:
+    CTrigger();
 
-  virtual void trigger(std::shared_ptr<CGameObject>,
-                       std::shared_ptr<CGameEvent>);
+    virtual void trigger(std::shared_ptr<CGameObject>, std::shared_ptr<CGameEvent>);
 
-private:
-  std::string object;
-  std::string event;
+  private:
+    std::string object;
+    std::string event;
 
-public:
-  std::string getObject();
+  public:
+    std::string getObject();
 
-  void setObject(std::string object);
+    void setObject(std::string object);
 
-  std::string getEvent();
+    std::string getEvent();
 
-  void setEvent(std::string event);
+    void setEvent(std::string event);
 };
 
 class CCustomTrigger : public CTrigger {
-  V_META(CCustomTrigger, CTrigger, vstd::meta::empty())
+    V_META(CCustomTrigger, CTrigger, vstd::meta::empty())
 
-  std::function<void(std::shared_ptr<CGameObject>, std::shared_ptr<CGameEvent>)>
-      _trigger;
+    std::function<void(std::shared_ptr<CGameObject>, std::shared_ptr<CGameEvent>)> _trigger;
 
-public:
-  template <typename T>
-  CCustomTrigger(std::string object, std::string event, T __trigger)
-      : _trigger(__trigger) {
-    setObject(object);
-    setEvent(event);
-  }
+  public:
+    template <fn::TriggerCallback T>
+    CCustomTrigger(std::string object, std::string event, T __trigger) : _trigger(__trigger) {
+        setObject(object);
+        setEvent(event);
+    }
 
-  void trigger(std::shared_ptr<CGameObject> object,
-               std::shared_ptr<CGameEvent> event) override;
+    void trigger(std::shared_ptr<CGameObject> object, std::shared_ptr<CGameEvent> event) override;
 };

--- a/test.py
+++ b/test.py
@@ -4205,6 +4205,9 @@ class GameTest(unittest.TestCase):
             return False, json.dumps({"error": "black executable is required to enforce formatting policy"})
 
         python_files = [str(path.relative_to(REPO_ROOT)) for path in iter_python_source_files()]
+        if not python_files:
+            return True, json.dumps({"checked_files": [], "skipped": "no changed Python files"}, sort_keys=True)
+
         return_code, output, errors = run_command(["black", "--check", "-l", "120", *python_files])
         log = {"command": "black --check -l 120", "stdout": output, "stderr": errors, "checked_files": python_files}
         return return_code == 0, json.dumps(log, indent=2, sort_keys=True)


### PR DESCRIPTION
## What changed
- Added `src/core/CConcepts.h` with shared C++20 concepts for object registration, serialization containers, JSON helpers, pathfinding coordinate-like values, SDL-safe callables, callbacks, and Python wrapper returns.
- Replaced several template/SFINAE constraints with concepts across core serialization, type registration, object creation, wrappers, callbacks, JSON utilities, tags, and pathfinding helpers.
- Updated the Python formatting test to skip cleanly when no Python files are present in the changed-file set.

## Why
Concepts make these template APIs fail earlier with clearer diagnostics and document the structural requirements at the call site.

## Validation
- `clang-format -i` on modified C++ files
- `black -l 120 test.py`
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` passed
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` passed
- `python3 test.py GameTest.test_python_black_formatting` passed
- `python3 test.py` passed: 97 tests
- `./scripts/run_coverage.sh` ran the tests successfully but failed the repository coverage gate: line coverage `53.5%` vs required `80.0%`

## Known limitations
- The branch leaves the existing superproject-pinned `rdg` and `vstd` submodule commits unchanged. I fetched and tested their latest `origin/main` tips, but that combination does not build: latest `rdg` calls `rdg::create_dungeon` with `vstd::rng()`, while latest `vstd::rng()` returns `std::mt19937_64` and `rdg` expects `std::mt19937`; latest `vstd` also changes helper return semantics used by the project.