### PR TITLE
Fix warnings and modernize pathfinder callbacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ function(configure_fon_cpp_target target_name)
         target_compile_options(${target_name} PRIVATE
             -include cmath
             -Wall
+            -fvisibility=hidden
             $<$<CONFIG:Release>:-O3>
             $<$<CONFIG:Release>:-s>
             $<$<CONFIG:Debug>:-g3>

--- a/src/core/CConcepts.h
+++ b/src/core/CConcepts.h
@@ -95,7 +95,7 @@ concept PathPassability = std::predicate<const clean_t<F> &, const Coords &>;
 template <typename F>
 concept PathWaypoint =
     std::invocable<const clean_t<F> &, const Coords &> &&
-    std::same_as<clean_t<std::invoke_result_t<const clean_t<F> &, const Coords &>>, std::pair<bool, Coords>>;
+    std::same_as<clean_t<std::invoke_result_t<const clean_t<F> &, const Coords &>>, std::optional<Coords>>;
 
 template <typename F>
 concept PathNeighbors =

--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -199,7 +199,7 @@ std::shared_ptr<vstd::future<Coords, void>> CNpcRandomController::control(std::s
                     self->path = CPathFinder::findPath(
                         creature->getCoords(), candidate,
                         [creature](const Coords &c) { return creature->getMap()->canStep(c); },
-                        [](auto) { return std::make_pair(false, ZERO); },
+                        [](auto) -> std::optional<Coords> { return std::nullopt; },
                         [creature](const Coords &coords) { return creature->getMap()->getAdjacentCoords(coords); },
                         [creature](const Coords &from, const Coords &to) {
                             return creature->getMap()->getDistance(from, to);
@@ -418,14 +418,14 @@ bool CPlayerController::canContinue(std::shared_ptr<CPlayer> player) { return ha
 std::vector<Coords> CPlayerController::calculatePath(std::shared_ptr<CPlayer> player) {
     return CPathFinder::findPath(
         player->getCoords(), *target, [player](Coords coords) { return player->getMap()->canStep(coords); },
-        [player](auto coords) {
+        [player](auto coords) -> std::optional<Coords> {
             for (auto ob : player->getMap()->getObjectsAtCoords(coords)) {
                 if (ob->getBoolProperty("waypoint")) {
-                    return std::make_pair(true, Coords(ob->getNumericProperty("x"), ob->getNumericProperty("y"),
-                                                       ob->getNumericProperty("z")));
+                    return Coords(ob->getNumericProperty("x"), ob->getNumericProperty("y"),
+                                  ob->getNumericProperty("z"));
                 }
             }
-            return std::make_pair(false, ZERO);
+            return std::nullopt;
         },
         [player](const Coords &coords) { return player->getMap()->getAdjacentCoords(coords); },
         [player](const Coords &from, const Coords &to) { return player->getMap()->getDistance(from, to); });

--- a/src/core/CGlobal.h
+++ b/src/core/CGlobal.h
@@ -49,6 +49,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <random>
 #include <ranges>

--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -474,14 +474,14 @@ std::set<std::shared_ptr<CMapObject>> CMap::getObjects() {
 void CMap::dumpPaths(std::string path) {
     CPathFinder::saveMap(
         getPlayer()->getCoords(), [this](auto coords) { return this->canStep(coords); }, path,
-        [this](auto coords) {
+        [this](auto coords) -> std::optional<Coords> {
             for (auto ob : getObjectsAtCoords(coords)) {
                 if (ob->getBoolProperty("waypoint")) {
-                    return std::make_pair(true, Coords(ob->getNumericProperty("x"), ob->getNumericProperty("y"),
-                                                       ob->getNumericProperty("z")));
+                    return Coords(ob->getNumericProperty("x"), ob->getNumericProperty("y"),
+                                  ob->getNumericProperty("z"));
                 }
             }
-            return std::make_pair(false, ZERO);
+            return std::nullopt;
         },
         [this](auto coords) { return this->getAdjacentCoords(coords); },
         [this](auto from, auto to) { return this->getDistance(from, to); });
@@ -589,7 +589,7 @@ std::vector<Coords> CMap::getAdjacentCoords(Coords coords, bool includeSelf) con
 
     auto add = [&adjacent, this](Coords candidate) {
         candidate = normalizeCoords(candidate);
-        if (std::find(adjacent.begin(), adjacent.end(), candidate) == adjacent.end()) {
+        if (std::ranges::find(adjacent, candidate) == adjacent.end()) {
             adjacent.push_back(candidate);
         }
     };

--- a/src/core/CPathFinder.cpp
+++ b/src/core/CPathFinder.cpp
@@ -89,8 +89,8 @@ void forEachCandidate(const Coords &coords, const Waypoint &waypoint, const Neig
         handle(neighbor);
     }
     auto waypoint_direction = waypoint(coords);
-    if (waypoint_direction.first) {
-        handle(waypoint_direction.second);
+    if (waypoint_direction) {
+        handle(*waypoint_direction);
     }
 }
 

--- a/src/core/CPathFinder.h
+++ b/src/core/CPathFinder.h
@@ -56,7 +56,7 @@ class CPathFinder {
     };
 
     using CanStep = std::function<bool(const Coords &)>;
-    using Waypoint = std::function<std::pair<bool, Coords>(const Coords &)>;
+    using Waypoint = std::function<std::optional<Coords>(const Coords &)>;
     using Neighbors = std::function<std::vector<Coords>(const Coords &)>;
     using Distance = std::function<double(const Coords &, const Coords &)>;
     using StepCost = std::function<int(const Coords &, const Coords &)>;

--- a/src/core/CPythonOverrides.h
+++ b/src/core/CPythonOverrides.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -24,49 +24,46 @@ class CGameObject;
 namespace CPythonOverrides {
 
 inline std::unordered_map<const CGameObject *, pybind11::object> &instances() {
-  // Intentionally leak the registry so pybind11::object destructors do not run
-  // during C++ static teardown after the Python interpreter has finalized.
-  static auto *registry =
-      new std::unordered_map<const CGameObject *, pybind11::object>();
-  return *registry;
+    // Intentionally leak the registry so pybind11::object destructors do not run
+    // during C++ static teardown after the Python interpreter has finalized.
+    static auto *registry = new std::unordered_map<const CGameObject *, pybind11::object>();
+    return *registry;
 }
 
-inline void retain(const std::shared_ptr<CGameObject> &object,
-                   const pybind11::object &instance) {
-  pybind11::gil_scoped_acquire gil;
-  instances()[object.get()] = instance;
+inline void retain(const std::shared_ptr<CGameObject> &object, const pybind11::object &instance) {
+    pybind11::gil_scoped_acquire gil;
+    instances()[object.get()] = instance;
 }
 
 inline pybind11::object *find(const CGameObject *object) {
-  auto it = instances().find(object);
-  if (it == instances().end()) {
-    return nullptr;
-  }
-  return &it->second;
+    auto it = instances().find(object);
+    if (it == instances().end()) {
+        return nullptr;
+    }
+    return &it->second;
 }
 
-inline pybind11::object find_override(const CGameObject *object,
-                                      const char *method_name) {
-  auto *instance = find(object);
-  if (!instance) {
-    return pybind11::none();
-  }
-
-  pybind11::tuple mro = instance->get_type().attr("__mro__");
-  for (pybind11::handle cls : mro) {
-    pybind11::object dict = pybind11::reinterpret_steal<pybind11::object>(
-        PyObject_GetAttrString(cls.ptr(), "__dict__"));
-    if (!dict.is_none() && PyMapping_HasKeyString(dict.ptr(), method_name) == 1) {
-      pybind11::object module = pybind11::reinterpret_steal<pybind11::object>(
-          PyObject_GetAttrString(cls.ptr(), "__module__"));
-      if (module.is_none() || module.cast<std::string>() == "_game") {
+inline pybind11::object find_override(const CGameObject *object, const char *method_name) {
+    auto *instance = find(object);
+    if (!instance) {
         return pybind11::none();
-      }
-      return instance->attr(method_name);
     }
-  }
 
-  return pybind11::none();
+    pybind11::tuple mro = pybind11::type::of(*instance).attr("__mro__");
+    for (pybind11::handle cls : mro) {
+        pybind11::object dict =
+            pybind11::reinterpret_steal<pybind11::object>(PyObject_GetAttrString(cls.ptr(), "__dict__"));
+        if (!dict.is_none() && PyMapping_HasKeyString(dict.ptr(), method_name) == 1) {
+            pybind11::object module =
+                pybind11::reinterpret_steal<pybind11::object>(PyObject_GetAttrString(cls.ptr(), "__module__"));
+            if (module.is_none() || module.cast<std::string>() == "_game") {
+                return pybind11::none();
+            }
+            return instance->attr(method_name);
+        }
+    }
+
+    return pybind11::none();
 }
 
 } // namespace CPythonOverrides

--- a/src/core/CTags.cpp
+++ b/src/core/CTags.cpp
@@ -17,7 +17,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "core/CTags.h"
 
+#include <algorithm>
 #include <array>
+#include <iterator>
 #include <stdexcept>
 #include <utility>
 
@@ -35,8 +37,7 @@ const std::array<TagDefinition, 6> TAG_DEFINITIONS = {{
 
 std::string supported_tags_message() {
     std::string message;
-    for (const auto &[tag, name] : TAG_DEFINITIONS) {
-        (void)tag;
+    for (std::string_view name : TAG_DEFINITIONS | std::views::values) {
         if (!message.empty()) {
             message += ", ";
         }
@@ -61,9 +62,7 @@ std::size_t CTags::size() const { return tags.size(); }
 std::vector<std::string> CTags::toStrings() const {
     std::vector<std::string> names;
     names.reserve(tags.size());
-    for (const auto &tag : tags) {
-        names.emplace_back(toString(tag));
-    }
+    std::ranges::transform(tags, std::back_inserter(names), [](CTag tag) { return std::string(toString(tag)); });
     return names;
 }
 
@@ -79,29 +78,27 @@ const std::vector<CTag> &CTags::all() {
     static const std::vector<CTag> tags = []() {
         std::vector<CTag> values;
         values.reserve(TAG_DEFINITIONS.size());
-        for (const auto &[tag, name] : TAG_DEFINITIONS) {
-            (void)name;
-            values.push_back(tag);
-        }
+        std::ranges::transform(TAG_DEFINITIONS, std::back_inserter(values),
+                               [](const TagDefinition &definition) { return definition.first; });
         return values;
     }();
     return tags;
 }
 
 CTag CTags::fromString(std::string_view tag) {
-    for (const auto &[value, name] : TAG_DEFINITIONS) {
-        if (name == tag) {
-            return value;
-        }
+    auto match = std::ranges::find_if(TAG_DEFINITIONS,
+                                      [tag](const TagDefinition &definition) { return definition.second == tag; });
+    if (match != TAG_DEFINITIONS.end()) {
+        return match->first;
     }
     throw std::invalid_argument("Unknown tag '" + std::string(tag) + "'. Supported tags: " + supported_tags_message());
 }
 
 std::string_view CTags::toString(CTag tag) {
-    for (const auto &[value, name] : TAG_DEFINITIONS) {
-        if (value == tag) {
-            return name;
-        }
+    auto match = std::ranges::find_if(TAG_DEFINITIONS,
+                                      [tag](const TagDefinition &definition) { return definition.first == tag; });
+    if (match != TAG_DEFINITIONS.end()) {
+        return match->second;
     }
     throw std::invalid_argument("Unknown tag enum value: " + std::to_string(std::to_underlying(tag)) + ".");
 }

--- a/src/core/CTypes.cpp
+++ b/src/core/CTypes.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -47,6 +47,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CWrapper.h"
 #include "core/CGame.h"
 
+#include <algorithm>
+#include <functional>
+#include <iterator>
+
 std::unordered_map<std::string, std::function<std::shared_ptr<CGameObject>()>> *CTypes::builders() {
     static std::unordered_map<std::string, std::function<std::shared_ptr<CGameObject>()>> reg;
     return &reg;
@@ -87,6 +91,62 @@ std::unordered_set<std::type_index> *CTypes::pointer_types() {
 }
 
 namespace {
+template <typename Value> std::set<Value> json_array_to_set(const std::shared_ptr<json> &object) {
+    std::set<Value> values;
+    std::ranges::transform(*object, std::inserter(values, values.end()),
+                           [](const json &value) { return value.get<Value>(); });
+    return values;
+}
+
+CTags json_array_to_tags(const std::shared_ptr<json> &object) {
+    CTags tags;
+    std::ranges::for_each(*object,
+                          [&tags](const json &value) { tags.insert(CTags::fromString(value.get<std::string>())); });
+    return tags;
+}
+
+template <typename Value> std::shared_ptr<json> set_to_json_array(const std::set<Value> &values) {
+    auto arr = std::make_shared<json>(json::array());
+    for (const auto &value : values) {
+        add_arr_member(arr, value);
+    }
+    return arr;
+}
+
+std::shared_ptr<json> tags_to_json_array(const CTags &tags) {
+    auto arr = std::make_shared<json>(json::array());
+    for (CTag tag : tags) {
+        add_arr_member(arr, std::string(CTags::toString(tag)));
+    }
+    return arr;
+}
+
+template <typename Value>
+std::map<std::string, Value> json_object_to_string_key_map(const std::shared_ptr<json> &object) {
+    std::map<std::string, Value> values;
+    for (auto [key, value] : object->items()) {
+        values.emplace(key, value.template get<Value>());
+    }
+    return values;
+}
+
+template <typename Value> std::map<int, Value> json_object_to_int_key_map(const std::shared_ptr<json> &object) {
+    std::map<int, Value> values;
+    for (auto [key, value] : object->items()) {
+        values.emplace(vstd::to_int(key).first, value.template get<Value>());
+    }
+    return values;
+}
+
+template <typename Key, typename Value, typename KeySerializer>
+std::shared_ptr<json> map_to_json_object(const std::map<Key, Value> &values, KeySerializer key_serializer) {
+    auto object = std::make_shared<json>();
+    for (const auto &[key, value] : values) {
+        add_member(object, key_serializer(key), value);
+    }
+    return object;
+}
+
 struct register_all_types {
     register_all_types() {
         // Original types1.cpp
@@ -189,117 +249,54 @@ struct register_all_types {
         }
 
         // Original types5.cpp (custom types)
-        auto array_string_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
-            std::set<std::string> objects;
-            for (unsigned int i = 0; i < object->size(); i++) {
-                objects.insert((*object)[i].get<std::string>());
-            }
-            return objects;
+        auto array_string_deserialize = [](std::shared_ptr<CGame>, std::shared_ptr<json> object) {
+            return json_array_to_set<std::string>(object);
         };
 
-        auto array_string_serialize = [](std::set<std::string> set) {
-            std::shared_ptr<json> arr = std::make_shared<json>();
-            for (std::string ob : set) {
-                add_arr_member(arr, ob);
-            }
-            return arr;
+        auto array_string_serialize = [](const std::set<std::string> &set) { return set_to_json_array(set); };
+
+        auto tags_deserialize = [](std::shared_ptr<CGame>, std::shared_ptr<json> object) {
+            return json_array_to_tags(object);
         };
 
-        auto tags_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
-            (void)game;
-            CTags tags;
-            for (unsigned int i = 0; i < object->size(); i++) {
-                tags.insert(CTags::fromString((*object)[i].get<std::string>()));
-            }
-            return tags;
+        auto tags_serialize = [](const CTags &tags) { return tags_to_json_array(tags); };
+
+        auto array_int_deserialize = [](std::shared_ptr<CGame>, std::shared_ptr<json> object) {
+            return json_array_to_set<int>(object);
         };
 
-        auto tags_serialize = [](CTags tags) {
-            std::shared_ptr<json> arr = std::make_shared<json>(json::array());
-            for (const auto &tag : tags) {
-                add_arr_member(arr, std::string(CTags::toString(tag)));
-            }
-            return arr;
+        auto array_int_serialize = [](const std::set<int> &set) { return set_to_json_array(set); };
+
+        auto map_string_string_deserialize = [](std::shared_ptr<CGame>, std::shared_ptr<json> object) {
+            return json_object_to_string_key_map<std::string>(object);
         };
 
-        auto array_int_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
-            std::set<int> objects;
-            for (unsigned int i = 0; i < object->size(); i++) {
-                objects.insert((*object)[i].get<int>());
-            }
-            return objects;
+        auto map_string_string_serialize = [](const std::map<std::string, std::string> &map) {
+            return map_to_json_object(map, std::identity{});
         };
 
-        auto array_int_serialize = [](std::set<int> set) {
-            std::shared_ptr<json> arr = std::make_shared<json>();
-            for (int ob : set) {
-                add_arr_member(arr, ob);
-            }
-            return arr;
+        auto map_string_int_deserialize = [](std::shared_ptr<CGame>, std::shared_ptr<json> object) {
+            return json_object_to_string_key_map<int>(object);
         };
 
-        auto map_string_string_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
-            std::map<std::string, std::string> objects;
-            for (auto [key, value] : object->items()) {
-                objects[key] = value.get<std::string>();
-            }
-            return objects;
+        auto map_string_int_serialize = [](const std::map<std::string, int> &map) {
+            return map_to_json_object(map, std::identity{});
         };
 
-        auto map_string_string_serialize = [](std::map<std::string, std::string> map) {
-            std::shared_ptr<json> arr = std::make_shared<json>();
-            for (auto ob : map) {
-                add_member(arr, ob.first, ob.second);
-            }
-            return arr;
+        auto map_int_string_deserialize = [](std::shared_ptr<CGame>, std::shared_ptr<json> object) {
+            return json_object_to_int_key_map<std::string>(object);
         };
 
-        auto map_string_int_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
-            std::map<std::string, int> objects;
-            for (auto [key, value] : object->items()) {
-                objects[key] = value.get<int>();
-            }
-            return objects;
+        auto map_int_string_serialize = [](const std::map<int, std::string> &map) {
+            return map_to_json_object(map, [](int key) { return vstd::str(key); });
         };
 
-        auto map_string_int_serialize = [](std::map<std::string, int> map) {
-            std::shared_ptr<json> arr = std::make_shared<json>();
-            for (auto ob : map) {
-                add_member(arr, ob.first, ob.second);
-            }
-            return arr;
+        auto map_int_int_deserialize = [](std::shared_ptr<CGame>, std::shared_ptr<json> object) {
+            return json_object_to_int_key_map<int>(object);
         };
 
-        auto map_int_string_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
-            std::map<int, std::string> objects;
-            for (auto [key, value] : object->items()) {
-                objects[vstd::to_int(key).first] = value.get<std::string>();
-            }
-            return objects;
-        };
-
-        auto map_int_string_serialize = [](std::map<int, std::string> map) {
-            std::shared_ptr<json> arr = std::make_shared<json>();
-            for (auto ob : map) {
-                add_member(arr, vstd::str(ob.first), ob.second);
-            }
-            return arr;
-        };
-
-        auto map_int_int_deserialize = [](std::shared_ptr<CGame> game, std::shared_ptr<json> object) {
-            std::map<int, int> objects;
-            for (auto [key, value] : object->items()) {
-                objects[vstd::to_int(key).first] = value.get<int>();
-            }
-            return objects;
-        };
-
-        auto map_int_int_serialize = [](std::map<int, int> map) {
-            std::shared_ptr<json> arr = std::make_shared<json>();
-            for (auto ob : map) {
-                add_member(arr, vstd::str(ob.first), ob.second);
-            }
-            return arr;
+        auto map_int_int_serialize = [](const std::map<int, int> &map) {
+            return map_to_json_object(map, [](int key) { return vstd::str(key); });
         };
 
         CTypes::register_custom_type<std::set<std::string>>(array_string_serialize, array_string_deserialize);

--- a/src/core/CTypes.h
+++ b/src/core/CTypes.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -65,12 +65,13 @@ class CTypes {
         };
     }
 
-    template <typename Serialized, typename Deserialized>
-    static void
-    register_custom_serializer(std::function<Serialized(Deserialized)> serialize,
-                               std::function<Deserialized(std::shared_ptr<CGame>, Serialized)> deserialize) {
+    template <typename Serialized, typename Deserialized, fn::SerializerCallable<Serialized, Deserialized> Serialize,
+              fn::DeserializerCallable<Serialized, Deserialized> Deserialize>
+    static void register_custom_serializer(Serialize serialize, Deserialize deserialize) {
         (*serializers())[vstd::type_pair<Serialized, Deserialized>()] =
-            std::make_shared<CCustomSerializer<Serialized, Deserialized>>(serialize, deserialize);
+            std::make_shared<CCustomSerializer<Serialized, Deserialized>>(
+                std::function<Serialized(Deserialized)>(std::move(serialize)),
+                std::function<Deserialized(std::shared_ptr<CGame>, Serialized)>(std::move(deserialize)));
     }
 
     template <fn::MetaRegisteredGameObject T> static void register_builder() {
@@ -128,10 +129,10 @@ class CTypes {
         register_any_cast<T, T>();
     }
 
-    template <typename T>
-    static void register_custom_type(std::function<std::shared_ptr<json>(T)> serialize,
-                                     std::function<T(std::shared_ptr<CGame>, std::shared_ptr<json>)> deserialize) {
-        register_custom_serializer(serialize, deserialize);
+    template <typename T, fn::SerializerCallable<std::shared_ptr<json>, T> Serialize,
+              fn::DeserializerCallable<std::shared_ptr<json>, T> Deserialize>
+    static void register_custom_type(Serialize serialize, Deserialize deserialize) {
+        register_custom_serializer<std::shared_ptr<json>, T>(std::move(serialize), std::move(deserialize));
         register_custom_setter<T>();
     }
 

--- a/src/core/CUtil.cpp
+++ b/src/core/CUtil.cpp
@@ -26,12 +26,7 @@ std::shared_ptr<SDL_Rect> CUtil::boxInBox(const std::shared_ptr<SDL_Rect> &out, 
 }
 
 std::shared_ptr<SDL_Rect> CUtil::rect(int x, int y, int w, int h) {
-    std::shared_ptr<SDL_Rect> ret = std::make_shared<SDL_Rect>();
-    ret->x = x;
-    ret->y = y;
-    ret->w = w;
-    ret->h = h;
-    return ret;
+    return std::make_shared<SDL_Rect>(SDL_Rect{x, y, w, h});
 }
 
 std::shared_ptr<SDL_Rect> CUtil::centeredRect(int centerX, int centerY, int w, int h) {

--- a/src/core/CUtil.h
+++ b/src/core/CUtil.h
@@ -98,13 +98,11 @@ class CUtil {
 
     template <fn::FilePredicate Predicate> static std::set<std::string> findFiles(std::string dir, Predicate pred) {
         std::set<std::string> retValue;
-        std::filesystem::directory_iterator iterator(dir), end;
-        while (iterator != end) {
-            auto path = iterator->path().string();
+        for (const auto &entry : std::filesystem::directory_iterator(dir)) {
+            auto path = entry.path().string();
             if (pred(path)) {
-                retValue.insert(path);
+                retValue.insert(std::move(path));
             }
-            iterator++;
         }
         return retValue;
     }

--- a/tests/unit/test_coords.cpp
+++ b/tests/unit/test_coords.cpp
@@ -65,7 +65,7 @@ struct ConceptCanStep {
 };
 
 struct ConceptWaypoint {
-    std::pair<bool, Coords> operator()(const Coords &) const { return {false, ZERO}; }
+    std::optional<Coords> operator()(const Coords &) const { return std::nullopt; }
 };
 
 struct ConceptNeighbors {
@@ -193,7 +193,7 @@ void test_pathfinder_find_path_without_obstacles() {
     auto can_step = [](const Coords &coords) {
         return coords.x >= 0 && coords.x <= 2 && coords.y >= 0 && coords.y <= 2 && coords.z == 0;
     };
-    auto no_waypoint = [](const Coords &) { return std::pair<bool, Coords>(false, ZERO); };
+    auto no_waypoint = [](const Coords &) -> std::optional<Coords> { return std::nullopt; };
 
     auto path = CPathFinder::findPath(Coords(0, 0, 0), Coords(2, 0, 0), can_step, no_waypoint);
     expect_true(path.size() == 2, "findPath should include each next step until goal");
@@ -206,7 +206,7 @@ void test_pathfinder_find_path_without_obstacles() {
 
 void test_pathfinder_waypoint_and_blocked_goal() {
     auto can_step = [](const Coords &coords) { return coords == Coords(0, 0, 0); };
-    auto no_waypoint = [](const Coords &) { return std::pair<bool, Coords>(false, ZERO); };
+    auto no_waypoint = [](const Coords &) -> std::optional<Coords> { return std::nullopt; };
 
     auto path = CPathFinder::findPath(Coords(0, 0, 0), Coords(2, 0, 0), can_step, no_waypoint);
     expect_true(path.size() == 1, "findPath should return only start when goal is unreachable");
@@ -219,7 +219,7 @@ void test_pathfinder_caches_passability_checks() {
         calls[coords]++;
         return coords == Coords(0, 0, 0) || coords == Coords(1, 0, 0) || coords == Coords(2, 0, 0);
     };
-    auto no_waypoint = [](const Coords &) { return std::pair<bool, Coords>(false, ZERO); };
+    auto no_waypoint = [](const Coords &) -> std::optional<Coords> { return std::nullopt; };
     auto duplicate_neighbors = [](const Coords &coords) {
         if (coords == Coords(0, 0, 0)) {
             return std::vector<Coords>{Coords(1, 0, 0), Coords(1, 0, 0)};
@@ -241,11 +241,11 @@ void test_pathfinder_waypoint_override() {
     auto can_step = [](const Coords &coords) {
         return coords.y == 0 && coords.x >= 0 && coords.x <= 2 && coords.z == 0;
     };
-    auto forced_waypoint = [](const Coords &coords) {
+    auto forced_waypoint = [](const Coords &coords) -> std::optional<Coords> {
         if (coords == Coords(0, 0, 0)) {
-            return std::pair<bool, Coords>(true, Coords(2, 0, 0));
+            return Coords(2, 0, 0);
         }
-        return std::pair<bool, Coords>(false, ZERO);
+        return std::nullopt;
     };
     auto next_step = CPathFinder::findNextStep(Coords(0, 0, 0), Coords(2, 0, 0), can_step, forced_waypoint);
     expect_true(next_step->get() == Coords(2, 0, 0), "findNextStep should allow waypoint override when available");
@@ -289,7 +289,7 @@ void test_toroidal_pathfinder_prefers_wrapped_route() {
         Coords normalized = normalize_toroidal(coords, x_bound, y_bound);
         return normalized.z == 0 && normalized.y == 0;
     };
-    auto no_waypoint = [](const Coords &) { return std::pair<bool, Coords>(false, ZERO); };
+    auto no_waypoint = [](const Coords &) -> std::optional<Coords> { return std::nullopt; };
     auto neighbors = [=](const Coords &coords) { return toroidal_neighbors(coords, x_bound, y_bound); };
     auto distance = [=](const Coords &a, const Coords &b) {
         return toroidal_distance(normalize_toroidal(a, x_bound, y_bound), normalize_toroidal(b, x_bound, y_bound),
@@ -312,7 +312,7 @@ void test_toroidal_pathfinder_wraps_on_both_axes() {
         Coords normalized = normalize_toroidal(coords, x_bound, y_bound);
         return normalized.z == 0;
     };
-    auto no_waypoint = [](const Coords &) { return std::pair<bool, Coords>(false, ZERO); };
+    auto no_waypoint = [](const Coords &) -> std::optional<Coords> { return std::nullopt; };
     auto neighbors = [=](const Coords &coords) { return toroidal_neighbors(coords, x_bound, y_bound); };
     auto distance = [=](const Coords &a, const Coords &b) {
         return toroidal_distance(normalize_toroidal(a, x_bound, y_bound), normalize_toroidal(b, x_bound, y_bound),


### PR DESCRIPTION
## What changed
- Hid non-MSVC C++ symbols by default and replaced a deprecated pybind11 type lookup to keep local builds warning-free.
- Tightened custom serializer registration with callable concepts and factored repeated JSON collection serializers into reusable helpers.
- Replaced pathfinder waypoint callbacks from pair<bool, Coords> with std::optional<Coords> and updated map/controller/unit-test call sites.
- Applied small ranges cleanup for tag, file, and adjacent-coordinate iteration.

## Why
- Continue the C++23 modernization follow-up after the core modernization PR landed.
- Make pathfinding callback intent explicit and remove legacy boolean-sentinel result plumbing.
- Keep compiler output clean under the current target flags.

## Validation
- cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)
- ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
- python3 test.py
- ./scripts/run_coverage.sh (90.7% line coverage)
- git diff --check

## Known limitations
- The coverage tool still reports its existing negative-hit warning for CMap.cpp during report generation; this is not a compiler warning.