### PR TITLE
[codex] Fix character panel list view rendering

### DIFF
--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -133,6 +133,9 @@ CListView::collection_pointer CListView::invokeCollection(std::shared_ptr<CGui> 
 }
 
 void CListView::invokeCallback(std::shared_ptr<CGui> gui, int i, std::shared_ptr<CGameObject> object) {
+    if (callback.empty()) {
+        return;
+    }
     getParent()
         ->meta()
         ->invoke_method<void, CGameGraphicsObject, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>>(
@@ -159,6 +162,9 @@ auto CListView::getArrowCallback(bool left) {
 }
 
 bool CListView::invokeSelect(std::shared_ptr<CGui> gui, int i, std::shared_ptr<CGameObject> object) {
+    if (select.empty()) {
+        return false;
+    }
     return getParent()
         ->meta()
         ->invoke_method<bool, CGameGraphicsObject, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>>(

--- a/test.py
+++ b/test.py
@@ -220,6 +220,7 @@ XVFB_GAMEPLAY_CHILD_TESTS = (
     "test_screenshot_after_mouse_move_has_rendered_pixels",
     "test_screenshot_after_save_hotkey_has_rendered_pixels",
     "test_screenshot_after_wait_hotkey_has_rendered_pixels",
+    "test_screenshot_character_panel_has_rendered_pixels",
     "test_screenshot_info_panel_has_rendered_pixels",
     "test_screenshot_inventory_equipped_selection_has_rendered_pixels",
     "test_screenshot_inventory_item_selection_has_rendered_pixels",
@@ -5050,6 +5051,11 @@ class XvfbGameplayProcessTest(unittest.TestCase):
 
         self.assertGreater(game_map.getTurn(), initial_turn)
         assert_screenshot_has_rendered_pixels(self, g, "xvfb_wait_hotkey_screenshot")
+
+    def test_screenshot_character_panel_has_rendered_pixels(self):
+        _, g, _, _ = create_xvfb_gameplay_session(self)
+        open_panel_for_screenshot(self, g, "characterPanel", "CGameCharacterPanel")
+        assert_screenshot_has_rendered_pixels(self, g, "xvfb_character_panel_screenshot")
 
     def test_screenshot_info_panel_has_rendered_pixels(self):
         _, g, _, _ = create_xvfb_gameplay_session(self)


### PR DESCRIPTION
## Summary

- treat empty CListView callback/select hook names as optional no-ops
- restore the characterPanel xvfb screenshot regression case
- verify the character panel renders through the real SDL/xvfb path without throwing on an empty list-view hook

## Why

The character panel contains a read-only interactions list. When that list is empty, rendering still asks the list view whether the empty slot is selected, but the panel has no select hook configured. That attempted to invoke an empty method name through vstd metadata and threw during screenshot rendering.

## Validation

- clang-format -i src/gui/panel/CListView.cpp
- python3 -m black -l 120 test.py
- cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)
- ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
- python3 test.py XvfbGameplayTest.test_keyboard_gameplay_under_xvfb
- python3 test.py

## Notes

- One full `python3 test.py` attempt hit the pre-existing intermittent `GameTest.test_inventory_panel_refreshes_only_after_event_loop_drains` assertion; the single rerun passed, and the final full suite passed.
