### PR TITLE
[codex] Add GUI selection regression tests

### DIFF
--- a/TODO_WORKLOG.md
+++ b/TODO_WORKLOG.md
@@ -319,3 +319,21 @@
   - `python3 test.py` -> `Ran 82 tests in 138.766s`, `OK`
   - `./scripts/run_coverage.sh` -> `Ran 82 tests in 622.127s`, `OK`, `lines: 83.12% (2944 out of 3542)`
 - Blockers if unresolved: None. Manual visual confirmation in the original screenshot scene is still advisable, but the verified proxy-hole repro is now covered automatically.
+
+## Batch 22
+- Location: `test.py`, `src/core/CModule.cpp`, `src/gui/panel/CCreatureView.cpp`, `src/gui/panel/CCreatureView.h`, `src/gui/panel/CListView.cpp`, `todo.txt`
+- Original TODO or summary: `todo.txt` still tracked missing regression coverage for quest-item selection guards in inventory/fight panels and inventory/equipped selection reset.
+- Status: fixed
+- What was changed: Added xvfb GUI regressions that assert quest-tagged `letterToBeren` items do not become selected in inventory or fight item lists, and that equipping an inventory sword clears inventory selection before selecting the equipped slot. Exposed `CGameFightPanel.setEnemy(...)` for nonblocking fight-panel fixtures. While wiring the fight-panel regression, fixed the creature-view effects collection signature to match `CListView` callback invocation and guarded `CListView` refresh-object connections against scripts that temporarily resolve to `None`.
+- Why the change is correct: The guarded item-selection behavior already existed but had no active regression coverage. The new tests verify the rendered selection state through serialized `CSelectionBox` children instead of visual screenshots, so they exercise the actual GUI callback path without adding image baselines. The fight-panel fixture also covers a real initialization path that previously crashed when nested list refresh scripts were scheduled before every target object was available.
+- Validation performed:
+  - source verification of `todo.txt`, `TODO_WORKLOG.md`, `test.py`, `src/core/CModule.cpp`, `src/gui/panel/CGameInventoryPanel.cpp`, `src/gui/panel/CGameFightPanel.cpp`, `src/gui/panel/CCreatureView.cpp`, `src/gui/panel/CCreatureView.h`, `src/gui/panel/CListView.cpp`, and `res/config/panels.json`
+  - `black -l 120 test.py` -> `1 file left unchanged`
+  - `clang-format -i src/core/CModule.cpp src/gui/panel/CCreatureView.h src/gui/panel/CCreatureView.cpp src/gui/panel/CListView.cpp`
+  - `env FON_XVFB_GAMEPLAY_CHILD=1 SDL_VIDEODRIVER=x11 SDL_AUDIODRIVER=dummy SDL_RENDER_DRIVER=software LIBGL_ALWAYS_SOFTWARE=1 xvfb-run -a --server-args="-screen 0 1920x1080x24" python3 test.py XvfbGameplayProcessTest.test_inventory_equipped_selection_resets_inventory_selection XvfbGameplayProcessTest.test_inventory_quest_item_selection_is_ignored XvfbGameplayProcessTest.test_fight_quest_item_selection_is_ignored` -> `Ran 3 tests in 20.706s`, `OK` (run outside the sandbox because sandboxed `/tmp/.X11-unix` permissions made successful xvfb children exit nonzero)
+  - `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` -> `[100%] Built target _game`, `[100%] Built target for_unit_tests`
+  - `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` -> `1/1 Test #1: for_unit_tests ... Passed`
+  - `python3 test.py` -> `Ran 120 tests in 268.767s`, `OK (skipped=19)` (run outside the sandbox for xvfb child processes)
+  - `./scripts/run_coverage.sh` -> configured and built `cmake-build-coverage`, `ctest` passed, embedded `python3 test.py` passed with `Ran 120 tests in 335.984s`, then report generation failed the configured total line gate: `lines: 81.9% (6737 out of 8222)`, below `90.0%`
+  - `python3 scripts/coverage_report.py --root . --build-dir cmake-build-coverage --report-dir coverage --min-line 90 --jobs $(nproc)` -> also failed the total line gate: `lines: 82.04% (6766 out of 8247)`, below `90.00%`
+- Blockers if unresolved: Functional validation passed, but the required coverage command still fails at report generation because the repository's total line coverage is below the configured 90% threshold.

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -643,7 +643,8 @@ PYBIND11_MODULE(_game, m) {
         .def("getMarket", &CGameTradePanel::getMarket, "Return market displayed by this panel.");
 
     py::class_<CGameFightPanel, CGamePanel, std::shared_ptr<CGameFightPanel>>(m, "CGameFightPanel", "Fight panel.")
-        .def("getEnemy", &CGameFightPanel::getEnemy, "Return current enemy creature.");
+        .def("getEnemy", &CGameFightPanel::getEnemy, "Return current enemy creature.")
+        .def("setEnemy", &CGameFightPanel::setEnemy, "Set current enemy creature.");
 
     py::class_<CGameCharacterPanel, CGamePanel, std::shared_ptr<CGameCharacterPanel>>(m, "CGameCharacterPanel",
                                                                                       "Character sheet panel.");

--- a/src/gui/panel/CCreatureView.cpp
+++ b/src/gui/panel/CCreatureView.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -21,21 +21,19 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CLayout.h"
 #include "object/CCreature.h"
 
-std::shared_ptr<CScript> CCreatureView::getCreatureScript() {
-  return creatureScript;
-}
+std::shared_ptr<CScript> CCreatureView::getCreatureScript() { return creatureScript; }
 
-void CCreatureView::setCreatureScript(
-    std::shared_ptr<CScript> _creatureScript) {
-  creatureScript = _creatureScript;
-}
+void CCreatureView::setCreatureScript(std::shared_ptr<CScript> _creatureScript) { creatureScript = _creatureScript; }
 
-std::list<std::shared_ptr<CGameGraphicsObject>>
-CCreatureView::getProxiedObjects(std::shared_ptr<CGui> gui, int x, int y) {
-  std::shared_ptr<CGameGraphicsObject> graphicsObject =
-      getCreature()->getGraphicsObject();
-  graphicsObject->setLayout(std::make_shared<CParentLayout>());
-  return vstd::as_list(graphicsObject);
+std::list<std::shared_ptr<CGameGraphicsObject>> CCreatureView::getProxiedObjects(std::shared_ptr<CGui> gui, int x,
+                                                                                 int y) {
+    auto creature = getCreature();
+    if (!creature) {
+        return {};
+    }
+    std::shared_ptr<CGameGraphicsObject> graphicsObject = creature->getGraphicsObject();
+    graphicsObject->setLayout(std::make_shared<CParentLayout>());
+    return vstd::as_list(graphicsObject);
 }
 
 int CCreatureView::getSizeX(std::shared_ptr<CGui> gui) { return 1; }
@@ -43,21 +41,23 @@ int CCreatureView::getSizeX(std::shared_ptr<CGui> gui) { return 1; }
 int CCreatureView::getSizeY(std::shared_ptr<CGui> gui) { return 1; }
 
 void CCreatureView::initialize() {
-  auto self = this->ptr<CCreatureView>();
-  vstd::call_when(
-      [self]() {
-        return self->getGui() != nullptr &&
-               self->getGui()->getGame() != nullptr &&
-               self->getGui()->getGame()->getMap() != nullptr;
-      },
-      [self]() { self->refresh(); });
+    auto self = this->ptr<CCreatureView>();
+    vstd::call_when(
+        [self]() {
+            return self->getGui() != nullptr && self->getGui()->getGame() != nullptr &&
+                   self->getGui()->getGame()->getMap() != nullptr;
+        },
+        [self]() { self->refresh(); });
 }
 
-CListView::collection_pointer CCreatureView::getEffects() {
-  return std::make_shared<CListView::collection_type>(
-      vstd::cast<CListView::collection_type>(getCreature()->getEffects()));
+CListView::collection_pointer CCreatureView::getEffects(std::shared_ptr<CGui>) {
+    auto creature = getCreature();
+    if (!creature) {
+        return std::make_shared<CListView::collection_type>();
+    }
+    return std::make_shared<CListView::collection_type>(vstd::cast<CListView::collection_type>(creature->getEffects()));
 }
 
 std::shared_ptr<CCreature> CCreatureView::getCreature() {
-  return creatureScript->invoke<CCreature>(getGui()->getGame(), this->ptr());
+    return creatureScript->invoke<CCreature>(getGui()->getGame(), this->ptr());
 }

--- a/src/gui/panel/CCreatureView.h
+++ b/src/gui/panel/CCreatureView.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -25,30 +25,27 @@ class CScript;
 class CCreature;
 
 class CCreatureView : public CProxyTargetGraphicsObject {
-  V_META(CCreatureView, CProxyTargetGraphicsObject,
-         V_PROPERTY(CCreatureView, std::shared_ptr<CScript>, creatureScript,
-                    getCreatureScript, setCreatureScript),
-         V_METHOD(CCreatureView, getEffects, CListView::collection_pointer),
-         V_METHOD(CCreatureView, getCreature, std::shared_ptr<CCreature>),
-         V_METHOD(CCreatureView, initialize))
-public:
-  std::list<std::shared_ptr<CGameGraphicsObject>>
-  getProxiedObjects(std::shared_ptr<CGui> gui, int x, int y) override;
+    V_META(CCreatureView, CProxyTargetGraphicsObject,
+           V_PROPERTY(CCreatureView, std::shared_ptr<CScript>, creatureScript, getCreatureScript, setCreatureScript),
+           V_METHOD(CCreatureView, getEffects, CListView::collection_pointer, std::shared_ptr<CGui>),
+           V_METHOD(CCreatureView, getCreature, std::shared_ptr<CCreature>), V_METHOD(CCreatureView, initialize))
+  public:
+    std::list<std::shared_ptr<CGameGraphicsObject>> getProxiedObjects(std::shared_ptr<CGui> gui, int x, int y) override;
 
-  int getSizeX(std::shared_ptr<CGui> gui) override;
+    int getSizeX(std::shared_ptr<CGui> gui) override;
 
-  int getSizeY(std::shared_ptr<CGui> gui) override;
+    int getSizeY(std::shared_ptr<CGui> gui) override;
 
-  void initialize();
+    void initialize();
 
-  std::shared_ptr<CScript> getCreatureScript();
+    std::shared_ptr<CScript> getCreatureScript();
 
-  void setCreatureScript(std::shared_ptr<CScript> _creature);
+    void setCreatureScript(std::shared_ptr<CScript> _creature);
 
-  CListView::collection_pointer getEffects();
+    CListView::collection_pointer getEffects(std::shared_ptr<CGui> gui);
 
-  std::shared_ptr<CCreature> getCreature();
+    std::shared_ptr<CCreature> getCreature();
 
-private:
-  std::shared_ptr<CScript> creatureScript;
+  private:
+    std::shared_ptr<CScript> creatureScript;
 };

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -309,10 +309,11 @@ void CListView::initialize() {
         },
         [self]() {
             if (self->refreshObject) {
-                self->refreshObject->invoke(self->getGui()->getGame(), self)
-                    ->connect(self->refreshEvent, self, "refresh");
-                self->refreshObject->invoke(self->getGui()->getGame(), self)
-                    ->connect(self->refreshEvent, self, "refreshAll");
+                auto refreshTarget = self->refreshObject->invoke(self->getGui()->getGame(), self);
+                if (refreshTarget) {
+                    refreshTarget->connect(self->refreshEvent, self, "refresh");
+                    refreshTarget->connect(self->refreshEvent, self, "refreshAll");
+                }
             }
             self->refresh();
         });

--- a/test.py
+++ b/test.py
@@ -227,6 +227,9 @@ XVFB_GAMEPLAY_CHILD_TESTS = (
     "test_screenshot_inventory_equipped_selection_has_rendered_pixels",
     "test_screenshot_inventory_item_selection_has_rendered_pixels",
     "test_screenshot_inventory_panel_has_rendered_pixels",
+    "test_inventory_equipped_selection_resets_inventory_selection",
+    "test_inventory_quest_item_selection_is_ignored",
+    "test_fight_quest_item_selection_is_ignored",
     "test_screenshot_question_panel_has_rendered_pixels",
     "test_screenshot_quest_panel_with_active_quest_has_rendered_pixels",
     "test_sidebar_mouse_opens_inventory_until_hotkey_closes_it",
@@ -639,6 +642,31 @@ def get_panel_proxy_child_totals_by_collection(panel):
         proxy_children = properties.get("children") or []
         totals[collection] = sum(len(proxy.get("properties", {}).get("children") or []) for proxy in proxy_children)
     return totals
+
+
+def get_panel_selection_box_counts_by_collection(panel):
+    game = load_game_module()
+    panel_data = json.loads(game.jsonify(panel))
+    counts = {}
+
+    def child_nodes(node):
+        return node.get("properties", {}).get("children") or []
+
+    def visit(node):
+        properties = node.get("properties", {})
+        collection = properties.get("collection")
+        if collection:
+            counts[collection] = sum(
+                1
+                for proxy in child_nodes(node)
+                for child in child_nodes(proxy)
+                if child.get("class") == "CSelectionBox"
+            )
+        for child in child_nodes(node):
+            visit(child)
+
+    visit(panel_data)
+    return counts
 
 
 def advance_turns(g, turns):
@@ -5147,6 +5175,59 @@ class XvfbGameplayProcessTest(unittest.TestCase):
         pump_event_loop(5)
 
         assert_screenshot_has_rendered_pixels(self, g, "xvfb_inventory_equipped_selection_screenshot")
+
+    def test_inventory_equipped_selection_resets_inventory_selection(self):
+        _, g, _, player = create_xvfb_gameplay_session(self)
+        player.addItem("Sword")
+        panel = open_panel_for_screenshot(self, g, "inventoryPanel", "CGameInventoryPanel")
+
+        push_sdl_mouse_click(585, 265)
+        pump_event_loop(5)
+        selected_after_inventory = get_panel_selection_box_counts_by_collection(panel)
+
+        push_sdl_mouse_click(1185, 265)
+        pump_event_loop(5)
+        selected_after_equip = get_panel_selection_box_counts_by_collection(panel)
+
+        push_sdl_mouse_click(1185, 265)
+        pump_event_loop(5)
+        selected_after_equipped_click = get_panel_selection_box_counts_by_collection(panel)
+
+        self.assertEqual(1, selected_after_inventory.get("inventoryCollection", 0))
+        self.assertEqual(0, selected_after_equip.get("inventoryCollection", 0))
+        self.assertEqual(0, selected_after_equip.get("equippedCollection", 0))
+        self.assertEqual(0, selected_after_equipped_click.get("inventoryCollection", 0))
+        self.assertEqual(1, selected_after_equipped_click.get("equippedCollection", 0))
+
+    def test_inventory_quest_item_selection_is_ignored(self):
+        game, g, _, player = create_xvfb_gameplay_session(self, map_name="nouraajd")
+        quest_item = g.createObject("letterToBeren")
+        self.assertTrue(quest_item.hasTag(game.CTag.QUEST))
+        player.addItem(quest_item)
+        panel = open_panel_for_screenshot(self, g, "inventoryPanel", "CGameInventoryPanel")
+
+        push_sdl_mouse_click(585, 265)
+        pump_event_loop(5)
+        selected_after_quest_click = get_panel_selection_box_counts_by_collection(panel)
+
+        self.assertEqual(0, selected_after_quest_click.get("inventoryCollection", 0))
+        self.assertEqual(0, selected_after_quest_click.get("equippedCollection", 0))
+
+    def test_fight_quest_item_selection_is_ignored(self):
+        game, g, _, player = create_xvfb_gameplay_session(self, map_name="nouraajd")
+        quest_item = g.createObject("letterToBeren")
+        self.assertTrue(quest_item.hasTag(game.CTag.QUEST))
+        player.addItem(quest_item)
+        panel = g.getGuiHandler().openPanel("fightPanel")
+        panel.setEnemy(g.createObject("GoblinThief"))
+        pump_event_loop(5)
+        self.assertTrue(gui_contains_class(g, "CGameFightPanel"))
+
+        push_sdl_mouse_click(585, 745)
+        pump_event_loop(5)
+        selected_after_quest_click = get_panel_selection_box_counts_by_collection(panel)
+
+        self.assertEqual(0, selected_after_quest_click.get("itemsCollection", 0))
 
     def test_screenshot_question_panel_has_rendered_pixels(self):
         _, g, _, _ = create_xvfb_gameplay_session(self)

--- a/todo.txt
+++ b/todo.txt
@@ -9,16 +9,12 @@
 //TODO: what if we return to oldMap after switch?
 //TODO: make function to compare objects
 //TODO: load assets from map
-//TODO: add regression coverage for quest-item selection guards
-    //TODO: inventory panel
-    //TODO: fight panel
 //TODO: replace buff with selfTarget
 //TODO: extend pathfinder to multilevel maps
 //TODO: separate class from race
 //TODO: mark primitve CGameObjects like CList and CMapString, CScript as primitive and unfold values field directly to properties
     generally items with one property, would require not counting props from CGameObject and getting field type from meta class
     because its not accesible in CSerialization
-//TODO: add regression coverage for inventory/equipped selection reset
 //TODO: implement property change listeners to enable AOP
 //TODO: siege
     //TODO: when changing canStep of gate creatures can get in but cant get out


### PR DESCRIPTION
## What changed
- Added xvfb GUI regression tests for inventory/equipped selection reset and quest-item selection guards in inventory and fight item lists.
- Exposed `CGameFightPanel.setEnemy(...)` to Python so nonblocking fight-panel fixtures can be configured in tests.
- Fixed fight-panel initialization issues by matching `CCreatureView.getEffects(...)` to the `CListView` callback signature and guarding refresh-object connections when a script temporarily resolves to `None`.
- Removed the resolved TODO entries and recorded Batch 22 in `TODO_WORKLOG.md`.

## Why
The guarded selection behavior already existed, but the backlog still tracked missing regression coverage for inventory, fight, and equipped-selection paths. The new tests verify actual rendered GUI selection state through serialized `CSelectionBox` children instead of screenshot baselines. While adding the fight-panel coverage, the test exposed an initialization crash path in nested list refresh setup, which is now guarded.

## Validation
- `black -l 120 test.py`
- `clang-format -i src/core/CModule.cpp src/gui/panel/CCreatureView.h src/gui/panel/CCreatureView.cpp src/gui/panel/CListView.cpp`
- Targeted xvfb tests: `Ran 3 tests in 20.706s`, `OK`
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py` -> `Ran 120 tests in 268.767s`, `OK (skipped=19)`

## Known limitation
- `./scripts/run_coverage.sh` completed configure, build, C++ tests, and embedded `python3 test.py` (`Ran 120 tests in 335.984s`, `OK`), but failed at report generation because total line coverage was below the configured 90% gate: `81.9% (6737 out of 8222)`. A direct `scripts/coverage_report.py` rerun similarly reported `82.04%`, below `90.00%`.