### PR TITLE
[codex] Optimize pathfinder candidate iteration

### DIFF
--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -575,6 +575,18 @@ Coords CMap::normalizeCoords(Coords coords) const {
 std::vector<Coords> CMap::getAdjacentCoords(Coords coords, bool includeSelf) const {
     std::vector<Coords> adjacent;
     adjacent.reserve(includeSelf ? 5 : 4);
+
+    if (!wrapsX(coords.z) && !wrapsY(coords.z)) {
+        if (includeSelf) {
+            adjacent.push_back(coords);
+        }
+        adjacent.push_back(coords + EAST);
+        adjacent.push_back(coords + WEST);
+        adjacent.push_back(coords + SOUTH);
+        adjacent.push_back(coords + NORTH);
+        return adjacent;
+    }
+
     auto add = [&adjacent, this](Coords candidate) {
         candidate = normalizeCoords(candidate);
         if (std::find(adjacent.begin(), adjacent.end(), candidate) == adjacent.end()) {

--- a/src/core/CPathFinder.cpp
+++ b/src/core/CPathFinder.cpp
@@ -82,17 +82,16 @@ template <fn::PathPassability CanStep> class PassabilityCache {
     std::unordered_map<Coords, bool> values;
 };
 
-template <fn::PathWaypoint Waypoint, fn::PathNeighbors Neighbors>
-std::vector<Coords> candidates(const Coords &coords, const Waypoint &waypoint, const Neighbors &neighbors) {
-    std::vector<Coords> list;
+template <fn::PathWaypoint Waypoint, fn::PathNeighbors Neighbors, typename CandidateHandler>
+void forEachCandidate(const Coords &coords, const Waypoint &waypoint, const Neighbors &neighbors,
+                      CandidateHandler handle) {
     for (const auto &neighbor : neighbors(coords)) {
-        list.push_back(neighbor);
+        handle(neighbor);
     }
     auto waypoint_direction = waypoint(coords);
     if (waypoint_direction.first) {
-        list.push_back(waypoint_direction.second);
+        handle(waypoint_direction.second);
     }
-    return list;
 }
 
 template <fn::PathPassability CanStep, fn::PathWaypoint Waypoint, fn::PathNeighbors Neighbors,
@@ -120,7 +119,7 @@ Values fillValues(const CanStep &canStep, const Coords &goal, const Waypoint &wa
             break;
         }
 
-        for (auto previous : candidates(current.coords, waypoint, neighbors)) {
+        forEachCandidate(current.coords, waypoint, neighbors, [&](Coords previous) {
             if ((stopAt && previous == *stopAt) || passability.canStepAt(previous)) {
                 const int edge_cost = std::max(1, stepCost(previous, current.coords));
                 const int next_cost = current.cost + edge_cost;
@@ -130,7 +129,7 @@ Values fillValues(const CanStep &canStep, const Coords &goal, const Waypoint &wa
                     nodes.push({next_cost, previous});
                 }
             }
-        }
+        });
     }
 
     return values;
@@ -191,9 +190,9 @@ std::vector<Coords> findAStarPath(Coords start, Coords goal, const CanStep &canS
             break;
         }
 
-        for (auto next : candidates(current.coords, waypoint, neighbors)) {
+        forEachCandidate(current.coords, waypoint, neighbors, [&](Coords next) {
             if (next != goal && !passability.canStepAt(next)) {
-                continue;
+                return;
             }
 
             const int edgeCost = std::max(1, stepCost(current.coords, next));
@@ -204,7 +203,7 @@ std::vector<Coords> findAStarPath(Coords start, Coords goal, const CanStep &canS
                 previous[next] = current.coords;
                 frontier.push({nextCost + estimateCost(distance, next, goal), nextCost, next});
             }
-        }
+        });
     }
 
     return buildPath(start, goal, previous);
@@ -240,9 +239,9 @@ Coords findAStarNextStep(Coords start, Coords goal, const CanStep &canStep, cons
             return current.firstStep;
         }
 
-        for (auto next : candidates(current.coords, waypoint, neighbors)) {
+        forEachCandidate(current.coords, waypoint, neighbors, [&](Coords next) {
             if (next != goal && !passability.canStepAt(next)) {
-                continue;
+                return;
             }
 
             const int edgeCost = std::max(1, stepCost(current.coords, next));
@@ -253,7 +252,7 @@ Coords findAStarNextStep(Coords start, Coords goal, const CanStep &canStep, cons
                 frontier.push({nextCost + estimateCost(distance, next, goal), nextCost, next,
                                current.coords == start ? next : current.firstStep});
             }
-        }
+        });
     }
 
     return start;

--- a/src/core/CPathFinder.h
+++ b/src/core/CPathFinder.h
@@ -37,8 +37,12 @@ template <fn::CoordsLike CoordsLike> std::list<Coords> near_coords_with(const Co
 }
 
 inline std::vector<Coords> default_neighbors(const Coords &coords) {
-    auto list = near_coords(coords);
-    return std::vector<Coords>(list.begin(), list.end());
+    std::vector<Coords> list;
+    list.reserve(CARDINAL_DIRECTIONS.size());
+    for (const auto &offset : CARDINAL_DIRECTIONS) {
+        list.push_back(coords + offset);
+    }
+    return list;
 }
 
 class CPathFinder {


### PR DESCRIPTION
## What changed
- Stream pathfinder candidates directly into relaxation logic instead of building a temporary candidate vector per expanded node.
- Build default neighbor vectors directly from cardinal directions instead of converting through a list.
- Add a non-wrapping fast path for CMap::getAdjacentCoords while preserving wrapped-map behavior.

## Why
Callgrind on `python3 test.py GameTest.test_pathfinder` showed avoidable overhead in pathfinder candidate generation and map neighbor lookup during real-map path dumps.

## Validation
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py` passed: 124 tests, 19 skipped
- `./scripts/run_coverage.sh` passed: line coverage 90.7%
- `valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=definite,indirect --error-exitcode=99 cmake-build-release/for_unit_tests` reported `ERROR SUMMARY: 0`
- Callgrind: scoped `CPathFinder::saveMap` dropped from 256.3M to 230.1M instructions; pathfinder work excluding unchanged PNG writing dropped from about 101.5M to 75.3M instructions.

## Known limitations
- Normal wall-clock timings for the Python pathfinder test varied between runs; Callgrind instruction counts were used for the stable comparison.
- Memcheck still reports existing reachable/Python/SDL/thread-pool allocations and possible TLS blocks, but no definite or indirect leaks.