### PR TITLE
Fix new-branch coverage detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,13 @@ jobs:
             base="${{ github.event.before }}"
             head="${{ github.sha }}"
             if [[ -z "${base}" || "${base}" == "0000000000000000000000000000000000000000" ]]; then
-              base="$(git rev-list --max-parents=0 "${head}")"
+              default_branch="origin/${{ github.event.repository.default_branch }}"
+              if git rev-parse --verify "${default_branch}" >/dev/null 2>&1 &&
+                merge_base="$(git merge-base "${default_branch}" "${head}")"; then
+                base="${merge_base}"
+              else
+                base="$(git rev-list --max-parents=0 "${head}")"
+              fi
             fi
           fi
 


### PR DESCRIPTION
## What changed
- Update the coverage detector so first pushes to new branches compare against the merge base with the default branch when available.
- Keep the existing root-commit fallback for repositories or checkouts without the default branch ref.

## Why
- A new branch push has an all-zero before SHA, which made CI diff against the repository root and run coverage for workflow-only changes.
- With the coverage threshold now at 90%, that redundant push run can fail even when the PR run correctly skips coverage for non-source changes.

## Validation
- git diff --check
- Local shell simulation of the new-branch push path showed run_coverage=false for this workflow-only branch.

## Known limitations / follow-up
- Full build and coverage were not rerun locally because this only changes CI detection logic.