### PR TITLE
docs: add AGENTS guidance for xvfb GUI tests and screenshot checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,26 @@ Testing section. Import the optional `game` module inside each test that
 requires it so that tests which don't depend on the compiled module can still
 run.
 
+### GUI tests under Xvfb and screenshot verification
+When adding or updating GUI-focused tests in `test.py`, follow the existing
+`XvfbGameplayTest` / `XvfbGameplayProcessTest` pattern:
+1. Guard platform/tooling preconditions (`os.name == "posix"`, `xvfb-run`,
+   and `xauth`) and skip cleanly when unavailable.
+2. Run GUI child tests with `xvfb-run -a --server-args=-screen 0 1920x1080x24`
+   and set `SDL_VIDEODRIVER=x11`, `SDL_AUDIODRIVER=dummy`,
+   `SDL_RENDER_DRIVER=software`, and `LIBGL_ALWAYS_SOFTWARE=1`.
+3. Keep assertions behavior-based (input handling, panel visibility, map turn
+   progression) and include a rendered-output check such as map proxy cells.
+
+For screenshot/image artifacts produced by tests (for example via
+`g.getMap().dumpPaths(...)`), add explicit verification:
+1. Assert the output file exists after rendering.
+2. Assert it is non-empty and has an expected image extension (typically
+   `.png`).
+3. If a deterministic baseline exists, compare against it in the test; if not,
+   at minimum validate dimensions/metadata or loadability to catch corrupt
+   screenshots.
+
 ## Debugging
 - Use `valgrind` for native memory diagnostics and runtime error investigation.
 - Use `callgrind` through `valgrind --tool=callgrind` when profiling hot paths


### PR DESCRIPTION
### Motivation
- Codify the repository's existing Xvfb-based GUI testing pattern so agents add GUI tests consistently and skip cleanly when prerequisites are missing. 
- Require explicit verification for screenshot/image artifacts produced by tests to catch corrupt or missing renders and to standardize comparisons.

### Description
- Added a new `GUI tests under Xvfb and screenshot verification` section to `AGENTS.md` that documents guarding platform/tooling preconditions and the `xvfb-run` invocation and environment variables to use. 
- Instructed authors to keep GUI assertions behavior-focused (input handling, panel visibility, map turn progression) and to include a rendered-output check such as map proxy cells. 
- Added guidance for screenshot artifact checks to assert file existence, non-empty contents and expected extensions, and to prefer deterministic baseline comparisons or at minimum loadability/metadata checks.

### Testing
- Ran the required build step `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` which failed due to a missing dependency (`nlohmann/json.hpp`) in this environment. 
- Ran `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` which could not run because the `for_unit_tests` binary was not built. 
- Ran the Python suite `python3 test.py` which failed broadly because the compiled `_game` module was unavailable (downstream of the failed build), producing multiple test errors and failures related to importing `_game`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba8b769e48326abee55aad76bea45)