### PR TITLE
Add test progress and coverage phase logging

### DIFF
--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -5,8 +5,39 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${BUILD_DIR:-cmake-build-coverage}"
 MIN_COVERAGE="${MIN_COVERAGE:-80}"
 REPORT_DIR="${ROOT_DIR}/coverage"
+SCRIPT_START=${SECONDS}
 
 cd "${ROOT_DIR}"
+
+format_duration() {
+    local elapsed="$1"
+    printf "%02d:%02d:%02d" $((elapsed / 3600)) $(((elapsed % 3600) / 60)) $((elapsed % 60))
+}
+
+log_phase() {
+    printf "[coverage %s] %s\n" "$(date "+%H:%M:%S")" "$*"
+}
+
+run_phase() {
+    local name="$1"
+    shift
+    local phase_start=${SECONDS}
+    local status=0
+
+    log_phase "START ${name}"
+    set +e
+    "$@"
+    status=$?
+    set -e
+
+    local elapsed=$((SECONDS - phase_start))
+    if [[ "${status}" -eq 0 ]]; then
+        log_phase "DONE ${name} ($(format_duration "${elapsed}"))"
+    else
+        log_phase "FAIL ${name} ($(format_duration "${elapsed}"), exit ${status})"
+    fi
+    return "${status}"
+}
 
 cmake_args=(
     --fresh
@@ -18,47 +49,50 @@ cmake_args=(
     -DCMAKE_SHARED_LINKER_FLAGS=--coverage
 )
 
-cmake "${cmake_args[@]}"
+generate_report() {
+    mkdir -p "${REPORT_DIR}" || return
 
-cmake --build "${BUILD_DIR}" --target _game for_unit_tests -j"$(nproc)"
+    if command -v gcovr >/dev/null 2>&1; then
+        # gcov can emit negative branch counts for some files; keep reporting and the line gate intact.
+        gcovr \
+            --root "${ROOT_DIR}" \
+            --object-directory "${BUILD_DIR}" \
+            --gcov-ignore-errors source_not_found --gcov-ignore-errors no_working_dir_found \
+            --gcov-ignore-parse-errors negative_hits.warn_once_per_file \
+            --filter "${ROOT_DIR}/src/core" \
+            --filter "${ROOT_DIR}/src/handler" \
+            --filter "${ROOT_DIR}/src/object" \
+            --exclude "${ROOT_DIR}/src/gui" \
+            --exclude "${ROOT_DIR}/vstd" \
+            --exclude "${ROOT_DIR}/random-dungeon-generator" \
+            --exclude "${ROOT_DIR}/src/core/CModule.cpp" \
+            --exclude "${ROOT_DIR}/src/core/CWrapper.h" \
+            --exclude "${ROOT_DIR}/src/core/CTypes.cpp" \
+            --exclude "${ROOT_DIR}/src/core/CTypes.h" \
+            --exclude "${ROOT_DIR}/src/core/CJsonUtil.h" \
+            --exclude "${ROOT_DIR}/cmake-build.*" \
+            --exclude "${ROOT_DIR}/build.*" \
+            --exclude "${ROOT_DIR}/package.*" \
+            --print-summary \
+            --txt "${REPORT_DIR}/coverage.txt" \
+            --html-details "${REPORT_DIR}/coverage.html" \
+            --fail-under-line "${MIN_COVERAGE}" || return
+    else
+        python3 "${ROOT_DIR}/scripts/coverage_report.py" \
+            --root "${ROOT_DIR}" \
+            --build-dir "${BUILD_DIR}" \
+            --report-dir "${REPORT_DIR}" \
+            --min-line "${MIN_COVERAGE}" || return
+    fi
+}
 
-find "${BUILD_DIR}" -name '*.gcda' -delete
-ctest --test-dir "${BUILD_DIR}" --output-on-failure
-GAME_BUILD_DIR="${BUILD_DIR}" python3 test.py
+run_phase "configure" cmake "${cmake_args[@]}"
+run_phase "build _game and for_unit_tests" cmake --build "${BUILD_DIR}" --target _game for_unit_tests -j"$(nproc)"
+run_phase "coverage data cleanup" find "${BUILD_DIR}" -name '*.gcda' -delete
+run_phase "ctest" ctest --test-dir "${BUILD_DIR}" --output-on-failure
+run_phase "python test suite" env GAME_BUILD_DIR="${BUILD_DIR}" python3 test.py
+run_phase "report generation" generate_report
 
-mkdir -p "${REPORT_DIR}"
-
-if command -v gcovr >/dev/null 2>&1; then
-    # gcov can emit negative branch counts for some files; keep reporting and the line gate intact.
-    gcovr \
-        --root "${ROOT_DIR}" \
-        --object-directory "${BUILD_DIR}" \
-        --gcov-ignore-errors source_not_found --gcov-ignore-errors no_working_dir_found \
-        --gcov-ignore-parse-errors negative_hits.warn_once_per_file \
-        --filter "${ROOT_DIR}/src/core" \
-        --filter "${ROOT_DIR}/src/handler" \
-        --filter "${ROOT_DIR}/src/object" \
-        --exclude "${ROOT_DIR}/src/gui" \
-        --exclude "${ROOT_DIR}/vstd" \
-        --exclude "${ROOT_DIR}/random-dungeon-generator" \
-        --exclude "${ROOT_DIR}/src/core/CModule.cpp" \
-        --exclude "${ROOT_DIR}/src/core/CWrapper.h" \
-        --exclude "${ROOT_DIR}/src/core/CTypes.cpp" \
-        --exclude "${ROOT_DIR}/src/core/CTypes.h" \
-        --exclude "${ROOT_DIR}/src/core/CJsonUtil.h" \
-        --exclude "${ROOT_DIR}/cmake-build.*" \
-        --exclude "${ROOT_DIR}/build.*" \
-        --exclude "${ROOT_DIR}/package.*" \
-        --print-summary \
-        --txt "${REPORT_DIR}/coverage.txt" \
-        --html-details "${REPORT_DIR}/coverage.html" \
-        --fail-under-line "${MIN_COVERAGE}"
-else
-    python3 "${ROOT_DIR}/scripts/coverage_report.py" \
-        --root "${ROOT_DIR}" \
-        --build-dir "${BUILD_DIR}" \
-        --report-dir "${REPORT_DIR}" \
-        --min-line "${MIN_COVERAGE}"
-fi
-
+total_elapsed=$((SECONDS - SCRIPT_START))
 echo "Coverage reports written to ${REPORT_DIR}/coverage.txt and ${REPORT_DIR}/coverage.html"
+log_phase "TOTAL $(format_duration "${total_elapsed}")"

--- a/test.py
+++ b/test.py
@@ -84,6 +84,80 @@ except Exception:
 MCP_PROTOCOL_VERSION = "2025-11-25"
 
 
+class ProgressTextTestResult(unittest.TextTestResult):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.showAll = False
+        self.dots = False
+        self.total_tests = 0
+        self.test_index = 0
+        self._test_start_times = {}
+
+    def startTest(self, test):
+        self.test_index += 1
+        self._test_start_times[id(test)] = time.monotonic()
+        self._write_progress(test, "start")
+        super().startTest(test)
+
+    def addSuccess(self, test):
+        unittest.TestResult.addSuccess(self, test)
+        self._write_progress(test, "ok", self._duration(test))
+
+    def addFailure(self, test, err):
+        unittest.TestResult.addFailure(self, test, err)
+        self._write_progress(test, "FAIL", self._duration(test))
+
+    def addError(self, test, err):
+        unittest.TestResult.addError(self, test, err)
+        self._write_progress(test, "ERROR", self._duration(test))
+
+    def addSkip(self, test, reason):
+        unittest.TestResult.addSkip(self, test, reason)
+        self._write_progress(test, "skip", self._duration(test), reason)
+
+    def addExpectedFailure(self, test, err):
+        unittest.TestResult.addExpectedFailure(self, test, err)
+        self._write_progress(test, "expected-failure", self._duration(test))
+
+    def addUnexpectedSuccess(self, test):
+        unittest.TestResult.addUnexpectedSuccess(self, test)
+        self._write_progress(test, "UNEXPECTED-SUCCESS", self._duration(test))
+
+    def _duration(self, test):
+        started_at = self._test_start_times.pop(id(test), None)
+        if started_at is None:
+            return None
+        return time.monotonic() - started_at
+
+    def _write_progress(self, test, status, duration=None, detail=None):
+        total = self.total_tests or "?"
+        test_name = self._test_name(test)
+        duration_text = "" if duration is None else f" {duration:.3f}s"
+        detail_text = "" if detail is None else f" {detail}"
+        self.stream.write(f"[test {self.test_index}/{total} {status}{duration_text}] {test_name}{detail_text}\n")
+        self.stream.flush()
+
+    @staticmethod
+    def _test_name(test):
+        test_id = test.id()
+        if test_id.startswith("__main__."):
+            return f"test.{test_id[len('__main__.'):]}"
+        return test_id
+
+
+class ProgressTextTestRunner(unittest.TextTestRunner):
+    resultclass = ProgressTextTestResult
+
+    def run(self, test):
+        self._total_tests = test.countTestCases()
+        return super().run(test)
+
+    def _makeResult(self):
+        result = super()._makeResult()
+        result.total_tests = getattr(self, "_total_tests", 0)
+        return result
+
+
 def load_game_module():
     game = importlib.import_module("game")
     builtins.game = game
@@ -4674,4 +4748,4 @@ class McpServerTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main(testRunner=unittest.TextTestRunner())
+    unittest.main(testRunner=ProgressTextTestRunner)


### PR DESCRIPTION
## Summary
- Add an always-on progress-aware unittest runner for direct `python3 test.py` runs.
- Print per-test start/result lines with test index, total count, full test name, and elapsed time.
- Add timestamped phase timing around `scripts/run_coverage.sh` configure, build, cleanup, CTest, Python suite, report generation, and total runtime.

## Validation
- `python3 -m py_compile test.py`
- `bash -n scripts/run_coverage.sh`
- `black -l 120 test.py`
- `GAME_BUILD_DIR=cmake-build-wsl-release python3 -m unittest test.GameTest.test_invalid_inputs`
- `GAME_BUILD_DIR=cmake-build-wsl-release python3 test.py GameTest.test_invalid_inputs`
- `ctest --test-dir cmake-build-wsl-release --output-on-failure -R for_unit_tests`
- `GAME_BUILD_DIR=cmake-build-wsl-release python3 test.py` -> `Ran 94 tests in 445.185s`, `OK`

Coverage was attempted with `./scripts/run_coverage.sh`, but the coverage build hung past the 40-minute tool timeout with long-lived compiler processes in `cmake-build-coverage`; the orphaned processes were stopped afterward. No coverage report was produced in this environment.