### PR TITLE
Install clang-format in Linux setup

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 sudo apt-get update
-sudo apt-get install -y build-essential cmake ninja-build ccache \
+sudo apt-get install -y build-essential cmake ninja-build ccache clang-format \
     python3 python3-dev \
     libboost-dev \
     libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \


### PR DESCRIPTION
## Summary
- install clang-format alongside the Linux build tools so the Python C++ formatting check has the executable it enforces
- keep the follow-up scoped to CI/setup after PR #236 was already merged

## Testing
- bash -n configure.sh
- GAME_BUILD_DIR=cmake-build-wsl-release python3 test.py GameTest.test_cpp_clang_formatting
- cmake --build cmake-build-wsl-release --target _game for_unit_tests -j$(nproc)
- ctest --test-dir cmake-build-wsl-release --output-on-failure -R for_unit_tests
- GAME_BUILD_DIR=cmake-build-wsl-release python3 test.py