### PR TITLE
Expose CCreature::getEffects to vstd metadata

### DIFF
--- a/src/object/CCreature.h
+++ b/src/object/CCreature.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -60,7 +60,8 @@ class CCreature : public CMapObject, public Moveable, public Visitable {
            V_PROPERTY(CCreature, std::shared_ptr<CFightController>, fightController, getFightController,
                       setFightController),
            V_PROPERTY(CCreature, bool, npc, isNpc, setNpc), V_METHOD(CCreature, getManaMax, int),
-           V_METHOD(CCreature, getHpMax, int), V_METHOD(CCreature, getManaRegRate, int))
+           V_METHOD(CCreature, getHpMax, int), V_METHOD(CCreature, getManaRegRate, int),
+           V_METHOD(CCreature, getEffects, std::set<std::shared_ptr<CEffect>>))
 
   public:
     CCreature();


### PR DESCRIPTION
### Motivation
- Runtime metadata dispatches that call `getEffects` on `CCreature` handles failed with `IndexError: vstd::meta: method not found: getEffects`, so the reflected vstd metadata needed an explicit method entry so `invoke_method("getEffects", ...)` works.

### Description
- Add `V_METHOD(CCreature, getEffects, std::set<std::shared_ptr<CEffect>>)` to `src/object/CCreature.h` and update the file header year range to include 2026.

### Testing
- Built and validated with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`, ran unit tests with `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` (for_unit_tests passed), and ran the Python integration suite `python3 test.py` which completed with 124 tests passed and 19 skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06f02aa9c8326b7eadc440e2711fe)