### PR TITLE
[codex] Raise coverage threshold to 90 percent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ Coverage command:
 ./scripts/run_coverage.sh
 ```
 
-The scoped line coverage threshold is 80%. Do not finish coverage-relevant work below that threshold without explicitly reporting it.
+The scoped line coverage threshold is 90%. Do not finish coverage-relevant work below that threshold without explicitly reporting it.
 
 Coverage reports are generated under `coverage/`.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For Windows Visual Studio builds, use `--config Release`, pass `-C Release` to `
 and set `GAME_BUILD_CONFIG=Release` before running `python test.py`.
 Also run `./scripts/run_coverage.sh` when a change touches tests (for example
 `test.py` or `tests/unit/**`), `src/core/**`, `src/handler/**`, `src/object/**`,
-or the coverage tooling. The total line coverage threshold for that run is 80%;
+or the coverage tooling. The total line coverage threshold for that run is 90%;
 see `docs/testing.md` for details.
 Data validation tests run without needing the compiled `_game` module, but
 other tests require it to be built.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,7 +34,7 @@ The script:
 - generates reports in `coverage/coverage.txt` and `coverage/coverage.html`
 - uses `gcovr` when available and falls back to the repo-local `gcov` parser otherwise
 - merges repeated template/header line records in supported `gcovr` versions so the line gate matches the fallback reporter
-- fails if total line coverage is below 80%
+- fails if total line coverage is below 90%
 
 Optional coverage speed controls:
 - `COVERAGE_CXX_COMPILER_LAUNCHER=<launcher>` overrides the compiler launcher for the coverage build

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${BUILD_DIR:-cmake-build-coverage}"
-MIN_COVERAGE="${MIN_COVERAGE:-80}"
+MIN_COVERAGE="${MIN_COVERAGE:-90}"
 REPORT_DIR="${ROOT_DIR}/coverage"
 COVERAGE_JOBS="${COVERAGE_JOBS:-$(nproc)}"
 SCRIPT_START=${SECONDS}


### PR DESCRIPTION
## What changed
- Raised the default coverage gate in `scripts/run_coverage.sh` from 80% to 90%.
- Updated coverage requirement documentation in `README.md`, `docs/testing.md`, and `AGENTS.md`.

## Why
The project coverage requirement should now enforce a 90% minimum line coverage threshold instead of 80%.

## Validation
- `./configure.sh` completed CMake generation for `cmake-build-release`; it printed sudo/pip setup errors from optional dependency-install steps before generating the build tree.
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` passed after rebase.
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` passed after rebase.
- `python3 test.py` passed after rebase: 116 tests, 16 skipped.
- `./scripts/run_coverage.sh` completed tests but failed report generation because current line coverage is 81.2% and the new minimum is 90.0%.

## Known limitations / follow-up
- Existing coverage is below the new threshold, so this PR will make the coverage workflow fail until coverage is raised to at least 90% or the gate policy is adjusted.