### PR TITLE
Use Ubuntu 24.04 for Linux CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## What changed
- Move the Linux build job from ubuntu-22.04 to ubuntu-24.04.

## Why
- PR #239 was merged with C++ formatted by clang-format 18, while the ubuntu-22.04 CI image installs clang-format 14 through configure.sh.
- Running Linux CI on ubuntu-24.04 aligns the CI formatter with the current development environment and prevents the merged pathfinder formatting from failing the formatter check.

## Validation
- git diff --check
- python3 test.py GameTest.test_cpp_clang_formatting

## Known limitations / follow-up
- Full build and coverage were not rerun locally because this change only updates the CI runner image and does not touch source, tests, or coverage tooling.