### PR TITLE
[codex] Fix empty MCP HTTP responses

### DIFF
--- a/mcp.py
+++ b/mcp.py
@@ -1144,10 +1144,7 @@ class EngineHttpRequestHandler(BaseHTTPRequestHandler):
         if path == "/mcp" and not self.server.mcp_server.validate_origin(self.headers.get("Origin")):
             self._write_mcp_error(HTTPStatus.FORBIDDEN, None, -32600, "Forbidden origin")
             return
-        self.send_response(HTTPStatus.NO_CONTENT)
-        self._add_default_headers()
-        self.send_header("Allow", "GET, POST, DELETE, OPTIONS")
-        self.end_headers()
+        self._write_empty(HTTPStatus.NO_CONTENT, allow="GET, POST, DELETE, OPTIONS")
 
     def do_GET(self) -> None:
         path = self.path.split("?", 1)[0]
@@ -1199,10 +1196,7 @@ class EngineHttpRequestHandler(BaseHTTPRequestHandler):
 
         accept = self.headers.get("Accept", "")
         if "text/event-stream" not in accept:
-            self.send_response(HTTPStatus.METHOD_NOT_ALLOWED)
-            self._add_default_headers()
-            self.send_header("Allow", "POST, DELETE, OPTIONS, GET")
-            self.end_headers()
+            self._write_empty(HTTPStatus.METHOD_NOT_ALLOWED, allow="POST, DELETE, OPTIONS, GET")
             return
 
         session_id = self.headers.get("MCP-Session-Id")
@@ -1280,9 +1274,7 @@ class EngineHttpRequestHandler(BaseHTTPRequestHandler):
             self._write_mcp_error(HTTPStatus.NOT_FOUND, None, -32001, "Unknown session")
             return
 
-        self.send_response(HTTPStatus.NO_CONTENT)
-        self._add_default_headers()
-        self.end_headers()
+        self._write_empty(HTTPStatus.NO_CONTENT)
 
     def do_POST(self) -> None:
         path = self.path.split("?", 1)[0]
@@ -1355,13 +1347,11 @@ class EngineHttpRequestHandler(BaseHTTPRequestHandler):
                 response_protocol_version = state.protocol_version
 
         if response is None:
-            self.send_response(status)
-            self._add_default_headers()
-            if response_session_id:
-                self.send_header("MCP-Session-Id", response_session_id)
-            if response_protocol_version:
-                self.send_header("MCP-Protocol-Version", response_protocol_version)
-            self.end_headers()
+            self._write_empty(
+                status,
+                session_id=response_session_id,
+                protocol_version=response_protocol_version,
+            )
             self.server.mcp_server._trace_message(
                 transport="http",
                 direction="send",
@@ -1384,6 +1374,25 @@ class EngineHttpRequestHandler(BaseHTTPRequestHandler):
             session_id=response_session_id,
             protocol_version=response_protocol_version,
         )
+
+    def _write_empty(
+        self,
+        status: HTTPStatus,
+        *,
+        session_id: str | None = None,
+        protocol_version: str | None = None,
+        allow: str | None = None,
+    ) -> None:
+        self.send_response(status)
+        self._add_default_headers()
+        if allow:
+            self.send_header("Allow", allow)
+        if session_id:
+            self.send_header("MCP-Session-Id", session_id)
+        if protocol_version:
+            self.send_header("MCP-Protocol-Version", protocol_version)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
 
     def log_message(self, format: str, *args: Any) -> None:
         logger.info('%s - "%s"', self.address_string(), format % args)

--- a/test.py
+++ b/test.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import ast
 import builtins
+import http.client
 import importlib
 import json
 import os
@@ -29,6 +30,7 @@ import threading
 import time
 import traceback
 import types
+from http import HTTPStatus
 from pathlib import Path
 import unittest
 
@@ -625,13 +627,17 @@ def find_adjacent_walkable_tile(game_map, origin):
     raise AssertionError(f"Expected an adjacent walkable tile near {origin.x},{origin.y},{origin.z}.")
 
 
-def get_panel_proxy_child_totals(panel):
+def get_panel_proxy_child_totals_by_collection(panel):
     game = load_game_module()
     panel_data = json.loads(game.jsonify(panel))
-    totals = []
+    totals = {}
     for child in panel_data.get("properties", {}).get("children") or []:
-        proxy_children = child.get("properties", {}).get("children") or []
-        totals.append(sum(len(proxy.get("properties", {}).get("children") or []) for proxy in proxy_children))
+        properties = child.get("properties", {})
+        collection = properties.get("collection")
+        if not collection:
+            continue
+        proxy_children = properties.get("children") or []
+        totals[collection] = sum(len(proxy.get("properties", {}).get("children") or []) for proxy in proxy_children)
     return totals
 
 
@@ -2350,21 +2356,22 @@ class GameTest(unittest.TestCase):
         pump_event_loop()
 
         player = g.getMap().getPlayer()
-        before_totals = get_panel_proxy_child_totals(panel)
+        before_totals = get_panel_proxy_child_totals_by_collection(panel)
 
         sword = g.createObject("Sword")
         player.addItem(sword)
-        after_add_without_pump = get_panel_proxy_child_totals(panel)
+        after_add_without_pump = get_panel_proxy_child_totals_by_collection(panel)
         pump_event_loop()
-        after_add_with_pump = get_panel_proxy_child_totals(panel)
+        after_add_with_pump = get_panel_proxy_child_totals_by_collection(panel)
 
         player.removeItem(lambda item: item == sword, False)
-        after_remove_without_pump = get_panel_proxy_child_totals(panel)
+        after_remove_without_pump = get_panel_proxy_child_totals_by_collection(panel)
         pump_event_loop()
-        after_remove_with_pump = get_panel_proxy_child_totals(panel)
+        after_remove_with_pump = get_panel_proxy_child_totals_by_collection(panel)
 
         self.assertEqual(before_totals, after_add_without_pump)
-        self.assertEqual(before_totals[0] + 1, after_add_with_pump[0])
+        self.assertEqual(before_totals["inventoryCollection"] + 1, after_add_with_pump["inventoryCollection"])
+        self.assertEqual(before_totals["equippedCollection"], after_add_with_pump["equippedCollection"])
         self.assertEqual(after_add_with_pump, after_remove_without_pump)
         self.assertEqual(before_totals, after_remove_with_pump)
 
@@ -5287,6 +5294,60 @@ class McpServerTest(unittest.TestCase):
         tools = batch_response[0].get("result", {}).get("tools", [])
         tool_names = {tool.get("name") for tool in tools}
         self.assertTrue({"engine_list", "engine_call", "engine_handle_call"}.issubset(tool_names))
+
+    def test_http_notification_response_declares_empty_body(self):
+        server = self.make_stub_server()
+        httpd = mcp.EngineHttpServer(("127.0.0.1", 0), mcp.EngineHttpRequestHandler, server)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        conn = http.client.HTTPConnection("127.0.0.1", httpd.server_address[1], timeout=5)
+        headers = {
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+        }
+        try:
+            conn.request(
+                "POST",
+                "/mcp",
+                body=json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": MCP_PROTOCOL_VERSION,
+                            "capabilities": {},
+                            "clientInfo": {"name": "mcp-test", "version": "1.0"},
+                        },
+                    }
+                ),
+                headers=headers,
+            )
+            initialize_response = conn.getresponse()
+            self.assertEqual(HTTPStatus.OK, initialize_response.status)
+            session_id = initialize_response.getheader("MCP-Session-Id")
+            self.assertTrue(session_id)
+            initialize_response.read()
+
+            notification_headers = dict(headers)
+            notification_headers["MCP-Session-Id"] = session_id
+            conn.request(
+                "POST",
+                "/mcp",
+                body=json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}),
+                headers=notification_headers,
+            )
+            notification_response = conn.getresponse()
+
+            self.assertEqual(HTTPStatus.ACCEPTED, notification_response.status)
+            self.assertEqual("0", notification_response.getheader("Content-Length"))
+            self.assertEqual(session_id, notification_response.getheader("MCP-Session-Id"))
+            self.assertEqual(MCP_PROTOCOL_VERSION, notification_response.getheader("MCP-Protocol-Version"))
+            self.assertEqual(b"", notification_response.read())
+        finally:
+            conn.close()
+            httpd.shutdown()
+            httpd.server_close()
 
     def test_stdio_handshake_and_tool_listing(self):
         script = REPO_ROOT / "mcp.py"


### PR DESCRIPTION
## Summary

- Add a shared HTTP helper for no-body MCP responses that sends `Content-Length: 0`.
- Apply it to OPTIONS, unsupported GET, DELETE, and notification responses.
- Add a regression test for HTTP notification responses and make the inventory panel refresh test independent of serialized child order.

## Validation

- `black -l 120 mcp.py test.py`
- `McpServerTest`: 9 tests OK
- `cmake --build cmake-build-release --config Release --target _game for_unit_tests`
- `ctest --test-dir cmake-build-release -C Release --output-on-failure -R for_unit_tests`
- full `python test.py`: 116 tests OK, 17 skipped
- `./scripts/run_coverage.sh`: line coverage 81.2%
