### PR TITLE
Add tests for 90 percent coverage gate

### DIFF
--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -78,6 +78,9 @@ generate_report() {
         if grep -q -- "--merge-lines" <<<"${gcovr_help}"; then
             gcovr_args+=(--merge-lines)
         fi
+        if grep -q -- "--merge-mode-functions" <<<"${gcovr_help}"; then
+            gcovr_args+=(--merge-mode-functions merge-use-line-min)
+        fi
 
         # gcov can emit negative branch counts for some files; keep reporting and the line gate intact.
         gcovr \

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -21,7 +21,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "CGlobal.h"
 #include "../../vstd/veventloop.h"
+#include "../gui/CAnimation.h"
 #include "../gui/CGui.h"
+#include "../gui/object/CMapGraphicsObject.h"
 #include "../gui/object/CSideBar.h"
 #include "../gui/object/CStatsGraphicsObject.h"
 #include "../gui/panel/CCreatureView.h"
@@ -48,6 +50,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CTags.h"
 #include "core/CWrapper.h"
 #include <pybind11/stl_bind.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 
@@ -167,6 +170,39 @@ py::object game_object_getattr(CGameObject &self, const std::string &name) {
 
     throw py::attribute_error(name);
 }
+
+py::list graphics_children(CGameGraphicsObject &self) {
+    py::list children;
+    for (const auto &child : self.getChildren()) {
+        children.append(child);
+    }
+    return children;
+}
+
+py::list graphics_proxied_objects(CProxyTargetGraphicsObject &self, const std::shared_ptr<CGui> &gui, int x, int y) {
+    py::list objects;
+    for (const auto &object : self.getProxiedObjects(gui, x, y)) {
+        objects.append(object);
+    }
+    return objects;
+}
+
+py::list list_view_collection_to_py(const CListView::collection_pointer &collection) {
+    py::list objects;
+    for (const auto &object : *collection) {
+        objects.append(object);
+    }
+    return objects;
+}
+
+std::vector<std::shared_ptr<CCreature>> creature_iterable_to_vector(const py::iterable &iterable) {
+    std::vector<std::shared_ptr<CCreature>> creatures;
+    for (const auto &item : iterable) {
+        creatures.push_back(item.is_none() ? nullptr : item.cast<std::shared_ptr<CCreature>>());
+    }
+    return creatures;
+}
+
 std::shared_ptr<CGameObject> cast_registered_python_object(const py::object &instance) {
     if (py::isinstance<CBuilding>(instance)) {
         return std::static_pointer_cast<CGameObject>(instance.cast<std::shared_ptr<CBuilding>>());
@@ -270,15 +306,81 @@ PYBIND11_MODULE(_game, m) {
     py::class_<CGameGraphicsObject, CGameObject, std::shared_ptr<CGameGraphicsObject>>(
         m, "CGameGraphicsObject", "Base class for GUI graphics objects.")
         .def("getGui", &CGameGraphicsObject::getGui, "Return the owning GUI object.")
-        .def("getParent", &CGameGraphicsObject::getParent, "Return the parent graphics object.");
+        .def("getParent", &CGameGraphicsObject::getParent, "Return the parent graphics object.")
+        .def("getChildren", &graphics_children, "Return this graphics object's children.")
+        .def("addChild", &CGameGraphicsObject::addChild, "Attach a graphics child.")
+        .def("pushChild", &CGameGraphicsObject::pushChild, "Attach a graphics child above existing children.")
+        .def("removeChild", &CGameGraphicsObject::removeChild, "Detach a graphics child.")
+        .def("findChild", py::overload_cast<const std::string &>(&CGameGraphicsObject::findChild),
+             "Find a child by C++ type name.")
+        .def(
+            "keyboardEvent",
+            [](CGameGraphicsObject &self, const std::shared_ptr<CGui> &gui, int type, int key) {
+                return self.keyboardEvent(gui, static_cast<SDL_EventType>(type), key);
+            },
+            "Dispatch a keyboard event to this object.")
+        .def(
+            "mouseEvent",
+            [](CGameGraphicsObject &self, const std::shared_ptr<CGui> &gui, int type, int button, int x, int y) {
+                return self.mouseEvent(gui, static_cast<SDL_EventType>(type), button, x, y);
+            },
+            "Dispatch a mouse button event to this object.");
 
     py::class_<CGui, CGameGraphicsObject, std::shared_ptr<CGui>>(m, "CGui", "Game GUI root object.")
         .def("getGame", &CGui::getGame, "Return the owning game.");
+
+    py::class_<CAnimation, CGameGraphicsObject, std::shared_ptr<CAnimation>>(m, "CAnimation",
+                                                                             "Base animation graphics object.")
+        .def("getObject", &CAnimation::getObject, "Return object represented by this animation.")
+        .def("setObject", &CAnimation::setObject, "Set object represented by this animation.");
+    py::class_<CStaticAnimation, CAnimation, std::shared_ptr<CStaticAnimation>>(m, "CStaticAnimation",
+                                                                                "Static bitmap animation.")
+        .def("getRotation", &CStaticAnimation::getRotation, "Return configured rotation.")
+        .def("setRotation", &CStaticAnimation::setRotation, "Set render rotation.")
+        .def("setColorMod", &CStaticAnimation::setColorMod, "Set texture color modulation.")
+        .def("clearColorMod", &CStaticAnimation::clearColorMod, "Clear texture color modulation.")
+        .def(
+            "renderObject",
+            [](CStaticAnimation &self, const std::shared_ptr<CGui> &gui, int x, int y, int w, int h, int frame_time) {
+                self.renderObject(gui, RECT(x, y, w, h), frame_time);
+            },
+            "Render the static animation into a rectangle.");
+    py::class_<CDynamicAnimation, CAnimation, std::shared_ptr<CDynamicAnimation>>(m, "CDynamicAnimation",
+                                                                                  "Frame-table animation.")
+        .def("initialize", &CDynamicAnimation::initialize, "Load animation frames from configuration.")
+        .def(
+            "renderObject",
+            [](CDynamicAnimation &self, const std::shared_ptr<CGui> &gui, int x, int y, int w, int h, int frame_time) {
+                self.renderObject(gui, RECT(x, y, w, h), frame_time);
+            },
+            "Render the dynamic animation into a rectangle.");
+    py::class_<CSelectionBox, CAnimation, std::shared_ptr<CSelectionBox>>(m, "CSelectionBox",
+                                                                          "Selection outline graphics object.")
+        .def("getThickness", &CSelectionBox::getThickness, "Return outline thickness.")
+        .def("setThickness", &CSelectionBox::setThickness, "Set outline thickness.")
+        .def(
+            "renderObject",
+            [](CSelectionBox &self, const std::shared_ptr<CGui> &gui, int x, int y, int w, int h, int frame_time) {
+                self.renderObject(gui, RECT(x, y, w, h), frame_time);
+            },
+            "Render the selection outline into a rectangle.");
 
     py::class_<CStatsGraphicsObject, CGameGraphicsObject, std::shared_ptr<CStatsGraphicsObject>>(
         m, "CStatsGraphicsObject");
 
     py::class_<CSideBar, CGameGraphicsObject, std::shared_ptr<CSideBar>>(m, "CSideBar");
+
+    py::class_<CProxyTargetGraphicsObject, CGameGraphicsObject, std::shared_ptr<CProxyTargetGraphicsObject>>(
+        m, "CProxyTargetGraphicsObject", "Graphics object that proxies child graphics for cells.")
+        .def("refresh", &CProxyTargetGraphicsObject::refresh, "Refresh proxy cell layout.")
+        .def("refreshAll", &CProxyTargetGraphicsObject::refreshAll, "Refresh all proxy cells.")
+        .def("refreshObject", &CProxyTargetGraphicsObject::refreshObject, "Refresh one proxy cell.")
+        .def("getProxiedObjects", &graphics_proxied_objects, "Return graphics objects proxied for a cell.");
+
+    py::class_<CMapGraphicsObject, CProxyTargetGraphicsObject, std::shared_ptr<CMapGraphicsObject>>(
+        m, "CMapGraphicsObject", "Map viewport graphics object.")
+        .def("refreshObject", py::overload_cast<Coords>(&CMapGraphicsObject::refreshObject),
+             "Refresh map proxies for a map coordinate.");
 
     py::class_<CCreatureView, CGameGraphicsObject, std::shared_ptr<CCreatureView>>(
         m, "CCreatureView", "Panel widget that renders a creature.")
@@ -348,7 +450,9 @@ PYBIND11_MODULE(_game, m) {
         .def("showSelection", &CGuiHandler::showSelection, "Open a selection panel.")
         .def("showInfo", &CGuiHandler::showInfo, "Open an info panel.")
         .def("openPanel", &CGuiHandler::openPanel, "Open a configured panel without blocking for user input.")
-        .def("showLoot", &CGuiHandler::showLoot, "Show loot acquisition UI.");
+        .def("showLoot", &CGuiHandler::showLoot, "Show loot acquisition UI.")
+        .def("showTooltip", &CGuiHandler::showTooltip, "Show a tooltip panel at screen coordinates.")
+        .def("flipPanel", &CGuiHandler::flipPanel, "Toggle a configured panel and bind its hotkey while open.");
 
     py::class_<CController, CGameObject, std::shared_ptr<CController>>(m, "CController", "Base movement controller.");
     py::class_<CPlayerController, CController, std::shared_ptr<CPlayerController>>(
@@ -435,7 +539,11 @@ PYBIND11_MODULE(_game, m) {
         .def("setDmgMin", &Stats::setDmgMin, "Set minimum base damage.")
         .def("setDmgMax", &Stats::setDmgMax, "Set maximum base damage.")
         .def("setHit", &Stats::setHit, "Set hit chance modifier.")
-        .def("setCrit", &Stats::setCrit, "Set critical chance percentage.");
+        .def("setCrit", &Stats::setCrit, "Set critical chance percentage.")
+        .def("getMainValue", &Stats::getMainValue, "Return current value of the configured main stat.")
+        .def("addBonus", &Stats::addBonus, "Add all numeric stats from another Stats object.")
+        .def("removeBonus", &Stats::removeBonus, "Remove all numeric stats from another Stats object.")
+        .def("getText", &Stats::getText, "Return formatted stat summary text.");
 
     auto ctile =
         py::class_<CTile, CWrapper<CTile>, std::shared_ptr<CTile>, CGameObject>(m, "CTile", "Base tile class.");
@@ -634,16 +742,76 @@ PYBIND11_MODULE(_game, m) {
         .def("getQuests", &CPlayer::getQuests, "Return the player's active quests.");
 
     py::class_<CListString, CGameObject, std::shared_ptr<CListString>>(m, "CListString", "String list wrapper object.")
-        .def("addValue", &CListString::addValue, "Append a value to the list.");
+        .def("addValue", &CListString::addValue, "Append a value to the list.")
+        .def("getValues", &CListString::getValues, "Return list values.")
+        .def("setValues", &CListString::setValues, "Replace list values.");
 
-    py::class_<CGamePanel, CGameGraphicsObject, std::shared_ptr<CGamePanel>>(m, "CGamePanel",
-                                                                             "Base in-game GUI panel.");
+    py::class_<CListInt, CGameObject, std::shared_ptr<CListInt>>(m, "CListInt", "Integer list wrapper object.")
+        .def("addValue", &CListInt::addValue, "Append a value to the list.")
+        .def("getValues", &CListInt::getValues, "Return list values.")
+        .def("setValues", &CListInt::setValues, "Replace list values.");
+
+    py::class_<CMapStringString, CGameObject, std::shared_ptr<CMapStringString>>(m, "CMapStringString",
+                                                                                 "String-to-string map wrapper.")
+        .def("getValues", &CMapStringString::getValues, "Return map values.")
+        .def("setValues", &CMapStringString::setValues, "Replace map values.");
+
+    py::class_<CMapStringInt, CGameObject, std::shared_ptr<CMapStringInt>>(m, "CMapStringInt",
+                                                                           "String-to-int map wrapper.")
+        .def("getValues", &CMapStringInt::getValues, "Return map values.")
+        .def("setValues", &CMapStringInt::setValues, "Replace map values.");
+
+    py::class_<CMapIntString, CGameObject, std::shared_ptr<CMapIntString>>(m, "CMapIntString",
+                                                                           "Int-to-string map wrapper.")
+        .def("getValues", &CMapIntString::getValues, "Return map values.")
+        .def("setValues", &CMapIntString::setValues, "Replace map values.");
+
+    py::class_<CMapIntInt, CGameObject, std::shared_ptr<CMapIntInt>>(m, "CMapIntInt", "Int-to-int map wrapper.")
+        .def("getValues", &CMapIntInt::getValues, "Return map values.")
+        .def("setValues", &CMapIntInt::setValues, "Replace map values.");
+
+    py::class_<CGamePanel, CGameGraphicsObject, std::shared_ptr<CGamePanel>>(m, "CGamePanel", "Base in-game GUI panel.")
+        .def("refreshViews", &CGamePanel::refreshViews, "Refresh list views contained by the panel.")
+        .def("close", &CGamePanel::close, "Close this panel.");
 
     py::class_<CGameTradePanel, CGamePanel, std::shared_ptr<CGameTradePanel>>(m, "CGameTradePanel", "Trade panel.")
         .def("getMarket", &CGameTradePanel::getMarket, "Return market displayed by this panel.");
 
     py::class_<CGameFightPanel, CGamePanel, std::shared_ptr<CGameFightPanel>>(m, "CGameFightPanel", "Fight panel.")
-        .def("getEnemy", &CGameFightPanel::getEnemy, "Return current enemy creature.");
+        .def("getEnemy", &CGameFightPanel::getEnemy, "Return current enemy creature.")
+        .def("setEnemy", &CGameFightPanel::setEnemy, "Set current enemy creature.")
+        .def(
+            "setEnemies",
+            [](CGameFightPanel &self, const py::iterable &creatures) {
+                self.setEnemies(creature_iterable_to_vector(creatures));
+            },
+            "Set available enemy creatures.")
+        .def("selectInteraction", &CGameFightPanel::selectInteraction, "Wait for and return selected interaction.")
+        .def(
+            "interactionsCollection",
+            [](CGameFightPanel &self, const std::shared_ptr<CGui> &gui) {
+                return list_view_collection_to_py(self.interactionsCollection(gui));
+            },
+            "Return player interactions shown by the fight panel.")
+        .def("interactionsCallback", &CGameFightPanel::interactionsCallback, "Handle interaction selection.")
+        .def("interactionsSelect", &CGameFightPanel::interactionsSelect, "Return whether interaction is selected.")
+        .def(
+            "itemsCollection",
+            [](CGameFightPanel &self, const std::shared_ptr<CGui> &gui) {
+                return list_view_collection_to_py(self.itemsCollection(gui));
+            },
+            "Return player items shown by the fight panel.")
+        .def("itemsCallback", &CGameFightPanel::itemsCallback, "Handle item selection.")
+        .def("itemsRightClickCallback", &CGameFightPanel::itemsRightClickCallback, "Handle direct item use.")
+        .def("itemsSelect", &CGameFightPanel::itemsSelect, "Return whether an item is selected.")
+        .def(
+            "enemiesCollection",
+            [](CGameFightPanel &self, const std::shared_ptr<CGui> &gui) {
+                return list_view_collection_to_py(self.enemiesCollection(gui));
+            },
+            "Return enemies shown by the fight panel.")
+        .def("enemiesCallback", &CGameFightPanel::enemiesCallback, "Handle enemy selection.")
+        .def("enemiesSelect", &CGameFightPanel::enemiesSelect, "Return whether an enemy is selected.");
 
     py::class_<CGameCharacterPanel, CGamePanel, std::shared_ptr<CGameCharacterPanel>>(m, "CGameCharacterPanel",
                                                                                       "Character sheet panel.");
@@ -661,10 +829,27 @@ PYBIND11_MODULE(_game, m) {
 
     py::class_<CGameTextPanel, CGamePanel, std::shared_ptr<CGameTextPanel>>(m, "CGameTextPanel", "Text display panel.");
 
-    py::class_<CProxyTargetGraphicsObject, CGameGraphicsObject, std::shared_ptr<CProxyTargetGraphicsObject>>(
-        m, "CProxyTargetGraphicsObject", "Graphics object that proxies a target object.");
-
-    py::class_<CListView, CProxyTargetGraphicsObject, std::shared_ptr<CListView>>(m, "CListView", "List view widget.");
+    py::class_<CListView, CProxyTargetGraphicsObject, std::shared_ptr<CListView>>(m, "CListView", "List view widget.")
+        .def("getCollection", &CListView::getCollection, "Return parent collection callback name.")
+        .def("setCollection", &CListView::setCollection, "Set parent collection callback name.")
+        .def("getCallback", &CListView::getCallback, "Return parent click callback name.")
+        .def("setCallback", &CListView::setCallback, "Set parent click callback name.")
+        .def("getRightClickCallback", &CListView::getRightClickCallback, "Return parent right-click callback name.")
+        .def("setRightClickCallback", &CListView::setRightClickCallback, "Set parent right-click callback name.")
+        .def("getSelect", &CListView::getSelect, "Return parent selection callback name.")
+        .def("setSelect", &CListView::setSelect, "Set parent selection callback name.")
+        .def("getXPrefferedSize", &CListView::getXPrefferedSize, "Return preferred X cell count.")
+        .def("setXPrefferedSize", &CListView::setXPrefferedSize, "Set preferred X cell count.")
+        .def("getYPrefferedSize", &CListView::getYPrefferedSize, "Return preferred Y cell count.")
+        .def("setYPrefferedSize", &CListView::setYPrefferedSize, "Set preferred Y cell count.")
+        .def("getTileSize", &CListView::getTileSize, "Return list tile size.")
+        .def("setTileSize", &CListView::setTileSize, "Set list tile size.")
+        .def("getAllowOversize", &CListView::getAllowOversize, "Return whether list scroll arrows are enabled.")
+        .def("setAllowOversize", &CListView::setAllowOversize, "Set whether list scroll arrows are enabled.")
+        .def("getShowEmpty", &CListView::getShowEmpty, "Return whether empty cells render boxes.")
+        .def("setShowEmpty", &CListView::setShowEmpty, "Set whether empty cells render boxes.")
+        .def("getGrouping", &CListView::getGrouping, "Return whether repeated type ids are grouped.")
+        .def("setGrouping", &CListView::setGrouping, "Set whether repeated type ids are grouped.");
     PY_WRAP_GENERIC_DOC(randint, "randint(lower, upper) -> int: Return a random integer in engine-defined bounds.");
     m.def("jsonify", &jsonify_py, "jsonify(obj) -> str: Serialize a game object to JSON text.");
     PY_WRAP_GENERIC_DOC(logger, "logger(message) -> None: Write an info log message to the engine logger.");

--- a/src/gui/CGui.cpp
+++ b/src/gui/CGui.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -20,39 +20,34 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CTextureCache.h"
 
 CGui::CGui() {
-  SDL_SAFE(SDL_Init(SDL_INIT_VIDEO));
-  SDL_SAFE(SDL_CreateWindowAndRenderer(width, height, SDL_WINDOW_OPENGL,
-                                       &window, &renderer));
-  // TODO: set icon
-  // TODO: check render flags
+    SDL_SAFE(SDL_Init(SDL_INIT_VIDEO));
+    SDL_SAFE(SDL_CreateWindowAndRenderer(width, height, 0, &window, &renderer));
+    // TODO: set icon
+    // TODO: check render flags
 }
 
 CGui::~CGui() {
-  SDL_SAFE(SDL_DestroyRenderer(renderer));
-  SDL_SAFE(SDL_DestroyWindow(window));
+    SDL_SAFE(SDL_DestroyRenderer(renderer));
+    SDL_SAFE(SDL_DestroyWindow(window));
 }
 
 void CGui::render(int i1) {
-  SDL_SAFE(SDL_SetRenderDrawColor(renderer, BLACK));
-  SDL_SAFE(SDL_RenderClear(renderer));
-  CGameGraphicsObject::render(this->ptr<CGui>(), i1);
-  SDL_SAFE(SDL_RenderPresent(renderer));
+    SDL_SAFE(SDL_SetRenderDrawColor(renderer, BLACK));
+    SDL_SAFE(SDL_RenderClear(renderer));
+    CGameGraphicsObject::render(this->ptr<CGui>(), i1);
+    SDL_SAFE(SDL_RenderPresent(renderer));
 }
 
-bool CGui::event(SDL_Event *event) {
-  return CGameGraphicsObject::event(this->ptr<CGui>(), event);
-}
+bool CGui::event(SDL_Event *event) { return CGameGraphicsObject::event(this->ptr<CGui>(), event); }
 
 SDL_Renderer *CGui::getRenderer() const { return renderer; }
 
 std::shared_ptr<CTextureCache> CGui::getTextureCache() {
-  return _textureCache.get(
-      [this]() { return std::make_shared<CTextureCache>(this->ptr<CGui>()); });
+    return _textureCache.get([this]() { return std::make_shared<CTextureCache>(this->ptr<CGui>()); });
 }
 
 std::shared_ptr<CTextManager> CGui::getTextManager() {
-  return _textManager.get(
-      [this]() { return std::make_shared<CTextManager>(this->ptr<CGui>()); });
+    return _textManager.get([this]() { return std::make_shared<CTextManager>(this->ptr<CGui>()); });
 }
 
 int CGui::getWidth() { return width; }

--- a/src/gui/CTextManager.cpp
+++ b/src/gui/CTextManager.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -19,104 +19,95 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CUtil.h"
 
 SDL_Texture *CTextManager::getTexture(const std::string &text, int width) {
-  auto anim = _textures.find(std::make_pair(text, width));
-  if (anim == _textures.end()) {
-    _textures[std::make_pair(text, width)] = this->loadTexture(text, width);
-    return getTexture(text, width);
-  }
-  return _textures[std::make_pair(text, width)];
+    auto anim = _textures.find(std::make_pair(text, width));
+    if (anim == _textures.end()) {
+        _textures[std::make_pair(text, width)] = this->loadTexture(text, width);
+        return getTexture(text, width);
+    }
+    return _textures[std::make_pair(text, width)];
 }
 
 SDL_Texture *CTextManager::loadTexture(std::string text, int width) {
-  SDL_Color textColor = {255, 255, 255, 0};
-  // in some sdl versions blended wrapped automatically treats 0 as not wrapper,
-  // other versions fail on width=0
-  SDL_Surface *surface =
-      SDL_SAFE(width ? TTF_RenderText_Blended_Wrapped(font, text.c_str(),
-                                                      textColor, width)
-                     : TTF_RenderText_Blended(font, text.c_str(), textColor));
-  auto _texture = SDL_SAFE(
-      SDL_CreateTextureFromSurface(_gui.lock()->getRenderer(), surface));
-  SDL_SAFE(SDL_FreeSurface(surface));
-  return _texture;
+    SDL_Color textColor = {255, 255, 255, 0};
+    // in some sdl versions blended wrapped automatically treats 0 as not wrapper,
+    // other versions fail on width=0
+    SDL_Surface *surface = SDL_SAFE(width ? TTF_RenderText_Blended_Wrapped(font, text.c_str(), textColor, width)
+                                          : TTF_RenderText_Blended(font, text.c_str(), textColor));
+    auto _texture = SDL_SAFE(SDL_CreateTextureFromSurface(_gui.lock()->getRenderer(), surface));
+    SDL_SAFE(SDL_FreeSurface(surface));
+    return _texture;
 }
 
 CTextManager::CTextManager(const std::shared_ptr<CGui> &_gui) {
-  SDL_SAFE(TTF_Init());
-  font = SDL_SAFE(TTF_OpenFont("fonts/ampersand.ttf", 24));
-  this->_gui = _gui;
+    SDL_SAFE(TTF_Init());
+    font = SDL_SAFE(TTF_OpenFont("fonts/ampersand.ttf", 24));
+    this->_gui = _gui;
 }
 
 CTextManager::~CTextManager() {
-  for (auto texture : _textures) {
-    SDL_SAFE(SDL_DestroyTexture(texture.second));
-  }
-  _textures.clear();
-  SDL_SAFE(TTF_CloseFont(font));
+    for (auto texture : _textures) {
+        SDL_SAFE(SDL_DestroyTexture(texture.second));
+    }
+    _textures.clear();
+    SDL_SAFE(TTF_CloseFont(font));
 }
 
 int CTextManager::countLines(const std::string &text, int w) {
-  SDL_Rect wrapped;
-  SDL_Texture *wrappedTexture = getTexture(text, w);
-  SDL_SAFE(SDL_QueryTexture(wrappedTexture, nullptr, nullptr, &wrapped.w,
-                            &wrapped.h));
-  SDL_Rect notWrapped;
-  SDL_Texture *notWrappedTexture = getTexture(text);
-  SDL_SAFE(SDL_QueryTexture(notWrappedTexture, nullptr, nullptr, &notWrapped.w,
-                            &notWrapped.h));
-  return wrapped.h / notWrapped.h;
+    SDL_Rect wrapped;
+    SDL_Texture *wrappedTexture = getTexture(text, w);
+    SDL_SAFE(SDL_QueryTexture(wrappedTexture, nullptr, nullptr, &wrapped.w, &wrapped.h));
+    SDL_Rect notWrapped;
+    SDL_Texture *notWrappedTexture = getTexture(text);
+    SDL_SAFE(SDL_QueryTexture(notWrappedTexture, nullptr, nullptr, &notWrapped.w, &notWrapped.h));
+    if (wrapped.h <= 0 || notWrapped.h <= 0) {
+        return 1;
+    }
+    int lines = wrapped.h / notWrapped.h;
+    return lines > 0 ? lines : 1;
 }
 
 void CTextManager::drawText(const std::string &text, int x, int y, int w) {
-  if (text.length() != 0) {
-    SDL_Rect actual;
-    actual.x = x;
-    actual.y = y;
-    SDL_Texture *pTexture = getTexture(text, w);
-    SDL_SAFE(
-        SDL_QueryTexture(pTexture, nullptr, nullptr, &actual.w, &actual.h));
-    SDL_SAFE(
-        SDL_RenderCopy(_gui.lock()->getRenderer(), pTexture, nullptr, &actual));
-  }
+    if (text.length() != 0) {
+        SDL_Rect actual;
+        actual.x = x;
+        actual.y = y;
+        SDL_Texture *pTexture = getTexture(text, w);
+        SDL_SAFE(SDL_QueryTexture(pTexture, nullptr, nullptr, &actual.w, &actual.h));
+        SDL_SAFE(SDL_RenderCopy(_gui.lock()->getRenderer(), pTexture, nullptr, &actual));
+    }
 }
 
-void CTextManager::drawTextCentered(const std::string &text, int x, int y,
-                                    int w, int h) {
-  if (text.length() != 0) {
-    SDL_Rect actual;
-    SDL_Texture *pTexture = getTexture(text, w);
-    SDL_SAFE(
-        SDL_QueryTexture(pTexture, nullptr, nullptr, &actual.w, &actual.h));
-    auto centered =
-        CUtil::boxInBox(RECT(x, y, w, h), RECT(0, 0, actual.w, actual.h));
-    SDL_SAFE(SDL_RenderCopy(_gui.lock()->getRenderer(), pTexture, nullptr,
-                            centered.get()));
-  }
+void CTextManager::drawTextCentered(const std::string &text, int x, int y, int w, int h) {
+    if (text.length() != 0) {
+        SDL_Rect actual;
+        SDL_Texture *pTexture = getTexture(text, w);
+        SDL_SAFE(SDL_QueryTexture(pTexture, nullptr, nullptr, &actual.w, &actual.h));
+        auto centered = CUtil::boxInBox(RECT(x, y, w, h), RECT(0, 0, actual.w, actual.h));
+        SDL_SAFE(SDL_RenderCopy(_gui.lock()->getRenderer(), pTexture, nullptr, centered.get()));
+    }
 }
 
-void CTextManager::drawTextCentered(const std::string &text,
-                                    const std::shared_ptr<SDL_Rect> &rect) {
-  drawTextCentered(text, rect->x, rect->y, rect->w, rect->h);
+void CTextManager::drawTextCentered(const std::string &text, const std::shared_ptr<SDL_Rect> &rect) {
+    drawTextCentered(text, rect->x, rect->y, rect->w, rect->h);
 }
 
-void CTextManager::drawText(const std::string &text,
-                            const std::shared_ptr<SDL_Rect> &rect) {
-  drawText(text, rect->x, rect->y, rect->w);
+void CTextManager::drawText(const std::string &text, const std::shared_ptr<SDL_Rect> &rect) {
+    drawText(text, rect->x, rect->y, rect->w);
 }
 
 std::pair<int, int> CTextManager::getTextureSize(std::string text) {
-  int w = 0, h = 0;
-  if (vstd::ctn(text, '\n')) {
-    for (const auto &line : vstd::split(text, '\n')) {
-      auto lineSize = getTextureSize(line);
-      if (lineSize.first > w) {
-        w = lineSize.first;
-      }
-      h += lineSize.second;
+    int w = 0, h = 0;
+    if (vstd::ctn(text, '\n')) {
+        for (const auto &line : vstd::split(text, '\n')) {
+            auto lineSize = getTextureSize(line);
+            if (lineSize.first > w) {
+                w = lineSize.first;
+            }
+            h += lineSize.second;
+        }
+    } else {
+        SDL_Texture *pTexture = getTexture(text);
+        SDL_SAFE(SDL_QueryTexture(pTexture, nullptr, nullptr, &w, &h));
     }
-  } else {
-    SDL_Texture *pTexture = getTexture(text);
-    SDL_SAFE(SDL_QueryTexture(pTexture, nullptr, nullptr, &w, &h));
-  }
-  return std::make_pair(w, h);
+    return std::make_pair(w, h);
 }

--- a/src/handler/CGuiHandler.cpp
+++ b/src/handler/CGuiHandler.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -101,8 +101,8 @@ void CGuiHandler::showDialog(std::shared_ptr<CDialog> dialog) {
     }
     std::shared_ptr<CGameDialogPanel> panel = game->createObject<CGameDialogPanel>("dialogPanel");
     panel->setDialog(dialog);
-    panel->reload();
     game->getGui()->pushChild(panel);
+    panel->reload();
     panel->awaitClosing();
 }
 

--- a/test.py
+++ b/test.py
@@ -209,6 +209,7 @@ SDL_PRESSED = 1
 SDL_RELEASED = 0
 SDL_SCANCODE_MASK = 1 << 30
 SDL_BUTTON_LEFT = 1
+SDL_BUTTON_RIGHT = 3
 SDL_PIXELFORMAT_RGBA32 = 376840196
 
 GUI_WIDTH = 1920
@@ -354,6 +355,21 @@ def push_sdl_mouse_click(x, y, button=SDL_BUTTON_LEFT):
     push_sdl_mouse_button_event(x, y, button, SDL_MOUSEBUTTONUP)
 
 
+def drain_sdl_events():
+    import ctypes
+
+    class SDL_Event(ctypes.Union):
+        _fields_ = [("padding", ctypes.c_uint8 * 56)]
+
+    sdl = load_sdl_library()
+    sdl.SDL_PollEvent.argtypes = [ctypes.POINTER(SDL_Event)]
+    sdl.SDL_PollEvent.restype = ctypes.c_int
+
+    event = SDL_Event()
+    while sdl.SDL_PollEvent(ctypes.byref(event)) == 1:
+        pass
+
+
 def capture_sdl_screenshot(path):
     import ctypes
     from PIL import Image
@@ -472,6 +488,17 @@ def gui_contains_class(g, class_name):
             return True
         stack.extend(node.get("properties", {}).get("children") or [])
     return False
+
+
+def collect_gui_children(root, class_name):
+    matches = []
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node.getType() == class_name:
+            matches.append(node)
+        stack.extend(node.getChildren())
+    return matches
 
 
 def get_map_proxy_child_counts(g):
@@ -3239,6 +3266,96 @@ class GameTest(unittest.TestCase):
         return True, json.dumps(report, sort_keys=True)
 
     @game_test
+    def test_stats_bonus_text_and_custom_collection_roundtrips(self):
+        game = load_game_module()
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGame(g, "empty")
+
+        base = g.createObject("Stats")
+        base.mainStat = "strength"
+        base.strength = 4
+        base.agility = 2
+        base.dmgMin = 1
+        base.dmgMax = 3
+        base.hit = 50
+        base.crit = 5
+
+        bonus = g.createObject("Stats")
+        bonus.strength = 6
+        bonus.damage = 2
+        bonus.attack = 10
+        bonus.block = 3
+        bonus.armor = 7
+
+        base.addBonus(bonus)
+        self.assertEqual(10, base.getMainValue())
+        self.assertEqual(3, base.dmgMin + base.damage)
+        text_after_bonus = base.getText(7)
+        self.assertIn("Level: 7", text_after_bonus)
+        self.assertIn("Strength: 10", text_after_bonus)
+        self.assertIn("Damage: 3-5", text_after_bonus)
+        self.assertIn("Hit: 60%", text_after_bonus)
+        self.assertIn("Armor: 7%", text_after_bonus)
+
+        base.removeBonus(bonus)
+        self.assertEqual(4, base.getMainValue())
+        self.assertEqual(0, base.damage)
+        self.assertEqual(0, base.attack)
+
+        list_string = g.createObject("CListString")
+        list_string.setValues({"north", "south"})
+        list_string.addValue("west")
+
+        list_int = g.createObject("CListInt")
+        list_int.setValues({1, 3})
+        list_int.addValue(5)
+
+        map_string_string = g.createObject("CMapStringString")
+        map_string_string.setValues({"i": "inventoryPanel", "j": "questPanel"})
+
+        map_string_int = g.createObject("CMapStringInt")
+        map_string_int.setValues({"CMapObject": 1, "CCreature": 2})
+
+        map_int_string = g.createObject("CMapIntString")
+        map_int_string.setValues({0: "GroundTile", 1: "WaterTile"})
+
+        map_int_int = g.createObject("CMapIntInt")
+        map_int_int.setValues({0: 25, 1: 51})
+
+        tagged = g.createObject("CItem")
+        tagged.addTag(game.CTag.HEAL)
+        tagged.addTag("mana")
+
+        roundtrip_objects = {
+            "list_string": list_string,
+            "list_int": list_int,
+            "map_string_string": map_string_string,
+            "map_string_int": map_string_int,
+            "map_int_string": map_int_string,
+            "map_int_int": map_int_int,
+            "tagged": tagged,
+        }
+        serialized = {name: json.loads(game.jsonify(obj))["properties"] for name, obj in roundtrip_objects.items()}
+        clones = {name: obj.clone() for name, obj in roundtrip_objects.items()}
+
+        self.assertEqual({"north", "south", "west"}, set(clones["list_string"].getValues()))
+        self.assertEqual({1, 3, 5}, set(clones["list_int"].getValues()))
+        self.assertEqual({"i": "inventoryPanel", "j": "questPanel"}, dict(clones["map_string_string"].getValues()))
+        self.assertEqual({"CMapObject": 1, "CCreature": 2}, dict(clones["map_string_int"].getValues()))
+        self.assertEqual({0: "GroundTile", 1: "WaterTile"}, dict(clones["map_int_string"].getValues()))
+        self.assertEqual({0: 25, 1: 51}, dict(clones["map_int_int"].getValues()))
+        self.assertTrue(clones["tagged"].hasTag(game.CTag.HEAL))
+        self.assertTrue(clones["tagged"].hasTag(game.CTag.MANA))
+
+        return True, json.dumps(
+            {
+                "stats_text": text_after_bonus.splitlines(),
+                "serialized": serialized,
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_domain_helpers_and_serialized_collections(self):
         game = load_game_module()
         g = game.CGameLoader.loadGame()
@@ -3445,6 +3562,160 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_python_wrapper_exceptions_are_caught_by_native_bridges(self):
+        game = load_game_module()
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGame(g, "empty")
+
+        calls = []
+
+        def fail(name):
+            calls.append(name)
+            raise RuntimeError(name)
+
+        class RaisingBuilding(game.CBuilding):
+            def onCreate(self, event):
+                fail("building_create")
+
+            def onTurn(self, event):
+                fail("building_turn")
+
+            def onDestroy(self, event):
+                fail("building_destroy")
+
+            def onEnter(self, event):
+                fail("building_enter")
+
+            def onLeave(self, event):
+                fail("building_leave")
+
+        class RaisingEvent(game.CEvent):
+            def onCreate(self, event):
+                fail("event_create")
+
+            def onTurn(self, event):
+                fail("event_turn")
+
+            def onDestroy(self, event):
+                fail("event_destroy")
+
+            def onEnter(self, event):
+                fail("event_enter")
+
+            def onLeave(self, event):
+                fail("event_leave")
+
+        class RaisingInteraction(game.CInteraction):
+            def performAction(self, first, second):
+                fail("interaction_perform")
+
+            def configureEffect(self, effect):
+                fail("interaction_configure")
+
+        class RaisingEffect(game.CEffect):
+            def onEffect(self):
+                fail("effect")
+
+        class RaisingTile(game.CTile):
+            def onStep(self, creature):
+                fail("tile")
+
+        class RaisingPotion(game.CPotion):
+            def onUse(self, event):
+                fail("potion")
+
+        class RaisingScroll(game.CScroll):
+            def onUse(self, event):
+                fail("scroll_use")
+
+            def isDisposable(self):
+                fail("scroll_disposable")
+
+        class RaisingTrigger(game.CTrigger):
+            def trigger(self, obj, event):
+                fail("trigger")
+
+        class RaisingQuest(game.CQuest):
+            def isCompleted(self):
+                fail("quest_completed")
+
+            def onComplete(self):
+                fail("quest_complete")
+
+        class RaisingPlugin(game.CPlugin):
+            def load(self, game_instance):
+                fail("plugin")
+
+        class RaisingDialog(game.CDialogBase):
+            def invokeAction(self, action):
+                fail(f"dialog_action_{action}")
+
+            def invokeCondition(self, condition):
+                fail(f"dialog_condition_{condition}")
+
+        creature = g.createObject("CCreature")
+        effect = g.createObject("CEffect")
+
+        for obj, base in ((RaisingBuilding(), game.CBuilding), (RaisingEvent(), game.CEvent)):
+            base.onCreate(obj, None)
+            base.onTurn(obj, None)
+            base.onDestroy(obj, None)
+            base.onEnter(obj, None)
+            base.onLeave(obj, None)
+
+        interaction = RaisingInteraction()
+        game.CInteraction.performAction(interaction, creature, creature)
+        self.assertFalse(game.CInteraction.configureEffect(interaction, effect))
+
+        game.CEffect.onEffect(RaisingEffect())
+        game.CTile.onStep(RaisingTile(), creature)
+        game.CPotion.onUse(RaisingPotion(), None)
+
+        scroll = RaisingScroll()
+        game.CScroll.onUse(scroll, None)
+        self.assertFalse(game.CScroll.isDisposable(scroll))
+
+        game.CTrigger.trigger(RaisingTrigger(), creature, None)
+
+        quest = RaisingQuest()
+        self.assertFalse(game.CQuest.isCompleted(quest))
+        game.CQuest.onComplete(quest)
+
+        game.CPlugin.load(RaisingPlugin(), g)
+
+        dialog = RaisingDialog()
+        game.CDialogBase.invokeAction(dialog, "open")
+        self.assertTrue(game.CDialogBase.invokeCondition(dialog, "ready"))
+
+        expected = {
+            "building_create",
+            "building_turn",
+            "building_destroy",
+            "building_enter",
+            "building_leave",
+            "event_create",
+            "event_turn",
+            "event_destroy",
+            "event_enter",
+            "event_leave",
+            "interaction_perform",
+            "interaction_configure",
+            "effect",
+            "tile",
+            "potion",
+            "scroll_use",
+            "scroll_disposable",
+            "trigger",
+            "quest_completed",
+            "quest_complete",
+            "plugin",
+            "dialog_action_open",
+            "dialog_condition_ready",
+        }
+        self.assertEqual(expected, set(calls))
+        return True, json.dumps(sorted(calls))
+
+    @game_test
     def test_tags_are_typed_in_bindings_and_persist_through_save_load(self):
         game = load_game_module()
         g = game.CGameLoader.loadGame()
@@ -3543,6 +3814,216 @@ class GameTest(unittest.TestCase):
         self.assertTrue(any(path.endswith(".py") for path in resources["plugins"]))
 
         return True, json.dumps(resources, sort_keys=True)
+
+    @game_test
+    def test_blocking_modal_gui_helpers_drive_panels(self):
+        game = load_game_module()
+        drain_sdl_events()
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.loadGui(g)
+        game.CGameLoader.startGameWithPlayer(g, "nouraajd", "Warrior")
+        pump_event_loop(5)
+
+        gui_handler = g.getGuiHandler()
+        player = g.getMap().getPlayer()
+
+        selection = g.createObject("CListString")
+        selection.addValue("FIRST")
+        selection.addValue("SECOND")
+        queue_sdl_inputs(game, lambda: push_sdl_mouse_click(960, 575))
+        self.assertEqual("SECOND", gui_handler.showSelection(selection))
+
+        queue_sdl_inputs(game, push_space_key)
+        gui_handler.showMessage("blocking message workflow")
+
+        queue_sdl_inputs(game, push_space_key)
+        gui_handler.showInfo("blocking info workflow", False)
+
+        queue_sdl_inputs(game, lambda: push_sdl_mouse_click(860, 650))
+        self.assertTrue(gui_handler.showQuestion("confirm yes?"))
+
+        queue_sdl_inputs(game, lambda: push_sdl_mouse_click(1060, 650))
+        self.assertFalse(gui_handler.showQuestion("confirm no?"))
+
+        market = g.createObject("CMarket")
+        market.sell = 50
+        market.buy = 25
+        market_item = g.createObject("Sword")
+        market.setItems({market_item})
+        player.addGold(1000)
+        player.addItem("Sword")
+        queue_sdl_inputs(
+            game,
+            lambda: push_sdl_mouse_click(585, 265),
+            lambda: push_sdl_mouse_click(1185, 265),
+            lambda: push_sdl_mouse_click(1060, 790),
+            lambda: push_sdl_mouse_click(860, 650),
+            lambda: push_sdl_mouse_click(585, 265),
+            lambda: push_sdl_mouse_click(860, 790),
+            lambda: push_sdl_mouse_click(860, 650),
+            push_space_key,
+        )
+        gui_handler.showTrade(market)
+        self.assertFalse(gui_contains_class(g, "CGameTradePanel"))
+
+        queue_sdl_inputs(game, lambda: push_digit_key(2))
+        gui_handler.showDialog(g.createObject("questDialog"))
+        self.assertFalse(gui_contains_class(g, "CGameDialogPanel"))
+
+        loot_creature = g.createObject("GoblinThief")
+        loot_item = g.createObject("Sword")
+        queue_sdl_inputs(game, lambda: push_sdl_mouse_click(585, 265), push_space_key)
+        gui_handler.showLoot(loot_creature, {loot_item})
+        self.assertFalse(gui_contains_class(g, "CGameLootPanel"))
+
+        gui_handler.showTooltip("workflow tooltip", 960, 540)
+        pump_event_loop(2)
+        self.assertTrue(gui_contains_class(g, "CTooltip"))
+
+        queue_sdl_inputs(
+            game,
+            lambda: push_sdl_key_event(ord("i"), 0, SDL_KEYDOWN),
+            lambda: push_sdl_key_event(ord("i"), 0, SDL_KEYUP),
+        )
+        gui_handler.flipPanel("inventoryPanel", "i")
+        self.assertFalse(gui_contains_class(g, "CGameInventoryPanel"))
+
+        return True, json.dumps(
+            {
+                "market_items": len(market.getItems()),
+                "player_swords": player.countItems("Sword"),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
+    def test_fight_panel_callbacks_and_list_views(self):
+        game = load_game_module()
+        drain_sdl_events()
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.loadGui(g)
+        game.CGameLoader.startGameWithPlayer(g, "test", "Warrior")
+        pump_event_loop(5)
+
+        gui = g.getGui()
+        player = g.getMap().getPlayer()
+        player.setMana(999)
+        player.addItem("Sword")
+        player.addItem("Sword")
+
+        static_object = g.createObject("CItem")
+        static_object.animation = "images/item"
+        static_animation = g.createObject("CStaticAnimation")
+        static_animation.setObject(static_object)
+        static_animation.renderObject(gui, 0, 0, 24, 24, 0)
+        static_animation.setColorMod(200, 100, 50, 180)
+        static_animation.setRotation(90)
+        static_animation.renderObject(gui, 0, 0, 24, 24, 1)
+        static_animation.clearColorMod()
+        self.assertEqual(90, static_animation.getRotation())
+
+        dynamic_object = g.createObject("CGameObject")
+        dynamic_object.animation = "images/monsters/octobogz"
+        dynamic_animation = g.createObject("CDynamicAnimation")
+        dynamic_animation.setObject(dynamic_object)
+        dynamic_animation.initialize()
+        pump_event_loop(5)
+        dynamic_animation.renderObject(gui, 0, 0, 24, 24, 100)
+
+        selection_box = g.createObject("CSelectionBox")
+        selection_box.setThickness(3)
+        selection_box.renderObject(gui, 0, 0, 24, 24, 0)
+        self.assertEqual(3, selection_box.getThickness())
+        self.assertFalse(selection_box.mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 0, 0))
+
+        quest_item = g.createObject("CItem")
+        quest_item.name = "unitQuestMarker"
+        quest_item.typeId = "unitQuestMarker"
+        quest_item.addTag(game.CTag.QUEST)
+        player.addItem(quest_item)
+
+        panel = g.createObject("CGameFightPanel")
+        self.assertEqual("CGameFightPanel", panel.getType())
+
+        enemy_a = g.createObject("GoblinThief")
+        enemy_a.name = "unitFightEnemyA"
+        enemy_a.setHp(enemy_a.getHpMax())
+        enemy_b = g.createObject("GoblinThief")
+        enemy_b.name = "unitFightEnemyB"
+        enemy_b.setHp(enemy_b.getHpMax())
+        dead_enemy = g.createObject("GoblinThief")
+        dead_enemy.name = "unitFightEnemyDead"
+        dead_enemy.setHp(0)
+
+        panel.setEnemy(enemy_a)
+        self.assertEqual("unitFightEnemyA", panel.getEnemy().getName())
+        panel.setEnemy(dead_enemy)
+        self.assertIsNone(panel.getEnemy())
+        panel.setEnemies([enemy_a, enemy_b, enemy_a, dead_enemy, None])
+        self.assertEqual(
+            ["unitFightEnemyA", "unitFightEnemyB"], [enemy.getName() for enemy in panel.enemiesCollection(gui)]
+        )
+        panel.enemiesCallback(gui, 1, enemy_b)
+        self.assertTrue(panel.enemiesSelect(gui, 1, enemy_b))
+        self.assertFalse(panel.enemiesSelect(gui, 0, enemy_a))
+
+        interactions = panel.interactionsCollection(gui)
+        self.assertTrue(interactions)
+        action = interactions[0]
+        panel.interactionsCallback(gui, 0, action)
+        self.assertTrue(panel.interactionsSelect(gui, 0, action))
+        panel.interactionsCallback(gui, 0, action)
+        self.assertEqual(action.getName(), panel.selectInteraction().getName())
+        self.assertFalse(panel.interactionsSelect(gui, 0, action))
+
+        items = panel.itemsCollection(gui)
+        normal_item = next(item for item in items if not item.hasTag(game.CTag.QUEST))
+        panel.itemsCallback(gui, 0, quest_item)
+        self.assertFalse(panel.itemsSelect(gui, 0, quest_item))
+        panel.itemsCallback(gui, 0, normal_item)
+        self.assertTrue(panel.itemsSelect(gui, 0, normal_item))
+        self.assertFalse(panel.itemsRightClickCallback(gui, 0, quest_item))
+        self.assertTrue(panel.itemsRightClickCallback(gui, 0, normal_item))
+        self.assertFalse(panel.itemsSelect(gui, 0, normal_item))
+
+        inventory_panel = g.getGuiHandler().openPanel("inventoryPanel")
+        pump_event_loop(5)
+        list_views = collect_gui_children(inventory_panel, "CListView")
+        self.assertGreaterEqual(len(list_views), 2)
+        proxied_counts = {}
+        for index, list_view in enumerate(list_views):
+            list_view.setTileSize(50)
+            list_view.setXPrefferedSize(2)
+            list_view.setYPrefferedSize(2)
+            list_view.setAllowOversize(True)
+            list_view.refresh()
+            first_cell = list_view.getProxiedObjects(gui, 0, 0)
+            proxied_counts[f"{index}:first"] = len(first_cell)
+            self.assertTrue(first_cell or not list_view.getShowEmpty())
+            for graphic in first_cell:
+                graphic.mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_RIGHT, 1, 1)
+                graphic.mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 1, 1)
+            self.assertTrue(list_view.mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 1, 1))
+            list_view.mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_RIGHT, 1, 1)
+            self.assertTrue(list_view.mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 999, 999))
+
+            for graphic in list_view.getProxiedObjects(gui, 1, 1):
+                graphic.mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 1, 1)
+            for graphic in list_view.getProxiedObjects(gui, 0, 1):
+                graphic.mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 1, 1)
+
+        panel.mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_RIGHT, 0, 0)
+        inventory_panel.close()
+        self.assertFalse(gui_contains_class(g, "CGameInventoryPanel"))
+
+        return True, json.dumps(
+            {
+                "enemies": [enemy.getName() for enemy in panel.enemiesCollection(gui)],
+                "list_views": len(list_views),
+                "proxied_counts": proxied_counts,
+            },
+            sort_keys=True,
+        )
 
     @game_test
     def test_resource_provider_resolves_and_loads_known_files(self):
@@ -5025,6 +5506,24 @@ def queue_panel_observer(game, g, class_name):
 
     game.event_loop.instance().invoke(observe)
     return observed
+
+
+def queue_sdl_inputs(game, *callbacks):
+    def dispatch():
+        for callback in callbacks:
+            callback()
+
+    game.event_loop.instance().invoke(dispatch)
+
+
+def push_space_key():
+    push_sdl_key_event(ord(" "), 44, SDL_KEYDOWN)
+    push_sdl_key_event(ord(" "), 44, SDL_KEYUP)
+
+
+def push_digit_key(digit):
+    push_sdl_key_event(ord(str(digit)), 0, SDL_KEYDOWN)
+    push_sdl_key_event(ord(str(digit)), 0, SDL_KEYUP)
 
 
 def open_panel_for_screenshot(test_case, g, panel_name, class_name):

--- a/tests/unit/test_coords.cpp
+++ b/tests/unit/test_coords.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CUtil.h"
 #include "core/CPathFinder.h"
 #include "handler/CScriptHandler.h"
+#include <rdg.h>
 #include "vcache.h"
 #include "vfunctional.h"
 #include "vutil.h"
@@ -630,6 +631,136 @@ void test_script_handler_executes_commands_and_wraps_functions() {
     expect_true(handler.get_object<int>("created_void_value") == 5,
                 "void call_created_function should update Python state and clean up its temporary function");
 }
+
+void test_random_dungeon_cell_flags_and_validation() {
+    rdg::Cell cell;
+    cell.setType(rdg::CellType::ROOM);
+    expect_true(cell.hasType(rdg::CellType::ROOM), "rdg cell should store a primary type");
+    expect_true(cell.isBlockedRoom(), "rdg room cells should block room placement");
+    expect_true(cell.isOpenspace(), "rdg room cells should be open space");
+    cell.addType(rdg::CellType::ENTRANCE);
+    cell.setLabel("A");
+    expect_true(cell.hasLabel() && cell.getLabel() == "A", "rdg cells should expose single-character labels");
+    expect_true(cell.isEspace(), "rdg labeled entrance cells should count as entrance space");
+    cell.clearEspace();
+    expect_true(!cell.hasLabel(), "rdg clearEspace should clear labels");
+    expect_true(!cell.hasType(rdg::CellType::ENTRANCE), "rdg clearEspace should clear entrance flags");
+    cell.setType(rdg::CellType::STAIR_DN);
+    cell.addType(rdg::CellType::STAIR_UP);
+    expect_true(cell.isStairs(), "rdg stair flags should be detected");
+    cell.clearTypes();
+    expect_true(!cell.isStairs(), "rdg clearTypes should remove stair flags");
+
+    rdg::Door locked_door{.kind = rdg::DoorKind::Locked};
+    rdg::Stairs up_stairs{.kind = rdg::StairKind::Up};
+    expect_true(locked_door.getKey() == "lock", "rdg door keys should describe locked doors");
+    expect_true(locked_door.getType() == "Locked Door", "rdg door labels should describe locked doors");
+    expect_true(up_stairs.getKey() == "up", "rdg stair keys should describe up stairs");
+
+    expect_true(rdg::dungeon_layout_from_string("Box") == rdg::DungeonLayout::Box,
+                "rdg dungeon layout parsing should accept Box");
+    expect_true(!rdg::dungeon_layout_from_string("Invalid"), "rdg dungeon layout parsing should reject unknown values");
+    expect_true(rdg::room_layout_from_string("Packed") == rdg::RoomLayout::Packed,
+                "rdg room layout parsing should accept Packed");
+    expect_true(!rdg::room_layout_from_string("Invalid"), "rdg room layout parsing should reject unknown values");
+    expect_true(rdg::map_style_from_string("Standard") == rdg::MapStyle::Standard,
+                "rdg map style parsing should accept Standard");
+    expect_true(!rdg::map_style_from_string("Invalid"), "rdg map style parsing should reject unknown values");
+    expect_true(rdg::to_string(rdg::DungeonLayout::Round) == "Round", "rdg layout strings should include Round");
+    expect_true(rdg::to_string(rdg::RoomLayout::Scattered) == "Scattered",
+                "rdg room layout strings should include Scattered");
+    expect_true(rdg::to_string(rdg::MapStyle::Standard) == "Standard", "rdg map style strings should include Standard");
+    expect_true(rdg::key(rdg::DoorKind::Portcullis) == "portc", "rdg door keys should include portcullis");
+    expect_true(rdg::to_string(rdg::DoorKind::Secret) == "Secret Door", "rdg door labels should include secret doors");
+    expect_true(rdg::key(rdg::StairKind::Down) == "down", "rdg stair keys should include down stairs");
+
+    rdg::Options options;
+    options.n_rows = 2;
+    expect_true(rdg::validate_options(options).has_value(), "rdg should reject tiny dimensions");
+    options.n_rows = 4;
+    options.n_cols = 5;
+    expect_true(rdg::validate_options(options).has_value(), "rdg should reject even dimensions");
+    options.n_rows = 5;
+    options.room_min = 0;
+    expect_true(rdg::validate_options(options).has_value(), "rdg should reject non-positive room sizes");
+    options.room_min = 7;
+    options.room_max = 3;
+    expect_true(rdg::validate_options(options).has_value(), "rdg should reject inverted room sizes");
+    options.room_min = 3;
+    options.room_max = 7;
+    options.remove_deadends = 101;
+    expect_true(rdg::validate_options(options).has_value(), "rdg should reject invalid dead-end percentages");
+    options.remove_deadends = 50;
+    options.add_stairs = -1;
+    expect_true(rdg::validate_options(options).has_value(), "rdg should reject negative stair counts");
+    options.add_stairs = 1;
+    options.cell_size = 0;
+    expect_true(rdg::validate_options(options).has_value(), "rdg should reject non-positive cell sizes");
+    options.cell_size = 18;
+    expect_true(!rdg::validate_options(options).has_value(), "rdg should accept valid options");
+}
+
+void test_random_dungeon_layout_variants_generate_accessible_maps() {
+    std::mt19937 rng(12345);
+    std::vector<rdg::Options> variants;
+
+    rdg::Options packed_box;
+    packed_box.n_rows = 17;
+    packed_box.n_cols = 17;
+    packed_box.room_layout = rdg::RoomLayout::Packed;
+    packed_box.dungeon_layout = rdg::DungeonLayout::Box;
+    packed_box.corridor_layout = rdg::CorridorLayout::STRAIGHT;
+    packed_box.add_stairs = 2;
+    variants.push_back(packed_box);
+
+    rdg::Options scattered_cross;
+    scattered_cross.n_rows = 21;
+    scattered_cross.n_cols = 21;
+    scattered_cross.room_layout = rdg::RoomLayout::Scattered;
+    scattered_cross.dungeon_layout = rdg::DungeonLayout::Cross;
+    scattered_cross.corridor_layout = rdg::CorridorLayout::BENT;
+    scattered_cross.remove_deadends = 50;
+    scattered_cross.add_stairs = 1;
+    variants.push_back(scattered_cross);
+
+    rdg::Options round_labyrinth;
+    round_labyrinth.n_rows = 19;
+    round_labyrinth.n_cols = 19;
+    round_labyrinth.room_layout = rdg::RoomLayout::Packed;
+    round_labyrinth.dungeon_layout = rdg::DungeonLayout::Round;
+    round_labyrinth.corridor_layout = rdg::CorridorLayout::LABYRINTH;
+    round_labyrinth.remove_deadends = 0;
+    round_labyrinth.add_stairs = 0;
+    variants.push_back(round_labyrinth);
+
+    for (const auto &options : variants) {
+        auto dungeon = rdg::create_dungeon(options, rng);
+        expect_true(dungeon.rowCount() == options.n_rows, "rdg dungeon should preserve requested row count");
+        expect_true(dungeon.colCount() == options.n_cols, "rdg dungeon should preserve requested column count");
+        expect_true(!dungeon.getCells().empty(), "rdg dungeon should expose generated cells");
+        expect_true(!dungeon.getRooms().empty(), "rdg dungeon variants should generate rooms");
+
+        int open_cells = 0;
+        int blocked_cells = 0;
+        int door_cells = 0;
+        int stair_cells = 0;
+        for (int row = 0; row < dungeon.rowCount(); ++row) {
+            for (int col = 0; col < dungeon.colCount(); ++col) {
+                const auto &cell = dungeon.cellAt(row, col);
+                open_cells += cell.isOpenspace() ? 1 : 0;
+                blocked_cells += cell.hasType(rdg::CellType::BLOCKED) ? 1 : 0;
+                door_cells += cell.isDoorspace() ? 1 : 0;
+                stair_cells += cell.isStairs() ? 1 : 0;
+            }
+        }
+
+        expect_true(open_cells > 0, "rdg dungeon variants should include open cells");
+        expect_true(blocked_cells >= 0, "rdg dungeon blocked count should be inspectable");
+        expect_true(door_cells >= 0, "rdg dungeon door count should be inspectable");
+        expect_true(stair_cells >= static_cast<int>(dungeon.getStairs().size()),
+                    "rdg stair records should correspond to stair cells");
+    }
+}
 } // namespace
 
 int main() {
@@ -659,6 +790,8 @@ int main() {
     test_vstd_allocation_random_and_value_helpers();
     test_vstd_string_helpers();
     test_script_handler_executes_commands_and_wraps_functions();
+    test_random_dungeon_cell_flags_and_validation();
+    test_random_dungeon_layout_variants_generate_accessible_maps();
 
     if (failures == 0) {
         std::cout << "All unit tests passed.\n";


### PR DESCRIPTION
## What changed

- Added native random-dungeon-generator unit coverage for option validation, cell flags, labels, doors, stairs, and generated layout variants.
- Added Python integration coverage for modal GUI flows, fight panel callbacks, list view behavior, wrapper exception bridges, stats bonus text, and custom collection serialization roundtrips.
- Exposed the small set of existing GUI/native methods needed to drive those paths from Python tests.
- Made GUI construction work without forcing an OpenGL window flag, guarded zero-height text line counting, and reloaded dialog panels after attaching them to the GUI tree.
- Made `scripts/run_coverage.sh` pass gcovr's duplicate function records with `--merge-mode-functions merge-use-line-min` when supported.

## Why

The coverage threshold is now 90%, and the existing suite was just below that gate on the updated main branch. These tests exercise real engine, GUI, wrapper, collection, and RDG paths so the new threshold is reachable without lowering the gate.

## Validation

- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py` (`121` tests, `16` skipped)
- `./scripts/run_coverage.sh` outside the sandbox after a sandbox-local socket/Xvfb failure; passed at `90.5%` line coverage (`7754 / 8565`)
- `black -l 120 test.py`
- `clang-format -i src/core/CModule.cpp src/gui/CGui.cpp src/gui/CTextManager.cpp src/handler/CGuiHandler.cpp tests/unit/test_coords.cpp`
- `git diff --check`

## Known limitations

The coverage run needed to be rerun outside the sandbox because the sandbox blocked a local socket in the MCP HTTP test and interfered with focused-window capture for Xvfb screenshot children. The escalated rerun completed successfully.