### PR TITLE
Harden save slot name validation for map save/load

### DIFF
--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -27,6 +27,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <pybind11/eval.h>
 #include <rdg.h>
 
+#include <algorithm>
+#include <cctype>
 #include <utility>
 
 namespace {
@@ -96,6 +98,19 @@ std::vector<std::string> build_tile_types(const json &tileset) {
     }
     return tileTypes;
 }
+
+bool is_valid_slot_name(const std::string &name) {
+    if (name.empty() || name.find("..") != std::string::npos) {
+        return false;
+    }
+
+    return std::all_of(name.begin(), name.end(), [](unsigned char ch) {
+        if (std::isalnum(ch)) {
+            return true;
+        }
+        return ch == '.' || ch == '_' || ch == '-';
+    });
+}
 } // namespace
 
 void CMapLoader::loadFromTmx(const std::shared_ptr<CMap> &map, const std::shared_ptr<json> &mapc) {
@@ -156,6 +171,11 @@ std::shared_ptr<CMap> CMapLoader::loadNewMap(const std::shared_ptr<CGame> &game,
 }
 
 std::shared_ptr<CMap> CMapLoader::loadSavedMap(const std::shared_ptr<CGame> &game, const std::string &name) {
+    if (!is_valid_slot_name(name)) {
+        vstd::logger::warning("Rejected invalid save slot name during load:", name);
+        return game->getObjectHandler()->createObject<CMap>(game);
+    }
+
     const std::string path = "save/" + name + ".json";
 
     if (std::shared_ptr<json> save = CConfigurationProvider::getConfig(path)) {
@@ -220,6 +240,11 @@ std::shared_ptr<CMap> CMapLoader::loadRandomMapWithPlayer(const std::shared_ptr<
 }
 
 void CMapLoader::save(const std::shared_ptr<CMap> &map, const std::string &name) {
+    if (!is_valid_slot_name(name)) {
+        vstd::logger::warning("Rejected invalid save slot name during save:", name);
+        return;
+    }
+
     CResourcesProvider::getInstance()->save(vstd::join({"save/", name, ".json"}, ""), JSONIFY_STYLED(map));
 }
 

--- a/test.py
+++ b/test.py
@@ -3056,6 +3056,48 @@ class GameTest(unittest.TestCase):
         return True, json.dumps({"log": log_text.strip(), "map_type": g.getMap().getType()})
 
     @game_test
+    def test_invalid_save_slot_names_are_rejected(self):
+        game = load_game_module()
+
+        unique = str(time.time_ns())
+        invalid_slots = [f"../evil_{unique}", f"a/b_{unique}"]
+        potential_writes = [
+            build_dir / f"evil_{unique}.json",
+            build_dir / "save" / "a" / f"b_{unique}.json",
+        ]
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGameWithPlayer(g, "test", "Warrior")
+        game_map = g.getMap()
+
+        log_path = make_temp_log_path()
+        try:
+            game.set_logger_sink("file", str(log_path))
+            for slot_name in invalid_slots:
+                game.CMapLoader.save(game_map, slot_name)
+                loaded_game = game.CGameLoader.loadGame()
+                game.CGameLoader.loadSavedGame(loaded_game, slot_name)
+                self.assertIsNotNone(loaded_game.getMap())
+                self.assertEqual("CMap", loaded_game.getMap().getType())
+        finally:
+            game.set_logger_sink("disabled", None)
+
+        log_text = log_path.read_text()
+        log_path.unlink(missing_ok=True)
+
+        for written_path in potential_writes:
+            self.assertFalse(written_path.exists(), f"Unexpected write for invalid slot: {written_path}")
+        self.assertIn("WARNING: Rejected invalid save slot name during save:", log_text)
+        self.assertIn("WARNING: Rejected invalid save slot name during load:", log_text)
+
+        return True, json.dumps(
+            {
+                "invalid_slots": invalid_slots,
+                "blocked_paths": [str(path) for path in potential_writes],
+            }
+        )
+
+    @game_test
     def test_objects(self):
         game = load_game_module()
 


### PR DESCRIPTION
### Motivation
- Prevent malformed or malicious save slot names from producing path traversal or writing files outside the intended `save/` area.
- Fail fast on invalid slot names to avoid attempting filesystem operations with derived paths.

### Description
- Added `is_valid_slot_name` in `src/core/CLoader.cpp` to allow only `[A-Za-z0-9._-]` characters and to reject empty names and any name containing `..`.
- Applied the validator in `CMapLoader::save` to skip and log a warning for invalid save names instead of attempting a write.
- Applied the validator in `CMapLoader::loadSavedMap` to reject invalid load requests early, log a warning, and return the safe empty `CMap` fallback.
- Added a Python regression test in `test.py` (`test_invalid_save_slot_names_are_rejected`) that attempts to save/load invalid slot names (e.g. `../evil`, `a/b`), asserts there is no crash, and verifies that no unexpected files are written outside `save/`.

### Testing
- Built native targets with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` and the build succeeded.
- Ran unit test executable with `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` and it passed.
- Ran the full Python test suite with `python3 test.py` and all tests passed (125 tests, 19 skipped), including the new regression test.
- Ran coverage via `./scripts/run_coverage.sh` which completed and reported scoped line coverage `90.86%` and generated coverage artifacts under `coverage/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07a0163d08326b75348cae78340e6)