### PR TITLE
Optimize coverage build and reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: submodules
         run: git submodule update --init --recursive
       - name: install python deps
-        run: python -m pip install --upgrade pybind11 pillow
+        run: python -m pip install --upgrade black pybind11 pillow
       - name: configure
         run: ./configure.sh
       - name: build test targets
@@ -105,7 +105,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install Python deps
-        run: python -m pip install --upgrade pybind11 pillow
+        run: python -m pip install --upgrade black pybind11 pillow
       - name: submodules
         run: git submodule update --init --recursive
       - name: Set up vcpkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -19,6 +21,39 @@ jobs:
           path: ~/.ccache
           key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: ${{ runner.os }}-ccache-
+      - name: detect coverage need
+        id: coverage-needed
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+            if [[ -z "${base}" || "${base}" == "0000000000000000000000000000000000000000" ]]; then
+              base="$(git rev-list --max-parents=0 "${head}")"
+            fi
+          fi
+
+          run_coverage=false
+          while IFS= read -r path; do
+            case "${path}" in
+              test.py|tests/*|scripts/run_coverage.sh|scripts/coverage_report.py|src/core/*|src/handler/*|src/object/*)
+                run_coverage=true
+                break
+                ;;
+            esac
+          done < <(git diff --name-only "${base}" "${head}")
+
+          echo "run=${run_coverage}" >> "${GITHUB_OUTPUT}"
+          if [[ "${run_coverage}" == "true" ]]; then
+            echo "Coverage is required for this change."
+          else
+            echo "Coverage is not required for the changed paths."
+          fi
       - name: submodules
         run: git submodule update --init --recursive
       - name: install python deps
@@ -27,12 +62,27 @@ jobs:
         run: ./configure.sh
       - name: build test targets
         run: cmake --build cmake-build-release --target _game for_unit_tests -j"$(nproc)"
+      - name: ccache stats after build
+        if: always()
+        shell: bash
+        run: |
+          if command -v ccache >/dev/null 2>&1; then
+            ccache --show-stats
+          fi
       - name: test (c++)
         run: ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
       - name: test (python)
         run: python3 test.py
       - name: coverage
+        if: steps.coverage-needed.outputs.run == 'true'
         run: ./scripts/run_coverage.sh
+      - name: ccache stats after coverage
+        if: always()
+        shell: bash
+        run: |
+          if command -v ccache >/dev/null 2>&1; then
+            ccache --show-stats
+          fi
       - name: package
         run: cmake --build cmake-build-release --target package -j"$(nproc)"
       - name: publish

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,6 +33,7 @@ The script:
 - runs `python3 test.py` against the coverage build
 - generates reports in `coverage/coverage.txt` and `coverage/coverage.html`
 - uses `gcovr` when available and falls back to the repo-local `gcov` parser otherwise
+- merges repeated template/header line records in supported `gcovr` versions so the line gate matches the fallback reporter
 - fails if total line coverage is below 80%
 
 Optional coverage speed controls:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,11 +28,18 @@ Run from the repository root when a change touches tests (for example
 
 The script:
 - configures a dedicated coverage build (`cmake-build-coverage`)
+- reuses the existing coverage configure by default; set `COVERAGE_FRESH_CONFIGURE=1` to force a fresh configure
 - builds `_game` with GCC/Clang coverage flags
 - runs `python3 test.py` against the coverage build
 - generates reports in `coverage/coverage.txt` and `coverage/coverage.html`
 - uses `gcovr` when available and falls back to the repo-local `gcov` parser otherwise
 - fails if total line coverage is below 80%
+
+Optional coverage speed controls:
+- `COVERAGE_CXX_COMPILER_LAUNCHER=<launcher>` overrides the compiler launcher for the coverage build
+- `COVERAGE_CXX_COMPILER_LAUNCHER=` disables the compiler launcher
+- when `COVERAGE_CXX_COMPILER_LAUNCHER` is unset, the script uses `ccache` automatically if it is available
+- `COVERAGE_JOBS=<n>` controls parallel coverage build and report collection jobs
 
 ## Coverage scope
 Coverage reports include every instrumented file under this repository root.

--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 import argparse
+import concurrent.futures
 import gzip
 import html
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -15,7 +17,18 @@ def parse_args():
     parser.add_argument("--build-dir", required=True, type=Path)
     parser.add_argument("--report-dir", required=True, type=Path)
     parser.add_argument("--min-line", required=True, type=float)
+    parser.add_argument("--jobs", default=max(1, os.cpu_count() or 1), type=positive_int)
     return parser.parse_args()
+
+
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{value!r} is not an integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("--jobs must be at least 1")
+    return parsed
 
 
 def normalize_path(path_str: str, cwd: Path) -> Path:
@@ -33,26 +46,46 @@ def is_included(root: Path, source_path: Path) -> bool:
     return True
 
 
-def collect_gcov_reports(build_dir: Path):
+def collect_reports_for_gcda(gcda: Path, output_dir: Path):
+    output_dir.mkdir()
+    subprocess.run(
+        ["gcov", "-j", "-p", str(gcda)],
+        cwd=output_dir,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    reports = []
+    for report_path in sorted(output_dir.glob("*.gcov.json.gz")):
+        with gzip.open(report_path, "rt", encoding="utf-8") as fh:
+            reports.append(json.load(fh))
+    return reports
+
+
+def collect_gcov_reports(build_dir: Path, jobs: int):
     gcda_files = sorted(build_dir.rglob("*.gcda"))
     if not gcda_files:
         raise RuntimeError(f"No .gcda files found under {build_dir}")
 
     with tempfile.TemporaryDirectory(prefix="fon-gcov-") as tmp_dir:
         tmp_path = Path(tmp_dir)
-        for gcda in gcda_files:
-            subprocess.run(
-                ["gcov", "-j", "-p", str(gcda)],
-                cwd=tmp_path,
-                check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-
         reports = []
-        for report_path in sorted(tmp_path.glob("*.gcov.json.gz")):
-            with gzip.open(report_path, "rt", encoding="utf-8") as fh:
-                reports.append(json.load(fh))
+        jobs = min(jobs, len(gcda_files))
+        print(f"Collecting gcov reports from {len(gcda_files)} data files with {jobs} job(s)")
+
+        if jobs == 1:
+            for index, gcda in enumerate(gcda_files):
+                reports.extend(collect_reports_for_gcda(gcda, tmp_path / f"gcov-{index}"))
+            return reports
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as executor:
+            futures = [
+                executor.submit(collect_reports_for_gcda, gcda, tmp_path / f"gcov-{index}")
+                for index, gcda in enumerate(gcda_files)
+            ]
+            for future in concurrent.futures.as_completed(futures):
+                reports.extend(future.result())
         return reports
 
 
@@ -161,7 +194,7 @@ def main():
     report_dir = args.report_dir.resolve()
     report_dir.mkdir(parents=True, exist_ok=True)
 
-    reports = collect_gcov_reports(build_dir)
+    reports = collect_gcov_reports(build_dir, args.jobs)
     merged = merge_line_counts(root, reports)
     summary, covered_lines, total_lines, total_percentage = summarize(root, merged)
 

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -69,8 +69,14 @@ generate_report() {
 
     if command -v gcovr >/dev/null 2>&1; then
         gcovr_args=()
-        if gcovr --help 2>/dev/null | grep -q -- "--gcov-parallel"; then
+        gcovr_help="$(gcovr --help 2>/dev/null || true)"
+        if grep -q -- "--gcov-parallel" <<<"${gcovr_help}"; then
             gcovr_args+=(--gcov-parallel "${COVERAGE_JOBS}")
+        elif grep -q -- "-j \\[GCOV_PARALLEL\\]" <<<"${gcovr_help}"; then
+            gcovr_args+=(-j "${COVERAGE_JOBS}")
+        fi
+        if grep -q -- "--merge-lines" <<<"${gcovr_help}"; then
+            gcovr_args+=(--merge-lines)
         fi
 
         # gcov can emit negative branch counts for some files; keep reporting and the line gate intact.

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -5,9 +5,15 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${BUILD_DIR:-cmake-build-coverage}"
 MIN_COVERAGE="${MIN_COVERAGE:-80}"
 REPORT_DIR="${ROOT_DIR}/coverage"
+COVERAGE_JOBS="${COVERAGE_JOBS:-$(nproc)}"
 SCRIPT_START=${SECONDS}
 
 cd "${ROOT_DIR}"
+
+if [[ ! "${COVERAGE_JOBS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "COVERAGE_JOBS must be a positive integer, got: ${COVERAGE_JOBS}" >&2
+    exit 2
+fi
 
 format_duration() {
     local elapsed="$1"
@@ -39,10 +45,17 @@ run_phase() {
     return "${status}"
 }
 
+cmake_launcher_args=()
+if [[ -v COVERAGE_CXX_COMPILER_LAUNCHER ]]; then
+    cmake_launcher_args=(-DCMAKE_CXX_COMPILER_LAUNCHER="${COVERAGE_CXX_COMPILER_LAUNCHER}")
+elif command -v ccache >/dev/null 2>&1; then
+    cmake_launcher_args=(-DCMAKE_CXX_COMPILER_LAUNCHER=ccache)
+fi
+
 cmake_args=(
     -S . -B "${BUILD_DIR}" -G Ninja
     -DCMAKE_BUILD_TYPE=Debug
-    -DCMAKE_CXX_COMPILER_LAUNCHER=
+    "${cmake_launcher_args[@]}"
     -DCMAKE_CXX_FLAGS=--coverage
     -DCMAKE_EXE_LINKER_FLAGS=--coverage
     -DCMAKE_SHARED_LINKER_FLAGS=--coverage
@@ -55,8 +68,14 @@ generate_report() {
     mkdir -p "${REPORT_DIR}" || return
 
     if command -v gcovr >/dev/null 2>&1; then
+        gcovr_args=()
+        if gcovr --help 2>/dev/null | grep -q -- "--gcov-parallel"; then
+            gcovr_args+=(--gcov-parallel "${COVERAGE_JOBS}")
+        fi
+
         # gcov can emit negative branch counts for some files; keep reporting and the line gate intact.
         gcovr \
+            "${gcovr_args[@]}" \
             --root "${ROOT_DIR}" \
             --object-directory "${BUILD_DIR}" \
             --gcov-ignore-errors source_not_found --gcov-ignore-errors no_working_dir_found \
@@ -70,12 +89,13 @@ generate_report() {
             --root "${ROOT_DIR}" \
             --build-dir "${BUILD_DIR}" \
             --report-dir "${REPORT_DIR}" \
-            --min-line "${MIN_COVERAGE}" || return
+            --min-line "${MIN_COVERAGE}" \
+            --jobs "${COVERAGE_JOBS}" || return
     fi
 }
 
 run_phase "configure" cmake "${cmake_args[@]}"
-run_phase "build _game and for_unit_tests" cmake --build "${BUILD_DIR}" --target _game for_unit_tests -j"$(nproc)"
+run_phase "build _game and for_unit_tests" cmake --build "${BUILD_DIR}" --target _game for_unit_tests -j"${COVERAGE_JOBS}"
 run_phase "coverage data cleanup" find "${BUILD_DIR}" -name '*.gcda' -delete
 run_phase "ctest" ctest --test-dir "${BUILD_DIR}" --output-on-failure
 run_phase "python test suite" env GAME_BUILD_DIR="${BUILD_DIR}" python3 test.py

--- a/tests/unit/test_coords.cpp
+++ b/tests/unit/test_coords.cpp
@@ -20,14 +20,41 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CUtil.h"
 #include "core/CPathFinder.h"
 #include "handler/CScriptHandler.h"
+#include "vcache.h"
+#include "vfunctional.h"
+#include "vutil.h"
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <iostream>
+#include <map>
 #include <pybind11/embed.h>
+#include <queue>
 #include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
 
 namespace {
 int failures = 0;
+int cache_value_calls = 0;
+
+int next_cache_value() { return ++cache_value_calls; }
+
+int cache_ttl() { return 5; }
+
+struct TagProbe {
+    CTags tags;
+
+    bool hasTag(CTag tag) { return tags.contains(tag); }
+};
+
+struct CastBase {
+    virtual ~CastBase() = default;
+};
+
+struct CastDerived : CastBase {};
 
 void expect_true(bool condition, const char *message) {
     if (!condition) {
@@ -270,6 +297,246 @@ void test_unknown_tag_rejection() {
     expect_true(threw, "Unknown tag strings should be rejected explicitly");
 }
 
+void test_tag_mutation_iteration_and_range_helpers() {
+    CTags tags{CTag::Quest, CTag::Buff};
+    tags.erase(CTag::Quest);
+    expect_true(!tags.contains(CTag::Quest), "CTags::erase should remove an existing tag");
+    expect_true(!tags.empty(), "CTags should remain non-empty when another tag is present");
+    expect_true(tags.values().count(CTag::Buff) == 1, "CTags::values should expose contained tags");
+    expect_true(tags.begin() != tags.end(), "CTags iterators should span contained tags");
+    expect_true(tags == CTags{CTag::Buff}, "CTags equality should compare stored tag values");
+
+    bool invalid_enum_threw = false;
+    try {
+        (void)CTags::toString(static_cast<CTag>(999));
+    } catch (const std::invalid_argument &) {
+        invalid_enum_threw = true;
+    }
+    expect_true(invalid_enum_threw, "Unknown tag enum values should be rejected explicitly");
+
+    auto tagged = std::make_shared<TagProbe>();
+    tagged->tags.insert(CTag::Heal);
+    std::vector<std::shared_ptr<TagProbe>> probes{tagged, std::make_shared<TagProbe>()};
+    expect_true(CTags::isTagPresent(probes, CTag::Heal), "isTagPresent should find a matching tag");
+    expect_true(!CTags::isTagPresent(probes, CTag::Wand), "isTagPresent should reject absent tags");
+}
+
+void test_delayed_future_handlers_run_through_event_loop() {
+    auto loop = vstd::event_loop<>::instance();
+    const int previous_fps = loop->getFps();
+    loop->setFps(1000);
+
+    std::atomic<int> later_calls = 0;
+    std::atomic<int> async_calls = 0;
+    vstd::call_delayed_later(1, [&]() { later_calls.fetch_add(1); });
+    vstd::call_delayed_async(1, [&]() { async_calls.fetch_add(1); });
+
+    for (int i = 0; i < 200 && (later_calls.load() == 0 || async_calls.load() == 0); ++i) {
+        SDL_Delay(2);
+        loop->run();
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    loop->setFps(previous_fps);
+    expect_true(later_calls.load() == 1, "call_delayed_later should run a delayed event-loop callback");
+    expect_true(async_calls.load() == 1, "call_delayed_async should run a delayed async callback");
+}
+
+void test_cache_helpers_reuse_and_expire_values() {
+    cache_value_calls = 0;
+    vstd::cache<std::string, int, next_cache_value, cache_ttl> cache;
+    expect_true(cache.get("alpha", 10) == 1, "cache should populate a missing value");
+    expect_true(cache.get("alpha", 12) == 1, "cache should reuse values before ttl expiry");
+    expect_true(cache.get("alpha", 20) == 2, "cache should refresh values after ttl expiry");
+
+    int callback_calls = 0;
+    vstd::cache2<std::string, int, cache_ttl> callback_cache;
+    auto callback = [&]() { return ++callback_calls; };
+    expect_true(callback_cache.get("beta", 1, callback) == 1, "cache2 should populate from callback");
+    expect_true(callback_cache.get("beta", 3, callback) == 1, "cache2 should reuse callback values before ttl expiry");
+    expect_true(callback_cache.get("beta", 8, callback) == 2, "cache2 should refresh callback values after ttl expiry");
+}
+
+void test_functional_helpers_transform_iterate_and_group() {
+    int void_call_result = 0;
+    vstd::functional::call([&]() { void_call_result = 4; });
+    expect_true(void_call_result == 4, "functional::call should invoke void callables");
+    expect_true(vstd::functional::call([](int value) { return value * 2; }, 5) == 10,
+                "functional::call should return non-void callable results");
+
+    std::set<int> numbers{1, 2, 3, 4};
+    auto labels = vstd::functional::map<std::set<std::string>>(
+        numbers, [](int value) { return value % 2 == 0 ? "even" : "odd"; });
+    expect_true(labels == std::set<std::string>({"even", "odd"}), "functional::map should transform into return set");
+
+    int foreach_sum = 0;
+    vstd::functional::foreach (numbers, [&](int value) { foreach_sum += value; });
+    expect_true(foreach_sum == 10, "functional::foreach should visit every value");
+    expect_true(vstd::functional::sum<int>(numbers) == 10, "functional::sum should add plain values");
+    expect_true(vstd::functional::sum<int>(numbers, [](int value) { return value * 3; }) == 30,
+                "functional::sum should add mapped values");
+
+    auto grouped =
+        vstd::functional::map_reduce<std::string>(numbers, [](int value) { return value % 2 == 0 ? "even" : "odd"; });
+    expect_true(grouped["even"] == std::set<int>({2, 4}), "map_reduce should group even values");
+    expect_true(grouped["odd"] == std::set<int>({1, 3}), "map_reduce should group odd values");
+}
+
+void test_vstd_container_and_pointer_helpers() {
+    std::set<int> ordered{1, 2, 3};
+    expect_true(*vstd::any(ordered) == 1, "any should return the first available element");
+    expect_true(vstd::ctn(ordered, 2), "ctn should find values in set-like containers");
+
+    std::string text = "abc";
+    expect_true(vstd::ctn(text, 'b'), "ctn should find values in strings");
+
+    std::vector<int> values{2, 4, 6};
+    expect_true(vstd::ctn(values, 3, [](int target, int value) { return target * 2 == value; }),
+                "ctn with comparator should use custom matching");
+    expect_true(vstd::ctn_pred(values, [](int value) { return value == 4; }), "ctn_pred should use custom predicates");
+    expect_true(*vstd::find_if(values, [](int value) { return value > 4; }) == 6,
+                "find_if should return the first predicate match");
+
+    int executed = 0;
+    vstd::execute_if(values, [](int value) { return value == 4; }, [&](int value) { executed = value; });
+    expect_true(executed == 4, "execute_if should run a callback for matching values");
+
+    vstd::erase(values, 4, [](int left, int right) { return left == right; });
+    expect_true(values == std::vector<int>({2, 6}), "erase should remove the first comparator match");
+    vstd::erase_if(values, [](int value) { return value == 2; });
+    expect_true(values == std::vector<int>({6}), "erase_if should remove the first predicate match");
+
+    std::vector<int> indexed{10, 20, 30};
+    const std::vector<int> const_indexed{40, 50};
+    expect_true(*vstd::get(indexed, 1) == 20, "get should return a pointer for a valid mutable index");
+    expect_true(vstd::get(indexed, -1) == nullptr, "get should reject negative mutable indexes");
+    expect_true(*vstd::get(const_indexed, 0) == 40, "get should return a pointer for a valid const index");
+    expect_true(vstd::get(const_indexed, 3) == nullptr, "get should reject out-of-bounds const indexes");
+
+    std::shared_ptr<CastBase> base = std::make_shared<CastDerived>();
+    expect_true(vstd::castable<CastDerived>(base), "castable should detect dynamic shared pointer casts");
+    expect_true(vstd::type_pair<int, std::string>() ==
+                    std::make_pair(std::type_index(typeid(int)), std::type_index(typeid(std::string))),
+                "type_pair should return a pair of type indexes");
+}
+
+void test_vstd_queue_collection_and_function_helpers() {
+    auto bound = vstd::bind([](int left, int right) { return left + right; }, 2, 3);
+    expect_true(bound() == 5, "bind should store function arguments");
+
+    auto unary = vstd::make_function([](int value) { return value + 1; });
+    auto nullary = vstd::make_function([]() { return 9; });
+    expect_true(unary(4) == 5, "make_function should wrap unary callables");
+    expect_true(nullary() == 9, "make_function should wrap nullary callables");
+
+    std::queue<int> queue;
+    queue.push(7);
+    expect_true(vstd::pop(queue) == 7, "pop should remove queue front values");
+
+    std::priority_queue<int> priority_queue;
+    priority_queue.push(3);
+    priority_queue.push(9);
+    expect_true(vstd::pop_p(priority_queue) == 9, "pop_p should remove priority queue top values");
+
+    vstd::list<int> custom_list;
+    custom_list.insert(4);
+    expect_true(custom_list.front() == 4, "vstd::list::insert should append values");
+
+    vstd::blocking_queue<int> blocking_queue;
+    blocking_queue.push(11);
+    int popped = 0;
+    expect_true(blocking_queue.pop(popped) && popped == 11, "blocking_queue should pop queued values");
+    blocking_queue.shutdown();
+    expect_true(!blocking_queue.pop(popped), "blocking_queue should stop popping after shutdown");
+    blocking_queue.reset();
+    blocking_queue.push(12);
+    expect_true(blocking_queue.pop(popped) && popped == 12, "blocking_queue reset should accept new values");
+}
+
+void test_vstd_allocation_random_and_value_helpers() {
+    auto allocated = vstd::allocate<int>(2);
+    allocated[0] = 3;
+    allocated[1] = 4;
+    expect_true(allocated[0] + allocated[1] == 7, "allocate should return writable storage");
+    vstd::deallocate(allocated, 2);
+
+    std::vector<int> array_source{5, 6};
+    auto array = vstd::as_array(array_source);
+    expect_true(array[0] == 5 && array[1] == 6, "as_array should copy vector values into allocated storage");
+    vstd::deallocate(array, array_source.size());
+
+    int observed = 0;
+    auto pointer = std::make_shared<int>(13);
+    vstd::if_not_null(pointer, [&](auto value) { observed = *value; });
+    vstd::if_not_null(std::shared_ptr<int>(), [&](auto) { observed = -1; });
+    expect_true(observed == 13, "if_not_null should only invoke callbacks for populated pointers");
+
+    expect_true(vstd::percent(80, 25) == 20, "percent should compute a percentage of a value");
+    expect_true(vstd::with<int>(pointer, [](auto value) { return *value + 1; }) == 14,
+                "with should return callback values for populated pointers");
+    expect_true(vstd::with<int>(std::shared_ptr<int>(), [](auto) { return 99; }) == 0,
+                "with should return a default value for empty pointers");
+
+    int void_with_value = 0;
+    vstd::with<void>(pointer, [&](auto value) { void_with_value = *value; });
+    expect_true(void_with_value == 13, "with<void> should run callbacks for populated pointers");
+
+    expect_true(vstd::all_equals(3, 3, 3), "all_equals should accept matching values");
+    expect_true(!vstd::all_equals(3, 4, 3), "all_equals should reject differing values");
+    expect_true(vstd::set(1) == std::set<int>({1}), "set should build a std::set");
+    expect_true(vstd::as_list(1).front() == 1, "as_list should build a std::list");
+
+    std::set<int> old_values{1, 2};
+    std::set<int> new_values{2, 3};
+    auto [to_add, to_remove] = vstd::set_difference(old_values, new_values);
+    expect_true(to_add == std::set<int>({3}) && to_remove == std::set<int>({1}),
+                "set_difference should identify additions and removals");
+
+    std::set<int> empty_choices;
+    std::set<int> single_choice{42};
+    expect_true(vstd::random_element(empty_choices) == empty_choices.end(),
+                "random_element should return end for empty containers");
+    expect_true(*vstd::random_element(single_choice) == 42, "random_element should return the only available element");
+
+    auto components = vstd::random_components(5, std::set<int>({1, 2}));
+    expect_true(vstd::functional::sum<int>(components) == 5, "random_components should decompose the requested value");
+    expect_true(vstd::square_ctn(10, 10, 9, 0), "square_ctn should accept coordinates inside bounds");
+    expect_true(!vstd::square_ctn(10, 10, 10, 0), "square_ctn should reject coordinates outside bounds");
+}
+
+void test_vstd_string_helpers() {
+    expect_true(vstd::str(Coords(1, 2, 3)) == "1,2,3", "vstd::str should use the Coords specialization");
+    expect_true(vstd::replace("red red", "red", "blue") == "blue blue", "replace should handle repeated matches");
+    expect_true(vstd::trim("  text\t") == "text", "trim should remove surrounding whitespace");
+    expect_true(vstd::is_empty(" \t"), "is_empty should treat whitespace as empty");
+    expect_true(vstd::str("a", 1, "b") == "a1b", "variadic str should concatenate stringified values");
+    expect_true(vstd::to_int("42").first == 42 && vstd::to_int("42").second, "to_int should parse integers");
+    expect_true(!vstd::to_int("42x").second, "to_int should reject partially parsed integers");
+    expect_true(!vstd::is_int("x"), "is_int should reject non-numeric strings");
+    expect_true(vstd::join(std::list<std::string>{"a", "b"}, ",") == "a,b", "join should use separators");
+    expect_true(vstd::split("a:b", ':') == std::vector<std::string>({"a", "b"}), "split should split on delimiter");
+    expect_true(vstd::string_equals(5, "5"), "string_equals should compare stringified values");
+    expect_true(vstd::ends_with("report.txt", ".txt"), "ends_with should detect matching suffixes");
+    expect_true(!vstd::ends_with("txt", "report.txt"), "ends_with should reject longer suffixes");
+
+    auto wide = vstd::to_wchar("abc");
+    expect_true(wide[0] == L'a' && wide[2] == L'c', "to_wchar should convert narrow text");
+    delete[] wide;
+
+    const char *args[] = {"one", "two"};
+    auto wide_args = vstd::to_wchar(2, args);
+    expect_true(wide_args[0][0] == L'o' && wide_args[1][0] == L't', "to_wchar should convert argument arrays");
+    delete[] wide_args[0];
+    delete[] wide_args[1];
+    delete[] wide_args;
+
+    std::string lines = "first";
+    vstd::add_line(lines, "second");
+    vstd::add_line(lines, "");
+    expect_true(lines == "first\nsecond", "add_line should append non-empty lines only");
+    expect_true(vstd::camel("hello world") == "Hello World ", "camel should title-case space-separated words");
+}
+
 void test_script_handler_executes_commands_and_wraps_functions() {
     CScriptHandler handler;
 
@@ -358,6 +625,14 @@ int main() {
     test_rect_bounds_inclusion();
     test_tag_round_trip_and_ordering();
     test_unknown_tag_rejection();
+    test_tag_mutation_iteration_and_range_helpers();
+    test_delayed_future_handlers_run_through_event_loop();
+    test_cache_helpers_reuse_and_expire_values();
+    test_functional_helpers_transform_iterate_and_group();
+    test_vstd_container_and_pointer_helpers();
+    test_vstd_queue_collection_and_function_helpers();
+    test_vstd_allocation_random_and_value_helpers();
+    test_vstd_string_helpers();
     test_script_handler_executes_commands_and_wraps_functions();
 
     if (failures == 0) {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,6 +3,7 @@
   "version-string": "0.1.0",
   "dependencies": [
     "boost-algorithm",
+    "boost-filesystem",
     "boost-pool",
     "nlohmann-json",
     "sdl2",


### PR DESCRIPTION
## Summary
- use ccache automatically for coverage builds, with COVERAGE_CXX_COMPILER_LAUNCHER override/disable support
- add COVERAGE_JOBS for coverage build/report parallelism and parallelize fallback gcov collection
- skip Linux CI coverage for unrelated paths while keeping normal build, C++ tests, and Python tests always on
- install black in CI so changed-Python formatting checks can run
- declare boost-filesystem for Windows vcpkg builds because vstd/vstring.h includes boost/filesystem.hpp
- document the new coverage speed controls

## Testing
- black -l 120 scripts/coverage_report.py
- bash -n scripts/run_coverage.sh
- python3 -m py_compile scripts/coverage_report.py
- python3 scripts/coverage_report.py --help
- COVERAGE_JOBS=0 ./scripts/run_coverage.sh exits before configure/build with validation error
- GAME_BUILD_DIR=cmake-build-wsl-release python3 test.py GameTest.test_indentation GameTest.test_python_black_formatting GameTest.test_cpp_clang_formatting
- cmake --build cmake-build-wsl-release --target _game for_unit_tests -j$(nproc)
- ctest --test-dir cmake-build-wsl-release --output-on-failure -R for_unit_tests
- GAME_BUILD_DIR=cmake-build-wsl-release python3 test.py

Coverage note: ./scripts/run_coverage.sh was attempted multiple times in this WSL /mnt/c checkout. It did not reach CTest/Python/report generation because coverage compilation stalled in the build phase; the final captured process state was cc1plus compiling src/core/CTypes.cpp under cmake-build-coverage.