### PR TITLE
[codex] Modernize C++23 core and SDL ownership

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #fall-of-nouraajd c++ dark fantasy game
-# Copyright (C) 2025  Andrzej Lis
+# Copyright (C) 2025-2026  Andrzej Lis
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,7 +22,6 @@ project(fall-of-nouraajd)
 
 if (WIN32)
     set(CPACK_GENERATOR "ZIP")
-    add_compile_definitions(SDL_MAIN_HANDLED)
 else ()
     set(CPACK_GENERATOR "TGZ")
 endif ()
@@ -30,24 +29,6 @@ endif ()
 include(${CMAKE_SOURCE_DIR}/cmake/cotire.cmake)
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_SOURCE_DIR}/cmake")
-
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-if (MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /bigobj /permissive- /Zc:preprocessor /EHsc /DBOOST_ALLOW_DEPRECATED_HEADERS /DBOOST_BIND_GLOBAL_PLACEHOLDERS /D_USE_MATH_DEFINES /DNOMINMAX /DWIN32_LEAN_AND_MEAN")
-else ()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include cmath -Wall")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -s")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g3")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_ALLOW_DEPRECATED_HEADERS -DBOOST_BIND_GLOBAL_PLACEHOLDERS")
-
-    if (WIN32)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_hypot=hypot -Wa,-mbig-obj")
-        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O")
-    endif ()
-endif ()
 
 file(GLOB_RECURSE GAME_SRC ${CMAKE_SOURCE_DIR}/src/**.cpp ${CMAKE_SOURCE_DIR}/src/**.h)
 
@@ -84,6 +65,54 @@ if (NOT NLOHMANN_JSON_INCLUDE_DIR)
     message(FATAL_ERROR "nlohmann/json.hpp was not found. On Debian/Ubuntu, run: sudo apt-get install nlohmann-json3-dev.")
 endif ()
 
+function(configure_fon_cpp_target target_name)
+    target_compile_features(${target_name} PRIVATE cxx_std_23)
+    set_target_properties(${target_name} PROPERTIES
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+    )
+    target_include_directories(${target_name} PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_SOURCE_DIR}/vstd
+        ${CMAKE_SOURCE_DIR}/random-dungeon-generator
+        ${Python3_INCLUDE_DIRS}
+        ${SDL2_INCLUDE_DIR}
+        ${SDL2_IMAGE_INCLUDE_DIR}
+        ${SDL2_TTF_INCLUDE_DIR}
+        ${NLOHMANN_JSON_INCLUDE_DIR}
+    )
+    target_compile_definitions(${target_name} PRIVATE
+        BOOST_ALLOW_DEPRECATED_HEADERS
+        BOOST_BIND_GLOBAL_PLACEHOLDERS
+    )
+    if (WIN32)
+        target_compile_definitions(${target_name} PRIVATE SDL_MAIN_HANDLED)
+    endif ()
+    if (MSVC)
+        target_compile_options(${target_name} PRIVATE /W3 /bigobj /permissive- /Zc:preprocessor /EHsc)
+        target_compile_definitions(${target_name} PRIVATE
+            _USE_MATH_DEFINES
+            NOMINMAX
+            WIN32_LEAN_AND_MEAN
+        )
+    else ()
+        target_compile_options(${target_name} PRIVATE
+            -include cmath
+            -Wall
+            $<$<CONFIG:Release>:-O3>
+            $<$<CONFIG:Release>:-s>
+            $<$<CONFIG:Debug>:-g3>
+        )
+        if (WIN32)
+            target_compile_options(${target_name} PRIVATE
+                -Wa,-mbig-obj
+                $<$<CONFIG:Debug>:-O>
+            )
+            target_compile_definitions(${target_name} PRIVATE _hypot=hypot)
+        endif ()
+    endif ()
+endfunction()
+
 set(SDL2_LIBS ${SDL2_LIBRARY})
 set(SDL2_EXECUTABLE_LIBS ${SDL2_LIBRARY})
 if (TARGET SDL2::SDL2)
@@ -101,18 +130,8 @@ if (TARGET SDL2_ttf::SDL2_ttf)
     set(SDL2_TTF_LIBS SDL2_ttf::SDL2_ttf)
 endif ()
 
-include_directories(${Python3_INCLUDE_DIRS})
-include_directories(${SDL2_INCLUDE_DIR})
-include_directories(${SDL2_IMAGE_INCLUDE_DIR})
-include_directories(${SDL2_TTF_INCLUDE_DIR})
-include_directories(${NLOHMANN_JSON_INCLUDE_DIR})
-
-include_directories(${CMAKE_SOURCE_DIR}/src)
-
-include_directories(${CMAKE_SOURCE_DIR}/vstd)
-include_directories(${CMAKE_SOURCE_DIR}/random-dungeon-generator)
-
 pybind11_add_module(_game NO_EXTRAS ${GAME_SRC})
+configure_fon_cpp_target(_game)
 target_link_libraries(_game PRIVATE ${SDL2_LIBS} ${SDL2_IMAGE_LIBS} ${SDL2_TTF_LIBS})
 
 set_source_files_properties(
@@ -372,15 +391,7 @@ add_executable(for_unit_tests
     src/handler/CScriptHandler.cpp
 )
 
-target_include_directories(for_unit_tests PRIVATE
-    ${CMAKE_SOURCE_DIR}/src
-    ${CMAKE_SOURCE_DIR}/vstd
-    ${NLOHMANN_JSON_INCLUDE_DIR}
-    ${Python3_INCLUDE_DIRS}
-    ${SDL2_INCLUDE_DIR}
-    ${SDL2_IMAGE_INCLUDE_DIR}
-    ${SDL2_TTF_INCLUDE_DIR}
-)
+configure_fon_cpp_target(for_unit_tests)
 
 target_link_libraries(for_unit_tests PRIVATE
     Python3::Python

--- a/src/core/CConcepts.h
+++ b/src/core/CConcepts.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -21,9 +21,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 class CGameEvent;
 
+class CGame;
+
 class CGameObject;
 
 class CGui;
+
+struct Coords;
 
 enum class CTag;
 
@@ -86,6 +90,31 @@ template <typename F>
 concept FilePredicate = std::predicate<F, std::string>;
 
 template <typename F>
+concept PathPassability = std::predicate<const clean_t<F> &, const Coords &>;
+
+template <typename F>
+concept PathWaypoint =
+    std::invocable<const clean_t<F> &, const Coords &> &&
+    std::same_as<clean_t<std::invoke_result_t<const clean_t<F> &, const Coords &>>, std::pair<bool, Coords>>;
+
+template <typename F>
+concept PathNeighbors =
+    std::invocable<const clean_t<F> &, const Coords &> &&
+    std::ranges::input_range<std::invoke_result_t<const clean_t<F> &, const Coords &>> &&
+    std::convertible_to<clean_t<std::ranges::range_value_t<std::invoke_result_t<const clean_t<F> &, const Coords &>>>,
+                        Coords>;
+
+template <typename F>
+concept PathDistance =
+    std::invocable<const clean_t<F> &, const Coords &, const Coords &> &&
+    std::convertible_to<std::invoke_result_t<const clean_t<F> &, const Coords &, const Coords &>, double>;
+
+template <typename F>
+concept PathStepCost =
+    std::invocable<const clean_t<F> &, const Coords &, const Coords &> &&
+    std::convertible_to<std::invoke_result_t<const clean_t<F> &, const Coords &, const Coords &>, int>;
+
+template <typename F>
 concept SdlStatusCallable = std::invocable<F &> && std::same_as<std::invoke_result_t<F &>, int>;
 
 template <typename F>
@@ -94,6 +123,11 @@ concept SdlVoidCallable = std::invocable<F &> && std::same_as<std::invoke_result
 template <typename F>
 concept SdlNullableCallable = std::invocable<F &> && !SdlStatusCallable<F> && !SdlVoidCallable<F>;
 
+template <typename T>
+concept SdlResourcePointer = std::is_pointer_v<clean_t<T>> && requires(clean_t<T> value) {
+    { value == nullptr } -> std::convertible_to<bool>;
+};
+
 template <typename F>
 concept AnimationCallback = std::is_invocable_r_v<bool, F, std::shared_ptr<CGui>, SDL_EventType, int, int, int>;
 
@@ -101,8 +135,26 @@ template <typename F>
 concept TriggerCallback = std::is_invocable_r_v<void, F, std::shared_ptr<CGameObject>, std::shared_ptr<CGameEvent>>;
 
 template <typename T>
+concept PythonCallback = std::same_as<clean_t<T>, pybind11::object> || std::invocable<T &>;
+
+template <typename T>
 concept PythonWrapperBase = GameObjectDerived<T>;
 
 template <typename T>
 concept PythonReturn = std::same_as<T, void> || std::default_initializable<T>;
+
+template <typename T, typename Value>
+concept ExpectedLike = requires(T result) {
+    { result.has_value() } -> std::convertible_to<bool>;
+    { *result } -> std::convertible_to<Value>;
+};
+
+template <typename F, typename Serialized, typename Deserialized>
+concept SerializerCallable =
+    std::invocable<F &, Deserialized> && std::same_as<std::invoke_result_t<F &, Deserialized>, Serialized>;
+
+template <typename F, typename Serialized, typename Deserialized>
+concept DeserializerCallable =
+    std::invocable<F &, std::shared_ptr<CGame>, Serialized> &&
+    std::same_as<std::invoke_result_t<F &, std::shared_ptr<CGame>, Serialized>, Deserialized>;
 } // namespace fn

--- a/src/core/CGlobal.h
+++ b/src/core/CGlobal.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -28,8 +28,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <SDL_ttf.h>
 
 #include <any>
+#include <array>
+#include <compare>
 #include <concepts>
 #include <condition_variable>
+#include <cmath>
 #include <csignal>
 #include <cstdio>
 #include <ctime>
@@ -37,6 +40,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <expected>
 #include <iomanip>
 #include <iostream>
 #include <nlohmann/json.hpp>
@@ -49,6 +53,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <random>
 #include <ranges>
 #include <set>
+#include <source_location>
 #include <sstream>
 #include <string>
 #include <thread>

--- a/src/core/CJsonUtil.h
+++ b/src/core/CJsonUtil.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -21,6 +21,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CGlobal.h"
 
 namespace CJsonUtil {
+struct JsonParseError {
+    std::string source;
+    std::string message;
+    std::string preview;
+    std::source_location location;
+};
+
+using JsonParseResult = std::expected<std::shared_ptr<json>, JsonParseError>;
+
 inline std::shared_ptr<json> alias(const std::shared_ptr<json> &owner, json &value) {
     return std::shared_ptr<json>(owner, &value);
 }
@@ -38,6 +47,11 @@ inline std::string preview_json(std::string text, size_t limit = 120) {
         return text;
     }
     return text.substr(0, limit) + "...";
+}
+
+inline void log_parse_error(const JsonParseError &error) {
+    vstd::logger::warning("Failed to parse json from", error.source.empty() ? "<unknown>" : error.source, ":",
+                          error.message, "preview:", error.preview);
 }
 
 template <fn::JsonObjectPointer T> bool hasStringProp(T object, std::string prop) {
@@ -78,15 +92,24 @@ template <fn::JsonMapPointer T> bool isMap(T object) {
     return true;
 }
 
-template <typename T = void>
-std::shared_ptr<json> from_string(std::string json_string, const std::string &source = std::string()) {
+inline JsonParseResult parse_expected(std::string json_string, const std::string &source = std::string(),
+                                      std::source_location location = std::source_location::current()) {
     try {
         return std::make_shared<json>(json::parse(json_string));
     } catch (const std::exception &exception) {
-        vstd::logger::warning("Failed to parse json from", source.empty() ? "<unknown>" : source, ":", exception.what(),
-                              "preview:", preview_json(std::move(json_string)));
+        return std::unexpected(
+            JsonParseError{source, exception.what(), preview_json(std::move(json_string)), location});
+    }
+}
+
+template <typename T = void>
+std::shared_ptr<json> from_string(std::string json_string, const std::string &source = std::string()) {
+    auto result = parse_expected(std::move(json_string), source);
+    if (!result) {
+        log_parse_error(result.error());
         return nullptr;
     }
+    return *result;
     //        vstd::logger::debug(json,reader.getFormatedErrorMessages());
 }
 

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -48,6 +48,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CLoader.h"
 #include "core/CPythonOverrides.h"
 #include "core/CTags.h"
+#include "core/CUtil.h"
 #include "core/CWrapper.h"
 #include <pybind11/stl_bind.h>
 #include <pybind11/stl.h>
@@ -342,7 +343,7 @@ PYBIND11_MODULE(_game, m) {
         .def(
             "renderObject",
             [](CStaticAnimation &self, const std::shared_ptr<CGui> &gui, int x, int y, int w, int h, int frame_time) {
-                self.renderObject(gui, RECT(x, y, w, h), frame_time);
+                self.renderObject(gui, CUtil::rect(x, y, w, h), frame_time);
             },
             "Render the static animation into a rectangle.");
     py::class_<CDynamicAnimation, CAnimation, std::shared_ptr<CDynamicAnimation>>(m, "CDynamicAnimation",
@@ -351,7 +352,7 @@ PYBIND11_MODULE(_game, m) {
         .def(
             "renderObject",
             [](CDynamicAnimation &self, const std::shared_ptr<CGui> &gui, int x, int y, int w, int h, int frame_time) {
-                self.renderObject(gui, RECT(x, y, w, h), frame_time);
+                self.renderObject(gui, CUtil::rect(x, y, w, h), frame_time);
             },
             "Render the dynamic animation into a rectangle.");
     py::class_<CSelectionBox, CAnimation, std::shared_ptr<CSelectionBox>>(m, "CSelectionBox",
@@ -361,7 +362,7 @@ PYBIND11_MODULE(_game, m) {
         .def(
             "renderObject",
             [](CSelectionBox &self, const std::shared_ptr<CGui> &gui, int x, int y, int w, int h, int frame_time) {
-                self.renderObject(gui, RECT(x, y, w, h), frame_time);
+                self.renderObject(gui, CUtil::rect(x, y, w, h), frame_time);
             },
             "Render the selection outline into a rectangle.");
 
@@ -777,8 +778,6 @@ PYBIND11_MODULE(_game, m) {
     py::class_<CGameTradePanel, CGamePanel, std::shared_ptr<CGameTradePanel>>(m, "CGameTradePanel", "Trade panel.")
         .def("getMarket", &CGameTradePanel::getMarket, "Return market displayed by this panel.");
 
-    py::class_<CGameFightPanel, CGamePanel, std::shared_ptr<CGameFightPanel>>(m, "CGameFightPanel", "Fight panel.")
-        .def("getEnemy", &CGameFightPanel::getEnemy, "Return current enemy creature.")
     py::class_<CGameFightPanel, CGamePanel, std::shared_ptr<CGameFightPanel>>(m, "CGameFightPanel", "Fight panel.")
         .def("getEnemy", &CGameFightPanel::getEnemy, "Return current enemy creature.")
         .def("setEnemy", &CGameFightPanel::setEnemy, "Set current enemy creature.")

--- a/src/core/CPathFinder.cpp
+++ b/src/core/CPathFinder.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "core/CPathFinder.h"
+#include "gui/CSdlResources.h"
 
 #include <algorithm>
 #include <cmath>
@@ -61,9 +62,9 @@ struct AStarCompare {
 using AStarQueue = std::priority_queue<AStarNode, std::vector<AStarNode>, AStarCompare>;
 using NextStepQueue = std::priority_queue<NextStepNode, std::vector<NextStepNode>, AStarCompare>;
 
-class PassabilityCache {
+template <fn::PathPassability CanStep> class PassabilityCache {
   public:
-    explicit PassabilityCache(const std::function<bool(const Coords &)> &canStep) : canStep(canStep) {}
+    explicit PassabilityCache(const CanStep &canStep) : canStep(canStep) {}
 
     bool canStepAt(const Coords &coords) {
         auto cached = values.find(coords);
@@ -77,14 +78,16 @@ class PassabilityCache {
     }
 
   private:
-    const std::function<bool(const Coords &)> &canStep;
+    const CanStep &canStep;
     std::unordered_map<Coords, bool> values;
 };
 
-std::vector<Coords> candidates(const Coords &coords,
-                               const std::function<std::pair<bool, Coords>(const Coords &)> &waypoint,
-                               const std::function<std::vector<Coords>(const Coords &)> &neighbors) {
-    auto list = neighbors(coords);
+template <fn::PathWaypoint Waypoint, fn::PathNeighbors Neighbors>
+std::vector<Coords> candidates(const Coords &coords, const Waypoint &waypoint, const Neighbors &neighbors) {
+    std::vector<Coords> list;
+    for (const auto &neighbor : neighbors(coords)) {
+        list.push_back(neighbor);
+    }
     auto waypoint_direction = waypoint(coords);
     if (waypoint_direction.first) {
         list.push_back(waypoint_direction.second);
@@ -92,10 +95,10 @@ std::vector<Coords> candidates(const Coords &coords,
     return list;
 }
 
-Values fillValues(const std::function<bool(const Coords &)> &canStep, const Coords &goal,
-                  const std::function<std::pair<bool, Coords>(const Coords &)> &waypoint,
-                  const std::function<std::vector<Coords>(const Coords &)> &neighbors,
-                  const CPathFinder::StepCost &stepCost, const Coords *stopAt = nullptr) {
+template <fn::PathPassability CanStep, fn::PathWaypoint Waypoint, fn::PathNeighbors Neighbors,
+          fn::PathStepCost StepCost>
+Values fillValues(const CanStep &canStep, const Coords &goal, const Waypoint &waypoint, const Neighbors &neighbors,
+                  const StepCost &stepCost, const Coords *stopAt = nullptr) {
     Values values = std::make_shared<std::unordered_map<Coords, int>>();
     PassabilityCache passability(canStep);
     Queue nodes;
@@ -133,8 +136,8 @@ Values fillValues(const std::function<bool(const Coords &)> &canStep, const Coor
     return values;
 }
 
-int estimateCost(const std::function<double(const Coords &, const Coords &)> &distance, const Coords &from,
-                 const Coords &goal) {
+template <fn::PathDistance Distance>
+int estimateCost(const Distance &distance, const Coords &from, const Coords &goal) {
     return std::max(0, static_cast<int>(std::floor(distance(from, goal))));
 }
 
@@ -157,11 +160,10 @@ std::vector<Coords> buildPath(const Coords &start, const Coords &goal,
     return path;
 }
 
-std::vector<Coords> findAStarPath(Coords start, Coords goal, const std::function<bool(const Coords &)> &canStep,
-                                  const std::function<std::pair<bool, Coords>(const Coords &)> &waypoint,
-                                  const std::function<std::vector<Coords>(const Coords &)> &neighbors,
-                                  const std::function<double(const Coords &, const Coords &)> &distance,
-                                  const CPathFinder::StepCost &stepCost) {
+template <fn::PathPassability CanStep, fn::PathWaypoint Waypoint, fn::PathNeighbors Neighbors,
+          fn::PathDistance Distance, fn::PathStepCost StepCost>
+std::vector<Coords> findAStarPath(Coords start, Coords goal, const CanStep &canStep, const Waypoint &waypoint,
+                                  const Neighbors &neighbors, const Distance &distance, const StepCost &stepCost) {
     if (start == goal) {
         return {start};
     }
@@ -208,11 +210,10 @@ std::vector<Coords> findAStarPath(Coords start, Coords goal, const std::function
     return buildPath(start, goal, previous);
 }
 
-Coords findAStarNextStep(Coords start, Coords goal, const std::function<bool(const Coords &)> &canStep,
-                         const std::function<std::pair<bool, Coords>(const Coords &)> &waypoint,
-                         const std::function<std::vector<Coords>(const Coords &)> &neighbors,
-                         const std::function<double(const Coords &, const Coords &)> &distance,
-                         const CPathFinder::StepCost &stepCost) {
+template <fn::PathPassability CanStep, fn::PathWaypoint Waypoint, fn::PathNeighbors Neighbors,
+          fn::PathDistance Distance, fn::PathStepCost StepCost>
+Coords findAStarNextStep(Coords start, Coords goal, const CanStep &canStep, const Waypoint &waypoint,
+                         const Neighbors &neighbors, const Distance &distance, const StepCost &stepCost) {
     if (start == goal) {
         return start;
     }
@@ -260,27 +261,20 @@ Coords findAStarNextStep(Coords start, Coords goal, const std::function<bool(con
 } // namespace
 
 std::shared_ptr<vstd::future<Coords, void>>
-CPathFinder::findNextStep(Coords start, Coords goal, const std::function<bool(const Coords &)> &canStep,
-                          const std::function<std::pair<bool, Coords>(const Coords &)> waypoint,
-                          const std::function<std::vector<Coords>(const Coords &)> &neighbors,
-                          const std::function<double(const Coords &, const Coords &)> &distance,
-                          const StepCost &stepCost) {
+CPathFinder::findNextStep(Coords start, Coords goal, const CanStep &canStep, const Waypoint waypoint,
+                          const Neighbors &neighbors, const Distance &distance, const StepCost &stepCost) {
     return vstd::async(
         [=]() { return findAStarNextStep(start, goal, canStep, waypoint, neighbors, distance, stepCost); });
 }
 
-std::vector<Coords> CPathFinder::findPath(Coords start, Coords goal, const std::function<bool(const Coords &)> &canStep,
-                                          const std::function<std::pair<bool, Coords>(const Coords &)> waypoint,
-                                          const std::function<std::vector<Coords>(const Coords &)> &neighbors,
-                                          const std::function<double(const Coords &, const Coords &)> &distance,
+std::vector<Coords> CPathFinder::findPath(Coords start, Coords goal, const CanStep &canStep, const Waypoint waypoint,
+                                          const Neighbors &neighbors, const Distance &distance,
                                           const StepCost &stepCost) {
     return findAStarPath(start, goal, canStep, waypoint, neighbors, distance, stepCost);
 }
 
-void CPathFinder::saveMap(Coords start, const std::function<bool(const Coords &)> &canStep, const std::string &path,
-                          const std::function<std::pair<bool, Coords>(const Coords &)> &waypoint,
-                          const std::function<std::vector<Coords>(const Coords &)> &neighbors,
-                          const std::function<double(const Coords &, const Coords &)> &, const StepCost &stepCost) {
+void CPathFinder::saveMap(Coords start, const CanStep &canStep, const std::string &path, const Waypoint &waypoint,
+                          const Neighbors &neighbors, const Distance &, const StepCost &stepCost) {
     Values values = fillValues(canStep, start, waypoint, neighbors, stepCost);
     int minx = std::numeric_limits<int>::max();
     int miny = std::numeric_limits<int>::max();
@@ -306,7 +300,11 @@ void CPathFinder::saveMap(Coords start, const std::function<bool(const Coords &)
         }
     }
     int factor = 4;
-    SDL_Surface *surface = SDL_CreateRGBSurface(0, factor * (maxx - minx), factor * (maxy - miny), 32, 0, 0, 0, 0);
+    auto surface = fn::sdl::SurfacePtr(
+        SDL_SAFE(SDL_CreateRGBSurface(0, factor * (maxx - minx), factor * (maxy - miny), 32, 0, 0, 0, 0)));
+    if (!surface) {
+        return;
+    }
     float scale = maxVal > 0 ? 256.0f / maxVal : 0.0f;
     for (const auto &entry : *values) {
         int posx = entry.first.x - minx;
@@ -318,8 +316,7 @@ void CPathFinder::saveMap(Coords start, const std::function<bool(const Coords &)
         rect.w = factor;
         rect.h = factor;
         float r = 256.0f - (scale * val);
-        SDL_FillRect(surface, &rect, SDL_MapRGB(surface->format, r, r, r));
+        SDL_FillRect(surface.get(), &rect, SDL_MapRGB(surface->format, r, r, r));
     }
-    IMG_SavePNG(surface, path.c_str());
-    SDL_FreeSurface(surface);
+    IMG_SavePNG(surface.get(), path.c_str());
 }

--- a/src/core/CPathFinder.h
+++ b/src/core/CPathFinder.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -24,14 +24,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 class CCreature;
 
 template <fn::CoordsLike CoordsLike> std::list<Coords> near_coords(const CoordsLike &coords) {
-    return {Coords(coords.x + 1, coords.y, coords.z), Coords(coords.x - 1, coords.y, coords.z),
-            Coords(coords.x, coords.y + 1, coords.z), Coords(coords.x, coords.y - 1, coords.z)};
+    auto shifted = CARDINAL_DIRECTIONS | std::views::transform([&coords](const Coords &offset) {
+                       return Coords(coords.x + offset.x, coords.y + offset.y, coords.z + offset.z);
+                   });
+    return {shifted.begin(), shifted.end()};
 }
 
 template <fn::CoordsLike CoordsLike> std::list<Coords> near_coords_with(const CoordsLike &coords) {
-    return {Coords(coords.x, coords.y, coords.z), Coords(coords.x + 1, coords.y, coords.z),
-            Coords(coords.x - 1, coords.y, coords.z), Coords(coords.x, coords.y + 1, coords.z),
-            Coords(coords.x, coords.y - 1, coords.z)};
+    auto neighbors = near_coords(coords);
+    neighbors.push_front(Coords(coords.x, coords.y, coords.z));
+    return neighbors;
 }
 
 inline std::vector<Coords> default_neighbors(const Coords &coords) {
@@ -41,30 +43,36 @@ inline std::vector<Coords> default_neighbors(const Coords &coords) {
 
 class CPathFinder {
   public:
+    struct DefaultDistance {
+        double operator()(const Coords &a, const Coords &b) const { return a.getDist(b); }
+    };
+
+    struct DefaultStepCost {
+        constexpr int operator()(const Coords &, const Coords &) const { return 1; }
+    };
+
+    using CanStep = std::function<bool(const Coords &)>;
+    using Waypoint = std::function<std::pair<bool, Coords>(const Coords &)>;
+    using Neighbors = std::function<std::vector<Coords>(const Coords &)>;
+    using Distance = std::function<double(const Coords &, const Coords &)>;
     using StepCost = std::function<int(const Coords &, const Coords &)>;
 
     // TODO change naming
-    static std::shared_ptr<vstd::future<Coords, void>> findNextStep(
-        Coords start, Coords goal, const std::function<bool(const Coords &)> &canStep,
-        const std::function<std::pair<bool, Coords>(const Coords &)> waypoint,
-        const std::function<std::vector<Coords>(const Coords &)> &neighbors = default_neighbors,
-        const std::function<double(const Coords &, const Coords &)> &distance =
-            [](const Coords &a, const Coords &b) { return a.getDist(b); },
-        const StepCost &stepCost = [](const Coords &, const Coords &) { return 1; });
+    static std::shared_ptr<vstd::future<Coords, void>> findNextStep(Coords start, Coords goal, const CanStep &canStep,
+                                                                    const Waypoint waypoint,
+                                                                    const Neighbors &neighbors = default_neighbors,
+                                                                    const Distance &distance = DefaultDistance{},
+                                                                    const StepCost &stepCost = DefaultStepCost{});
 
-    static std::vector<Coords> findPath(
-        Coords start, Coords goal, const std::function<bool(const Coords &)> &canStep,
-        const std::function<std::pair<bool, Coords>(const Coords &)> waypoint,
-        const std::function<std::vector<Coords>(const Coords &)> &neighbors = default_neighbors,
-        const std::function<double(const Coords &, const Coords &)> &distance =
-            [](const Coords &a, const Coords &b) { return a.getDist(b); },
-        const StepCost &stepCost = [](const Coords &, const Coords &) { return 1; });
+    static std::vector<Coords> findPath(Coords start, Coords goal, const CanStep &canStep, const Waypoint waypoint,
+                                        const Neighbors &neighbors = default_neighbors,
+                                        const Distance &distance = DefaultDistance{},
+                                        const StepCost &stepCost = DefaultStepCost{});
 
-    static void saveMap(
-        Coords start, const std::function<bool(const Coords &)> &canStep, const std::string &path,
-        const std::function<std::pair<bool, Coords>(const Coords &)> &waypoint,
-        const std::function<std::vector<Coords>(const Coords &)> &neighbors = default_neighbors,
-        const std::function<double(const Coords &, const Coords &)> &distance =
-            [](const Coords &a, const Coords &b) { return a.getDist(b); },
-        const StepCost &stepCost = [](const Coords &, const Coords &) { return 1; });
+    static void saveMap(Coords start, const CanStep &canStep, const std::string &path, const Waypoint &waypoint,
+                        const Neighbors &neighbors = default_neighbors, const Distance &distance = DefaultDistance{},
+                        const StepCost &stepCost = DefaultStepCost{});
 };
+
+static_assert(fn::PathDistance<CPathFinder::DefaultDistance>);
+static_assert(fn::PathStepCost<CPathFinder::DefaultStepCost>);

--- a/src/core/CProvider.cpp
+++ b/src/core/CProvider.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -66,14 +66,49 @@ std::shared_ptr<CResourcesProvider> CResourcesProvider::getInstance() {
     return instance;
 }
 
+std::expected<std::string, CResourcesProvider::LoadFailure>
+CResourcesProvider::loadExpected(std::string path, std::source_location location) {
+    const std::string requestedPath = path;
+    auto resolvedPath = getPath(std::move(path));
+    if (resolvedPath.empty()) {
+        return std::unexpected(LoadFailure{requestedPath, resolvedPath, "resource path was not found", location});
+    }
+
+    std::ifstream stream(resolvedPath);
+    if (!stream) {
+        return std::unexpected(LoadFailure{requestedPath, resolvedPath, "resource file could not be opened", location});
+    }
+
+    return std::string(std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>());
+}
+
+void CResourcesProvider::logLoadFailure(const LoadFailure &failure) {
+    vstd::logger::warning("Failed to load resource:", failure.requestedPath, "resolved:", failure.resolvedPath,
+                          "reason:", failure.message);
+}
+
 std::string CResourcesProvider::load(std::string path) {
-    std::ifstream t(getPath(std::move(path)));
-    return {std::istreambuf_iterator<char>(t), std::istreambuf_iterator<char>()};
+    auto result = loadExpected(std::move(path));
+    if (!result) {
+        logLoadFailure(result.error());
+        return {};
+    }
+    return std::move(*result);
 }
 
 std::shared_ptr<json> CResourcesProvider::loadJson(std::string path) {
     auto source = path;
-    return CJsonUtil::from_string(load(std::move(path)), source);
+    auto text = loadExpected(std::move(path));
+    if (!text) {
+        logLoadFailure(text.error());
+        return nullptr;
+    }
+    auto parsed = CJsonUtil::parse_expected(std::move(*text), source);
+    if (!parsed) {
+        CJsonUtil::log_parse_error(parsed.error());
+        return nullptr;
+    }
+    return *parsed;
 }
 
 std::string CResourcesProvider::getPath(std::string path) {

--- a/src/core/CProvider.h
+++ b/src/core/CProvider.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -121,6 +121,18 @@ class CResourcesProvider {
     CResourcesProvider() = default;
 
   private:
+    struct LoadFailure {
+        std::string requestedPath;
+        std::string resolvedPath;
+        std::string message;
+        std::source_location location;
+    };
+
+    std::expected<std::string, LoadFailure>
+    loadExpected(std::string path, std::source_location location = std::source_location::current());
+
+    static void logLoadFailure(const LoadFailure &failure);
+
     static std::list<std::string> searchPath;
 };
 

--- a/src/core/CTags.cpp
+++ b/src/core/CTags.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -103,5 +103,5 @@ std::string_view CTags::toString(CTag tag) {
             return name;
         }
     }
-    throw std::invalid_argument("Unknown tag enum value.");
+    throw std::invalid_argument("Unknown tag enum value: " + std::to_string(std::to_underlying(tag)) + ".");
 }

--- a/src/core/CTags.h
+++ b/src/core/CTags.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by

--- a/src/core/CUtil.cpp
+++ b/src/core/CUtil.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -17,138 +17,79 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "core/CUtil.h"
 
-Coords ZERO(0, 0, 0), EAST(1, 0, 0), WEST(-1, 0, 0), NORTH(0, -1, 0),
-    SOUTH(0, 1, 0), UP(0, 0, 1), DOWN(0, 0, -1);
+#include <algorithm>
 
-template <> std::string vstd::str(Coords coords) {
-  return vstd::str(coords.x) + "," + vstd::str(coords.y) + "," +
-         vstd::str(coords.z);
-}
+template <> std::string vstd::str(Coords coords) { return vstd::str(coords.x, ",", coords.y, ",", coords.z); }
 
-Coords::Coords() { x = y = z = 0; }
-
-Coords::Coords(int x, int y, int z) : x(x), y(y), z(z) {}
-
-bool Coords::operator==(const Coords &other) const {
-  return (x == other.x && y == other.y && z == other.z);
-}
-
-bool Coords::operator!=(const Coords &other) const {
-  return !operator==(other);
-}
-
-bool Coords::operator<(const Coords &other) const {
-  if (x < other.x) {
-    return true;
-  }
-  if (y < other.y && x == other.x) {
-    return true;
-  }
-  if (z < other.z && x == other.x && y == other.y) {
-    return true;
-  }
-  return false;
-}
-
-bool Coords::operator>(const Coords &other) const { return !operator<(other); }
-
-Coords Coords::operator-(const Coords &other) const {
-  return {x - other.x, y - other.y, z - other.z};
-}
-
-Coords Coords::operator+(const Coords &other) const {
-  return {x + other.x, y + other.y, z + other.z};
-}
-
-Coords Coords::operator*() const { return *this; }
-
-double Coords::getDist(const Coords &a) const {
-  double _x = this->x - a.x;
-  double _y = this->y - a.y;
-  return sqrt(_x * _x + _y * _y);
-}
-
-bool Coords::adjacent(const Coords &a) const { return getDist(a) == 1; }
-
-bool Coords::same(const Coords &a) const { return getDist(a) == 0; }
-
-bool Coords::adjacentOrSame(const Coords &a) const {
-  return adjacent(a) || same(a);
-}
-
-std::shared_ptr<SDL_Rect> CUtil::boxInBox(const std::shared_ptr<SDL_Rect> &out,
-                                          const std::shared_ptr<SDL_Rect> &in) {
-  return RECT(out->x + out->w / 2 - in->w / 2, out->y + out->h / 2 - in->h / 2,
-              in->w, in->h);
+std::shared_ptr<SDL_Rect> CUtil::boxInBox(const std::shared_ptr<SDL_Rect> &out, const std::shared_ptr<SDL_Rect> &in) {
+    return rect(out->x + out->w / 2 - in->w / 2, out->y + out->h / 2 - in->h / 2, in->w, in->h);
 }
 
 std::shared_ptr<SDL_Rect> CUtil::rect(int x, int y, int w, int h) {
-  std::shared_ptr<SDL_Rect> ret = std::make_shared<SDL_Rect>();
-  ret->x = x;
-  ret->y = y;
-  ret->w = w;
-  ret->h = h;
-  return ret;
+    std::shared_ptr<SDL_Rect> ret = std::make_shared<SDL_Rect>();
+    ret->x = x;
+    ret->y = y;
+    ret->w = w;
+    ret->h = h;
+    return ret;
 }
 
-std::shared_ptr<SDL_Rect> CUtil::centeredRect(int centerX, int centerY, int w,
-                                              int h) {
-  return RECT(centerX - w / 2, centerY - h / 2, w, h);
+std::shared_ptr<SDL_Rect> CUtil::centeredRect(int centerX, int centerY, int w, int h) {
+    return rect(centerX - w / 2, centerY - h / 2, w, h);
 }
 
 std::shared_ptr<SDL_Rect> CUtil::bounds(const std::shared_ptr<SDL_Rect> &rect) {
-  return RECT(rect->x, rect->x + rect->w, rect->y, rect->y + rect->h);
+    return CUtil::rect(rect->x, rect->x + rect->w, rect->y, rect->y + rect->h);
 }
 
 bool CUtil::isIn(const std::shared_ptr<SDL_Rect> &rect, int x, int y) {
-  auto bound = bounds(rect);
-  return x >= bound->x && x <= bound->y && y >= bound->w && y <= bound->h;
+    auto bound = bounds(rect);
+    return x >= bound->x && x <= bound->y && y >= bound->w && y <= bound->h;
 }
 
 int CUtil::parseKey(SDL_Keycode i) {
-  switch (i) {
-  case SDLK_0:
-    return 0;
-  case SDLK_1:
-    return 1;
-  case SDLK_2:
-    return 2;
-  case SDLK_3:
-    return 3;
-  case SDLK_4:
-    return 4;
-  case SDLK_5:
-    return 5;
-  case SDLK_6:
-    return 6;
-  case SDLK_7:
-    return 7;
-  case SDLK_8:
-    return 8;
-  case SDLK_9:
-    return 9;
-  default:
-    return -1;
-  }
+    switch (i) {
+    case SDLK_0:
+        return 0;
+    case SDLK_1:
+        return 1;
+    case SDLK_2:
+        return 2;
+    case SDLK_3:
+        return 3;
+    case SDLK_4:
+        return 4;
+    case SDLK_5:
+        return 5;
+    case SDLK_6:
+        return 6;
+    case SDLK_7:
+        return 7;
+    case SDLK_8:
+        return 8;
+    case SDLK_9:
+        return 9;
+    default:
+        return -1;
+    }
 }
 
 Coords::Direction CUtil::getDirection(Coords coords) {
-  if (coords == ZERO) {
-    return Coords::Direction::ZERO;
-  } else if (coords == EAST) {
-    return Coords::Direction::EAST;
-  } else if (coords == WEST) {
-    return Coords::Direction::WEST;
-  } else if (coords == NORTH) {
-    return Coords::Direction::NORTH;
-  } else if (coords == SOUTH) {
-    return Coords::Direction::SOUTH;
-  } else if (coords == UP) {
-    return Coords::Direction::UP;
-  } else if (coords == DOWN) {
-    return Coords::Direction::DOWN;
-  }
-  return Coords::Direction::UNDEFINED;
+    constexpr std::array<std::pair<Coords, Coords::Direction>, 7> directions{{
+        {ZERO, Coords::Direction::ZERO},
+        {EAST, Coords::Direction::EAST},
+        {WEST, Coords::Direction::WEST},
+        {NORTH, Coords::Direction::NORTH},
+        {SOUTH, Coords::Direction::SOUTH},
+        {UP, Coords::Direction::UP},
+        {DOWN, Coords::Direction::DOWN},
+    }};
+    const auto match = std::ranges::find_if(directions, [coords](const auto &entry) { return entry.first == coords; });
+    return match != directions.end() ? match->second : Coords::Direction::UNDEFINED;
+}
+
+int CUtil::setRenderDrawColor(SDL_Renderer *renderer, SDL_Color color) {
+    return SDL_SAFE(SDL_SetRenderDrawColor(renderer, color.r, color.g, color.b, color.a));
 }
 
 // TODO: implement drag_drop

--- a/src/core/CUtil.h
+++ b/src/core/CUtil.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -25,36 +25,57 @@ class CGameObject;
 class CMapObject;
 
 struct Coords {
-    Coords();
+    constexpr Coords() = default;
 
-    Coords(int x, int y, int z);
+    constexpr Coords(int x, int y, int z) : x(x), y(y), z(z) {}
 
-    int x, y, z;
+    int x = 0;
+    int y = 0;
+    int z = 0;
 
-    bool operator==(const Coords &other) const;
+    constexpr auto operator<=>(const Coords &other) const = default;
 
-    bool operator!=(const Coords &other) const;
+    constexpr Coords operator-(const Coords &other) const { return {x - other.x, y - other.y, z - other.z}; }
 
-    bool operator<(const Coords &other) const;
+    constexpr Coords operator+(const Coords &other) const { return {x + other.x, y + other.y, z + other.z}; }
 
-    bool operator>(const Coords &other) const;
+    constexpr Coords operator*() const { return *this; }
 
-    Coords operator-(const Coords &other) const;
+    double getDist(const Coords &a) const {
+        const double dx = x - a.x;
+        const double dy = y - a.y;
+        return std::sqrt(dx * dx + dy * dy);
+    }
 
-    Coords operator+(const Coords &other) const;
+    constexpr bool same(const Coords &a) const { return x == a.x && y == a.y; }
 
-    Coords operator*() const;
+    constexpr bool adjacent(const Coords &a) const {
+        const int dx = x - a.x;
+        const int dy = y - a.y;
+        return dx * dx + dy * dy == 1;
+    }
 
-    double getDist(const Coords &a) const;
-
-    bool adjacent(const Coords &a) const;
-
-    bool same(const Coords &a) const;
-
-    bool adjacentOrSame(const Coords &a) const;
+    constexpr bool adjacentOrSame(const Coords &a) const { return adjacent(a) || same(a); }
 
     enum Direction { UNDEFINED, ZERO, EAST, WEST, NORTH, SOUTH, UP, DOWN };
-} extern ZERO, EAST, WEST, NORTH, SOUTH, UP, DOWN;
+};
+
+inline constexpr Coords ZERO{0, 0, 0};
+inline constexpr Coords EAST{1, 0, 0};
+inline constexpr Coords WEST{-1, 0, 0};
+inline constexpr Coords NORTH{0, -1, 0};
+inline constexpr Coords SOUTH{0, 1, 0};
+inline constexpr Coords UP{0, 0, 1};
+inline constexpr Coords DOWN{0, 0, -1};
+inline constexpr std::array<Coords, 4> CARDINAL_DIRECTIONS{EAST, WEST, SOUTH, NORTH};
+inline constexpr std::array<Coords, 6> AXIAL_DIRECTIONS{EAST, WEST, SOUTH, NORTH, UP, DOWN};
+
+namespace CColors {
+inline constexpr SDL_Color Blue{0, 0, 255, 0};
+inline constexpr SDL_Color Red{255, 0, 0, 0};
+inline constexpr SDL_Color Yellow{255, 255, 0, 0};
+inline constexpr SDL_Color Black{0, 0, 0, 0};
+} // namespace CColors
 
 class CUtil {
   public:
@@ -72,6 +93,8 @@ class CUtil {
     static int parseKey(SDL_Keycode i);
 
     static Coords::Direction getDirection(Coords coords);
+
+    static int setRenderDrawColor(SDL_Renderer *renderer, SDL_Color color);
 
     template <fn::FilePredicate Predicate> static std::set<std::string> findFiles(std::string dir, Predicate pred) {
         std::set<std::string> retValue;
@@ -126,4 +149,3 @@ template <fn::SdlVoidCallable F> void sdl_safe(F f) { f(); }
 
 #define JSONIFY(x) CJsonUtil::to_string(CSerialization::serialize<std::shared_ptr<json>>(x))
 #define JSONIFY_STYLED(x) CJsonUtil::to_string(CSerialization::serialize<std::shared_ptr<json>>(x), -1)
-#define RECT(x, y, w, h) CUtil::rect(x, y, w, h)

--- a/src/gui/CAnimation.cpp
+++ b/src/gui/CAnimation.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CTextManager.h"
 #include "CTooltip.h"
 #include "core/CProvider.h"
+#include "core/CUtil.h"
 #include "gui/CGui.h"
 #include "gui/CTextureCache.h"
 
@@ -152,7 +153,7 @@ void CSelectionBox::setThickness(int _thickness) { this->thickness = _thickness;
 int CSelectionBox::getThickness() { return thickness; }
 
 void CSelectionBox::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int frameTime) {
-    SDL_SetRenderDrawColor(gui->getRenderer(), YELLOW);
+    CUtil::setRenderDrawColor(gui->getRenderer(), CColors::Yellow);
     SDL_Rect tmp = {rect->x, rect->y, thickness, rect->h};
     SDL_Rect tmp2 = {rect->x, rect->y, rect->w, thickness};
     SDL_Rect tmp3 = {rect->x, rect->y + rect->h - thickness, rect->w, thickness};

--- a/src/gui/CGui.cpp
+++ b/src/gui/CGui.cpp
@@ -16,31 +16,33 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "CGui.h"
+#include "core/CUtil.h"
 #include "gui/CTextManager.h"
 #include "gui/CTextureCache.h"
 
 CGui::CGui() {
     SDL_SAFE(SDL_Init(SDL_INIT_VIDEO));
-    SDL_SAFE(SDL_CreateWindowAndRenderer(width, height, 0, &window, &renderer));
+    SDL_Window *rawWindow = nullptr;
+    SDL_Renderer *rawRenderer = nullptr;
+    SDL_SAFE(SDL_CreateWindowAndRenderer(width, height, 0, &rawWindow, &rawRenderer));
+    window.reset(rawWindow);
+    renderer.reset(rawRenderer);
     // TODO: set icon
     // TODO: check render flags
 }
 
-CGui::~CGui() {
-    SDL_SAFE(SDL_DestroyRenderer(renderer));
-    SDL_SAFE(SDL_DestroyWindow(window));
-}
+CGui::~CGui() = default;
 
 void CGui::render(int i1) {
-    SDL_SAFE(SDL_SetRenderDrawColor(renderer, BLACK));
-    SDL_SAFE(SDL_RenderClear(renderer));
+    CUtil::setRenderDrawColor(renderer.get(), CColors::Black);
+    SDL_SAFE(SDL_RenderClear(renderer.get()));
     CGameGraphicsObject::render(this->ptr<CGui>(), i1);
-    SDL_SAFE(SDL_RenderPresent(renderer));
+    SDL_SAFE(SDL_RenderPresent(renderer.get()));
 }
 
 bool CGui::event(SDL_Event *event) { return CGameGraphicsObject::event(this->ptr<CGui>(), event); }
 
-SDL_Renderer *CGui::getRenderer() const { return renderer; }
+SDL_Renderer *CGui::getRenderer() const { return renderer.get(); }
 
 std::shared_ptr<CTextureCache> CGui::getTextureCache() {
     return _textureCache.get([this]() { return std::make_shared<CTextureCache>(this->ptr<CGui>()); });

--- a/src/gui/CGui.h
+++ b/src/gui/CGui.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "core/CGame.h"
 #include "core/CGlobal.h"
+#include "gui/CSdlResources.h"
 #include "gui/object/CGameGraphicsObject.h"
 #include "object/CGameObject.h"
 
@@ -27,58 +28,51 @@ class CTextureCache;
 class CTextManager;
 
 class CGui : public CGameGraphicsObject {
-  V_META(CGui, CGameGraphicsObject,
-         V_PROPERTY(CGui, int, height, getHeight, setHeight),
-         V_PROPERTY(CGui, int, width, getWidth, setWidth),
-         V_PROPERTY(CGui, int, tileSize, getTileSize, setTileSize))
-  SDL_Window *window = 0;
-  SDL_Renderer *renderer = 0;
+    V_META(CGui, CGameGraphicsObject, V_PROPERTY(CGui, int, height, getHeight, setHeight),
+           V_PROPERTY(CGui, int, width, getWidth, setWidth), V_PROPERTY(CGui, int, tileSize, getTileSize, setTileSize))
+    fn::sdl::WindowPtr window;
+    fn::sdl::RendererPtr renderer;
 
-public:
-  using CGameGraphicsObject::render;
+  public:
+    using CGameGraphicsObject::render;
 
-  SDL_Renderer *getRenderer() const;
+    SDL_Renderer *getRenderer() const;
 
-  int getWidth();
+    int getWidth();
 
-  void setWidth(int width);
+    void setWidth(int width);
 
-  int getHeight();
+    int getHeight();
 
-  void setHeight(int height);
+    void setHeight(int height);
 
-  int getTileSize();
+    int getTileSize();
 
-  void setTileSize(int tileSize);
+    void setTileSize(int tileSize);
 
-  int getTileCountX();
+    int getTileCountX();
 
-  int getTileCountY();
+    int getTileCountY();
 
-private:
-  int height = 1080;
-  int tileSize = 50;
-  int width = 1920;
+  private:
+    int height = 1080;
+    int tileSize = 50;
+    int width = 1920;
 
-public:
-  CGui();
+  public:
+    CGui();
 
-  ~CGui() override;
+    ~CGui() override;
 
-  void render(int i1);
+    void render(int i1);
 
-  bool event(SDL_Event *event);
+    bool event(SDL_Event *event);
 
-  std::shared_ptr<CTextureCache> getTextureCache();
+    std::shared_ptr<CTextureCache> getTextureCache();
 
-  std::shared_ptr<CTextManager> getTextManager();
+    std::shared_ptr<CTextManager> getTextManager();
 
-  vstd::lazy<CTextureCache> _textureCache;
+    vstd::lazy<CTextureCache> _textureCache;
 
-  vstd::lazy<CTextManager> _textManager;
+    vstd::lazy<CTextManager> _textManager;
 };
-
-#define BLUE 0, 0, 255, 0
-#define RED 255, 0, 0, 0
-#define YELLOW 255, 255, 0, 0
-#define BLACK 0, 0, 0, 0

--- a/src/gui/CLayout.cpp
+++ b/src/gui/CLayout.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -18,14 +18,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "CLayout.h"
 #include "core/CGame.h"
+#include "core/CUtil.h"
 #include "gui/object/CProxyGraphicsObject.h"
 #include "handler/CScriptHandler.h"
 
-std::shared_ptr<SDL_Rect>
-CLayout::getParentRect(std::shared_ptr<CGameGraphicsObject> object) {
-  return object->getParent()
-             ? object->getParent()->getLayout()->getRect(object->getParent())
-             : RECT(0, 0, 0, 0);
+std::shared_ptr<SDL_Rect> CLayout::getParentRect(std::shared_ptr<CGameGraphicsObject> object) {
+    return object->getParent() ? object->getParent()->getLayout()->getRect(object->getParent())
+                               : CUtil::rect(0, 0, 0, 0);
 }
 
 std::string CLayout::getW() { return w; }
@@ -45,115 +44,95 @@ std::string CLayout::getY() { return y; }
 void CLayout::setY(std::string y) { CLayout::y = y; }
 
 void CLayout::setRect(int x, int y, int w, int h) {
-  setX(vstd::str(x));
-  setY(vstd::str(y));
-  setW(vstd::str(w));
-  setH(vstd::str(h));
+    setX(vstd::str(x));
+    setY(vstd::str(y));
+    setW(vstd::str(w));
+    setH(vstd::str(h));
 }
 
-void CLayout::setRect(const std::shared_ptr<SDL_Rect> &rect) {
-  setRect(rect->x, rect->y, rect->w, rect->h);
-}
+void CLayout::setRect(const std::shared_ptr<SDL_Rect> &rect) { setRect(rect->x, rect->y, rect->w, rect->h); }
 
-void CLayout::setHorizontal(std::string horizontal) {
-  CLayout::horizontal = horizontal;
-}
+void CLayout::setHorizontal(std::string horizontal) { CLayout::horizontal = horizontal; }
 
 std::string CLayout::getHorizontal() { return horizontal; }
 
-void CLayout::setVertical(std::string vertical) {
-  CLayout::vertical = vertical;
-}
+void CLayout::setVertical(std::string vertical) { CLayout::vertical = vertical; }
 
 std::string CLayout::getVertical() { return vertical; }
 
-std::pair<CLayout::TYPE, int>
-CLayout::parseValue(std::shared_ptr<CGameGraphicsObject> object,
-                    std::string value) {
-  if (vstd::ends_with(value, "%") &&
-      vstd::is_int(value.substr(0, value.length() - 1))) {
+std::pair<CLayout::TYPE, int> CLayout::parseValue(std::shared_ptr<CGameGraphicsObject> object, std::string value) {
+    if (vstd::ends_with(value, "%") && vstd::is_int(value.substr(0, value.length() - 1))) {
+        return std::make_pair(PERCENT, vstd::to_int(value.substr(0, value.length() - 1)).first);
+    } else if (vstd::is_int(value)) {
+        return std::make_pair(SIMPLE, vstd::to_int(value).first);
+    }
+    // TODO: rethink parsing and validating script and script output
     return std::make_pair(
-        PERCENT, vstd::to_int(value.substr(0, value.length() - 1)).first);
-  } else if (vstd::is_int(value)) {
-    return std::make_pair(SIMPLE, vstd::to_int(value).first);
-  }
-  // TODO: rethink parsing and validating script and script output
-  return std::make_pair(
-      SIMPLE,
-      object->getGame()
-          ->getScriptHandler()
-          ->call_created_function<int, std::shared_ptr<CGameGraphicsObject>>(
-              value, {"self"}, object));
+        SIMPLE, object->getGame()->getScriptHandler()->call_created_function<int, std::shared_ptr<CGameGraphicsObject>>(
+                    value, {"self"}, object));
 }
 
 int CLayout::parseValue(std::pair<TYPE, int> value, int parentValue) {
-  switch (value.first) {
-  case SIMPLE:
-    return value.second;
-  case PERCENT:
-    return value.second * parentValue / 100.0;
-  }
-  return vstd::fail_if(true, "Should not happen!");
+    switch (value.first) {
+    case SIMPLE:
+        return value.second;
+    case PERCENT:
+        return value.second * parentValue / 100.0;
+    }
+    return vstd::fail_if(true, "Should not happen!");
 }
 
-int CLayout::parseValue(std::shared_ptr<CGameGraphicsObject> object,
-                        std::string value, int parentValue) {
-  return parseValue(parseValue(object, value), parentValue);
+int CLayout::parseValue(std::shared_ptr<CGameGraphicsObject> object, std::string value, int parentValue) {
+    return parseValue(parseValue(object, value), parentValue);
 }
 
-std::shared_ptr<SDL_Rect>
-CLayout::getRect(std::shared_ptr<CGameGraphicsObject> object) {
-  auto parent = getParentRect(object);
+std::shared_ptr<SDL_Rect> CLayout::getRect(std::shared_ptr<CGameGraphicsObject> object) {
+    auto parent = getParentRect(object);
 
-  int x = parseValue(object, getX(), parent->w);
-  int y = parseValue(object, getY(), parent->h);
-  int w = horizontal == "PARENT" ? parent->w
-                                 : parseValue(object, getW(), parent->w);
-  int h =
-      vertical == "PARENT" ? parent->h : parseValue(object, getH(), parent->h);
+    int x = parseValue(object, getX(), parent->w);
+    int y = parseValue(object, getY(), parent->h);
+    int w = horizontal == "PARENT" ? parent->w : parseValue(object, getW(), parent->w);
+    int h = vertical == "PARENT" ? parent->h : parseValue(object, getH(), parent->h);
 
-  if (horizontal == "LEFT" || horizontal == "PARENT") {
-    x = 0;
-  } else if (horizontal == "RIGHT") {
-    x = parent->w - w;
-  } else if (horizontal == "CENTER") {
-    x = parent->w / 2 - w / 2;
-  } else if (!horizontal.empty()) {
-    vstd::logger::debug("Unknown horizontal layout:", horizontal);
-  }
+    if (horizontal == "LEFT" || horizontal == "PARENT") {
+        x = 0;
+    } else if (horizontal == "RIGHT") {
+        x = parent->w - w;
+    } else if (horizontal == "CENTER") {
+        x = parent->w / 2 - w / 2;
+    } else if (!horizontal.empty()) {
+        vstd::logger::debug("Unknown horizontal layout:", horizontal);
+    }
 
-  if (vertical == "UP" || vertical == "PARENT") {
-    y = 0;
-  } else if (vertical == "DOWN") {
-    y = parent->h - h;
-  } else if (vertical == "CENTER") {
-    y = parent->h / 2 - h / 2;
-  } else if (!vertical.empty()) {
-    vstd::logger::debug("Unknown vertical layout:", vertical);
-  }
+    if (vertical == "UP" || vertical == "PARENT") {
+        y = 0;
+    } else if (vertical == "DOWN") {
+        y = parent->h - h;
+    } else if (vertical == "CENTER") {
+        y = parent->h / 2 - h / 2;
+    } else if (!vertical.empty()) {
+        vstd::logger::debug("Unknown vertical layout:", vertical);
+    }
 
-  return RECT(parent->x + x, parent->y + y, w, h);
+    return CUtil::rect(parent->x + x, parent->y + y, w, h);
 }
 
 CParentLayout::CParentLayout() {
-  setHorizontal("PARENT");
-  setVertical("PARENT");
+    setHorizontal("PARENT");
+    setVertical("PARENT");
 }
 
 CCenteredLayout::CCenteredLayout() {
-  setHorizontal("CENTER");
-  setVertical("CENTER");
+    setHorizontal("CENTER");
+    setVertical("CENTER");
 }
 
 void CProxyGraphicsLayout::setTileSize(int _tileSize) { tileSize = _tileSize; }
 
 int CProxyGraphicsLayout::getTileSize() { return tileSize; }
 
-std::shared_ptr<SDL_Rect>
-CProxyGraphicsLayout::getRect(std::shared_ptr<CGameGraphicsObject> object) {
-  auto pRect = getParentRect(object);
-  return RECT(
-      pRect->x + vstd::cast<CProxyGraphicsObject>(object)->getX() * tileSize,
-      pRect->y + vstd::cast<CProxyGraphicsObject>(object)->getY() * tileSize,
-      tileSize, tileSize);
+std::shared_ptr<SDL_Rect> CProxyGraphicsLayout::getRect(std::shared_ptr<CGameGraphicsObject> object) {
+    auto pRect = getParentRect(object);
+    return CUtil::rect(pRect->x + vstd::cast<CProxyGraphicsObject>(object)->getX() * tileSize,
+                       pRect->y + vstd::cast<CProxyGraphicsObject>(object)->getY() * tileSize, tileSize, tileSize);
 }

--- a/src/gui/CSdlResources.h
+++ b/src/gui/CSdlResources.h
@@ -1,0 +1,68 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "core/CGlobal.h"
+
+namespace fn::sdl {
+struct SurfaceDeleter {
+    void operator()(SDL_Surface *surface) const noexcept {
+        if (surface) {
+            SDL_FreeSurface(surface);
+        }
+    }
+};
+
+struct TextureDeleter {
+    void operator()(SDL_Texture *texture) const noexcept {
+        if (texture) {
+            SDL_DestroyTexture(texture);
+        }
+    }
+};
+
+struct RendererDeleter {
+    void operator()(SDL_Renderer *renderer) const noexcept {
+        if (renderer) {
+            SDL_DestroyRenderer(renderer);
+        }
+    }
+};
+
+struct WindowDeleter {
+    void operator()(SDL_Window *window) const noexcept {
+        if (window) {
+            SDL_DestroyWindow(window);
+        }
+    }
+};
+
+struct FontDeleter {
+    void operator()(TTF_Font *font) const noexcept {
+        if (font) {
+            TTF_CloseFont(font);
+        }
+    }
+};
+
+using SurfacePtr = std::unique_ptr<SDL_Surface, SurfaceDeleter>;
+using TexturePtr = std::unique_ptr<SDL_Texture, TextureDeleter>;
+using RendererPtr = std::unique_ptr<SDL_Renderer, RendererDeleter>;
+using WindowPtr = std::unique_ptr<SDL_Window, WindowDeleter>;
+using FontPtr = std::unique_ptr<TTF_Font, FontDeleter>;
+} // namespace fn::sdl

--- a/src/gui/CTextManager.cpp
+++ b/src/gui/CTextManager.cpp
@@ -19,37 +19,37 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CUtil.h"
 
 SDL_Texture *CTextManager::getTexture(const std::string &text, int width) {
-    auto anim = _textures.find(std::make_pair(text, width));
-    if (anim == _textures.end()) {
-        _textures[std::make_pair(text, width)] = this->loadTexture(text, width);
-        return getTexture(text, width);
+    auto key = std::make_pair(text, width);
+    auto texture = _textures.find(key);
+    if (texture == _textures.end()) {
+        auto [inserted, _] = _textures.emplace(std::move(key), this->loadTexture(text, width));
+        return inserted->second.get();
     }
-    return _textures[std::make_pair(text, width)];
+    return texture->second.get();
 }
 
-SDL_Texture *CTextManager::loadTexture(std::string text, int width) {
+fn::sdl::TexturePtr CTextManager::loadTexture(std::string text, int width) {
     SDL_Color textColor = {255, 255, 255, 0};
     // in some sdl versions blended wrapped automatically treats 0 as not wrapper,
     // other versions fail on width=0
-    SDL_Surface *surface = SDL_SAFE(width ? TTF_RenderText_Blended_Wrapped(font, text.c_str(), textColor, width)
-                                          : TTF_RenderText_Blended(font, text.c_str(), textColor));
-    auto _texture = SDL_SAFE(SDL_CreateTextureFromSurface(_gui.lock()->getRenderer(), surface));
-    SDL_SAFE(SDL_FreeSurface(surface));
-    return _texture;
+    auto surface =
+        fn::sdl::SurfacePtr(SDL_SAFE(width ? TTF_RenderText_Blended_Wrapped(font.get(), text.c_str(), textColor, width)
+                                           : TTF_RenderText_Blended(font.get(), text.c_str(), textColor)));
+    if (!surface) {
+        return nullptr;
+    }
+    return fn::sdl::TexturePtr(SDL_SAFE(SDL_CreateTextureFromSurface(_gui.lock()->getRenderer(), surface.get())));
 }
 
 CTextManager::CTextManager(const std::shared_ptr<CGui> &_gui) {
     SDL_SAFE(TTF_Init());
-    font = SDL_SAFE(TTF_OpenFont("fonts/ampersand.ttf", 24));
+    font.reset(SDL_SAFE(TTF_OpenFont("fonts/ampersand.ttf", 24)));
     this->_gui = _gui;
 }
 
 CTextManager::~CTextManager() {
-    for (auto texture : _textures) {
-        SDL_SAFE(SDL_DestroyTexture(texture.second));
-    }
     _textures.clear();
-    SDL_SAFE(TTF_CloseFont(font));
+    font.reset();
 }
 
 int CTextManager::countLines(const std::string &text, int w) {
@@ -82,7 +82,7 @@ void CTextManager::drawTextCentered(const std::string &text, int x, int y, int w
         SDL_Rect actual;
         SDL_Texture *pTexture = getTexture(text, w);
         SDL_SAFE(SDL_QueryTexture(pTexture, nullptr, nullptr, &actual.w, &actual.h));
-        auto centered = CUtil::boxInBox(RECT(x, y, w, h), RECT(0, 0, actual.w, actual.h));
+        auto centered = CUtil::boxInBox(CUtil::rect(x, y, w, h), CUtil::rect(0, 0, actual.w, actual.h));
         SDL_SAFE(SDL_RenderCopy(_gui.lock()->getRenderer(), pTexture, nullptr, centered.get()));
     }
 }

--- a/src/gui/CTextManager.h
+++ b/src/gui/CTextManager.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -19,11 +19,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gui/CAnimation.h"
 #include "gui/CGui.h"
+#include "gui/CSdlResources.h"
 #include "object/CGameObject.h"
 
 class CTextManager : public CGameObject {
     V_META(CTextManager, CGameObject, vstd::meta::empty())
-    std::unordered_map<std::pair<std::string, int>, SDL_Texture *> _textures;
+    std::unordered_map<std::pair<std::string, int>, fn::sdl::TexturePtr> _textures;
 
   public:
     explicit CTextManager(const std::shared_ptr<CGui> &_gui = nullptr);
@@ -45,9 +46,9 @@ class CTextManager : public CGameObject {
   private:
     SDL_Texture *getTexture(const std::string &text, int width = 0);
 
-    SDL_Texture *loadTexture(std::string text, int width = 0);
+    fn::sdl::TexturePtr loadTexture(std::string text, int width = 0);
 
     std::weak_ptr<CGui> _gui;
 
-    TTF_Font *font;
+    fn::sdl::FontPtr font;
 };

--- a/src/gui/CTextureCache.cpp
+++ b/src/gui/CTextureCache.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "CTextureCache.h"
+#include "core/CUtil.h"
 
 Uint32 getpixel(SDL_Surface *surface, int x, int y) {
     int bpp = surface->format->BytesPerPixel;
@@ -83,31 +84,26 @@ SDL_Texture *CTextureCache::getTexture(std::string path) {
     if (vstd::ends_with(path, ".png")) {
         auto anim = _textures.find(path);
         if (anim == _textures.end()) {
-            _textures[path] = this->loadTexture(path);
-            return getTexture(path);
+            auto [inserted, _] = _textures.emplace(path, this->loadTexture(path));
+            return inserted->second.get();
         }
-        return _textures[path];
+        return anim->second.get();
     }
     return getTexture(path + ".png");
 }
 
-SDL_Texture *CTextureCache::loadTexture(std::string path) {
-    SDL_Surface *surface = IMG_Load(path.c_str());
+fn::sdl::TexturePtr CTextureCache::loadTexture(std::string path) {
+    auto surface = fn::sdl::SurfacePtr(IMG_Load(path.c_str()));
     if (!surface) {
         vstd::logger::error("CTextureCache::loadTexture: cannot load", path);
         return nullptr;
     }
-    return CTextureUtil::calculateAlpha(_gui.lock()->getRenderer(), surface);
+    return CTextureUtil::calculateAlpha(_gui.lock()->getRenderer(), std::move(surface));
 }
 
 CTextureCache::CTextureCache(std::shared_ptr<CGui> _gui) : _gui(_gui) {}
 
-CTextureCache::~CTextureCache() {
-    for (auto texture : _textures) {
-        SDL_DestroyTexture(texture.second);
-    }
-    _textures.clear();
-}
+CTextureCache::~CTextureCache() { _textures.clear(); }
 
 CTextureCache::CTextureCache() {}
 
@@ -125,7 +121,7 @@ auto CTextureUtil::getPixelRgba(SDL_Surface *surface, int x, int y) {
     return std::make_tuple(r, g, b, a);
 }
 
-SDL_Texture *CTextureUtil::calculateAlpha(SDL_Renderer *renderer, SDL_Surface *surface) {
+fn::sdl::TexturePtr CTextureUtil::calculateAlpha(SDL_Renderer *renderer, fn::sdl::SurfacePtr surface) {
     if (!surface) {
         vstd::logger::error("CTextureUtil::calculateAlpha: null surface");
         return nullptr;
@@ -136,41 +132,39 @@ SDL_Texture *CTextureUtil::calculateAlpha(SDL_Renderer *renderer, SDL_Surface *s
 
     if (w <= 0 || h <= 0) {
         vstd::logger::error("CTextureUtil::calculateAlpha: invalid surface size", w, h);
-        SDL_SAFE(SDL_FreeSurface(surface));
         return nullptr;
     }
 
-    auto secondSurface =
-        SDL_CreateRGBSurfaceWithFormat(surface->flags, surface->w, surface->h, 32, SDL_PIXELFORMAT_RGBA32);
+    auto secondSurface = fn::sdl::SurfacePtr(
+        SDL_SAFE(SDL_CreateRGBSurfaceWithFormat(surface->flags, surface->w, surface->h, 32, SDL_PIXELFORMAT_RGBA32)));
+    if (!secondSurface) {
+        return nullptr;
+    }
 
-    auto maskPixel = getPixelRgba(surface, 0, 0);
+    auto maskPixel = getPixelRgba(surface.get(), 0, 0);
 
-    bool shouldAddMask = vstd::all_equals(getPixelColor(surface, 0, 0), getPixelColor(surface, 0, h - 1),
-                                          getPixelColor(surface, w - 1, 0), getPixelColor(surface, w - 1, h - 1)) &&
-                         std::get<3>(maskPixel) == 255;
+    bool shouldAddMask =
+        vstd::all_equals(getPixelColor(surface.get(), 0, 0), getPixelColor(surface.get(), 0, h - 1),
+                         getPixelColor(surface.get(), w - 1, 0), getPixelColor(surface.get(), w - 1, h - 1)) &&
+        std::get<3>(maskPixel) == 255;
 
     std::unordered_set<std::pair<int, int>> mask =
-        shouldAddMask ? calculateMask(surface) : std::unordered_set<std::pair<int, int>>();
+        shouldAddMask ? calculateMask(surface.get()) : std::unordered_set<std::pair<int, int>>();
 
     for (auto verticalIndex = 0; verticalIndex < h; verticalIndex++) {
         for (auto horizontalIndex = 0; horizontalIndex < w; horizontalIndex++) {
-            auto currentPixel = getPixelRgba(surface, horizontalIndex, verticalIndex);
+            auto currentPixel = getPixelRgba(surface.get(), horizontalIndex, verticalIndex);
 
             auto [r, g, b, a] = currentPixel;
             if (vstd::ctn(mask, std::make_pair(horizontalIndex, verticalIndex))) {
-                setPixelColor(secondSurface, horizontalIndex, verticalIndex, {r, g, b, 0});
+                setPixelColor(secondSurface.get(), horizontalIndex, verticalIndex, {r, g, b, 0});
             } else {
-                setPixelColor(secondSurface, horizontalIndex, verticalIndex, {r, g, b, a});
+                setPixelColor(secondSurface.get(), horizontalIndex, verticalIndex, {r, g, b, a});
             }
         }
     }
 
-    auto texture = SDL_SAFE(SDL_CreateTextureFromSurface(renderer, secondSurface));
-
-    SDL_SAFE(SDL_FreeSurface(surface));
-    SDL_SAFE(SDL_FreeSurface(secondSurface));
-
-    return texture;
+    return fn::sdl::TexturePtr(SDL_SAFE(SDL_CreateTextureFromSurface(renderer, secondSurface.get())));
 }
 
 std::unordered_set<std::pair<int, int>> CTextureUtil::calculateMask(SDL_Surface *pSurface) {

--- a/src/gui/CTextureCache.h
+++ b/src/gui/CTextureCache.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -19,41 +19,39 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gui/CAnimation.h"
 #include "gui/CGui.h"
+#include "gui/CSdlResources.h"
 #include "object/CGameObject.h"
 
 // TODO: generify all cache classes
 
 class CTextureCache : public CGameObject {
-  V_META(CTextureCache, CGameObject, vstd::meta::empty())
-  std::unordered_map<std::string, SDL_Texture *> _textures;
+    V_META(CTextureCache, CGameObject, vstd::meta::empty())
+    std::unordered_map<std::string, fn::sdl::TexturePtr> _textures;
 
-public:
-  CTextureCache(std::shared_ptr<CGui> _gui);
+  public:
+    CTextureCache(std::shared_ptr<CGui> _gui);
 
-  CTextureCache();
+    CTextureCache();
 
-  ~CTextureCache();
+    ~CTextureCache();
 
-  SDL_Texture *getTexture(std::string path);
+    SDL_Texture *getTexture(std::string path);
 
-private:
-  SDL_Texture *loadTexture(std::string path);
+  private:
+    fn::sdl::TexturePtr loadTexture(std::string path);
 
-  std::weak_ptr<CGui> _gui;
+    std::weak_ptr<CGui> _gui;
 };
 
 class CTextureUtil {
-public:
-  static SDL_Texture *calculateAlpha(SDL_Renderer *renderer,
-                                     SDL_Surface *texture);
+  public:
+    static fn::sdl::TexturePtr calculateAlpha(SDL_Renderer *renderer, fn::sdl::SurfacePtr surface);
 
-  static auto getPixelRgba(SDL_Surface *surface, int x, int y);
+    static auto getPixelRgba(SDL_Surface *surface, int x, int y);
 
-  static auto getPixelColor(SDL_Surface *surface, int x, int y);
+    static auto getPixelColor(SDL_Surface *surface, int x, int y);
 
-  static void setPixelColor(SDL_Surface *surface, int x, int y,
-                            std::tuple<Uint8, Uint8, Uint8, Uint8> color);
+    static void setPixelColor(SDL_Surface *surface, int x, int y, std::tuple<Uint8, Uint8, Uint8, Uint8> color);
 
-  static std::unordered_set<std::pair<int, int>>
-  calculateMask(SDL_Surface *pSurface);
+    static std::unordered_set<std::pair<int, int>> calculateMask(SDL_Surface *pSurface);
 };

--- a/src/gui/CTooltip.cpp
+++ b/src/gui/CTooltip.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -20,34 +20,29 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CGui.h"
 #include "CTextManager.h"
 #include "CTextureCache.h"
+#include "core/CUtil.h"
 
 CTooltip::CTooltip() {
-  // TODO: extract to json
-  setModal(true);
-  setBackground("images/tooltip");
+    // TODO: extract to json
+    setModal(true);
+    setBackground("images/tooltip");
 }
 
-void CTooltip::renderObject(std::shared_ptr<CGui> gui,
-                            std::shared_ptr<SDL_Rect> rect, int frameTime) {
-  // TODO: move this inside textManager
-  auto textureSize = gui->getTextManager()->getTextureSize(text);
-  gui->getTextManager()->drawText(
-      text,
-      CUtil::boxInBox(rect, RECT(0, 0, textureSize.first, textureSize.second)));
+void CTooltip::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int frameTime) {
+    // TODO: move this inside textManager
+    auto textureSize = gui->getTextManager()->getTextureSize(text);
+    gui->getTextManager()->drawText(text,
+                                    CUtil::boxInBox(rect, CUtil::rect(0, 0, textureSize.first, textureSize.second)));
 }
 
-bool CTooltip::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type,
-                          int button, int x, int y) {
-  if (type == SDL_MOUSEBUTTONUP && button == SDL_BUTTON_RIGHT) {
-    getParent()->removeChild(this->ptr<CTooltip>());
-  }
-  return true;
+bool CTooltip::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button, int x, int y) {
+    if (type == SDL_MOUSEBUTTONUP && button == SDL_BUTTON_RIGHT) {
+        getParent()->removeChild(this->ptr<CTooltip>());
+    }
+    return true;
 }
 
-bool CTooltip::keyboardEvent(std::shared_ptr<CGui> sharedPtr,
-                             SDL_EventType type, SDL_Keycode i) {
-  return true;
-}
+bool CTooltip::keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i) { return true; }
 
 void CTooltip::setText(std::string _text) { this->text = _text; }
 

--- a/src/gui/object/CStatsGraphicsObject.cpp
+++ b/src/gui/object/CStatsGraphicsObject.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CStatsGraphicsObject.h"
 #include "core/CMap.h"
 #include "core/CScript.h"
+#include "core/CUtil.h"
 #include "gui/CGui.h"
 #include "gui/CTextManager.h"
 #include "object/CPlayer.h"
@@ -30,16 +31,16 @@ void CStatsGraphicsUtil::drawStats(std::shared_ptr<CGui> gui, std::shared_ptr<CC
 
     const int barCount = showExp ? 3 : 2;
 
-    drawBar(gui, creature->getHpRatio(), 0, barCount, RED, x, y, w, h);
+    drawBar(gui, creature->getHpRatio(), 0, barCount, CColors::Red, x, y, w, h);
     if (showNumeric) {
         drawValues(gui, creature->getHp(), creature->getHpMax(), 0, barCount, x, y, w, h);
     }
-    drawBar(gui, creature->getManaRatio(), 1, barCount, BLUE, x, y, w, h);
+    drawBar(gui, creature->getManaRatio(), 1, barCount, CColors::Blue, x, y, w, h);
     if (showNumeric) {
         drawValues(gui, creature->getMana(), creature->getManaMax(), 1, barCount, x, y, w, h);
     }
     if (showExp) {
-        drawBar(gui, creature->getExpRatio(), 2, barCount, YELLOW, x, y, w, h);
+        drawBar(gui, creature->getExpRatio(), 2, barCount, CColors::Yellow, x, y, w, h);
         if (showNumeric) {
             drawValues(gui, creature->getExp(), creature->getExpForNextLevel(), 2, barCount, x, y, w, h);
         }
@@ -57,8 +58,8 @@ std::shared_ptr<CScript> CStatsGraphicsObject::getCreature() { return creature; 
 
 void CStatsGraphicsObject::setCreature(std::shared_ptr<CScript> _creature) { creature = _creature; }
 
-void CStatsGraphicsUtil::drawBar(std::shared_ptr<CGui> gui, int ratio, int index, int barCount, Uint8 r, Uint8 g,
-                                 Uint8 b, Uint8 a, int x, int y, int w, int h) {
+void CStatsGraphicsUtil::drawBar(std::shared_ptr<CGui> gui, int ratio, int index, int barCount, SDL_Color color, int x,
+                                 int y, int w, int h) {
     h = h / std::max(1, barCount);
     SDL_Rect filledBar;
     filledBar.x = x;
@@ -66,7 +67,7 @@ void CStatsGraphicsUtil::drawBar(std::shared_ptr<CGui> gui, int ratio, int index
     filledBar.h = h;
     filledBar.w = (int)(ratio / 100.0 * w);
 
-    SDL_SetRenderDrawColor(gui->getRenderer(), r, g, b, a);
+    CUtil::setRenderDrawColor(gui->getRenderer(), color);
     SDL_RenderFillRect(gui->getRenderer(), &filledBar);
 
     SDL_Rect emptyBar;
@@ -75,7 +76,7 @@ void CStatsGraphicsUtil::drawBar(std::shared_ptr<CGui> gui, int ratio, int index
     emptyBar.h = h;
     emptyBar.w = w - filledBar.w;
 
-    SDL_SetRenderDrawColor(gui->getRenderer(), BLACK);
+    CUtil::setRenderDrawColor(gui->getRenderer(), CColors::Black);
     SDL_RenderFillRect(gui->getRenderer(), &emptyBar);
 }
 

--- a/src/gui/object/CStatsGraphicsObject.h
+++ b/src/gui/object/CStatsGraphicsObject.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -30,8 +30,8 @@ class CStatsGraphicsUtil {
                           bool showNumeric, bool showExp);
 
   private:
-    static void drawBar(std::shared_ptr<CGui> gui, int ratio, int index, int barCount, Uint8 r, Uint8 g, Uint8 b,
-                        Uint8 a, int x, int y, int h, int w);
+    static void drawBar(std::shared_ptr<CGui> gui, int ratio, int index, int barCount, SDL_Color color, int x, int y,
+                        int h, int w);
 
     static void drawValues(std::shared_ptr<CGui> gui, int left, int right, int index, int barCount, int x, int y, int h,
                            int w);

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CGame.h"
 #include "core/CMap.h"
 #include "core/CScript.h"
+#include "core/CUtil.h"
 #include "gui/CGui.h"
 #include "gui/CLayout.h"
 #include "gui/CTextureCache.h"
@@ -97,8 +98,8 @@ CListView::calculateIndices(const std::shared_ptr<CGui> &gui) {
 
 std::shared_ptr<SDL_Rect> CListView::calculateIndexPosition(const std::shared_ptr<CGui> &gui,
                                                             const std::shared_ptr<SDL_Rect> &loc, int index) {
-    return RECT(tileSize * (index % getSizeX(gui)) + loc->x, tileSize * (index / getSizeX(gui)) + loc->y, tileSize,
-                tileSize);
+    return CUtil::rect(tileSize * (index % getSizeX(gui)) + loc->x, tileSize * (index / getSizeX(gui)) + loc->y,
+                       tileSize, tileSize);
 }
 
 bool CListView::isOversized(const std::shared_ptr<CGui> &gui) {

--- a/tests/unit/test_coords.cpp
+++ b/tests/unit/test_coords.cpp
@@ -17,8 +17,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "core/CTags.h"
-#include "core/CUtil.h"
+#include "core/CJsonUtil.h"
 #include "core/CPathFinder.h"
+#include "core/CUtil.h"
+#include "gui/CSdlResources.h"
 #include "handler/CScriptHandler.h"
 #include <rdg.h>
 #include "vcache.h"
@@ -35,6 +37,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <type_traits>
 #include <vector>
 
 namespace {
@@ -56,6 +59,35 @@ struct CastBase {
 };
 
 struct CastDerived : CastBase {};
+
+struct ConceptCanStep {
+    bool operator()(const Coords &) const { return true; }
+};
+
+struct ConceptWaypoint {
+    std::pair<bool, Coords> operator()(const Coords &) const { return {false, ZERO}; }
+};
+
+struct ConceptNeighbors {
+    std::vector<Coords> operator()(const Coords &coords) const { return default_neighbors(coords); }
+};
+
+struct ConceptDistance {
+    double operator()(const Coords &from, const Coords &to) const { return from.getDist(to); }
+};
+
+struct ConceptStepCost {
+    int operator()(const Coords &, const Coords &) const { return 1; }
+};
+
+static_assert(fn::PathPassability<ConceptCanStep>);
+static_assert(fn::PathWaypoint<ConceptWaypoint>);
+static_assert(fn::PathNeighbors<ConceptNeighbors>);
+static_assert(fn::PathDistance<ConceptDistance>);
+static_assert(fn::PathStepCost<ConceptStepCost>);
+static_assert(std::is_const_v<std::remove_reference_t<decltype(ZERO)>>);
+static_assert(EAST + SOUTH == Coords(1, 1, 0));
+static_assert(UP - DOWN == Coords(0, 0, 2));
 
 void expect_true(bool condition, const char *message) {
     if (!condition) {
@@ -88,6 +120,7 @@ void test_comparison_and_ordering() {
     expect_true(Coords(1, 2, 3) < Coords(1, 2, 4), "operator< should compare z when x and y are equal");
     expect_true(!(Coords(2, 0, 0) < Coords(1, 99, 99)), "operator< should reject larger x values");
     expect_true(Coords(2, 0, 0) > Coords(1, 99, 99), "operator> should invert operator< for non-equal values");
+    expect_true(!(Coords(1, 2, 3) > Coords(1, 2, 3)), "operator> should reject equal coordinates");
     expect_true(Coords(1, 2, 3) != Coords(1, 2, 4), "operator!= should detect different coordinates");
 }
 
@@ -291,6 +324,38 @@ void test_toroidal_pathfinder_wraps_on_both_axes() {
     expect_true(path.front() == Coords(0, 25, 0) || path.front() == Coords(25, 0, 0),
                 "Toroidal path should take a wrapped step on one axis first");
     expect_true(path.back() == Coords(25, 25, 0), "Toroidal path should end at the wrapped goal coordinate");
+}
+
+void test_json_parse_expected_success_and_failure() {
+    auto parsed = CJsonUtil::parse_expected("{\"value\": 3}", "unit-json");
+    expect_true(parsed.has_value() && (*parsed)->at("value").get<int>() == 3,
+                "parse_expected should return parsed json on success");
+
+    auto failed = CJsonUtil::parse_expected("{", "unit-json-error");
+    expect_true(!failed.has_value(), "parse_expected should expose malformed json as an expected error");
+    if (!failed) {
+        expect_true(failed.error().source == "unit-json-error", "parse_expected error should retain source context");
+        expect_true(failed.error().preview == "{", "parse_expected error should retain a compact preview");
+    }
+    expect_true(CJsonUtil::from_string("{", "unit-json-wrapper") == nullptr,
+                "from_string should keep the public nullptr behavior on parse failure");
+}
+
+void test_sdl_raii_alias_owns_surface() {
+    auto surface = fn::sdl::SurfacePtr(SDL_CreateRGBSurfaceWithFormat(0, 2, 2, 32, SDL_PIXELFORMAT_RGBA32));
+    expect_true(surface != nullptr, "SurfacePtr should own SDL surfaces created by SDL");
+    if (!surface) {
+        return;
+    }
+
+    auto color = SDL_MapRGBA(surface->format, 1, 2, 3, 4);
+    SDL_FillRect(surface.get(), nullptr, color);
+    Uint8 r = 0;
+    Uint8 g = 0;
+    Uint8 b = 0;
+    Uint8 a = 0;
+    SDL_GetRGBA(color, surface->format, &r, &g, &b, &a);
+    expect_true(r == 1 && g == 2 && b == 3 && a == 4, "SurfacePtr should provide raw non-owning access via get");
 }
 
 void test_tag_round_trip_and_ordering() {
@@ -777,6 +842,8 @@ int main() {
     test_pathfinder_waypoint_override();
     test_toroidal_pathfinder_prefers_wrapped_route();
     test_toroidal_pathfinder_wraps_on_both_axes();
+    test_json_parse_expected_success_and_failure();
+    test_sdl_raii_alias_owns_surface();
     test_direction_mapping();
     test_rect_bounds_inclusion();
     test_tag_round_trip_and_ordering();


### PR DESCRIPTION
## What Changed
- Moved CMake C++23, include directories, compile definitions, and warning/options setup to target-scoped configuration for `_game` and `for_unit_tests`.
- Made `Coords` constexpr-friendly with defaulted three-way comparison and immutable inline direction constants, then updated direction, rect, color, and pathfinding helpers around those types.
- Added concept coverage for pathfinding callbacks, JSON/expected helpers, SDL-safe callables, Python callbacks, and serializer boundaries.
- Added internal `std::expected` paths for JSON/resource load failures while preserving public `nullptr`/empty-string wrapper behavior.
- Added SDL/TTF RAII aliases and moved GUI texture/font/window/renderer/surface ownership to `std::unique_ptr` custom deleters while keeping raw-pointer getters as non-owning views.
- Replaced the `RECT` and color macros with typed helpers/constants where used.
- Fixed a duplicated `CGameFightPanel` pybind registration fragment that blocked `_game` compilation.

## Why
This modernizes the C++ core toward the C++23 baseline without changing Python-facing names, JSON/resource schemas, save behavior, or gameplay behavior. The SDL changes reduce manual lifetime management in GUI rendering paths.

## Validation
- `clang-format -i` on modified C++ files.
- `git diff --check`
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py` (124 tests, 19 skipped)
- `./scripts/run_coverage.sh` (line coverage 90.7%)

## Known Limitations / Follow-up
- Existing pybind11 deprecation and visibility warnings still appear during native builds; this PR does not address them.
- The untracked local `.codex` path was left out of the PR scope.