### PR TITLE
Namespace saved-map config keys to prevent save-slot/type collisions

### DIFF
--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -111,6 +111,8 @@ bool is_valid_slot_name(const std::string &name) {
         return ch == '.' || ch == '_' || ch == '-';
     });
 }
+
+std::string build_saved_map_config_key(const std::string &slotName) { return "__save_slot__/" + slotName; }
 } // namespace
 
 void CMapLoader::loadFromTmx(const std::shared_ptr<CMap> &map, const std::shared_ptr<json> &mapc) {
@@ -177,6 +179,7 @@ std::shared_ptr<CMap> CMapLoader::loadSavedMap(const std::shared_ptr<CGame> &gam
     }
 
     const std::string path = "save/" + name + ".json";
+    const std::string saveConfigKey = build_saved_map_config_key(name);
 
     if (std::shared_ptr<json> save = CConfigurationProvider::getConfig(path)) {
         const auto mapName = (*save)["properties"]["mapName"].get<std::string>();
@@ -185,9 +188,9 @@ std::shared_ptr<CMap> CMapLoader::loadSavedMap(const std::shared_ptr<CGame> &gam
         CPluginLoader::loadPlugin(game, getScriptPath(mapName));
         game->getObjectHandler()->registerConfig(getConfigPaths(mapName)); // TODO: duplicate?
 
-        game->getObjectHandler()->registerConfig(name, save);
+        game->getObjectHandler()->registerConfig(saveConfigKey, save);
 
-        auto map = game->getObjectHandler()->createObject<CMap>(game, name);
+        auto map = game->getObjectHandler()->createObject<CMap>(game, saveConfigKey);
         if (std::shared_ptr<json> mapc = CConfigurationProvider::getConfig(getMapPath(mapName))) {
             map->setDefaultTiles({});
             map->setOutOfBoundsTiles({});

--- a/test.py
+++ b/test.py
@@ -2360,6 +2360,39 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_load_saved_map_slot_name_does_not_override_object_type_configs(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGameWithPlayer(g, "test", "Warrior")
+        save_name = "Sword"
+        save_path = Path.cwd() / "save" / f"{save_name}.json"
+        existing_save = save_path.read_text(encoding="utf-8") if save_path.exists() else None
+
+        try:
+            game.CMapLoader.save(g.getMap(), save_name)
+
+            loaded_game = game.CGameLoader.loadGame()
+            game.CGameLoader.loadSavedGame(loaded_game, save_name)
+
+            sword = loaded_game.createObject("Sword")
+            self.assertIsNotNone(sword)
+            self.assertEqual("CWeapon", sword.getType())
+
+            return True, json.dumps(
+                {
+                    "save_slot": save_name,
+                    "created_type": sword.getType(),
+                },
+                sort_keys=True,
+            )
+        finally:
+            if existing_save is None:
+                save_path.unlink(missing_ok=True)
+            else:
+                save_path.write_text(existing_save, encoding="utf-8")
+
+    @game_test
     def test_map_proxy_cells_remain_populated_after_player_move(self):
         game = load_game_module()
 


### PR DESCRIPTION
### Motivation
- Saved map JSON was being registered under the raw save-slot key which can collide with existing object/type ids (e.g. a slot named `Sword`) and interfere with normal `createObject` resolution.

### Description
- Add `build_saved_map_config_key` helper and use a namespaced key `__save_slot__/<slot>` when registering saved-map JSON and when creating the saved map in `CMapLoader::loadSavedMap`.
- Keep file path resolution unchanged (`save/<slot>.json`) so external save filenames and on-disk layout are stable.
- Add a regression test `test_load_saved_map_slot_name_does_not_override_object_type_configs` in `test.py` that saves/loads with slot name `Sword` and verifies `createObject("Sword")` still returns the normal config-backed weapon type after loading.
- Update copyright year range in `src/core/CLoader.cpp`.

### Testing
- Ran formatters: `clang-format -i src/core/CLoader.cpp` and `black -l 120 test.py` successfully.
- Built the engine and unit-tests with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` which completed successfully.
- Ran CTest `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` which passed.
- Ran the full Python regression suite `python3 test.py` and all tests passed (125 tests, 19 skipped for xvfb process tests) after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f079fc08648326afb6ac4a2e0b7901)