### PR TITLE
Optimize target pathfinding reuse

### DIFF
--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -25,6 +25,25 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CPlayer.h"
 
 namespace {
+struct FlowQueueNode {
+    int cost;
+    Coords coords;
+};
+
+struct FlowQueueCompare {
+    bool operator()(const FlowQueueNode &a, const FlowQueueNode &b) const { return a.cost > b.cost; }
+};
+
+struct TargetFlowField {
+    std::weak_ptr<CMap> map;
+    std::uint64_t revision = 0;
+    Coords goal;
+    std::unordered_map<Coords, Coords> nextSteps;
+};
+
+std::mutex targetFlowMutex;
+std::vector<std::shared_ptr<TargetFlowField>> targetFlowCache;
+
 bool creature_can_follow_step(const std::shared_ptr<CCreature> &creature, const Coords &step) {
     if (!creature || !creature->getMap()) {
         return false;
@@ -33,6 +52,98 @@ bool creature_can_follow_step(const std::shared_ptr<CCreature> &creature, const 
     auto current = map->normalizeCoords(creature->getCoords());
     auto target = map->normalizeCoords(step);
     return target != current && map->canStep(target);
+}
+
+std::shared_ptr<TargetFlowField> build_target_flow_field(const std::shared_ptr<CMap> &map, const Coords &goal,
+                                                         std::uint64_t revision) {
+    auto field = std::make_shared<TargetFlowField>();
+    field->map = map;
+    field->revision = revision;
+    field->goal = goal;
+
+    if (!map->canStep(goal)) {
+        return field;
+    }
+
+    std::unordered_map<Coords, int> costs;
+    std::priority_queue<FlowQueueNode, std::vector<FlowQueueNode>, FlowQueueCompare> frontier;
+    costs[goal] = 0;
+    frontier.push({0, goal});
+
+    while (!frontier.empty()) {
+        auto current = frontier.top();
+        frontier.pop();
+
+        auto best = costs.find(current.coords);
+        if (best == costs.end() || best->second != current.cost) {
+            continue;
+        }
+
+        for (auto previous : map->getAdjacentCoords(current.coords)) {
+            if (previous != goal && !map->canStep(previous)) {
+                continue;
+            }
+
+            const int nextCost = current.cost + 1;
+            auto previousCost = costs.find(previous);
+            if (previousCost == costs.end() || nextCost < previousCost->second) {
+                costs[previous] = nextCost;
+                field->nextSteps[previous] = current.coords;
+                frontier.push({nextCost, previous});
+            }
+        }
+    }
+
+    return field;
+}
+
+std::shared_ptr<TargetFlowField> get_target_flow_field(const std::shared_ptr<CMap> &map, const Coords &goal) {
+    constexpr std::size_t maxCachedFlowFields = 32;
+    const auto revision = map->getNavigationRevision();
+    std::lock_guard<std::mutex> lock(targetFlowMutex);
+
+    targetFlowCache.erase(std::remove_if(targetFlowCache.begin(), targetFlowCache.end(),
+                                         [](const auto &field) { return !field || field->map.expired(); }),
+                          targetFlowCache.end());
+
+    auto cached = std::find_if(targetFlowCache.begin(), targetFlowCache.end(), [&](const auto &field) {
+        return field->map.lock() == map && field->revision == revision && field->goal == goal;
+    });
+    if (cached != targetFlowCache.end()) {
+        return *cached;
+    }
+
+    auto field = build_target_flow_field(map, goal, revision);
+    targetFlowCache.push_back(field);
+    while (targetFlowCache.size() > maxCachedFlowFields) {
+        targetFlowCache.erase(targetFlowCache.begin());
+    }
+    return field;
+}
+
+Coords find_shared_target_next_step(const std::shared_ptr<CCreature> &creature,
+                                    const std::shared_ptr<CMapObject> &targetObject) {
+    if (!creature || !targetObject || !creature->getMap()) {
+        return creature ? creature->getCoords() : ZERO;
+    }
+
+    auto map = creature->getMap();
+    auto start = map->normalizeCoords(creature->getCoords());
+    auto goal = map->normalizeCoords(targetObject->getCoords());
+    if (start == goal || !map->canStep(goal)) {
+        return start;
+    }
+
+    auto flow = get_target_flow_field(map, goal);
+    auto next = flow->nextSteps.find(start);
+    if (next == flow->nextSteps.end()) {
+        return start;
+    }
+    auto step = map->normalizeCoords(next->second);
+    if (!creature_can_follow_step(creature, step)) {
+        return start;
+    }
+    return step;
 }
 } // namespace
 
@@ -43,12 +154,7 @@ std::shared_ptr<vstd::future<Coords, void>> CTargetController::control(std::shar
     if (!target_object) {
         return vstd::later([creature]() { return creature->getCoords(); });
     }
-    return CPathFinder::findNextStep(
-        creature->getCoords(), target_object->getCoords(),
-        [creature](const Coords &coords) { return creature->getMap()->canStep(coords); },
-        [](auto) { return std::make_pair(false, ZERO); },
-        [creature](const Coords &coords) { return creature->getMap()->getAdjacentCoords(coords); },
-        [creature](const Coords &from, const Coords &to) { return creature->getMap()->getDistance(from, to); });
+    return vstd::async([creature, target_object]() { return find_shared_target_next_step(creature, target_object); });
 }
 
 std::shared_ptr<vstd::future<Coords, void>> CController::control(std::shared_ptr<CCreature> c) {

--- a/src/core/CPathFinder.cpp
+++ b/src/core/CPathFinder.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -61,6 +61,26 @@ struct AStarCompare {
 using AStarQueue = std::priority_queue<AStarNode, std::vector<AStarNode>, AStarCompare>;
 using NextStepQueue = std::priority_queue<NextStepNode, std::vector<NextStepNode>, AStarCompare>;
 
+class PassabilityCache {
+  public:
+    explicit PassabilityCache(const std::function<bool(const Coords &)> &canStep) : canStep(canStep) {}
+
+    bool canStepAt(const Coords &coords) {
+        auto cached = values.find(coords);
+        if (cached != values.end()) {
+            return cached->second;
+        }
+
+        bool result = canStep(coords);
+        values.emplace(coords, result);
+        return result;
+    }
+
+  private:
+    const std::function<bool(const Coords &)> &canStep;
+    std::unordered_map<Coords, bool> values;
+};
+
 std::vector<Coords> candidates(const Coords &coords,
                                const std::function<std::pair<bool, Coords>(const Coords &)> &waypoint,
                                const std::function<std::vector<Coords>(const Coords &)> &neighbors) {
@@ -77,9 +97,10 @@ Values fillValues(const std::function<bool(const Coords &)> &canStep, const Coor
                   const std::function<std::vector<Coords>(const Coords &)> &neighbors,
                   const CPathFinder::StepCost &stepCost, const Coords *stopAt = nullptr) {
     Values values = std::make_shared<std::unordered_map<Coords, int>>();
+    PassabilityCache passability(canStep);
     Queue nodes;
 
-    if (canStep(goal) || (stopAt && goal == *stopAt)) {
+    if (passability.canStepAt(goal) || (stopAt && goal == *stopAt)) {
         (*values)[goal] = 0;
         nodes.push({0, goal});
     }
@@ -97,7 +118,7 @@ Values fillValues(const std::function<bool(const Coords &)> &canStep, const Coor
         }
 
         for (auto previous : candidates(current.coords, waypoint, neighbors)) {
-            if ((stopAt && previous == *stopAt) || canStep(previous)) {
+            if ((stopAt && previous == *stopAt) || passability.canStepAt(previous)) {
                 const int edge_cost = std::max(1, stepCost(previous, current.coords));
                 const int next_cost = current.cost + edge_cost;
                 auto value = values->find(previous);
@@ -144,7 +165,8 @@ std::vector<Coords> findAStarPath(Coords start, Coords goal, const std::function
     if (start == goal) {
         return {start};
     }
-    if (!canStep(goal)) {
+    PassabilityCache passability(canStep);
+    if (!passability.canStepAt(goal)) {
         return {start};
     }
 
@@ -168,7 +190,7 @@ std::vector<Coords> findAStarPath(Coords start, Coords goal, const std::function
         }
 
         for (auto next : candidates(current.coords, waypoint, neighbors)) {
-            if (next != goal && !canStep(next)) {
+            if (next != goal && !passability.canStepAt(next)) {
                 continue;
             }
 
@@ -194,7 +216,8 @@ Coords findAStarNextStep(Coords start, Coords goal, const std::function<bool(con
     if (start == goal) {
         return start;
     }
-    if (!canStep(goal)) {
+    PassabilityCache passability(canStep);
+    if (!passability.canStepAt(goal)) {
         return start;
     }
 
@@ -217,7 +240,7 @@ Coords findAStarNextStep(Coords start, Coords goal, const std::function<bool(con
         }
 
         for (auto next : candidates(current.coords, waypoint, neighbors)) {
-            if (next != goal && !canStep(next)) {
+            if (next != goal && !passability.canStepAt(next)) {
                 continue;
             }
 

--- a/test.py
+++ b/test.py
@@ -1,5 +1,5 @@
 # fall-of-nouraajd c++ dark fantasy game
-# Copyright (C) 2025  Andrzej Lis
+# Copyright (C) 2025-2026  Andrzej Lis
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -2502,6 +2502,56 @@ class GameTest(unittest.TestCase):
         coords = chaser.getCoords()
         self.assertEqual((coords.x, coords.y, coords.z), (25, 13, 0))
         return True, json.dumps({"chaser_coords": [coords.x, coords.y, coords.z]})
+
+    @game_test
+    def test_target_controller_flow_field_invalidates_after_navigation_change(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGameWithPlayer(g, "test", "Warrior")
+        game_map = g.getMap()
+
+        for coords in [
+            game.Coords(10, 10, 0),
+            game.Coords(11, 10, 0),
+            game.Coords(12, 10, 0),
+            game.Coords(10, 11, 0),
+            game.Coords(11, 11, 0),
+            game.Coords(12, 11, 0),
+        ]:
+            game_map.replaceTile("RoadTile", coords)
+
+        target = g.createObject("CEvent")
+        target.setStringProperty("name", "flowTarget")
+        game_map.addObject(target)
+        target.moveTo(12, 10, 0)
+
+        chaser = g.createObject("Cultist")
+        controller = g.createObject("CTargetController")
+        controller.setTarget("flowTarget")
+        chaser.setController(controller)
+        chaser.setBoolProperty("npc", True)
+        game_map.addObject(chaser)
+        chaser.moveTo(10, 10, 0)
+
+        game_map.move()
+        first_step = chaser.getCoords()
+        self.assertEqual((first_step.x, first_step.y, first_step.z), (11, 10, 0))
+
+        chaser.moveTo(10, 10, 0)
+        game_map.replaceTile("WaterTile", game.Coords(11, 10, 0))
+        game_map.replaceTile("WaterTile", game.Coords(9, 10, 0))
+        game_map.replaceTile("WaterTile", game.Coords(10, 9, 0))
+
+        game_map.move()
+        second_step = chaser.getCoords()
+        self.assertEqual((second_step.x, second_step.y, second_step.z), (10, 11, 0))
+        return True, json.dumps(
+            {
+                "first_step": [first_step.x, first_step.y, first_step.z],
+                "second_step": [second_step.x, second_step.y, second_step.z],
+            }
+        )
 
     @game_test
     def test_new_player_classes_and_resources(self):

--- a/tests/unit/test_coords.cpp
+++ b/tests/unit/test_coords.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -177,6 +177,30 @@ void test_pathfinder_waypoint_and_blocked_goal() {
     auto path = CPathFinder::findPath(Coords(0, 0, 0), Coords(2, 0, 0), can_step, no_waypoint);
     expect_true(path.size() == 1, "findPath should return only start when goal is unreachable");
     expect_true(path.front() == Coords(0, 0, 0), "findPath should remain on start if no route exists");
+}
+
+void test_pathfinder_caches_passability_checks() {
+    std::map<Coords, int> calls;
+    auto can_step = [&calls](const Coords &coords) {
+        calls[coords]++;
+        return coords == Coords(0, 0, 0) || coords == Coords(1, 0, 0) || coords == Coords(2, 0, 0);
+    };
+    auto no_waypoint = [](const Coords &) { return std::pair<bool, Coords>(false, ZERO); };
+    auto duplicate_neighbors = [](const Coords &coords) {
+        if (coords == Coords(0, 0, 0)) {
+            return std::vector<Coords>{Coords(1, 0, 0), Coords(1, 0, 0)};
+        }
+        if (coords == Coords(1, 0, 0)) {
+            return std::vector<Coords>{Coords(2, 0, 0)};
+        }
+        return std::vector<Coords>{};
+    };
+
+    auto path = CPathFinder::findPath(Coords(0, 0, 0), Coords(2, 0, 0), can_step, no_waypoint, duplicate_neighbors);
+    expect_true(path.size() == 2, "findPath should follow the duplicate-neighbor route");
+    expect_true(path.front() == Coords(1, 0, 0), "findPath should still include the first route step");
+    expect_true(path.back() == Coords(2, 0, 0), "findPath should still end on the goal");
+    expect_true(calls[Coords(1, 0, 0)] == 1, "findPath should cache repeated passability checks");
 }
 
 void test_pathfinder_waypoint_override() {
@@ -618,6 +642,7 @@ int main() {
     test_near_coords_helpers();
     test_pathfinder_find_path_without_obstacles();
     test_pathfinder_waypoint_and_blocked_goal();
+    test_pathfinder_caches_passability_checks();
     test_pathfinder_waypoint_override();
     test_toroidal_pathfinder_prefers_wrapped_route();
     test_toroidal_pathfinder_wraps_on_both_axes();


### PR DESCRIPTION
What changed: Added shared target flow-field caching for CTargetController keyed by map, target coordinate, and navigation revision. Added per-search pathfinder passability caching. Added native and Python regression tests. Why: Reuses one reverse path map for creatures chasing the same target and reduces repeated canStep lookups during path searches. Validation performed: clang-format on modified C++ files, black -l 120 test.py, cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc), ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests, python3 test.py passed with 117 tests and 16 skipped, ./scripts/run_coverage.sh passed with line coverage 81.1%. Known limitations or follow-up work: Flow-field cache is process-local and capped at 32 entries. It still uses map adjacency and unit movement cost like the previous target controller pathing.