### PR TITLE
Run clang-format across C++ source tree

### DIFF
--- a/src/core/CFuture.cpp
+++ b/src/core/CFuture.cpp
@@ -19,56 +19,45 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace vstd {
 std::function<void(std::function<void()>)> get_call_later_handler() {
-  return [](std::function<void()> f) {
-    vstd::event_loop<>::instance()->invoke(f);
-  };
+    return [](std::function<void()> f) { vstd::event_loop<>::instance()->invoke(f); };
 }
 
 std::function<void(std::function<void()>)> get_call_async_handler() {
-  return [](std::function<void()> f) {
-    static std::shared_ptr<vstd::thread_pool<16>> pool =
-        std::make_shared<vstd::thread_pool<16>>()->start();
-    pool->execute(f);
-  };
+    return [](std::function<void()> f) {
+        static std::shared_ptr<vstd::thread_pool<16>> pool = std::make_shared<vstd::thread_pool<16>>()->start();
+        pool->execute(f);
+    };
 }
 
 std::function<void(std::function<void()>)> get_call_now_handler() {
-  return [](std::function<void()> f) { f(); };
+    return [](std::function<void()> f) { f(); };
 }
 
 std::function<void(std::function<void()>)> get_call_later_block_handler() {
-  return
-      [](std::function<void()> f) { vstd::event_loop<>::instance()->await(f); };
+    return [](std::function<void()> f) { vstd::event_loop<>::instance()->await(f); };
 }
 
 std::function<void(std::function<bool()>)> get_wait_until_handler() {
-  return [](std::function<bool()> pred) {
-    vstd::call_later_block([pred]() {
-      while (!pred()) {
-        vstd::event_loop<>::instance()->run();
-      }
-    });
-  };
+    return [](std::function<bool()> pred) {
+        vstd::call_later_block([pred]() {
+            while (!pred()) {
+                vstd::event_loop<>::instance()->run();
+            }
+        });
+    };
 }
 
-std::function<void(std::function<bool()>, std::function<void()>)>
-get_call_when_handler() {
-  return [](std::function<bool()> pred, std::function<void()> func) {
-    vstd::event_loop<>::instance()->invoke_when(pred, func);
-  };
+std::function<void(std::function<bool()>, std::function<void()>)> get_call_when_handler() {
+    return [](std::function<bool()> pred, std::function<void()> func) {
+        vstd::event_loop<>::instance()->invoke_when(pred, func);
+    };
 }
 
-std::function<void(int, std::function<void()>)>
-get_call_delayed_later_handler() {
-  return [](int t, std::function<void()> f) {
-    vstd::event_loop<>::instance()->delay(t, f);
-  };
+std::function<void(int, std::function<void()>)> get_call_delayed_later_handler() {
+    return [](int t, std::function<void()> f) { vstd::event_loop<>::instance()->delay(t, f); };
 }
 
-std::function<void(int, std::function<void()>)>
-get_call_delayed_async_handler() {
-  return [](int t, std::function<void()> f) {
-    vstd::event_loop<>::instance()->delay(t, [f]() { vstd::async(f); });
-  };
+std::function<void(int, std::function<void()>)> get_call_delayed_async_handler() {
+    return [](int t, std::function<void()> f) { vstd::event_loop<>::instance()->delay(t, [f]() { vstd::async(f); }); };
 }
 } // namespace vstd

--- a/src/core/CGame.cpp
+++ b/src/core/CGame.cpp
@@ -23,41 +23,34 @@ CGame::CGame() {}
 
 CGame::~CGame() {}
 
-void CGame::changeMap(std::string file) {
-  CGameLoader::changeMap(this->ptr<CGame>(), file);
-}
+void CGame::changeMap(std::string file) { CGameLoader::changeMap(this->ptr<CGame>(), file); }
 
 std::shared_ptr<CMap> CGame::getMap() const { return map; }
 
 void CGame::setMap(std::shared_ptr<CMap> map) { this->map = map; }
 
 std::shared_ptr<CGuiHandler> CGame::getGuiHandler() {
-  return guiHandler.get(
-      [this]() { return std::make_shared<CGuiHandler>(this->ptr<CGame>()); });
+    return guiHandler.get([this]() { return std::make_shared<CGuiHandler>(this->ptr<CGame>()); });
 }
 
 std::shared_ptr<CScriptHandler> CGame::getScriptHandler() {
-  return scriptHandler.get([]() { return std::make_shared<CScriptHandler>(); });
+    return scriptHandler.get([]() { return std::make_shared<CScriptHandler>(); });
 }
 
 std::shared_ptr<CObjectHandler> CGame::getObjectHandler() {
-  return objectHandler.get([]() { return std::make_shared<CObjectHandler>(); });
+    return objectHandler.get([]() { return std::make_shared<CObjectHandler>(); });
 }
 
-void CGame::loadPlugin(std::function<std::shared_ptr<CPlugin>()> plugin) {
-  plugin()->load(this->ptr<CGame>());
-}
+void CGame::loadPlugin(std::function<std::shared_ptr<CPlugin>()> plugin) { plugin()->load(this->ptr<CGame>()); }
 
 std::shared_ptr<CGui> CGame::getGui() const { return _gui; }
 
 void CGame::setGui(std::shared_ptr<CGui> _gui) { CGame::_gui = _gui; }
 
 std::shared_ptr<CSlotConfig> CGame::getSlotConfiguration() {
-  return slotConfiguration.get(
-      [this]() { return createObject<CSlotConfig>("slotConfiguration"); });
+    return slotConfiguration.get([this]() { return createObject<CSlotConfig>("slotConfiguration"); });
 }
 
 std::shared_ptr<CRngHandler> CGame::getRngHandler() {
-  return rngHandler.get(
-      [this]() { return std::make_shared<CRngHandler>(this->ptr<CGame>()); });
+    return rngHandler.get([this]() { return std::make_shared<CRngHandler>(this->ptr<CGame>()); });
 }

--- a/src/core/CList.h
+++ b/src/core/CList.h
@@ -20,38 +20,35 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CGameObject.h"
 
 class CListString : public CGameObject {
-  V_META(CListString, CGameObject,
-         V_PROPERTY(CListString, std::set<std::string>, values, getValues,
-                    setValues))
-public:
-  CListString() = default;
+    V_META(CListString, CGameObject, V_PROPERTY(CListString, std::set<std::string>, values, getValues, setValues))
+  public:
+    CListString() = default;
 
-private:
-  std::set<std::string> values;
+  private:
+    std::set<std::string> values;
 
-public:
-  void addValue(std::string val) { values.insert(val); }
+  public:
+    void addValue(std::string val) { values.insert(val); }
 
-  void setValues(std::set<std::string> _values) { this->values = _values; }
+    void setValues(std::set<std::string> _values) { this->values = _values; }
 
-  std::set<std::string> getValues() { return values; }
+    std::set<std::string> getValues() { return values; }
 };
 
 class CListInt : public CGameObject {
-  V_META(CListInt, CGameObject,
-         V_PROPERTY(CListInt, std::set<int>, values, getValues, setValues))
-public:
-  CListInt() = default;
+    V_META(CListInt, CGameObject, V_PROPERTY(CListInt, std::set<int>, values, getValues, setValues))
+  public:
+    CListInt() = default;
 
-private:
-  std::set<int> values;
+  private:
+    std::set<int> values;
 
-public:
-  void addValue(int val) { values.insert(val); }
+  public:
+    void addValue(int val) { values.insert(val); }
 
-  void setValues(std::set<int> _values) { this->values = _values; }
+    void setValues(std::set<int> _values) { this->values = _values; }
 
-  std::set<int> getValues() { return values; }
+    std::set<int> getValues() { return values; }
 };
 
 typedef std::map<std::string, std::string> string_string_map;
@@ -60,66 +57,57 @@ typedef std::map<int, std::string> int_string_map;
 typedef std::map<int, int> int_int_map;
 
 class CMapStringString : public CGameObject {
-  V_META(CMapStringString, CGameObject,
-         V_PROPERTY(CMapStringString, string_string_map, values, getValues,
-                    setValues))
-public:
-  CMapStringString() = default;
+    V_META(CMapStringString, CGameObject, V_PROPERTY(CMapStringString, string_string_map, values, getValues, setValues))
+  public:
+    CMapStringString() = default;
 
-private:
-  std::map<std::string, std::string> values;
+  private:
+    std::map<std::string, std::string> values;
 
-public:
-  void setValues(std::map<std::string, std::string> _values) {
-    this->values = _values;
-  }
+  public:
+    void setValues(std::map<std::string, std::string> _values) { this->values = _values; }
 
-  std::map<std::string, std::string> getValues() { return values; }
+    std::map<std::string, std::string> getValues() { return values; }
 };
 
 class CMapStringInt : public CGameObject {
-  V_META(CMapStringInt, CGameObject,
-         V_PROPERTY(CMapStringInt, string_int_map, values, getValues,
-                    setValues))
-public:
-  CMapStringInt() = default;
+    V_META(CMapStringInt, CGameObject, V_PROPERTY(CMapStringInt, string_int_map, values, getValues, setValues))
+  public:
+    CMapStringInt() = default;
 
-private:
-  std::map<std::string, int> values;
+  private:
+    std::map<std::string, int> values;
 
-public:
-  void setValues(std::map<std::string, int> _values) { this->values = _values; }
+  public:
+    void setValues(std::map<std::string, int> _values) { this->values = _values; }
 
-  std::map<std::string, int> getValues() { return values; }
+    std::map<std::string, int> getValues() { return values; }
 };
 
 class CMapIntString : public CGameObject {
-  V_META(CMapIntString, CGameObject,
-         V_PROPERTY(CMapIntString, int_string_map, values, getValues,
-                    setValues))
-public:
-  CMapIntString() = default;
+    V_META(CMapIntString, CGameObject, V_PROPERTY(CMapIntString, int_string_map, values, getValues, setValues))
+  public:
+    CMapIntString() = default;
 
-private:
-  std::map<int, std::string> values;
+  private:
+    std::map<int, std::string> values;
 
-public:
-  void setValues(std::map<int, std::string> _values) { this->values = _values; }
+  public:
+    void setValues(std::map<int, std::string> _values) { this->values = _values; }
 
-  std::map<int, std::string> getValues() { return values; }
+    std::map<int, std::string> getValues() { return values; }
 };
 
 class CMapIntInt : public CGameObject {
-  V_META(CMapIntInt, CGameObject,
-         V_PROPERTY(CMapIntInt, int_int_map, values, getValues, setValues))
-public:
-  CMapIntInt() = default;
+    V_META(CMapIntInt, CGameObject, V_PROPERTY(CMapIntInt, int_int_map, values, getValues, setValues))
+  public:
+    CMapIntInt() = default;
 
-private:
-  std::map<int, int> values;
+  private:
+    std::map<int, int> values;
 
-public:
-  void setValues(std::map<int, int> _values) { this->values = _values; }
+  public:
+    void setValues(std::map<int, int> _values) { this->values = _values; }
 
-  std::map<int, int> getValues() { return values; }
+    std::map<int, int> getValues() { return values; }
 };

--- a/src/core/CPlugin.h
+++ b/src/core/CPlugin.h
@@ -26,7 +26,7 @@ class CGame;
 class CMap;
 
 class CPlugin : public CGameObject {
-  V_META(CPlugin, CGameObject, vstd::meta::empty())
-public:
-  virtual void load(std::shared_ptr<CGame> game);
+    V_META(CPlugin, CGameObject, vstd::meta::empty())
+  public:
+    virtual void load(std::shared_ptr<CGame> game);
 };

--- a/src/core/CScript.cpp
+++ b/src/core/CScript.cpp
@@ -19,13 +19,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CGame.h"
 #include "handler/CScriptHandler.h"
 
-std::shared_ptr<CGameObject>
-CScript::invoke(std::shared_ptr<CGame> game,
-                std::shared_ptr<CGameObject> self) {
-  return game->getScriptHandler()
-      ->call_created_function<std::shared_ptr<CGameObject>,
-                              std::shared_ptr<CGameObject>>("return " + script,
-                                                            {"self"}, self);
+std::shared_ptr<CGameObject> CScript::invoke(std::shared_ptr<CGame> game, std::shared_ptr<CGameObject> self) {
+    return game->getScriptHandler()->call_created_function<std::shared_ptr<CGameObject>, std::shared_ptr<CGameObject>>(
+        "return " + script, {"self"}, self);
 }
 
 std::string CScript::getScript() { return script; }

--- a/src/core/CSlotConfig.cpp
+++ b/src/core/CSlotConfig.cpp
@@ -21,31 +21,28 @@ CSlotConfig::CSlotConfig() {}
 
 CSlotMap CSlotConfig::getConfiguration() { return configuration; }
 
-void CSlotConfig::setConfiguration(CSlotMap configuration) {
-  CSlotConfig::configuration = configuration;
-}
+void CSlotConfig::setConfiguration(CSlotMap configuration) { CSlotConfig::configuration = configuration; }
 
 bool CSlotConfig::canFit(std::string slot, std::shared_ptr<CItem> item) {
-  if (vstd::ctn(configuration, slot)) {
-    auto types = configuration.find(slot)->second->getTypes();
-    for (auto type : types) {
-      if (item->meta()->inherits(type)) {
-        return true;
-      }
+    if (vstd::ctn(configuration, slot)) {
+        auto types = configuration.find(slot)->second->getTypes();
+        for (auto type : types) {
+            if (item->meta()->inherits(type)) {
+                return true;
+            }
+        }
     }
-  }
-  return false;
+    return false;
 }
 
-std::set<std::string>
-CSlotConfig::getFittingSlots(std::shared_ptr<CItem> item) {
-  std::set<std::string> ret;
-  for (auto it : configuration) {
-    if (canFit(it.first, item)) {
-      ret.insert(it.first);
+std::set<std::string> CSlotConfig::getFittingSlots(std::shared_ptr<CItem> item) {
+    std::set<std::string> ret;
+    for (auto it : configuration) {
+        if (canFit(it.first, item)) {
+            ret.insert(it.first);
+        }
     }
-  }
-  return ret;
+    return ret;
 }
 
 CSlot::CSlot() {}

--- a/src/core/CSlotConfig.h
+++ b/src/core/CSlotConfig.h
@@ -21,44 +21,42 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CItem.h"
 
 class CSlot : public CGameObject {
-  V_META(CSlot, CGameObject,
-         V_PROPERTY(CSlot, std::string, slotName, getSlotName, setSlotName),
-         V_PROPERTY(CSlot, std::set<std::string>, types, getTypes, setTypes))
-public:
-  CSlot();
+    V_META(CSlot, CGameObject, V_PROPERTY(CSlot, std::string, slotName, getSlotName, setSlotName),
+           V_PROPERTY(CSlot, std::set<std::string>, types, getTypes, setTypes))
+  public:
+    CSlot();
 
-private:
-  std::string slotName;
-  std::set<std::string> types;
+  private:
+    std::string slotName;
+    std::set<std::string> types;
 
-public:
-  std::string getSlotName();
+  public:
+    std::string getSlotName();
 
-  void setSlotName(std::string slotName);
+    void setSlotName(std::string slotName);
 
-  std::set<std::string> getTypes();
+    std::set<std::string> getTypes();
 
-  void setTypes(std::set<std::string> types);
+    void setTypes(std::set<std::string> types);
 };
 
 typedef std::map<std::string, std::shared_ptr<CSlot>> CSlotMap;
 
 class CSlotConfig : public CGameObject {
-  V_META(CSlotConfig, CGameObject,
-         V_PROPERTY(CSlotConfig, CSlotMap, configuration, getConfiguration,
-                    setConfiguration))
-public:
-  CSlotConfig();
+    V_META(CSlotConfig, CGameObject,
+           V_PROPERTY(CSlotConfig, CSlotMap, configuration, getConfiguration, setConfiguration))
+  public:
+    CSlotConfig();
 
-private:
-  CSlotMap configuration;
+  private:
+    CSlotMap configuration;
 
-public:
-  CSlotMap getConfiguration();
+  public:
+    CSlotMap getConfiguration();
 
-  void setConfiguration(CSlotMap configuration);
+    void setConfiguration(CSlotMap configuration);
 
-  bool canFit(std::string slot, std::shared_ptr<CItem> item);
+    bool canFit(std::string slot, std::shared_ptr<CItem> item);
 
-  std::set<std::string> getFittingSlots(std::shared_ptr<CItem> item);
+    std::set<std::string> getFittingSlots(std::shared_ptr<CItem> item);
 };

--- a/src/core/CStats.h
+++ b/src/core/CStats.h
@@ -23,166 +23,160 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 class Stats : public CGameObject {
 
-  V_META(Stats, CGameObject,
-         V_PROPERTY(Stats, int, strength, getStrength, setStrength),
-         V_PROPERTY(Stats, int, agility, getAgility, setAgility),
-         V_PROPERTY(Stats, int, stamina, getStamina, setStamina),
-         V_PROPERTY(Stats, int, intelligence, getIntelligence, setIntelligence),
-         V_PROPERTY(Stats, int, armor, getArmor, setArmor),
-         V_PROPERTY(Stats, int, block, getBlock, setBlock),
-         V_PROPERTY(Stats, int, dmgMin, getDmgMin, setDmgMin),
-         V_PROPERTY(Stats, int, dmgMax, getDmgMax, setDmgMax),
-         V_PROPERTY(Stats, int, attack, getAttack, setAttack),
-         V_PROPERTY(Stats, int, hit, getHit, setHit),
-         V_PROPERTY(Stats, int, crit, getCrit, setCrit),
-         V_PROPERTY(Stats, int, fireResist, getFireResist, setFireResist),
-         V_PROPERTY(Stats, int, frostResist, getFrostResist, setFrostResist),
-         V_PROPERTY(Stats, int, normalResist, getNormalResist, setNormalResist),
-         V_PROPERTY(Stats, int, thunderResist, getThunderResist,
-                    setThunderResist),
-         V_PROPERTY(Stats, int, shadowResist, getShadowResist, setShadowResist),
-         V_PROPERTY(Stats, int, damage, getDamage, setDamage),
-         V_PROPERTY(Stats, std::string, mainStat, getMainStat, setMainStat))
+    V_META(Stats, CGameObject, V_PROPERTY(Stats, int, strength, getStrength, setStrength),
+           V_PROPERTY(Stats, int, agility, getAgility, setAgility),
+           V_PROPERTY(Stats, int, stamina, getStamina, setStamina),
+           V_PROPERTY(Stats, int, intelligence, getIntelligence, setIntelligence),
+           V_PROPERTY(Stats, int, armor, getArmor, setArmor), V_PROPERTY(Stats, int, block, getBlock, setBlock),
+           V_PROPERTY(Stats, int, dmgMin, getDmgMin, setDmgMin), V_PROPERTY(Stats, int, dmgMax, getDmgMax, setDmgMax),
+           V_PROPERTY(Stats, int, attack, getAttack, setAttack), V_PROPERTY(Stats, int, hit, getHit, setHit),
+           V_PROPERTY(Stats, int, crit, getCrit, setCrit),
+           V_PROPERTY(Stats, int, fireResist, getFireResist, setFireResist),
+           V_PROPERTY(Stats, int, frostResist, getFrostResist, setFrostResist),
+           V_PROPERTY(Stats, int, normalResist, getNormalResist, setNormalResist),
+           V_PROPERTY(Stats, int, thunderResist, getThunderResist, setThunderResist),
+           V_PROPERTY(Stats, int, shadowResist, getShadowResist, setShadowResist),
+           V_PROPERTY(Stats, int, damage, getDamage, setDamage),
+           V_PROPERTY(Stats, std::string, mainStat, getMainStat, setMainStat))
 
-  int attack = 0;
-  int damage = 0;
-  int shadowResist = 0;
-  int thunderResist = 0;
-  int normalResist = 0;
-  int frostResist = 0;
-  int fireResist = 0;
-  int crit = 0;
-  int hit = 0;
-  int dmgMax = 0;
-  int dmgMin = 0;
-  int block = 0;
-  int armor = 0;
-  int intelligence = 0;
-  int stamina = 0;
-  int agility = 0;
-  int strength = 0;
+    int attack = 0;
+    int damage = 0;
+    int shadowResist = 0;
+    int thunderResist = 0;
+    int normalResist = 0;
+    int frostResist = 0;
+    int fireResist = 0;
+    int crit = 0;
+    int hit = 0;
+    int dmgMax = 0;
+    int dmgMin = 0;
+    int block = 0;
+    int armor = 0;
+    int intelligence = 0;
+    int stamina = 0;
+    int agility = 0;
+    int strength = 0;
 
-public:
-  Stats();
+  public:
+    Stats();
 
-  void addBonus(std::shared_ptr<Stats> stats);
+    void addBonus(std::shared_ptr<Stats> stats);
 
-  void removeBonus(std::shared_ptr<Stats> stats);
+    void removeBonus(std::shared_ptr<Stats> stats);
 
-  std::string getText(int level);
+    std::string getText(int level);
 
-  int getAttack() const;
+    int getAttack() const;
 
-  void setAttack(int value);
+    void setAttack(int value);
 
-  int getDamage() const;
+    int getDamage() const;
 
-  void setDamage(int value);
+    void setDamage(int value);
 
-  int getShadowResist() const;
+    int getShadowResist() const;
 
-  void setShadowResist(int value);
+    void setShadowResist(int value);
 
-  int getThunderResist() const;
+    int getThunderResist() const;
 
-  void setThunderResist(int value);
+    void setThunderResist(int value);
 
-  int getNormalResist() const;
+    int getNormalResist() const;
 
-  void setNormalResist(int value);
+    void setNormalResist(int value);
 
-  int getFrostResist() const;
+    int getFrostResist() const;
 
-  void setFrostResist(int value);
+    void setFrostResist(int value);
 
-  int getFireResist() const;
+    int getFireResist() const;
 
-  void setFireResist(int value);
+    void setFireResist(int value);
 
-  int getCrit() const;
+    int getCrit() const;
 
-  void setCrit(int value);
+    void setCrit(int value);
 
-  int getHit() const;
+    int getHit() const;
 
-  void setHit(int value);
+    void setHit(int value);
 
-  int getDmgMax() const;
+    int getDmgMax() const;
 
-  void setDmgMax(int value);
+    void setDmgMax(int value);
 
-  int getDmgMin() const;
+    int getDmgMin() const;
 
-  void setDmgMin(int value);
+    void setDmgMin(int value);
 
-  int getBlock() const;
+    int getBlock() const;
 
-  void setBlock(int value);
+    void setBlock(int value);
 
-  int getArmor() const;
+    int getArmor() const;
 
-  void setArmor(int value);
+    void setArmor(int value);
 
-  int getIntelligence() const;
+    int getIntelligence() const;
 
-  void setIntelligence(int value);
+    void setIntelligence(int value);
 
-  int getStamina() const;
+    int getStamina() const;
 
-  void setStamina(int value);
+    void setStamina(int value);
 
-  int getAgility() const;
+    int getAgility() const;
 
-  void setAgility(int value);
+    void setAgility(int value);
 
-  int getStrength() const;
+    int getStrength() const;
 
-  void setStrength(int value);
+    void setStrength(int value);
 
-  std::string getMainStat() const;
+    std::string getMainStat() const;
 
-  void setMainStat(const std::string &value);
+    void setMainStat(const std::string &value);
 
-  int getMainValue();
+    int getMainValue();
 
-private:
-  std::string mainStat;
+  private:
+    std::string mainStat;
 };
 
 class Damage : public CGameObject {
 
-  V_META(Damage, CGameObject, V_PROPERTY(Damage, int, fire, getFire, setFire),
-         V_PROPERTY(Damage, int, thunder, getThunder, setThunder),
-         V_PROPERTY(Damage, int, shadow, getShadow, setShadow),
-         V_PROPERTY(Damage, int, frost, getFrost, setFrost),
-         V_PROPERTY(Damage, int, normal, getNormal, setNormal))
+    V_META(Damage, CGameObject, V_PROPERTY(Damage, int, fire, getFire, setFire),
+           V_PROPERTY(Damage, int, thunder, getThunder, setThunder),
+           V_PROPERTY(Damage, int, shadow, getShadow, setShadow), V_PROPERTY(Damage, int, frost, getFrost, setFrost),
+           V_PROPERTY(Damage, int, normal, getNormal, setNormal))
 
-  int fire = 0;
-  int frost = 0;
-  int thunder = 0;
-  int shadow = 0;
-  int normal = 0;
+    int fire = 0;
+    int frost = 0;
+    int thunder = 0;
+    int shadow = 0;
+    int normal = 0;
 
-public:
-  Damage();
+  public:
+    Damage();
 
-  int getFire() const;
+    int getFire() const;
 
-  void setFire(int value);
+    void setFire(int value);
 
-  int getFrost() const;
+    int getFrost() const;
 
-  void setFrost(int value);
+    void setFrost(int value);
 
-  int getThunder() const;
+    int getThunder() const;
 
-  void setThunder(int value);
+    void setThunder(int value);
 
-  int getShadow() const;
+    int getShadow() const;
 
-  void setShadow(int value);
+    void setShadow(int value);
 
-  int getNormal() const;
+    int getNormal() const;
 
-  void setNormal(int value);
+    void setNormal(int value);
 };

--- a/src/core/CTypes.cpp
+++ b/src/core/CTypes.cpp
@@ -161,9 +161,13 @@ struct register_all_types {
                 CTypes::register_type<CMonsterFightController, CFightController, CGameObject>();
             }
             CTypes::register_type<CGameEvent, CGameObject>();
-            { CTypes::register_type<CGameEventCaused, CGameEvent, CGameObject>(); }
+            {
+                CTypes::register_type<CGameEventCaused, CGameEvent, CGameObject>();
+            }
             CTypes::register_type<CPlugin, CGameObject>();
-            { CTypes::register_type<CWrapper<CPlugin>, CPlugin, CGameObject>(); }
+            {
+                CTypes::register_type<CWrapper<CPlugin>, CPlugin, CGameObject>();
+            }
         }
 
         // Original types2.cpp
@@ -172,27 +176,41 @@ struct register_all_types {
             CTypes::register_type<CMapObject, CGameObject>();
             {
                 CTypes::register_type<CBuilding, CMapObject, CGameObject>();
-                { CTypes::register_type<CWrapper<CBuilding>, CBuilding, CMapObject, CGameObject>(); }
+                {
+                    CTypes::register_type<CWrapper<CBuilding>, CBuilding, CMapObject, CGameObject>();
+                }
                 CTypes::register_type<CEvent, CMapObject, CGameObject>();
-                { CTypes::register_type<CWrapper<CEvent>, CEvent, CMapObject, CGameObject>(); }
+                {
+                    CTypes::register_type<CWrapper<CEvent>, CEvent, CMapObject, CGameObject>();
+                }
                 CTypes::register_type<CItem, CMapObject, CGameObject>();
                 {
                     CTypes::register_type<CWeapon, CItem, CMapObject, CGameObject>();
-                    { CTypes::register_type<CSmallWeapon, CWeapon, CItem, CMapObject, CGameObject>(); }
+                    {
+                        CTypes::register_type<CSmallWeapon, CWeapon, CItem, CMapObject, CGameObject>();
+                    }
                     CTypes::register_type<CArmor, CItem, CMapObject, CGameObject>();
                     CTypes::register_type<CPotion, CItem, CMapObject, CGameObject>();
-                    { CTypes::register_type<CWrapper<CPotion>, CPotion, CItem, CMapObject, CGameObject>(); }
+                    {
+                        CTypes::register_type<CWrapper<CPotion>, CPotion, CItem, CMapObject, CGameObject>();
+                    }
                     CTypes::register_type<CHelmet, CItem, CMapObject, CGameObject>();
                     CTypes::register_type<CBoots, CItem, CMapObject, CGameObject>();
                     CTypes::register_type<CBelt, CItem, CMapObject, CGameObject>();
                     CTypes::register_type<CGloves, CItem, CMapObject, CGameObject>();
                     CTypes::register_type<CScroll, CItem, CMapObject, CGameObject>();
-                    { CTypes::register_type<CWrapper<CScroll>, CScroll, CItem, CMapObject, CGameObject>(); }
+                    {
+                        CTypes::register_type<CWrapper<CScroll>, CScroll, CItem, CMapObject, CGameObject>();
+                    }
                 }
-                { CTypes::register_type<CWrapper<CScroll>, CScroll, CItem, CMapObject, CGameObject>(); }
+                {
+                    CTypes::register_type<CWrapper<CScroll>, CScroll, CItem, CMapObject, CGameObject>();
+                }
 
                 CTypes::register_type<CCreature, CMapObject, CGameObject>();
-                { CTypes::register_type<CPlayer, CCreature, CMapObject, CGameObject>(); }
+                {
+                    CTypes::register_type<CPlayer, CCreature, CMapObject, CGameObject>();
+                }
             }
         }
 
@@ -200,28 +218,40 @@ struct register_all_types {
         CTypes::register_type<CGameObject>();
         {
             CTypes::register_type<CEffect, CGameObject>();
-            { CTypes::register_type<CWrapper<CEffect>, CEffect, CGameObject>(); }
+            {
+                CTypes::register_type<CWrapper<CEffect>, CEffect, CGameObject>();
+            }
 
             CTypes::register_type<CMarket, CGameObject>();
             CTypes::register_type<CDialog, CGameObject>();
-            { CTypes::register_type<CWrapper<CDialog>, CDialog, CGameObject>(); }
+            {
+                CTypes::register_type<CWrapper<CDialog>, CDialog, CGameObject>();
+            }
             CTypes::register_type<CDialogOption, CGameObject>();
             CTypes::register_type<CDialogState, CGameObject>();
 
             CTypes::register_type<CTrigger, CGameObject>();
-            { CTypes::register_type<CWrapper<CTrigger>, CTrigger, CGameObject>(); }
+            {
+                CTypes::register_type<CWrapper<CTrigger>, CTrigger, CGameObject>();
+            }
 
             CTypes::register_type<CQuest, CGameObject>();
-            { CTypes::register_type<CWrapper<CQuest>, CQuest, CGameObject>(); }
+            {
+                CTypes::register_type<CWrapper<CQuest>, CQuest, CGameObject>();
+            }
 
             CTypes::register_type<Stats, CGameObject>();
             CTypes::register_type<Damage, CGameObject>();
 
             CTypes::register_type<CTile, CGameObject>();
-            { CTypes::register_type<CWrapper<CTile>, CTile, CGameObject>(); }
+            {
+                CTypes::register_type<CWrapper<CTile>, CTile, CGameObject>();
+            }
 
             CTypes::register_type<CInteraction, CGameObject>();
-            { CTypes::register_type<CWrapper<CInteraction>, CInteraction, CGameObject>(); }
+            {
+                CTypes::register_type<CWrapper<CInteraction>, CInteraction, CGameObject>();
+            }
 
             CTypes::register_type<CController, CGameObject>();
             {

--- a/src/gui/CLayout.h
+++ b/src/gui/CLayout.h
@@ -21,95 +21,86 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CGameObject.h"
 
 class CLayout : public CGameObject {
-  V_META(CLayout, CGameObject, V_PROPERTY(CLayout, std::string, w, getW, setW),
-         V_PROPERTY(CLayout, std::string, h, getH, setH),
-         V_PROPERTY(CLayout, std::string, x, getX, setX),
-         V_PROPERTY(CLayout, std::string, y, getY, setY),
-         V_PROPERTY(CLayout, std::string, vertical, getVertical, setVertical),
-         V_PROPERTY(CLayout, std::string, horizontal, getHorizontal,
-                    setHorizontal))
-public:
-  virtual std::shared_ptr<SDL_Rect>
-  getRect(std::shared_ptr<CGameGraphicsObject> object);
+    V_META(CLayout, CGameObject, V_PROPERTY(CLayout, std::string, w, getW, setW),
+           V_PROPERTY(CLayout, std::string, h, getH, setH), V_PROPERTY(CLayout, std::string, x, getX, setX),
+           V_PROPERTY(CLayout, std::string, y, getY, setY),
+           V_PROPERTY(CLayout, std::string, vertical, getVertical, setVertical),
+           V_PROPERTY(CLayout, std::string, horizontal, getHorizontal, setHorizontal))
+  public:
+    virtual std::shared_ptr<SDL_Rect> getRect(std::shared_ptr<CGameGraphicsObject> object);
 
-private:
-  enum TYPE { SIMPLE, PERCENT };
+  private:
+    enum TYPE { SIMPLE, PERCENT };
 
-  std::pair<TYPE, int> parseValue(std::shared_ptr<CGameGraphicsObject> object,
-                                  std::string value);
+    std::pair<TYPE, int> parseValue(std::shared_ptr<CGameGraphicsObject> object, std::string value);
 
-  int parseValue(std::pair<TYPE, int> value, int parentValue);
+    int parseValue(std::pair<TYPE, int> value, int parentValue);
 
-  int parseValue(std::shared_ptr<CGameGraphicsObject> object, std::string value,
-                 int parentValue);
+    int parseValue(std::shared_ptr<CGameGraphicsObject> object, std::string value, int parentValue);
 
-protected:
-  static std::shared_ptr<SDL_Rect>
-  getParentRect(std::shared_ptr<CGameGraphicsObject> object);
+  protected:
+    static std::shared_ptr<SDL_Rect> getParentRect(std::shared_ptr<CGameGraphicsObject> object);
 
-public:
-  std::string getW();
+  public:
+    std::string getW();
 
-  void setW(std::string _width);
+    void setW(std::string _width);
 
-  std::string getH();
+    std::string getH();
 
-  void setH(std::string _height);
+    void setH(std::string _height);
 
-  std::string getX();
+    std::string getX();
 
-  void setX(std::string _x);
+    void setX(std::string _x);
 
-  std::string getY();
+    std::string getY();
 
-  void setY(std::string _y);
+    void setY(std::string _y);
 
-  void setRect(int x, int y, int w, int h);
+    void setRect(int x, int y, int w, int h);
 
-  void setRect(const std::shared_ptr<SDL_Rect> &rect);
+    void setRect(const std::shared_ptr<SDL_Rect> &rect);
 
-  std::string getVertical();
+    std::string getVertical();
 
-  void setVertical(std::string vertical);
+    void setVertical(std::string vertical);
 
-  std::string getHorizontal();
+    std::string getHorizontal();
 
-  void setHorizontal(std::string horizontal);
+    void setHorizontal(std::string horizontal);
 
-private:
-  std::string w = "0";
-  std::string h = "0";
-  std::string x = "0";
-  std::string y = "0";
-  std::string vertical;
-  std::string horizontal;
+  private:
+    std::string w = "0";
+    std::string h = "0";
+    std::string x = "0";
+    std::string y = "0";
+    std::string vertical;
+    std::string horizontal;
 };
 
 class CCenteredLayout : public CLayout {
-  V_META(CCenteredLayout, CLayout, vstd::meta::empty())
-public:
-  CCenteredLayout();
+    V_META(CCenteredLayout, CLayout, vstd::meta::empty())
+  public:
+    CCenteredLayout();
 };
 
 class CParentLayout : public CLayout {
-  V_META(CParentLayout, CLayout, vstd::meta::empty())
-public:
-  CParentLayout();
+    V_META(CParentLayout, CLayout, vstd::meta::empty())
+  public:
+    CParentLayout();
 };
 
 // TODO: remove
 class CProxyGraphicsLayout : public CLayout {
-  V_META(CProxyGraphicsLayout, CLayout,
-         V_PROPERTY(CProxyGraphicsLayout, int, tileSize, getTileSize,
-                    setTileSize))
-public:
-  std::shared_ptr<SDL_Rect>
-  getRect(std::shared_ptr<CGameGraphicsObject> object) override;
+    V_META(CProxyGraphicsLayout, CLayout, V_PROPERTY(CProxyGraphicsLayout, int, tileSize, getTileSize, setTileSize))
+  public:
+    std::shared_ptr<SDL_Rect> getRect(std::shared_ptr<CGameGraphicsObject> object) override;
 
-  int getTileSize();
+    int getTileSize();
 
-  void setTileSize(int _tileSize);
+    void setTileSize(int _tileSize);
 
-private:
-  int tileSize;
+  private:
+    int tileSize;
 };

--- a/src/gui/CTooltip.h
+++ b/src/gui/CTooltip.h
@@ -23,23 +23,20 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 class CGui;
 
 class CTooltip : public CGameGraphicsObject {
-  V_META(CTooltip, CGameGraphicsObject, vstd::meta::empty())
+    V_META(CTooltip, CGameGraphicsObject, vstd::meta::empty())
 
-  std::string text;
+    std::string text;
 
-public:
-  CTooltip();
+  public:
+    CTooltip();
 
-  void renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect,
-                    int frameTime) override;
+    void renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int frameTime) override;
 
-  bool mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button,
-                  int x, int y) override;
+    bool mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button, int x, int y) override;
 
-  bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
-                     SDL_Keycode i) override;
+    bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i) override;
 
-  void setText(std::string _text);
+    void setText(std::string _text);
 
-  std::string getText();
+    std::string getText();
 };

--- a/src/gui/object/CConsoleGraphicsObject.cpp
+++ b/src/gui/object/CConsoleGraphicsObject.cpp
@@ -19,96 +19,88 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CGui.h"
 #include "gui/CTextManager.h"
 
-void CConsoleGraphicsObject::renderObject(std::shared_ptr<CGui> gui,
-                                          std::shared_ptr<SDL_Rect> rect,
-                                          int frameTime) {
-  gui->getTextManager()->drawText(consoleState, rect->x, rect->y, rect->w);
+void CConsoleGraphicsObject::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int frameTime) {
+    gui->getTextManager()->drawText(consoleState, rect->x, rect->y, rect->w);
 }
 
 CConsoleGraphicsObject::CConsoleGraphicsObject() {
-  registerEventCallback(
-      [](std::shared_ptr<CGui> gui, std::shared_ptr<CGameGraphicsObject> self,
-         SDL_Event *event) { return event->type == SDL_KEYDOWN; },
-      [this](std::shared_ptr<CGui> gui,
-             std::shared_ptr<CGameGraphicsObject> self, SDL_Event *event) {
-        if (inProgress) {
-          if (event->key.keysym.sym == SDLK_TAB) {
-            stopInput();
-          } else if (event->key.keysym.sym == SDLK_RETURN &&
-                     consoleState.length() > 0) {
-            gui->getGame()->getScriptHandler()->call_created_function(
-                consoleState, {"game"}, gui->getGame());
-            stopInput();
-          } else if (event->key.keysym.sym == SDLK_BACKSPACE) {
-            consoleState = consoleState.substr(0, consoleState.length() - 1);
-          } else if (event->key.keysym.sym == SDLK_UP) {
-            decrementHistoryIndex();
-            consoleState = consoleHistory[historyIndex];
-          } else if (event->key.keysym.sym == SDLK_DOWN) {
-            incrementHistoryIndex();
-            consoleState = consoleHistory[historyIndex];
-          }
-          return true;
-        } else {
-          if (event->key.keysym.sym == SDLK_TAB) {
-            startInput();
+    registerEventCallback(
+        [](std::shared_ptr<CGui> gui, std::shared_ptr<CGameGraphicsObject> self, SDL_Event *event) {
+            return event->type == SDL_KEYDOWN;
+        },
+        [this](std::shared_ptr<CGui> gui, std::shared_ptr<CGameGraphicsObject> self, SDL_Event *event) {
+            if (inProgress) {
+                if (event->key.keysym.sym == SDLK_TAB) {
+                    stopInput();
+                } else if (event->key.keysym.sym == SDLK_RETURN && consoleState.length() > 0) {
+                    gui->getGame()->getScriptHandler()->call_created_function(consoleState, {"game"}, gui->getGame());
+                    stopInput();
+                } else if (event->key.keysym.sym == SDLK_BACKSPACE) {
+                    consoleState = consoleState.substr(0, consoleState.length() - 1);
+                } else if (event->key.keysym.sym == SDLK_UP) {
+                    decrementHistoryIndex();
+                    consoleState = consoleHistory[historyIndex];
+                } else if (event->key.keysym.sym == SDLK_DOWN) {
+                    incrementHistoryIndex();
+                    consoleState = consoleHistory[historyIndex];
+                }
+                return true;
+            } else {
+                if (event->key.keysym.sym == SDLK_TAB) {
+                    startInput();
+                    return true;
+                }
+            }
+            return false;
+        });
+    registerEventCallback(
+        [this](std::shared_ptr<CGui> gui, std::shared_ptr<CGameGraphicsObject> self, SDL_Event *event) {
+            return event->type == SDL_TEXTINPUT && inProgress;
+        },
+        [this](std::shared_ptr<CGui> gui, std::shared_ptr<CGameGraphicsObject> self, SDL_Event *event) {
+            consoleState += event->text.text;
             return true;
-          }
-        }
-        return false;
-      });
-  registerEventCallback(
-      [this](std::shared_ptr<CGui> gui,
-             std::shared_ptr<CGameGraphicsObject> self, SDL_Event *event) {
-        return event->type == SDL_TEXTINPUT && inProgress;
-      },
-      [this](std::shared_ptr<CGui> gui,
-             std::shared_ptr<CGameGraphicsObject> self, SDL_Event *event) {
-        consoleState += event->text.text;
-        return true;
-      });
+        });
 }
 
 void CConsoleGraphicsObject::incrementHistoryIndex() {
-  historyIndex++;
-  historyIndex = historyIndex % consoleHistory.size();
+    historyIndex++;
+    historyIndex = historyIndex % consoleHistory.size();
 }
 
 void CConsoleGraphicsObject::decrementHistoryIndex() {
-  historyIndex--;
-  if (historyIndex < 0) {
-    historyIndex = consoleHistory.size() + historyIndex;
-  }
+    historyIndex--;
+    if (historyIndex < 0) {
+        historyIndex = consoleHistory.size() + historyIndex;
+    }
 }
 
 void CConsoleGraphicsObject::startInput() {
-  SDL_StartTextInput();
-  inProgress = true;
+    SDL_StartTextInput();
+    inProgress = true;
 }
 
 void CConsoleGraphicsObject::stopInput() {
-  SDL_StopTextInput();
-  inProgress = false;
-  clearConsole();
+    SDL_StopTextInput();
+    inProgress = false;
+    clearConsole();
 }
 
 void CConsoleGraphicsObject::clearConsole() {
-  consoleHistory.push_back(consoleState);
-  consoleState = "";
+    consoleHistory.push_back(consoleState);
+    consoleState = "";
 }
 
 std::string CConsoleGraphicsObject::getConsoleState() { return consoleState; }
 
 void CConsoleGraphicsObject::setConsoleState(std::string consoleState) {
-  CConsoleGraphicsObject::consoleState = consoleState;
+    CConsoleGraphicsObject::consoleState = consoleState;
 }
 
 std::list<std::string> CConsoleGraphicsObject::getConsoleHistory() {
-  return std::list<std::string>(consoleHistory.begin(), consoleHistory.end());
+    return std::list<std::string>(consoleHistory.begin(), consoleHistory.end());
 }
 
-void CConsoleGraphicsObject::setConsoleHistory(
-    std::list<std::string> consoleHistory) {
-  this->consoleHistory =
-      std::vector<std::string>(consoleHistory.begin(), consoleHistory.end());
+void CConsoleGraphicsObject::setConsoleHistory(std::list<std::string> consoleHistory) {
+    this->consoleHistory = std::vector<std::string>(consoleHistory.begin(), consoleHistory.end());
 }

--- a/src/gui/object/CConsoleGraphicsObject.h
+++ b/src/gui/object/CConsoleGraphicsObject.h
@@ -20,39 +20,37 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CGameGraphicsObject.h"
 
 class CConsoleGraphicsObject : public CGameGraphicsObject {
-  V_META(CConsoleGraphicsObject, CGameGraphicsObject,
-         V_PROPERTY(CConsoleGraphicsObject, std::string, consoleState,
-                    getConsoleState, setConsoleState),
-         V_PROPERTY(CConsoleGraphicsObject, std::list<std::string>,
-                    consoleHistory, getConsoleHistory, setConsoleHistory))
-public:
-  CConsoleGraphicsObject();
+    V_META(CConsoleGraphicsObject, CGameGraphicsObject,
+           V_PROPERTY(CConsoleGraphicsObject, std::string, consoleState, getConsoleState, setConsoleState),
+           V_PROPERTY(CConsoleGraphicsObject, std::list<std::string>, consoleHistory, getConsoleHistory,
+                      setConsoleHistory))
+  public:
+    CConsoleGraphicsObject();
 
-  void renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect,
-                    int frameTime) override;
+    void renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int frameTime) override;
 
-  std::string getConsoleState();
+    std::string getConsoleState();
 
-  void setConsoleState(std::string consoleState);
+    void setConsoleState(std::string consoleState);
 
-  std::list<std::string> getConsoleHistory();
+    std::list<std::string> getConsoleHistory();
 
-  void setConsoleHistory(std::list<std::string> consoleHistory);
+    void setConsoleHistory(std::list<std::string> consoleHistory);
 
-private:
-  bool inProgress = false;
-  std::string consoleState = "";
-  // TODO: persist order when saving
-  std::vector<std::string> consoleHistory = {""};
-  int historyIndex = 0;
+  private:
+    bool inProgress = false;
+    std::string consoleState = "";
+    // TODO: persist order when saving
+    std::vector<std::string> consoleHistory = {""};
+    int historyIndex = 0;
 
-  void stopInput();
+    void stopInput();
 
-  void startInput();
+    void startInput();
 
-  void clearConsole();
+    void clearConsole();
 
-  void decrementHistoryIndex();
+    void decrementHistoryIndex();
 
-  void incrementHistoryIndex();
+    void incrementHistoryIndex();
 };

--- a/src/gui/object/CGameGraphicsObject.h
+++ b/src/gui/object/CGameGraphicsObject.h
@@ -33,127 +33,109 @@ class CGameGraphicsObject;
 
 // TODO: generify
 struct priority_comparator {
-  bool operator()(const std::shared_ptr<CGameGraphicsObject> &a,
-                  const std::shared_ptr<CGameGraphicsObject> &b) const;
+    bool operator()(const std::shared_ptr<CGameGraphicsObject> &a, const std::shared_ptr<CGameGraphicsObject> &b) const;
 };
 
 class CGameGraphicsObject : public CGameObject {
-  // TODO: replace with interceptor
-  friend class CGui;
+    // TODO: replace with interceptor
+    friend class CGui;
 
-  friend class CProxyGraphicsObject;
+    friend class CProxyGraphicsObject;
 
-  friend class CProxyTargetGraphicsObject;
+    friend class CProxyTargetGraphicsObject;
 
-  V_META(CGameGraphicsObject, CGameObject,
-         V_PROPERTY(CGameGraphicsObject, int, priority, getPriority,
-                    setPriority),
-         V_PROPERTY(CGameGraphicsObject, std::shared_ptr<CLayout>, layout,
-                    getLayout, setLayout),
-         V_PROPERTY(CGameGraphicsObject,
-                    std::set<std::shared_ptr<CGameGraphicsObject>>, children,
-                    getChildren, setChildren),
-         V_PROPERTY(CGameGraphicsObject, bool, modal, getModal, setModal),
-         V_PROPERTY(CGameGraphicsObject, std::shared_ptr<CScript>, visible,
-                    getVisible, setVisible))
+    V_META(CGameGraphicsObject, CGameObject, V_PROPERTY(CGameGraphicsObject, int, priority, getPriority, setPriority),
+           V_PROPERTY(CGameGraphicsObject, std::shared_ptr<CLayout>, layout, getLayout, setLayout),
+           V_PROPERTY(CGameGraphicsObject, std::set<std::shared_ptr<CGameGraphicsObject>>, children, getChildren,
+                      setChildren),
+           V_PROPERTY(CGameGraphicsObject, bool, modal, getModal, setModal),
+           V_PROPERTY(CGameGraphicsObject, std::shared_ptr<CScript>, visible, getVisible, setVisible))
 
-  std::list<std::pair<
-      std::function<bool(std::shared_ptr<CGui>,
-                         std::shared_ptr<CGameGraphicsObject>, SDL_Event *)>,
-      std::function<bool(std::shared_ptr<CGui>,
-                         std::shared_ptr<CGameGraphicsObject>, SDL_Event *)>>>
-      eventCallbackList;
+    std::list<std::pair<std::function<bool(std::shared_ptr<CGui>, std::shared_ptr<CGameGraphicsObject>, SDL_Event *)>,
+                        std::function<bool(std::shared_ptr<CGui>, std::shared_ptr<CGameGraphicsObject>, SDL_Event *)>>>
+        eventCallbackList;
 
-  std::set<std::shared_ptr<CGameGraphicsObject>, priority_comparator> children;
-  std::weak_ptr<CGameGraphicsObject> parent;
+    std::set<std::shared_ptr<CGameGraphicsObject>, priority_comparator> children;
+    std::weak_ptr<CGameGraphicsObject> parent;
 
-  std::shared_ptr<CLayout> layout;
-  int priority = 0;
+    std::shared_ptr<CLayout> layout;
+    int priority = 0;
 
-public:
-  int getPriority();
+  public:
+    int getPriority();
 
-  void setPriority(int priority);
+    void setPriority(int priority);
 
-  std::set<std::shared_ptr<CGameGraphicsObject>> getChildren();
+    std::set<std::shared_ptr<CGameGraphicsObject>> getChildren();
 
-  void setChildren(std::set<std::shared_ptr<CGameGraphicsObject>> _children);
+    void setChildren(std::set<std::shared_ptr<CGameGraphicsObject>> _children);
 
-  virtual bool keyboardEvent(std::shared_ptr<CGui> sharedPtr,
-                             SDL_EventType type, SDL_Keycode i);
+    virtual bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i);
 
-  virtual bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
-                          int button, int x, int y);
+    virtual bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int button, int x, int y);
 
-  virtual void renderObject(std::shared_ptr<CGui> reneder,
-                            std::shared_ptr<SDL_Rect> rect, int frameTime);
+    virtual void renderObject(std::shared_ptr<CGui> reneder, std::shared_ptr<SDL_Rect> rect, int frameTime);
 
-  void registerEventCallback(
-      std::function<bool(std::shared_ptr<CGui>,
-                         std::shared_ptr<CGameGraphicsObject>, SDL_Event *)>
-          pred,
-      std::function<bool(std::shared_ptr<CGui>,
-                         std::shared_ptr<CGameGraphicsObject>, SDL_Event *)>
-          func);
+    void registerEventCallback(
+        std::function<bool(std::shared_ptr<CGui>, std::shared_ptr<CGameGraphicsObject>, SDL_Event *)> pred,
+        std::function<bool(std::shared_ptr<CGui>, std::shared_ptr<CGameGraphicsObject>, SDL_Event *)> func);
 
-  // TODO: add posibility to search for parent with type or name
-  std::shared_ptr<CGameGraphicsObject> getParent();
+    // TODO: add posibility to search for parent with type or name
+    std::shared_ptr<CGameGraphicsObject> getParent();
 
-  std::shared_ptr<CGameGraphicsObject> getTopParent();
+    std::shared_ptr<CGameGraphicsObject> getTopParent();
 
-  void setParent(std::shared_ptr<CGameGraphicsObject> _parent);
+    void setParent(std::shared_ptr<CGameGraphicsObject> _parent);
 
-  std::shared_ptr<CLayout> getLayout();
+    std::shared_ptr<CLayout> getLayout();
 
-  void setLayout(std::shared_ptr<CLayout> layout);
+    void setLayout(std::shared_ptr<CLayout> layout);
 
-  void addChild(const std::shared_ptr<CGameGraphicsObject> &child);
+    void addChild(const std::shared_ptr<CGameGraphicsObject> &child);
 
-  void pushChild(const std::shared_ptr<CGameGraphicsObject> &child);
+    void pushChild(const std::shared_ptr<CGameGraphicsObject> &child);
 
-  void removeChild(const std::shared_ptr<CGameGraphicsObject> &child);
+    void removeChild(const std::shared_ptr<CGameGraphicsObject> &child);
 
-  // TODO: more flexible
-  std::shared_ptr<CGameGraphicsObject> findChild(const std::string &type);
+    // TODO: more flexible
+    std::shared_ptr<CGameGraphicsObject> findChild(const std::string &type);
 
-  std::shared_ptr<CGameGraphicsObject>
-  findChild(const std::shared_ptr<CGameGraphicsObject> &type);
+    std::shared_ptr<CGameGraphicsObject> findChild(const std::shared_ptr<CGameGraphicsObject> &type);
 
-  void removeParent();
+    void removeParent();
 
-  std::shared_ptr<CGui> getGui();
+    std::shared_ptr<CGui> getGui();
 
-  bool getModal();
+    bool getModal();
 
-  void setModal(bool _modal);
+    void setModal(bool _modal);
 
-  std::shared_ptr<CScript> getVisible();
+    std::shared_ptr<CScript> getVisible();
 
-  void setVisible(std::shared_ptr<CScript> hidden);
+    void setVisible(std::shared_ptr<CScript> hidden);
 
-  bool isVisible();
+    bool isVisible();
 
-  std::string getBackground();
+    std::string getBackground();
 
-  void setBackground(std::string _background);
+    void setBackground(std::string _background);
 
-  int getTileSize(const std::shared_ptr<CGameGraphicsObject> &object);
+    int getTileSize(const std::shared_ptr<CGameGraphicsObject> &object);
 
-private:
-  virtual void render(std::shared_ptr<CGui> renderer, int frameTime);
+  private:
+    virtual void render(std::shared_ptr<CGui> renderer, int frameTime);
 
-  bool event(std::shared_ptr<CGui> gui, SDL_Event *event);
+    bool event(std::shared_ptr<CGui> gui, SDL_Event *event);
 
-  int getTopPriority();
+    int getTopPriority();
 
-  std::shared_ptr<SDL_Rect> getRect();
+    std::shared_ptr<SDL_Rect> getRect();
 
-  std::shared_ptr<CScript> visible;
+    std::shared_ptr<CScript> visible;
 
-  void renderBackground(std::shared_ptr<CGui> sharedPtr,
-                        std::shared_ptr<SDL_Rect> rect, int time);
+    void renderBackground(std::shared_ptr<CGui> sharedPtr, std::shared_ptr<SDL_Rect> rect, int time);
 
-  std::string background;
+    std::string background;
 
-  bool modal = false;
+    bool modal = false;
 };

--- a/src/gui/object/CProxyGraphicsObject.h
+++ b/src/gui/object/CProxyGraphicsObject.h
@@ -22,25 +22,24 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 class CMapGraphicsObject;
 
 class CProxyGraphicsObject : public CGameGraphicsObject {
-  V_META(CProxyGraphicsObject, CGameGraphicsObject,
-         V_PROPERTY(CProxyGraphicsObject, int, x, getX, setX),
-         V_PROPERTY(CProxyGraphicsObject, int, y, getY, setY))
+    V_META(CProxyGraphicsObject, CGameGraphicsObject, V_PROPERTY(CProxyGraphicsObject, int, x, getX, setX),
+           V_PROPERTY(CProxyGraphicsObject, int, y, getY, setY))
 
-private:
-  int x, y;
+  private:
+    int x, y;
 
-public:
-  CProxyGraphicsObject() = default;
+  public:
+    CProxyGraphicsObject() = default;
 
-  CProxyGraphicsObject(int x, int y);
+    CProxyGraphicsObject(int x, int y);
 
-  int getX() { return x; }
+    int getX() { return x; }
 
-  void setX(int _x) { this->x = _x; }
+    void setX(int _x) { this->x = _x; }
 
-  int getY() { return y; }
+    int getY() { return y; }
 
-  void setY(int _y) { this->y = _y; }
+    void setY(int _y) { this->y = _y; }
 
-  void refresh();
+    void refresh();
 };

--- a/src/gui/object/CSideBar.cpp
+++ b/src/gui/object/CSideBar.cpp
@@ -20,41 +20,32 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CGui.h"
 #include "gui/panel/CGamePanel.h"
 
-void CSideBar::clickInventory(std::shared_ptr<CGui> gui) {
-  flipPanel(gui, "inventoryPanel");
-}
+void CSideBar::clickInventory(std::shared_ptr<CGui> gui) { flipPanel(gui, "inventoryPanel"); }
 
-void CSideBar::clickJournal(std::shared_ptr<CGui> gui) {
-  flipPanel(gui, "questPanel");
-}
+void CSideBar::clickJournal(std::shared_ptr<CGui> gui) { flipPanel(gui, "questPanel"); }
 
-void CSideBar::clickCharacter(std::shared_ptr<CGui> gui) {
-  flipPanel(gui, "characterPanel");
-}
+void CSideBar::clickCharacter(std::shared_ptr<CGui> gui) { flipPanel(gui, "characterPanel"); }
 
 std::shared_ptr<CMapStringString> CSideBar::getPanelKeys() { return panelKeys; }
 
-void CSideBar::setPanelKeys(std::shared_ptr<CMapStringString> _panelKeys) {
-  this->panelKeys = _panelKeys;
-}
+void CSideBar::setPanelKeys(std::shared_ptr<CMapStringString> _panelKeys) { this->panelKeys = _panelKeys; }
 
 void CSideBar::flipPanel(std::shared_ptr<CGui> gui, std::string panel) {
-  for (auto val : panelKeys->getValues()) {
-    if (val.second == panel) {
-      gui->getGame()->getGuiHandler()->flipPanel(panel, val.first);
+    for (auto val : panelKeys->getValues()) {
+        if (val.second == panel) {
+            gui->getGame()->getGuiHandler()->flipPanel(panel, val.first);
+        }
     }
-  }
 }
 
-bool CSideBar::keyboardEvent(std::shared_ptr<CGui> sharedPtr,
-                             SDL_EventType type, SDL_Keycode i) {
-  if (type == SDL_KEYDOWN) {
-    for (auto val : panelKeys->getValues()) {
-      if (i == val.first[0]) {
-        flipPanel(sharedPtr, val.second);
-        return true;
-      }
+bool CSideBar::keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i) {
+    if (type == SDL_KEYDOWN) {
+        for (auto val : panelKeys->getValues()) {
+            if (i == val.first[0]) {
+                flipPanel(sharedPtr, val.second);
+                return true;
+            }
+        }
     }
-  }
-  return false;
+    return false;
 }

--- a/src/gui/object/CSideBar.h
+++ b/src/gui/object/CSideBar.h
@@ -22,28 +22,26 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 class CMapStringString;
 
 class CSideBar : public CGameGraphicsObject {
-  V_META(CSideBar, CGameGraphicsObject,
-         V_PROPERTY(CSideBar, std::shared_ptr<CMapStringString>, panelKeys,
-                    getPanelKeys, setPanelKeys),
-         V_METHOD(CSideBar, clickInventory, void, std::shared_ptr<CGui>),
-         V_METHOD(CSideBar, clickJournal, void, std::shared_ptr<CGui>),
-         V_METHOD(CSideBar, clickCharacter, void, std::shared_ptr<CGui>))
-public:
-  void clickInventory(std::shared_ptr<CGui> gui);
+    V_META(CSideBar, CGameGraphicsObject,
+           V_PROPERTY(CSideBar, std::shared_ptr<CMapStringString>, panelKeys, getPanelKeys, setPanelKeys),
+           V_METHOD(CSideBar, clickInventory, void, std::shared_ptr<CGui>),
+           V_METHOD(CSideBar, clickJournal, void, std::shared_ptr<CGui>),
+           V_METHOD(CSideBar, clickCharacter, void, std::shared_ptr<CGui>))
+  public:
+    void clickInventory(std::shared_ptr<CGui> gui);
 
-  void clickJournal(std::shared_ptr<CGui> gui);
+    void clickJournal(std::shared_ptr<CGui> gui);
 
-  void clickCharacter(std::shared_ptr<CGui> gui);
+    void clickCharacter(std::shared_ptr<CGui> gui);
 
-  std::shared_ptr<CMapStringString> getPanelKeys();
+    std::shared_ptr<CMapStringString> getPanelKeys();
 
-  void setPanelKeys(std::shared_ptr<CMapStringString> panelKeys);
+    void setPanelKeys(std::shared_ptr<CMapStringString> panelKeys);
 
-  bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
-                     SDL_Keycode i) override;
+    bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i) override;
 
-private:
-  void flipPanel(std::shared_ptr<CGui> gui, std::string panel);
+  private:
+    void flipPanel(std::shared_ptr<CGui> gui, std::string panel);
 
-  std::shared_ptr<CMapStringString> panelKeys;
+    std::shared_ptr<CMapStringString> panelKeys;
 };

--- a/src/gui/panel/CGameCharacterPanel.cpp
+++ b/src/gui/panel/CGameCharacterPanel.cpp
@@ -20,31 +20,24 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CMap.h"
 #include "gui/CTextManager.h"
 
-void CGameCharacterPanel::renderObject(std::shared_ptr<CGui> gui,
-                                       std::shared_ptr<SDL_Rect> rect, int i) {
-  std::string text;
-  for (auto [key, value] : charSheet->getValues()) {
-    std::shared_ptr<CPlayer> player = gui->getGame()->getMap()->getPlayer();
-    text += key + ": " +
-            vstd::str(player->meta()->invoke_method<int>(value, player)) + "\n";
-  }
-  gui->getTextManager()->drawText(text, rect->x, rect->y, rect->w);
+void CGameCharacterPanel::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int i) {
+    std::string text;
+    for (auto [key, value] : charSheet->getValues()) {
+        std::shared_ptr<CPlayer> player = gui->getGame()->getMap()->getPlayer();
+        text += key + ": " + vstd::str(player->meta()->invoke_method<int>(value, player)) + "\n";
+    }
+    gui->getTextManager()->drawText(text, rect->x, rect->y, rect->w);
 }
 
 CGameCharacterPanel::~CGameCharacterPanel() {}
 
-std::shared_ptr<CMapStringString> CGameCharacterPanel::getCharSheet() {
-  return charSheet;
+std::shared_ptr<CMapStringString> CGameCharacterPanel::getCharSheet() { return charSheet; }
+
+void CGameCharacterPanel::setCharSheet(std::shared_ptr<CMapStringString> charSheet) {
+    CGameCharacterPanel::charSheet = charSheet;
 }
 
-void CGameCharacterPanel::setCharSheet(
-    std::shared_ptr<CMapStringString> charSheet) {
-  CGameCharacterPanel::charSheet = charSheet;
-}
-
-CListView::collection_pointer
-CGameCharacterPanel::interactionsCollection(std::shared_ptr<CGui> gui) {
-  return std::make_shared<CListView::collection_type>(
-      vstd::cast<CListView::collection_type>(
-          gui->getGame()->getMap()->getPlayer()->getInteractions()));
+CListView::collection_pointer CGameCharacterPanel::interactionsCollection(std::shared_ptr<CGui> gui) {
+    return std::make_shared<CListView::collection_type>(
+        vstd::cast<CListView::collection_type>(gui->getGame()->getMap()->getPlayer()->getInteractions()));
 }

--- a/src/gui/panel/CGameCharacterPanel.h
+++ b/src/gui/panel/CGameCharacterPanel.h
@@ -21,25 +21,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CList.h"
 
 class CGameCharacterPanel : public CGamePanel {
-  V_META(CGameCharacterPanel, CGamePanel,
-         V_PROPERTY(CGameCharacterPanel, std::shared_ptr<CMapStringString>,
-                    charSheet, getCharSheet, setCharSheet),
-         V_METHOD(CGameCharacterPanel, interactionsCollection,
-                  CListView::collection_pointer, std::shared_ptr<CGui>))
+    V_META(CGameCharacterPanel, CGamePanel,
+           V_PROPERTY(CGameCharacterPanel, std::shared_ptr<CMapStringString>, charSheet, getCharSheet, setCharSheet),
+           V_METHOD(CGameCharacterPanel, interactionsCollection, CListView::collection_pointer, std::shared_ptr<CGui>))
 
-  void renderObject(std::shared_ptr<CGui> shared_ptr,
-                    std::shared_ptr<SDL_Rect> rect, int i) override;
+    void renderObject(std::shared_ptr<CGui> shared_ptr, std::shared_ptr<SDL_Rect> rect, int i) override;
 
-public:
-  std::shared_ptr<CMapStringString> getCharSheet();
+  public:
+    std::shared_ptr<CMapStringString> getCharSheet();
 
-  void setCharSheet(std::shared_ptr<CMapStringString> charSheet);
+    void setCharSheet(std::shared_ptr<CMapStringString> charSheet);
 
-  ~CGameCharacterPanel();
+    ~CGameCharacterPanel();
 
-  CListView::collection_pointer
-  interactionsCollection(std::shared_ptr<CGui> gui);
+    CListView::collection_pointer interactionsCollection(std::shared_ptr<CGui> gui);
 
-private:
-  std::shared_ptr<CMapStringString> charSheet;
+  private:
+    std::shared_ptr<CMapStringString> charSheet;
 };

--- a/src/gui/panel/CGameDialogPanel.h
+++ b/src/gui/panel/CGameDialogPanel.h
@@ -24,29 +24,26 @@ class CDialog;
 class CDialogOption;
 
 class CGameDialogPanel : public CGamePanel {
-  V_META(CGameDialogPanel, CGamePanel,
-         V_PROPERTY(CGameDialogPanel, std::shared_ptr<CDialog>, dialog,
-                    getDialog, setDialog))
-public:
-  const std::shared_ptr<CDialog> &getDialog() const;
+    V_META(CGameDialogPanel, CGamePanel,
+           V_PROPERTY(CGameDialogPanel, std::shared_ptr<CDialog>, dialog, getDialog, setDialog))
+  public:
+    const std::shared_ptr<CDialog> &getDialog() const;
 
-  void setDialog(const std::shared_ptr<CDialog> &_dialog);
+    void setDialog(const std::shared_ptr<CDialog> &_dialog);
 
-  void reload();
+    void reload();
 
-  bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
-                     SDL_Keycode i) override;
+    bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i) override;
 
-private:
-  std::shared_ptr<CDialog> dialog;
-  std::string currentStateId = "ENTRY";
+  private:
+    std::shared_ptr<CDialog> dialog;
+    std::string currentStateId = "ENTRY";
 
-  std::shared_ptr<CDialogOption> getOption(int option);
+    std::shared_ptr<CDialogOption> getOption(int option);
 
-  void selectOption(int option);
+    void selectOption(int option);
 
-  void selectOption(const std::shared_ptr<CDialogOption> &option);
+    void selectOption(const std::shared_ptr<CDialogOption> &option);
 
-  std::map<int, std::shared_ptr<CDialogOption>, std::greater<>>
-  getCurrentOptions();
+    std::map<int, std::shared_ptr<CDialogOption>, std::greater<>> getCurrentOptions();
 };

--- a/src/gui/panel/CGameFightPanel.cpp
+++ b/src/gui/panel/CGameFightPanel.cpp
@@ -27,192 +27,170 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace {
 void refresh_proxy_children(const std::shared_ptr<CGameGraphicsObject> &object) {
-  if (!object) {
-    return;
-  }
-  if (auto proxy = vstd::cast<CProxyTargetGraphicsObject>(object)) {
-    proxy->refreshAll();
-  }
-  for (const auto &child : object->getChildren()) {
-    refresh_proxy_children(child);
-  }
+    if (!object) {
+        return;
+    }
+    if (auto proxy = vstd::cast<CProxyTargetGraphicsObject>(object)) {
+        proxy->refreshAll();
+    }
+    for (const auto &child : object->getChildren()) {
+        refresh_proxy_children(child);
+    }
 }
 } // namespace
 
-CListView::collection_pointer
-CGameFightPanel::interactionsCollection(std::shared_ptr<CGui> gui) {
-  return std::make_shared<CListView::collection_type>(
-      vstd::cast<CListView::collection_type>(
-          gui->getGame()->getMap()->getPlayer()->getInteractions()));
+CListView::collection_pointer CGameFightPanel::interactionsCollection(std::shared_ptr<CGui> gui) {
+    return std::make_shared<CListView::collection_type>(
+        vstd::cast<CListView::collection_type>(gui->getGame()->getMap()->getPlayer()->getInteractions()));
 }
 
-void CGameFightPanel::interactionsCallback(
-    std::shared_ptr<CGui> gui, int index,
-    std::shared_ptr<CGameObject> _newSelection) {
-  auto newSelection = vstd::cast<CInteraction>(_newSelection);
-  if (selected.lock() != newSelection &&
-      newSelection->getManaCost() <=
-          gui->getGame()->getMap()->getPlayer()->getMana()) {
-    selected = newSelection;
-  } else if (newSelection && selected.lock() == newSelection &&
-             newSelection->getManaCost() <=
-                 gui->getGame()->getMap()->getPlayer()->getMana()) {
-    finalSelected = newSelection;
-  } else {
-    // TODO: rethink moving selection to CListView
-    selected.reset();
-  }
-  refreshEncounterViews();
+void CGameFightPanel::interactionsCallback(std::shared_ptr<CGui> gui, int index,
+                                           std::shared_ptr<CGameObject> _newSelection) {
+    auto newSelection = vstd::cast<CInteraction>(_newSelection);
+    if (selected.lock() != newSelection &&
+        newSelection->getManaCost() <= gui->getGame()->getMap()->getPlayer()->getMana()) {
+        selected = newSelection;
+    } else if (newSelection && selected.lock() == newSelection &&
+               newSelection->getManaCost() <= gui->getGame()->getMap()->getPlayer()->getMana()) {
+        finalSelected = newSelection;
+    } else {
+        // TODO: rethink moving selection to CListView
+        selected.reset();
+    }
+    refreshEncounterViews();
 }
 
-bool CGameFightPanel::interactionsSelect(std::shared_ptr<CGui> gui, int index,
-                                         std::shared_ptr<CGameObject> object) {
-  return selected.lock() && selected.lock() == object;
+bool CGameFightPanel::interactionsSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
+    return selected.lock() && selected.lock() == object;
 }
 
-CListView::collection_pointer
-CGameFightPanel::itemsCollection(std::shared_ptr<CGui> gui) {
-  return std::make_shared<CListView::collection_type>(
-      vstd::cast<CListView::collection_type>(
-          gui->getGame()->getMap()->getPlayer()->getItems()));
+CListView::collection_pointer CGameFightPanel::itemsCollection(std::shared_ptr<CGui> gui) {
+    return std::make_shared<CListView::collection_type>(
+        vstd::cast<CListView::collection_type>(gui->getGame()->getMap()->getPlayer()->getItems()));
 }
 
-void CGameFightPanel::itemsCallback(
-    std::shared_ptr<CGui> gui, int index,
-    std::shared_ptr<CGameObject> _newSelection) {
-  auto newSelection = vstd::cast<CItem>(_newSelection);
-  if (newSelection && newSelection->hasTag(CTag::Quest)) {
-    return;
-  }
-  if (selectedItem.lock() != newSelection) {
-    selectedItem = newSelection;
-  } else if (selectedItem.lock() && selectedItem.lock() == newSelection) {
+void CGameFightPanel::itemsCallback(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> _newSelection) {
+    auto newSelection = vstd::cast<CItem>(_newSelection);
+    if (newSelection && newSelection->hasTag(CTag::Quest)) {
+        return;
+    }
+    if (selectedItem.lock() != newSelection) {
+        selectedItem = newSelection;
+    } else if (selectedItem.lock() && selectedItem.lock() == newSelection) {
+        gui->getGame()->getMap()->getPlayer()->useItem(newSelection);
+        selectedItem.reset();
+    }
+    refreshEncounterViews();
+}
+
+bool CGameFightPanel::itemsRightClickCallback(std::shared_ptr<CGui> gui, int index,
+                                              std::shared_ptr<CGameObject> _newSelection) {
+    auto newSelection = vstd::cast<CItem>(_newSelection);
+    if (!newSelection || newSelection->hasTag(CTag::Quest)) {
+        return false;
+    }
     gui->getGame()->getMap()->getPlayer()->useItem(newSelection);
     selectedItem.reset();
-  }
-  refreshEncounterViews();
+    refreshViews();
+    return true;
 }
 
-bool CGameFightPanel::itemsRightClickCallback(
-    std::shared_ptr<CGui> gui, int index,
-    std::shared_ptr<CGameObject> _newSelection) {
-  auto newSelection = vstd::cast<CItem>(_newSelection);
-  if (!newSelection || newSelection->hasTag(CTag::Quest)) {
-    return false;
-  }
-  gui->getGame()->getMap()->getPlayer()->useItem(newSelection);
-  selectedItem.reset();
-  refreshViews();
-  return true;
-}
-
-bool CGameFightPanel::itemsSelect(std::shared_ptr<CGui> gui, int index,
-                                  std::shared_ptr<CGameObject> object) {
-  return object && !object->hasTag(CTag::Quest) && selectedItem.lock() &&
-         selectedItem.lock() == object;
+bool CGameFightPanel::itemsSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
+    return object && !object->hasTag(CTag::Quest) && selectedItem.lock() && selectedItem.lock() == object;
 }
 
 CGameFightPanel::CGameFightPanel() {}
 
-bool CGameFightPanel::mouseEvent(std::shared_ptr<CGui> gui,
-                                 SDL_EventType type, int button, int x,
-                                 int y) {
-  if (type == SDL_MOUSEBUTTONDOWN && button == SDL_BUTTON_RIGHT) {
-    selected.reset();
-    selectedItem.reset();
-    finalSelected.reset();
-    refreshEncounterViews();
-  }
-  return true;
+bool CGameFightPanel::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button, int x, int y) {
+    if (type == SDL_MOUSEBUTTONDOWN && button == SDL_BUTTON_RIGHT) {
+        selected.reset();
+        selectedItem.reset();
+        finalSelected.reset();
+        refreshEncounterViews();
+    }
+    return true;
 }
 
 void CGameFightPanel::refreshEncounterViews() {
-  refreshViews();
-  refresh_proxy_children(this->ptr<CGameFightPanel>());
+    refreshViews();
+    refresh_proxy_children(this->ptr<CGameFightPanel>());
 }
 
 std::shared_ptr<CInteraction> CGameFightPanel::selectInteraction() {
-  auto self = this->ptr<CGameFightPanel>();
-  vstd::call_later_block([self]() {
-    while (self->finalSelected.lock() == nullptr) {
-      auto gui = self->getGui();
-      if (!gui || gui->findChild(self) == nullptr) {
-        return;
-      }
-      if (!vstd::event_loop<>::instance()->run()) {
-        SDL_Event quit_event;
-        SDL_zero(quit_event);
-        quit_event.type = SDL_QUIT;
-        SDL_PushEvent(&quit_event);
-        return;
-      }
-    }
-  });
-  auto ret = self->finalSelected.lock();
-  self->finalSelected.reset();
-  self->selected.reset();
-  self->refreshEncounterViews();
-  return ret;
+    auto self = this->ptr<CGameFightPanel>();
+    vstd::call_later_block([self]() {
+        while (self->finalSelected.lock() == nullptr) {
+            auto gui = self->getGui();
+            if (!gui || gui->findChild(self) == nullptr) {
+                return;
+            }
+            if (!vstd::event_loop<>::instance()->run()) {
+                SDL_Event quit_event;
+                SDL_zero(quit_event);
+                quit_event.type = SDL_QUIT;
+                SDL_PushEvent(&quit_event);
+                return;
+            }
+        }
+    });
+    auto ret = self->finalSelected.lock();
+    self->finalSelected.reset();
+    self->selected.reset();
+    self->refreshEncounterViews();
+    return ret;
 }
 
 std::shared_ptr<CCreature> CGameFightPanel::getEnemy() { return enemy.lock(); }
 
 void CGameFightPanel::setEnemy(std::shared_ptr<CCreature> en) {
-  if (en && en->isAlive() &&
-      std::find(enemies.begin(), enemies.end(), en) == enemies.end()) {
-    enemies.push_back(en);
-  }
-  enemy = en && en->isAlive() ? en : nullptr;
-  if (enemy.lock()) {
-    refreshEncounterViews();
-  } else {
-    refreshViews();
-  }
-}
-
-void CGameFightPanel::setEnemies(
-    const std::vector<std::shared_ptr<CCreature>> &value) {
-  enemies.clear();
-  std::unordered_set<std::string> names;
-  for (const auto &candidate : value) {
-    if (candidate && candidate->isAlive() &&
-        names.insert(candidate->getName()).second) {
-      enemies.push_back(candidate);
+    if (en && en->isAlive() && std::find(enemies.begin(), enemies.end(), en) == enemies.end()) {
+        enemies.push_back(en);
     }
-  }
-
-  auto current = enemy.lock();
-  auto current_it = std::find(enemies.begin(), enemies.end(), current);
-  enemy = current_it != enemies.end()
-              ? *current_it
-              : (enemies.empty() ? std::shared_ptr<CCreature>() : enemies.front());
-  if (enemy.lock()) {
-    refreshEncounterViews();
-  } else {
-    refreshViews();
-  }
+    enemy = en && en->isAlive() ? en : nullptr;
+    if (enemy.lock()) {
+        refreshEncounterViews();
+    } else {
+        refreshViews();
+    }
 }
 
-CListView::collection_pointer
-CGameFightPanel::enemiesCollection(std::shared_ptr<CGui> gui) {
-  auto collection = std::make_shared<CListView::collection_type>();
-  for (const auto &candidate : enemies) {
-    collection->push_back(candidate);
-  }
-  return collection;
+void CGameFightPanel::setEnemies(const std::vector<std::shared_ptr<CCreature>> &value) {
+    enemies.clear();
+    std::unordered_set<std::string> names;
+    for (const auto &candidate : value) {
+        if (candidate && candidate->isAlive() && names.insert(candidate->getName()).second) {
+            enemies.push_back(candidate);
+        }
+    }
+
+    auto current = enemy.lock();
+    auto current_it = std::find(enemies.begin(), enemies.end(), current);
+    enemy =
+        current_it != enemies.end() ? *current_it : (enemies.empty() ? std::shared_ptr<CCreature>() : enemies.front());
+    if (enemy.lock()) {
+        refreshEncounterViews();
+    } else {
+        refreshViews();
+    }
 }
 
-void CGameFightPanel::enemiesCallback(
-    std::shared_ptr<CGui> gui, int index,
-    std::shared_ptr<CGameObject> _newSelection) {
-  auto newSelection = vstd::cast<CCreature>(_newSelection);
-  if (newSelection && newSelection->isAlive()) {
-    enemy = newSelection;
-    refreshEncounterViews();
-  }
+CListView::collection_pointer CGameFightPanel::enemiesCollection(std::shared_ptr<CGui> gui) {
+    auto collection = std::make_shared<CListView::collection_type>();
+    for (const auto &candidate : enemies) {
+        collection->push_back(candidate);
+    }
+    return collection;
 }
 
-bool CGameFightPanel::enemiesSelect(std::shared_ptr<CGui> gui, int index,
-                                    std::shared_ptr<CGameObject> object) {
-  return object && enemy.lock() && enemy.lock() == object;
+void CGameFightPanel::enemiesCallback(std::shared_ptr<CGui> gui, int index,
+                                      std::shared_ptr<CGameObject> _newSelection) {
+    auto newSelection = vstd::cast<CCreature>(_newSelection);
+    if (newSelection && newSelection->isAlive()) {
+        enemy = newSelection;
+        refreshEncounterViews();
+    }
+}
+
+bool CGameFightPanel::enemiesSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
+    return object && enemy.lock() && enemy.lock() == object;
 }

--- a/src/gui/panel/CGameFightPanel.h
+++ b/src/gui/panel/CGameFightPanel.h
@@ -24,77 +24,61 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CPlayer.h"
 
 class CGameFightPanel : public CGamePanel {
-  V_META(CGameFightPanel, CGamePanel,
-         V_METHOD(CGameFightPanel, interactionsCollection,
-                  CListView::collection_pointer, std::shared_ptr<CGui>),
-         V_METHOD(CGameFightPanel, interactionsCallback, void,
-                  std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameFightPanel, interactionsSelect, bool,
-                  std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameFightPanel, itemsCollection,
-                  CListView::collection_pointer, std::shared_ptr<CGui>),
-         V_METHOD(CGameFightPanel, itemsCallback, void, std::shared_ptr<CGui>,
-                  int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameFightPanel, itemsRightClickCallback, bool,
-                  std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameFightPanel, itemsSelect, bool, std::shared_ptr<CGui>,
-                  int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameFightPanel, enemiesCollection,
-                  CListView::collection_pointer, std::shared_ptr<CGui>),
-         V_METHOD(CGameFightPanel, enemiesCallback, void, std::shared_ptr<CGui>,
-                  int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameFightPanel, enemiesSelect, bool, std::shared_ptr<CGui>,
-                  int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameFightPanel, getEnemy, std::shared_ptr<CCreature>))
+    V_META(CGameFightPanel, CGamePanel,
+           V_METHOD(CGameFightPanel, interactionsCollection, CListView::collection_pointer, std::shared_ptr<CGui>),
+           V_METHOD(CGameFightPanel, interactionsCallback, void, std::shared_ptr<CGui>, int,
+                    std::shared_ptr<CGameObject>),
+           V_METHOD(CGameFightPanel, interactionsSelect, bool, std::shared_ptr<CGui>, int,
+                    std::shared_ptr<CGameObject>),
+           V_METHOD(CGameFightPanel, itemsCollection, CListView::collection_pointer, std::shared_ptr<CGui>),
+           V_METHOD(CGameFightPanel, itemsCallback, void, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
+           V_METHOD(CGameFightPanel, itemsRightClickCallback, bool, std::shared_ptr<CGui>, int,
+                    std::shared_ptr<CGameObject>),
+           V_METHOD(CGameFightPanel, itemsSelect, bool, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
+           V_METHOD(CGameFightPanel, enemiesCollection, CListView::collection_pointer, std::shared_ptr<CGui>),
+           V_METHOD(CGameFightPanel, enemiesCallback, void, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
+           V_METHOD(CGameFightPanel, enemiesSelect, bool, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
+           V_METHOD(CGameFightPanel, getEnemy, std::shared_ptr<CCreature>))
 
-public:
-  CGameFightPanel();
+  public:
+    CGameFightPanel();
 
-  std::shared_ptr<CInteraction> selectInteraction();
+    std::shared_ptr<CInteraction> selectInteraction();
 
-  std::shared_ptr<CCreature> getEnemy();
+    std::shared_ptr<CCreature> getEnemy();
 
-  void setEnemy(std::shared_ptr<CCreature> en);
+    void setEnemy(std::shared_ptr<CCreature> en);
 
-  void setEnemies(const std::vector<std::shared_ptr<CCreature>> &value);
+    void setEnemies(const std::vector<std::shared_ptr<CCreature>> &value);
 
-private:
-  std::vector<std::shared_ptr<CCreature>> enemies;
-  std::weak_ptr<CCreature> enemy;
-  std::weak_ptr<CInteraction> selected;
-  std::weak_ptr<CItem> selectedItem;
-  std::weak_ptr<CInteraction> finalSelected;
-  bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
-                  int button, int x, int y) override;
+  private:
+    std::vector<std::shared_ptr<CCreature>> enemies;
+    std::weak_ptr<CCreature> enemy;
+    std::weak_ptr<CInteraction> selected;
+    std::weak_ptr<CItem> selectedItem;
+    std::weak_ptr<CInteraction> finalSelected;
+    bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int button, int x, int y) override;
 
-  void refreshEncounterViews();
+    void refreshEncounterViews();
 
-public:
-  CListView::collection_pointer
-  interactionsCollection(std::shared_ptr<CGui> gui);
+  public:
+    CListView::collection_pointer interactionsCollection(std::shared_ptr<CGui> gui);
 
-  void interactionsCallback(std::shared_ptr<CGui> gui, int index,
-                            std::shared_ptr<CGameObject> _newSelection);
+    void interactionsCallback(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> _newSelection);
 
-  bool interactionsSelect(std::shared_ptr<CGui> gui, int index,
-                          std::shared_ptr<CGameObject> object);
+    bool interactionsSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object);
 
-  CListView::collection_pointer itemsCollection(std::shared_ptr<CGui> gui);
+    CListView::collection_pointer itemsCollection(std::shared_ptr<CGui> gui);
 
-  void itemsCallback(std::shared_ptr<CGui> gui, int index,
-                     std::shared_ptr<CGameObject> _newSelection);
+    void itemsCallback(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> _newSelection);
 
-  bool itemsRightClickCallback(std::shared_ptr<CGui> gui, int index,
-                               std::shared_ptr<CGameObject> _newSelection);
+    bool itemsRightClickCallback(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> _newSelection);
 
-  bool itemsSelect(std::shared_ptr<CGui> gui, int index,
-                   std::shared_ptr<CGameObject> object);
+    bool itemsSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object);
 
-  CListView::collection_pointer enemiesCollection(std::shared_ptr<CGui> gui);
+    CListView::collection_pointer enemiesCollection(std::shared_ptr<CGui> gui);
 
-  void enemiesCallback(std::shared_ptr<CGui> gui, int index,
-                       std::shared_ptr<CGameObject> _newSelection);
+    void enemiesCallback(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> _newSelection);
 
-  bool enemiesSelect(std::shared_ptr<CGui> gui, int index,
-                     std::shared_ptr<CGameObject> object);
+    bool enemiesSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object);
 };

--- a/src/gui/panel/CGameInventoryPanel.cpp
+++ b/src/gui/panel/CGameInventoryPanel.cpp
@@ -21,117 +21,96 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CGui.h"
 #include "gui/CTextureCache.h"
 
-CListView::collection_pointer
-CGameInventoryPanel::inventoryCollection(std::shared_ptr<CGui> gui) {
-  return std::make_shared<CListView::collection_type>(
-      vstd::cast<CListView::collection_type>(
-          gui->getGame()->getMap()->getPlayer()->getItems()));
+CListView::collection_pointer CGameInventoryPanel::inventoryCollection(std::shared_ptr<CGui> gui) {
+    return std::make_shared<CListView::collection_type>(
+        vstd::cast<CListView::collection_type>(gui->getGame()->getMap()->getPlayer()->getItems()));
 }
 
-void CGameInventoryPanel::inventoryCallback(
-    std::shared_ptr<CGui> gui, int index,
-    std::shared_ptr<CGameObject> _newSelection) {
-  auto newSelection = vstd::cast<CItem>(_newSelection);
-  if (newSelection && newSelection->hasTag(CTag::Quest)) {
-    return;
-  }
-  if (selectedInventory.lock() != newSelection) {
-    selectedEquipped.reset();
-    selectedInventory = newSelection;
-  } else if (selectedInventory.lock() &&
-             selectedInventory.lock() == newSelection) {
-    gui->getGame()->getMap()->getPlayer()->useItem(newSelection);
-    selectedInventory.reset();
-  } else if (selectedInventory.lock() == nullptr &&
-             selectedEquipped.lock() != nullptr) {
-    gui->getGame()->getMap()->getPlayer()->equipItem(
-        gui->getGame()->getMap()->getPlayer()->getSlotWithItem(
-            selectedEquipped.lock()),
-        nullptr);
-    selectedEquipped.reset();
-  }
-  refreshViews();
-}
-
-bool CGameInventoryPanel::inventoryRightClickCallback(
-    std::shared_ptr<CGui> gui, int index,
-    std::shared_ptr<CGameObject> _newSelection) {
-  auto newSelection = vstd::cast<CItem>(_newSelection);
-  if (!newSelection || newSelection->hasTag(CTag::Quest)) {
-    return false;
-  }
-  selectedEquipped.reset();
-  selectedInventory.reset();
-  gui->getGame()->getMap()->getPlayer()->useItem(newSelection);
-  refreshViews();
-  return true;
-}
-
-bool CGameInventoryPanel::inventorySelect(std::shared_ptr<CGui> gui, int index,
-                                          std::shared_ptr<CGameObject> object) {
-  return object && !object->hasTag(CTag::Quest) && selectedInventory.lock() &&
-         selectedInventory.lock() == object;
-}
-
-CListView::collection_pointer
-CGameInventoryPanel::equippedCollection(std::shared_ptr<CGui> gui) {
-  CListView::collection_pointer ret =
-      std::make_shared<CListView::collection_type>();
-  auto map = gui->getGame()->getMap()->getPlayer()->getEquipped();
-  for (unsigned int i = 0;
-       i < gui->getGame()->getSlotConfiguration()->getConfiguration().size();
-       i++) {
-    if (vstd::ctn(map, vstd::str(i))) {
-      (*ret).insert(map.at(vstd::str(i)));
-    } else {
-      (*ret).insert(nullptr);
+void CGameInventoryPanel::inventoryCallback(std::shared_ptr<CGui> gui, int index,
+                                            std::shared_ptr<CGameObject> _newSelection) {
+    auto newSelection = vstd::cast<CItem>(_newSelection);
+    if (newSelection && newSelection->hasTag(CTag::Quest)) {
+        return;
     }
-  }
-  return ret;
+    if (selectedInventory.lock() != newSelection) {
+        selectedEquipped.reset();
+        selectedInventory = newSelection;
+    } else if (selectedInventory.lock() && selectedInventory.lock() == newSelection) {
+        gui->getGame()->getMap()->getPlayer()->useItem(newSelection);
+        selectedInventory.reset();
+    } else if (selectedInventory.lock() == nullptr && selectedEquipped.lock() != nullptr) {
+        gui->getGame()->getMap()->getPlayer()->equipItem(
+            gui->getGame()->getMap()->getPlayer()->getSlotWithItem(selectedEquipped.lock()), nullptr);
+        selectedEquipped.reset();
+    }
+    refreshViews();
 }
 
-void CGameInventoryPanel::equippedCallback(
-    std::shared_ptr<CGui> gui, int index,
-    std::shared_ptr<CGameObject> _newSelection) {
-  auto newSelection = vstd::cast<CItem>(_newSelection);
-  if (newSelection && newSelection->hasTag(CTag::Quest)) {
-    return;
-  }
-  std::string slotName = vstd::str(index);
-  if (selectedEquipped.lock()) {
-    gui->getGame()->getMap()->getPlayer()->equipItem(slotName, nullptr);
+bool CGameInventoryPanel::inventoryRightClickCallback(std::shared_ptr<CGui> gui, int index,
+                                                      std::shared_ptr<CGameObject> _newSelection) {
+    auto newSelection = vstd::cast<CItem>(_newSelection);
+    if (!newSelection || newSelection->hasTag(CTag::Quest)) {
+        return false;
+    }
     selectedEquipped.reset();
-  } else if (selectedInventory.lock() &&
-             gui->getGame()->getSlotConfiguration()->canFit(
-                 slotName, selectedInventory.lock())) {
-    gui->getGame()->getMap()->getPlayer()->equipItem(slotName,
-                                                     selectedInventory.lock());
     selectedInventory.reset();
-  } else {
-    selectedInventory.reset();
-    selectedEquipped = newSelection;
-  }
-  refreshViews();
+    gui->getGame()->getMap()->getPlayer()->useItem(newSelection);
+    refreshViews();
+    return true;
 }
 
-bool CGameInventoryPanel::equippedSelect(std::shared_ptr<CGui> gui, int index,
-                                         std::shared_ptr<CGameObject> object) {
-  return (!object || !object->hasTag(CTag::Quest)) &&
-         ((selectedInventory.lock() &&
-           gui->getGame()->getSlotConfiguration()->canFit(
-               vstd::str(index), selectedInventory.lock())) ||
-          (selectedEquipped.lock() && selectedEquipped.lock() == object));
+bool CGameInventoryPanel::inventorySelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
+    return object && !object->hasTag(CTag::Quest) && selectedInventory.lock() && selectedInventory.lock() == object;
+}
+
+CListView::collection_pointer CGameInventoryPanel::equippedCollection(std::shared_ptr<CGui> gui) {
+    CListView::collection_pointer ret = std::make_shared<CListView::collection_type>();
+    auto map = gui->getGame()->getMap()->getPlayer()->getEquipped();
+    for (unsigned int i = 0; i < gui->getGame()->getSlotConfiguration()->getConfiguration().size(); i++) {
+        if (vstd::ctn(map, vstd::str(i))) {
+            (*ret).insert(map.at(vstd::str(i)));
+        } else {
+            (*ret).insert(nullptr);
+        }
+    }
+    return ret;
+}
+
+void CGameInventoryPanel::equippedCallback(std::shared_ptr<CGui> gui, int index,
+                                           std::shared_ptr<CGameObject> _newSelection) {
+    auto newSelection = vstd::cast<CItem>(_newSelection);
+    if (newSelection && newSelection->hasTag(CTag::Quest)) {
+        return;
+    }
+    std::string slotName = vstd::str(index);
+    if (selectedEquipped.lock()) {
+        gui->getGame()->getMap()->getPlayer()->equipItem(slotName, nullptr);
+        selectedEquipped.reset();
+    } else if (selectedInventory.lock() &&
+               gui->getGame()->getSlotConfiguration()->canFit(slotName, selectedInventory.lock())) {
+        gui->getGame()->getMap()->getPlayer()->equipItem(slotName, selectedInventory.lock());
+        selectedInventory.reset();
+    } else {
+        selectedInventory.reset();
+        selectedEquipped = newSelection;
+    }
+    refreshViews();
+}
+
+bool CGameInventoryPanel::equippedSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
+    return (!object || !object->hasTag(CTag::Quest)) &&
+           ((selectedInventory.lock() &&
+             gui->getGame()->getSlotConfiguration()->canFit(vstd::str(index), selectedInventory.lock())) ||
+            (selectedEquipped.lock() && selectedEquipped.lock() == object));
 }
 
 CGameInventoryPanel::CGameInventoryPanel() {}
 
-bool CGameInventoryPanel::mouseEvent(std::shared_ptr<CGui> gui,
-                                     SDL_EventType type, int button, int x,
-                                     int y) {
-  if (type == SDL_MOUSEBUTTONDOWN && button == SDL_BUTTON_RIGHT) {
-    selectedInventory.reset();
-    selectedEquipped.reset();
-    refreshViews();
-  }
-  return true;
+bool CGameInventoryPanel::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button, int x, int y) {
+    if (type == SDL_MOUSEBUTTONDOWN && button == SDL_BUTTON_RIGHT) {
+        selectedInventory.reset();
+        selectedEquipped.reset();
+        refreshViews();
+    }
+    return true;
 }

--- a/src/gui/panel/CGameInventoryPanel.h
+++ b/src/gui/panel/CGameInventoryPanel.h
@@ -21,48 +21,38 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CPlayer.h"
 
 class CGameInventoryPanel : public CGamePanel {
-  V_META(CGameInventoryPanel, CGamePanel,
-         V_METHOD(CGameInventoryPanel, inventoryCollection,
-                  CListView::collection_pointer, std::shared_ptr<CGui>),
-         V_METHOD(CGameInventoryPanel, inventoryCallback, void,
-                  std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameInventoryPanel, inventoryRightClickCallback, bool,
-                  std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameInventoryPanel, inventorySelect, bool,
-                  std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameInventoryPanel, equippedCollection,
-                  CListView::collection_pointer, std::shared_ptr<CGui>),
-         V_METHOD(CGameInventoryPanel, equippedCallback, void,
-                  std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameInventoryPanel, equippedSelect, bool,
-                  std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>))
+    V_META(
+        CGameInventoryPanel, CGamePanel,
+        V_METHOD(CGameInventoryPanel, inventoryCollection, CListView::collection_pointer, std::shared_ptr<CGui>),
+        V_METHOD(CGameInventoryPanel, inventoryCallback, void, std::shared_ptr<CGui>, int,
+                 std::shared_ptr<CGameObject>),
+        V_METHOD(CGameInventoryPanel, inventoryRightClickCallback, bool, std::shared_ptr<CGui>, int,
+                 std::shared_ptr<CGameObject>),
+        V_METHOD(CGameInventoryPanel, inventorySelect, bool, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
+        V_METHOD(CGameInventoryPanel, equippedCollection, CListView::collection_pointer, std::shared_ptr<CGui>),
+        V_METHOD(CGameInventoryPanel, equippedCallback, void, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
+        V_METHOD(CGameInventoryPanel, equippedSelect, bool, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>))
 
-public:
-  CGameInventoryPanel();
+  public:
+    CGameInventoryPanel();
 
-  CListView::collection_pointer inventoryCollection(std::shared_ptr<CGui> gui);
+    CListView::collection_pointer inventoryCollection(std::shared_ptr<CGui> gui);
 
-  void inventoryCallback(std::shared_ptr<CGui> gui, int index,
-                         std::shared_ptr<CGameObject> _newSelection);
+    void inventoryCallback(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> _newSelection);
 
-  bool inventoryRightClickCallback(std::shared_ptr<CGui> gui, int index,
-                                   std::shared_ptr<CGameObject> _newSelection);
+    bool inventoryRightClickCallback(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> _newSelection);
 
-  bool inventorySelect(std::shared_ptr<CGui> gui, int index,
-                       std::shared_ptr<CGameObject> object);
+    bool inventorySelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object);
 
-  CListView::collection_pointer equippedCollection(std::shared_ptr<CGui> gui);
+    CListView::collection_pointer equippedCollection(std::shared_ptr<CGui> gui);
 
-  void equippedCallback(std::shared_ptr<CGui> gui, int index,
-                        std::shared_ptr<CGameObject> _newSelection);
+    void equippedCallback(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> _newSelection);
 
-  bool equippedSelect(std::shared_ptr<CGui> gui, int index,
-                      std::shared_ptr<CGameObject> object);
+    bool equippedSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object);
 
-private:
-  std::weak_ptr<CItem> selectedInventory;
-  std::weak_ptr<CItem> selectedEquipped;
+  private:
+    std::weak_ptr<CItem> selectedInventory;
+    std::weak_ptr<CItem> selectedEquipped;
 
-  bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
-                  int button, int x, int y) override;
+    bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int button, int x, int y) override;
 };

--- a/src/gui/panel/CGameLootPanel.cpp
+++ b/src/gui/panel/CGameLootPanel.cpp
@@ -17,33 +17,24 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "CGameLootPanel.h"
 
-void CGameLootPanel::setItems(const std::set<std::shared_ptr<CItem>> &_items) {
-  items = _items;
-}
+void CGameLootPanel::setItems(const std::set<std::shared_ptr<CItem>> &_items) { items = _items; }
 
-CListView::collection_pointer
-CGameLootPanel::itemsCollection(const std::shared_ptr<CGui> &gui) {
-  return std::make_shared<CListView::collection_type>(
-      vstd::cast<CListView::collection_type>(items));
+CListView::collection_pointer CGameLootPanel::itemsCollection(const std::shared_ptr<CGui> &gui) {
+    return std::make_shared<CListView::collection_type>(vstd::cast<CListView::collection_type>(items));
 }
 
 std::set<std::shared_ptr<CItem>> CGameLootPanel::getItems() { return items; }
 
-bool CGameLootPanel::keyboardEvent(std::shared_ptr<CGui> gui,
-                                   SDL_EventType type, SDL_Keycode i) {
-  if (type == SDL_KEYDOWN) {
-    // TODO: get rid of this
-    if (i == SDLK_SPACE) {
-      close();
+bool CGameLootPanel::keyboardEvent(std::shared_ptr<CGui> gui, SDL_EventType type, SDL_Keycode i) {
+    if (type == SDL_KEYDOWN) {
+        // TODO: get rid of this
+        if (i == SDLK_SPACE) {
+            close();
+        }
     }
-  }
-  return true;
+    return true;
 }
 
-const std::shared_ptr<CCreature> &CGameLootPanel::getCreature() const {
-  return creature;
-}
+const std::shared_ptr<CCreature> &CGameLootPanel::getCreature() const { return creature; }
 
-void CGameLootPanel::setCreature(const std::shared_ptr<CCreature> &_creature) {
-  creature = _creature;
-}
+void CGameLootPanel::setCreature(const std::shared_ptr<CCreature> &_creature) { creature = _creature; }

--- a/src/gui/panel/CGameLootPanel.h
+++ b/src/gui/panel/CGameLootPanel.h
@@ -23,30 +23,25 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CItem.h"
 
 class CGameLootPanel : public CGamePanel {
-  V_META(CGameLootPanel, CGamePanel,
-         V_PROPERTY(CGameLootPanel, std::set<std::shared_ptr<CItem>>, items,
-                    getItems, setItems),
-         V_PROPERTY(CGameLootPanel, std::shared_ptr<CCreature>, creature,
-                    getCreature, setCreature),
-         V_METHOD(CGameLootPanel, itemsCollection,
-                  CListView::collection_pointer, std::shared_ptr<CGui>))
-public:
-  void setItems(const std::set<std::shared_ptr<CItem>> &_items);
+    V_META(CGameLootPanel, CGamePanel,
+           V_PROPERTY(CGameLootPanel, std::set<std::shared_ptr<CItem>>, items, getItems, setItems),
+           V_PROPERTY(CGameLootPanel, std::shared_ptr<CCreature>, creature, getCreature, setCreature),
+           V_METHOD(CGameLootPanel, itemsCollection, CListView::collection_pointer, std::shared_ptr<CGui>))
+  public:
+    void setItems(const std::set<std::shared_ptr<CItem>> &_items);
 
-  std::set<std::shared_ptr<CItem>> getItems();
+    std::set<std::shared_ptr<CItem>> getItems();
 
-  CListView::collection_pointer
-  itemsCollection(const std::shared_ptr<CGui> &gui);
+    CListView::collection_pointer itemsCollection(const std::shared_ptr<CGui> &gui);
 
-  bool keyboardEvent(std::shared_ptr<CGui> gui, SDL_EventType type,
-                     SDL_Keycode i) override;
+    bool keyboardEvent(std::shared_ptr<CGui> gui, SDL_EventType type, SDL_Keycode i) override;
 
-private:
-  std::set<std::shared_ptr<CItem>> items;
-  std::shared_ptr<CCreature> creature;
+  private:
+    std::set<std::shared_ptr<CItem>> items;
+    std::shared_ptr<CCreature> creature;
 
-public:
-  const std::shared_ptr<CCreature> &getCreature() const;
+  public:
+    const std::shared_ptr<CCreature> &getCreature() const;
 
-  void setCreature(const std::shared_ptr<CCreature> &creature);
+    void setCreature(const std::shared_ptr<CCreature> &creature);
 };

--- a/src/gui/panel/CGamePanel.cpp
+++ b/src/gui/panel/CGamePanel.cpp
@@ -20,35 +20,29 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CTextureCache.h"
 #include "gui/object/CWidget.h"
 
-bool CGamePanel::keyboardEvent(std::shared_ptr<CGui> sharedPtr,
-                               SDL_EventType type, SDL_Keycode i) {
-  return true;
-}
+bool CGamePanel::keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i) { return true; }
 
-bool CGamePanel::mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
-                            int button, int x, int y) {
-  return true;
+bool CGamePanel::mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int button, int x, int y) {
+    return true;
 }
 
 void CGamePanel::refreshViews() {
-  for (auto child : getChildren()) {
-    if (child->meta()->inherits(CListView::static_meta()->name())) {
-      vstd::cast<CListView>(child)->refreshAll();
+    for (auto child : getChildren()) {
+        if (child->meta()->inherits(CListView::static_meta()->name())) {
+            vstd::cast<CListView>(child)->refreshAll();
+        }
     }
-  }
 }
 
 CGamePanel::CGamePanel() {
-  // TODO: extract to json
-  setBackground("images/panel");
-  setModal(true);
+    // TODO: extract to json
+    setBackground("images/panel");
+    setModal(true);
 }
 
 void CGamePanel::awaitClosing() {
-  auto self = this->ptr<CGamePanel>();
-  vstd::wait_until([self]() {
-    return !self->getGui() || self->getGui()->findChild(self) == nullptr;
-  });
+    auto self = this->ptr<CGamePanel>();
+    vstd::wait_until([self]() { return !self->getGui() || self->getGui()->findChild(self) == nullptr; });
 }
 
 void CGamePanel::close() { getGui()->removeChild(this->ptr<CGamePanel>()); }

--- a/src/gui/panel/CGamePanel.h
+++ b/src/gui/panel/CGamePanel.h
@@ -24,19 +24,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 class CWidget;
 
 class CGamePanel : public CGameGraphicsObject {
-  V_META(CGamePanel, CGameGraphicsObject, vstd::meta::empty())
-public:
-  CGamePanel();
+    V_META(CGamePanel, CGameGraphicsObject, vstd::meta::empty())
+  public:
+    CGamePanel();
 
-  bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
-                     SDL_Keycode i) override;
+    bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i) override;
 
-  bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
-                  int button, int x, int y) override;
+    bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int button, int x, int y) override;
 
-  void refreshViews();
+    void refreshViews();
 
-  void awaitClosing();
+    void awaitClosing();
 
-  void close();
+    void close();
 };

--- a/src/gui/panel/CGameQuestPanel.cpp
+++ b/src/gui/panel/CGameQuestPanel.cpp
@@ -20,22 +20,20 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CGui.h"
 #include "gui/CTextManager.h"
 
-void CGameQuestPanel::renderObject(std::shared_ptr<CGui> gui,
-                                   std::shared_ptr<SDL_Rect> rect, int i) {
-  gui->getTextManager()->drawText(getText(gui), rect->x, rect->y, rect->w);
+void CGameQuestPanel::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int i) {
+    gui->getTextManager()->drawText(getText(gui), rect->x, rect->y, rect->w);
 }
 
 std::string CGameQuestPanel::getText(std::shared_ptr<CGui> ptr) {
-  std::string text = "";
-  for (auto quest :
-       ptr->getGame()->getMap()->getPlayer()->getCompletedQuests()) {
-    text += quest->getDescription();
-    text += "(completed)";
-    text += "\n";
-  }
-  for (auto quest : ptr->getGame()->getMap()->getPlayer()->getQuests()) {
-    text += quest->getDescription();
-    text += "\n";
-  }
-  return text;
+    std::string text = "";
+    for (auto quest : ptr->getGame()->getMap()->getPlayer()->getCompletedQuests()) {
+        text += quest->getDescription();
+        text += "(completed)";
+        text += "\n";
+    }
+    for (auto quest : ptr->getGame()->getMap()->getPlayer()->getQuests()) {
+        text += quest->getDescription();
+        text += "\n";
+    }
+    return text;
 }

--- a/src/gui/panel/CGameQuestPanel.h
+++ b/src/gui/panel/CGameQuestPanel.h
@@ -20,11 +20,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CGamePanel.h"
 
 class CGameQuestPanel : public CGamePanel {
-  V_META(CGameQuestPanel, CGamePanel, vstd::meta::empty())
+    V_META(CGameQuestPanel, CGamePanel, vstd::meta::empty())
 
-  void renderObject(std::shared_ptr<CGui> shared_ptr,
-                    std::shared_ptr<SDL_Rect> rect, int i) override;
+    void renderObject(std::shared_ptr<CGui> shared_ptr, std::shared_ptr<SDL_Rect> rect, int i) override;
 
-public:
-  std::string getText(std::shared_ptr<CGui> ptr);
+  public:
+    std::string getText(std::shared_ptr<CGui> ptr);
 };

--- a/src/gui/panel/CGameQuestionPanel.cpp
+++ b/src/gui/panel/CGameQuestionPanel.cpp
@@ -22,27 +22,23 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 std::string CGameQuestionPanel::getQuestion() { return question; }
 
-void CGameQuestionPanel::setQuestion(std::string question) {
-  this->question = question;
-}
+void CGameQuestionPanel::setQuestion(std::string question) { this->question = question; }
 
 bool CGameQuestionPanel::awaitAnswer() {
-  vstd::wait_until([this]() { return selection != nullptr; });
-  return *selection;
+    vstd::wait_until([this]() { return selection != nullptr; });
+    return *selection;
 }
 
 void CGameQuestionPanel::clickNo(std::shared_ptr<CGui> gui) {
-  selection = std::make_shared<bool>(false);
-  close();
+    selection = std::make_shared<bool>(false);
+    close();
 }
 
 void CGameQuestionPanel::clickYes(std::shared_ptr<CGui> gui) {
-  selection = std::make_shared<bool>(true);
-  close();
+    selection = std::make_shared<bool>(true);
+    close();
 }
 
-void CGameQuestionPanel::renderQuestion(std::shared_ptr<CGui> gui,
-                                        std::shared_ptr<SDL_Rect> pRect,
-                                        int i) {
-  gui->getTextManager()->drawTextCentered(question, pRect);
+void CGameQuestionPanel::renderQuestion(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> pRect, int i) {
+    gui->getTextManager()->drawTextCentered(question, pRect);
 }

--- a/src/gui/panel/CGameQuestionPanel.h
+++ b/src/gui/panel/CGameQuestionPanel.h
@@ -20,30 +20,27 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CGamePanel.h"
 
 class CGameQuestionPanel : public CGamePanel {
-  V_META(CGameQuestionPanel, CGamePanel,
-         V_PROPERTY(CGameQuestionPanel, std::string, question, getQuestion,
-                    setQuestion),
-         V_METHOD(CGameQuestionPanel, renderQuestion, void,
-                  std::shared_ptr<CGui>, std::shared_ptr<SDL_Rect>, int),
-         V_METHOD(CGameQuestionPanel, clickNo, void, std::shared_ptr<CGui>),
-         V_METHOD(CGameQuestionPanel, clickYes, void, std::shared_ptr<CGui>))
+    V_META(CGameQuestionPanel, CGamePanel,
+           V_PROPERTY(CGameQuestionPanel, std::string, question, getQuestion, setQuestion),
+           V_METHOD(CGameQuestionPanel, renderQuestion, void, std::shared_ptr<CGui>, std::shared_ptr<SDL_Rect>, int),
+           V_METHOD(CGameQuestionPanel, clickNo, void, std::shared_ptr<CGui>),
+           V_METHOD(CGameQuestionPanel, clickYes, void, std::shared_ptr<CGui>))
 
-public:
-  bool awaitAnswer();
+  public:
+    bool awaitAnswer();
 
-  std::string getQuestion();
+    std::string getQuestion();
 
-  void setQuestion(std::string question);
+    void setQuestion(std::string question);
 
-  void renderQuestion(std::shared_ptr<CGui> gui,
-                      std::shared_ptr<SDL_Rect> pRect, int i);
+    void renderQuestion(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> pRect, int i);
 
-  void clickYes(std::shared_ptr<CGui> gui);
+    void clickYes(std::shared_ptr<CGui> gui);
 
-  void clickNo(std::shared_ptr<CGui> gui);
+    void clickNo(std::shared_ptr<CGui> gui);
 
-private:
-  std::string question;
+  private:
+    std::string question;
 
-  std::shared_ptr<bool> selection;
+    std::shared_ptr<bool> selection;
 };

--- a/src/gui/panel/CGameTextPanel.cpp
+++ b/src/gui/panel/CGameTextPanel.cpp
@@ -23,25 +23,22 @@ std::string CGameTextPanel::getText() { return text; }
 
 void CGameTextPanel::setText(std::string _text) { text = _text; }
 
-void CGameTextPanel::renderObject(std::shared_ptr<CGui> gui,
-                                  std::shared_ptr<SDL_Rect> rect, int i) {
-  if (centered) {
-    gui->getTextManager()->drawTextCentered(text, rect->x, rect->y, rect->w,
-                                            rect->h);
-  } else {
-    gui->getTextManager()->drawText(text, rect->x, rect->y, rect->w);
-  }
+void CGameTextPanel::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int i) {
+    if (centered) {
+        gui->getTextManager()->drawTextCentered(text, rect->x, rect->y, rect->w, rect->h);
+    } else {
+        gui->getTextManager()->drawText(text, rect->x, rect->y, rect->w);
+    }
 }
 
-bool CGameTextPanel::keyboardEvent(std::shared_ptr<CGui> gui,
-                                   SDL_EventType type, SDL_Keycode i) {
-  if (type == SDL_KEYDOWN) {
-    // TODO: get rid of this
-    if (i == SDLK_SPACE) {
-      close();
+bool CGameTextPanel::keyboardEvent(std::shared_ptr<CGui> gui, SDL_EventType type, SDL_Keycode i) {
+    if (type == SDL_KEYDOWN) {
+        // TODO: get rid of this
+        if (i == SDLK_SPACE) {
+            close();
+        }
     }
-  }
-  return true;
+    return true;
 }
 
 CGameTextPanel::~CGameTextPanel() {}

--- a/src/gui/panel/CGameTextPanel.h
+++ b/src/gui/panel/CGameTextPanel.h
@@ -21,27 +21,24 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 // TODO: unify with CTextWidget
 class CGameTextPanel : public CGamePanel {
-  V_META(CGameTextPanel, CGamePanel,
-         V_PROPERTY(CGameTextPanel, std::string, text, getText, setText))
+    V_META(CGameTextPanel, CGamePanel, V_PROPERTY(CGameTextPanel, std::string, text, getText, setText))
 
-  void renderObject(std::shared_ptr<CGui> shared_ptr,
-                    std::shared_ptr<SDL_Rect> rect, int i) override;
+    void renderObject(std::shared_ptr<CGui> shared_ptr, std::shared_ptr<SDL_Rect> rect, int i) override;
 
-  bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
-                     SDL_Keycode i) override;
+    bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i) override;
 
-private:
-  std::string text;
-  bool centered = false;
+  private:
+    std::string text;
+    bool centered = false;
 
-public:
-  ~CGameTextPanel();
+  public:
+    ~CGameTextPanel();
 
-  std::string getText();
+    std::string getText();
 
-  void setText(std::string ext);
+    void setText(std::string ext);
 
-  bool getCentered();
+    bool getCentered();
 
-  void setCentered(bool ext);
+    void setCentered(bool ext);
 };

--- a/src/gui/panel/CGameTradePanel.cpp
+++ b/src/gui/panel/CGameTradePanel.cpp
@@ -21,152 +21,123 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CTextManager.h"
 #include "gui/CTextureCache.h"
 
-CListView::collection_pointer
-CGameTradePanel::inventoryCollection(std::shared_ptr<CGui> gui) {
-  return std::make_shared<CListView::collection_type>(
-      vstd::cast<CListView::collection_type>(
-          gui->getGame()->getMap()->getPlayer()->getItems()));
+CListView::collection_pointer CGameTradePanel::inventoryCollection(std::shared_ptr<CGui> gui) {
+    return std::make_shared<CListView::collection_type>(
+        vstd::cast<CListView::collection_type>(gui->getGame()->getMap()->getPlayer()->getItems()));
 }
 
-void CGameTradePanel::inventoryCallback(
-    std::shared_ptr<CGui> gui, int index,
-    std::shared_ptr<CGameObject> _newSelection) {
-  this->selectInventory(vstd::cast<CItem>(_newSelection));
-  refreshViews();
-}
-
-bool CGameTradePanel::inventorySelect(std::shared_ptr<CGui> gui, int index,
-                                      std::shared_ptr<CGameObject> object) {
-  return vstd::ctn(selectedInventory, object,
-                   [](auto a, auto b) { return a == b.lock(); });
-}
-
-CListView::collection_pointer
-CGameTradePanel::marketCollection(std::shared_ptr<CGui> gui) {
-  return std::make_shared<CListView::collection_type>(
-      vstd::cast<CListView::collection_type>(market->getItems()));
-}
-
-void CGameTradePanel::marketCallback(
-    std::shared_ptr<CGui> gui, int index,
-    std::shared_ptr<CGameObject> _newSelection) {
-  this->selectMarket(vstd::cast<CItem>(_newSelection));
-  refreshViews();
-}
-
-bool CGameTradePanel::marketSelect(std::shared_ptr<CGui> gui, int index,
-                                   std::shared_ptr<CGameObject> object) {
-  return vstd::ctn(selectedMarket, object,
-                   [](auto a, auto b) { return a == b.lock(); });
-}
-
-bool CGameTradePanel::mouseEvent(std::shared_ptr<CGui> gui,
-                                 SDL_EventType type, int button, int x,
-                                 int y) {
-  if (type == SDL_MOUSEBUTTONDOWN && button == SDL_BUTTON_RIGHT) {
-    selectedInventory.clear();
-    selectedMarket.clear();
+void CGameTradePanel::inventoryCallback(std::shared_ptr<CGui> gui, int index,
+                                        std::shared_ptr<CGameObject> _newSelection) {
+    this->selectInventory(vstd::cast<CItem>(_newSelection));
     refreshViews();
-  }
-  return true;
 }
 
-bool CGameTradePanel::keyboardEvent(std::shared_ptr<CGui> gui,
-                                    SDL_EventType type, SDL_Keycode i) {
-  if (type == SDL_KEYDOWN) {
-    // TODO: get rid of this
-    if (i == SDLK_SPACE) {
-      close();
+bool CGameTradePanel::inventorySelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
+    return vstd::ctn(selectedInventory, object, [](auto a, auto b) { return a == b.lock(); });
+}
+
+CListView::collection_pointer CGameTradePanel::marketCollection(std::shared_ptr<CGui> gui) {
+    return std::make_shared<CListView::collection_type>(vstd::cast<CListView::collection_type>(market->getItems()));
+}
+
+void CGameTradePanel::marketCallback(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> _newSelection) {
+    this->selectMarket(vstd::cast<CItem>(_newSelection));
+    refreshViews();
+}
+
+bool CGameTradePanel::marketSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
+    return vstd::ctn(selectedMarket, object, [](auto a, auto b) { return a == b.lock(); });
+}
+
+bool CGameTradePanel::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button, int x, int y) {
+    if (type == SDL_MOUSEBUTTONDOWN && button == SDL_BUTTON_RIGHT) {
+        selectedInventory.clear();
+        selectedMarket.clear();
+        refreshViews();
     }
-  }
-  return true;
+    return true;
+}
+
+bool CGameTradePanel::keyboardEvent(std::shared_ptr<CGui> gui, SDL_EventType type, SDL_Keycode i) {
+    if (type == SDL_KEYDOWN) {
+        // TODO: get rid of this
+        if (i == SDLK_SPACE) {
+            close();
+        }
+    }
+    return true;
 }
 
 CGameTradePanel::CGameTradePanel() {}
 
 void CGameTradePanel::finalizeSell(std::shared_ptr<CGui> gui) {
-  if (!selectedInventory.empty() &&
-      gui->getGame()->getGuiHandler()->showQuestion(
-          "Do You want to sell these items: " +
-          vstd::join(getItemNames(selectedInventory), ", "))) {
-    for (auto item : selectedInventory) {
-      market->buyItem(gui->getGame()->getMap()->getPlayer(), item.lock());
+    if (!selectedInventory.empty() &&
+        gui->getGame()->getGuiHandler()->showQuestion("Do You want to sell these items: " +
+                                                      vstd::join(getItemNames(selectedInventory), ", "))) {
+        for (auto item : selectedInventory) {
+            market->buyItem(gui->getGame()->getMap()->getPlayer(), item.lock());
+        }
+        selectedInventory.clear();
     }
-    selectedInventory.clear();
-  }
 }
 
 void CGameTradePanel::finalizeBuy(std::shared_ptr<CGui> gui) {
-  if (getTotalBuyCost() > gui->getGame()->getMap()->getPlayer()->getGold()) {
-    gui->getGame()->getGuiHandler()->showInfo(
-        "You cannot afford all selected items!");
-  } else {
-    if (!selectedMarket.empty() &&
-        gui->getGame()->getGuiHandler()->showQuestion(
-            "Do You want to buy these items: " +
-            vstd::join(getItemNames(selectedMarket), ", "))) {
-      for (auto item : selectedMarket) {
-        market->sellItem(gui->getGame()->getMap()->getPlayer(), item.lock());
-      }
-      selectedMarket.clear();
+    if (getTotalBuyCost() > gui->getGame()->getMap()->getPlayer()->getGold()) {
+        gui->getGame()->getGuiHandler()->showInfo("You cannot afford all selected items!");
+    } else {
+        if (!selectedMarket.empty() &&
+            gui->getGame()->getGuiHandler()->showQuestion("Do You want to buy these items: " +
+                                                          vstd::join(getItemNames(selectedMarket), ", "))) {
+            for (auto item : selectedMarket) {
+                market->sellItem(gui->getGame()->getMap()->getPlayer(), item.lock());
+            }
+            selectedMarket.clear();
+        }
     }
-  }
 }
 
-std::set<std::string>
-CGameTradePanel::getItemNames(std::list<std::weak_ptr<CItem>> items) {
-  return vstd::functional::map<std::set<std::string>>(
-      items, [](std::weak_ptr<CItem> ob) { return ob.lock()->getLabel(); });
+std::set<std::string> CGameTradePanel::getItemNames(std::list<std::weak_ptr<CItem>> items) {
+    return vstd::functional::map<std::set<std::string>>(items,
+                                                        [](std::weak_ptr<CItem> ob) { return ob.lock()->getLabel(); });
 }
 
 int CGameTradePanel::getTotalSellCost() {
-  return vstd::functional::sum<int>(selectedInventory, [this](auto item) {
-    return market->getSellCost(item.lock());
-  });
+    return vstd::functional::sum<int>(selectedInventory,
+                                      [this](auto item) { return market->getSellCost(item.lock()); });
 }
 
 int CGameTradePanel::getTotalBuyCost() {
-  return vstd::functional::sum<int>(selectedMarket, [this](auto item) {
-    return market->getBuyCost(item.lock());
-  });
+    return vstd::functional::sum<int>(selectedMarket, [this](auto item) { return market->getBuyCost(item.lock()); });
 }
 
 void CGameTradePanel::selectMarket(std::weak_ptr<CItem> selection) {
-  if (selection.lock()) {
-    if (vstd::ctn(selectedMarket, selection,
-                  [](auto a, auto b) { return a.lock() == b.lock(); })) {
-      vstd::erase(selectedMarket, selection,
-                  [](auto a, auto b) { return a.lock() == b.lock(); });
-    } else {
-      selectedMarket.push_back(selection);
+    if (selection.lock()) {
+        if (vstd::ctn(selectedMarket, selection, [](auto a, auto b) { return a.lock() == b.lock(); })) {
+            vstd::erase(selectedMarket, selection, [](auto a, auto b) { return a.lock() == b.lock(); });
+        } else {
+            selectedMarket.push_back(selection);
+        }
     }
-  }
 }
 
 void CGameTradePanel::selectInventory(std::weak_ptr<CItem> selection) {
-  if (selection.lock() && !selection.lock()->hasTag(CTag::Quest)) {
-    if (vstd::ctn(selectedInventory, selection,
-                  [](auto a, auto b) { return a.lock() == b.lock(); })) {
-      vstd::erase(selectedInventory, selection,
-                  [](auto a, auto b) { return a.lock() == b.lock(); });
-    } else {
-      selectedInventory.push_back(selection);
+    if (selection.lock() && !selection.lock()->hasTag(CTag::Quest)) {
+        if (vstd::ctn(selectedInventory, selection, [](auto a, auto b) { return a.lock() == b.lock(); })) {
+            vstd::erase(selectedInventory, selection, [](auto a, auto b) { return a.lock() == b.lock(); });
+        } else {
+            selectedInventory.push_back(selection);
+        }
     }
-  }
 }
 
-void CGameTradePanel::setMarket(std::shared_ptr<CMarket> _market) {
-  market = _market;
-}
+void CGameTradePanel::setMarket(std::shared_ptr<CMarket> _market) { market = _market; }
 
 std::shared_ptr<CMarket> CGameTradePanel::getMarket() { return market; }
 
-void CGameTradePanel::renderSellCost(std::shared_ptr<CGui> gui,
-                                     std::shared_ptr<SDL_Rect> pRect, int i) {
-  gui->getTextManager()->drawTextCentered(vstd::str(getTotalSellCost()), pRect);
+void CGameTradePanel::renderSellCost(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> pRect, int i) {
+    gui->getTextManager()->drawTextCentered(vstd::str(getTotalSellCost()), pRect);
 }
 
-void CGameTradePanel::renderBuyCost(std::shared_ptr<CGui> gui,
-                                    std::shared_ptr<SDL_Rect> pRect, int i) {
-  gui->getTextManager()->drawTextCentered(vstd::str(getTotalBuyCost()), pRect);
+void CGameTradePanel::renderBuyCost(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> pRect, int i) {
+    gui->getTextManager()->drawTextCentered(vstd::str(getTotalBuyCost()), pRect);
 }

--- a/src/gui/panel/CGameTradePanel.h
+++ b/src/gui/panel/CGameTradePanel.h
@@ -21,82 +21,65 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CPlayer.h"
 
 class CGameTradePanel : public CGamePanel {
-  V_META(CGameTradePanel, CGamePanel,
-         // TODO: unify this with CGameInventoryPanel
-         // TODO: allow selecting couple of grouped objects
-         V_PROPERTY(CGameTradePanel, std::shared_ptr<CMarket>, market,
-                    getMarket, setMarket),
-         V_METHOD(CGameTradePanel, inventoryCollection,
-                  CListView::collection_pointer, std::shared_ptr<CGui>),
-         V_METHOD(CGameTradePanel, inventoryCallback, void,
-                  std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameTradePanel, inventorySelect, bool, std::shared_ptr<CGui>,
-                  int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameTradePanel, marketCollection,
-                  CListView::collection_pointer, std::shared_ptr<CGui>),
-         V_METHOD(CGameTradePanel, marketCallback, void, std::shared_ptr<CGui>,
-                  int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameTradePanel, marketSelect, bool, std::shared_ptr<CGui>,
-                  int, std::shared_ptr<CGameObject>),
-         V_METHOD(CGameTradePanel, renderSellCost, void, std::shared_ptr<CGui>,
-                  std::shared_ptr<SDL_Rect>, int),
-         V_METHOD(CGameTradePanel, renderBuyCost, void, std::shared_ptr<CGui>,
-                  std::shared_ptr<SDL_Rect>, int),
-         V_METHOD(CGameTradePanel, finalizeSell, void, std::shared_ptr<CGui>),
-         V_METHOD(CGameTradePanel, finalizeBuy, void, std::shared_ptr<CGui>))
+    V_META(CGameTradePanel, CGamePanel,
+           // TODO: unify this with CGameInventoryPanel
+           // TODO: allow selecting couple of grouped objects
+           V_PROPERTY(CGameTradePanel, std::shared_ptr<CMarket>, market, getMarket, setMarket),
+           V_METHOD(CGameTradePanel, inventoryCollection, CListView::collection_pointer, std::shared_ptr<CGui>),
+           V_METHOD(CGameTradePanel, inventoryCallback, void, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
+           V_METHOD(CGameTradePanel, inventorySelect, bool, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
+           V_METHOD(CGameTradePanel, marketCollection, CListView::collection_pointer, std::shared_ptr<CGui>),
+           V_METHOD(CGameTradePanel, marketCallback, void, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
+           V_METHOD(CGameTradePanel, marketSelect, bool, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
+           V_METHOD(CGameTradePanel, renderSellCost, void, std::shared_ptr<CGui>, std::shared_ptr<SDL_Rect>, int),
+           V_METHOD(CGameTradePanel, renderBuyCost, void, std::shared_ptr<CGui>, std::shared_ptr<SDL_Rect>, int),
+           V_METHOD(CGameTradePanel, finalizeSell, void, std::shared_ptr<CGui>),
+           V_METHOD(CGameTradePanel, finalizeBuy, void, std::shared_ptr<CGui>))
 
-public:
-  CGameTradePanel();
+  public:
+    CGameTradePanel();
 
-  std::shared_ptr<CMarket> getMarket();
+    std::shared_ptr<CMarket> getMarket();
 
-  void setMarket(std::shared_ptr<CMarket> _market);
+    void setMarket(std::shared_ptr<CMarket> _market);
 
-  CListView::collection_pointer inventoryCollection(std::shared_ptr<CGui> gui);
+    CListView::collection_pointer inventoryCollection(std::shared_ptr<CGui> gui);
 
-  void inventoryCallback(std::shared_ptr<CGui> gui, int index,
-                         std::shared_ptr<CGameObject> _newSelection);
+    void inventoryCallback(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> _newSelection);
 
-  bool inventorySelect(std::shared_ptr<CGui> gui, int index,
-                       std::shared_ptr<CGameObject> object);
+    bool inventorySelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object);
 
-  CListView::collection_pointer marketCollection(std::shared_ptr<CGui> gui);
+    CListView::collection_pointer marketCollection(std::shared_ptr<CGui> gui);
 
-  void marketCallback(std::shared_ptr<CGui> gui, int index,
-                      std::shared_ptr<CGameObject> _newSelection);
+    void marketCallback(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> _newSelection);
 
-  bool marketSelect(std::shared_ptr<CGui> gui, int index,
-                    std::shared_ptr<CGameObject> object);
+    bool marketSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object);
 
-  void renderSellCost(std::shared_ptr<CGui> gui,
-                      std::shared_ptr<SDL_Rect> pRect, int i);
+    void renderSellCost(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> pRect, int i);
 
-  void renderBuyCost(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> pRect,
-                     int i);
+    void renderBuyCost(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> pRect, int i);
 
-  void finalizeSell(std::shared_ptr<CGui> shared_ptr);
+    void finalizeSell(std::shared_ptr<CGui> shared_ptr);
 
-  void finalizeBuy(std::shared_ptr<CGui> shared_ptr);
+    void finalizeBuy(std::shared_ptr<CGui> shared_ptr);
 
-private:
-  std::shared_ptr<CMarket> market;
-  std::list<std::weak_ptr<CItem>> selectedInventory;
-  std::list<std::weak_ptr<CItem>> selectedMarket;
+  private:
+    std::shared_ptr<CMarket> market;
+    std::list<std::weak_ptr<CItem>> selectedInventory;
+    std::list<std::weak_ptr<CItem>> selectedMarket;
 
-  bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
-                  int button, int x, int y) override;
+    bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int button, int x, int y) override;
 
-  bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
-                     SDL_Keycode i) override;
+    bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i) override;
 
-  void selectMarket(std::weak_ptr<CItem> selection);
+    void selectMarket(std::weak_ptr<CItem> selection);
 
-  void selectInventory(std::weak_ptr<CItem> selection);
+    void selectInventory(std::weak_ptr<CItem> selection);
 
-  int getTotalSellCost();
+    int getTotalSellCost();
 
-  int getTotalBuyCost();
+    int getTotalBuyCost();
 
-  // TODO: should be not unique collection. items get merged
-  std::set<std::string> getItemNames(std::list<std::weak_ptr<CItem>> items);
+    // TODO: should be not unique collection. items get merged
+    std::set<std::string> getItemNames(std::list<std::weak_ptr<CItem>> items);
 };

--- a/src/gui/panel/CListView.h
+++ b/src/gui/panel/CListView.h
@@ -24,187 +24,164 @@ class CProxyGraphicsObject;
 class CScript;
 
 class CListView : public CProxyTargetGraphicsObject {
-  V_META(CListView, CProxyTargetGraphicsObject,
-         V_PROPERTY(CListView, std::string, collection, getCollection,
-                    setCollection),
-         V_PROPERTY(CListView, std::string, select, getSelect, setSelect),
-         V_PROPERTY(CListView, std::string, callback, getCallback, setCallback),
-         V_PROPERTY(CListView, std::string, rightClickCallback,
-                    getRightClickCallback, setRightClickCallback),
-         V_PROPERTY(CListView, std::shared_ptr<CScript>, refreshObject,
-                    getRefreshObject, setRefreshObject),
-         V_PROPERTY(CListView, std::string, refreshEvent, getRefreshEvent,
-                    setRefreshEvent),
-         V_PROPERTY(CListView, int, xPrefferedSize, getXPrefferedSize,
-                    setXPrefferedSize),
-         V_PROPERTY(CListView, int, yPrefferedSize, getYPrefferedSize,
-                    setYPrefferedSize),
-         V_PROPERTY(CListView, int, tileSize, getTileSize, setTileSize),
-         V_PROPERTY(CListView, bool, allowOversize, getAllowOversize,
-                    setAllowOversize),
-         V_PROPERTY(CListView, bool, showEmpty, getShowEmpty, setShowEmpty),
-         V_PROPERTY(CListView, bool, grouping, getGrouping, setGrouping),
-         V_METHOD(CListView, initialize))
+    V_META(CListView, CProxyTargetGraphicsObject,
+           V_PROPERTY(CListView, std::string, collection, getCollection, setCollection),
+           V_PROPERTY(CListView, std::string, select, getSelect, setSelect),
+           V_PROPERTY(CListView, std::string, callback, getCallback, setCallback),
+           V_PROPERTY(CListView, std::string, rightClickCallback, getRightClickCallback, setRightClickCallback),
+           V_PROPERTY(CListView, std::shared_ptr<CScript>, refreshObject, getRefreshObject, setRefreshObject),
+           V_PROPERTY(CListView, std::string, refreshEvent, getRefreshEvent, setRefreshEvent),
+           V_PROPERTY(CListView, int, xPrefferedSize, getXPrefferedSize, setXPrefferedSize),
+           V_PROPERTY(CListView, int, yPrefferedSize, getYPrefferedSize, setYPrefferedSize),
+           V_PROPERTY(CListView, int, tileSize, getTileSize, setTileSize),
+           V_PROPERTY(CListView, bool, allowOversize, getAllowOversize, setAllowOversize),
+           V_PROPERTY(CListView, bool, showEmpty, getShowEmpty, setShowEmpty),
+           V_PROPERTY(CListView, bool, grouping, getGrouping, setGrouping), V_METHOD(CListView, initialize))
 
-  std::string collection;
+    std::string collection;
 
-  std::string callback;
+    std::string callback;
 
-  std::string rightClickCallback;
+    std::string rightClickCallback;
 
-  std::string select;
+    std::string select;
 
-  std::shared_ptr<CScript> refreshObject;
+    std::shared_ptr<CScript> refreshObject;
 
-public:
-  typedef vstd::list<std::shared_ptr<CGameObject>> collection_type;
-  typedef std::shared_ptr<collection_type> collection_pointer;
+  public:
+    typedef vstd::list<std::shared_ptr<CGameObject>> collection_type;
+    typedef std::shared_ptr<collection_type> collection_pointer;
 
-  typedef std::set<std::shared_ptr<CGameGraphicsObject>> children_type;
-  typedef std::shared_ptr<children_type> children_pointer;
+    typedef std::set<std::shared_ptr<CGameGraphicsObject>> children_type;
+    typedef std::shared_ptr<children_type> children_pointer;
 
-  std::shared_ptr<CScript> getRefreshObject();
+    std::shared_ptr<CScript> getRefreshObject();
 
-  void setRefreshObject(std::shared_ptr<CScript> refreshObject);
+    void setRefreshObject(std::shared_ptr<CScript> refreshObject);
 
-  std::string getRefreshEvent();
+    std::string getRefreshEvent();
 
-  void setRefreshEvent(std::string refreshEvent);
+    void setRefreshEvent(std::string refreshEvent);
 
-  void initialize();
+    void initialize();
 
-private:
-  std::string refreshEvent;
+  private:
+    std::string refreshEvent;
 
-  bool allowOversize = true;
+    bool allowOversize = true;
 
-  bool showEmpty = true;
+    bool showEmpty = true;
 
-  bool grouping = false;
+    bool grouping = false;
 
-  int selectionThickness = 5;
+    int selectionThickness = 5;
 
-  int shift = 0;
+    int shift = 0;
 
-  int xPrefferedSize = -1;
+    int xPrefferedSize = -1;
 
-  int yPrefferedSize = -1;
+    int yPrefferedSize = -1;
 
-  int tileSize = 50;
+    int tileSize = 50;
 
-public:
-  CListView() = default;
+  public:
+    CListView() = default;
 
-  bool getAllowOversize();
+    bool getAllowOversize();
 
-  void setAllowOversize(bool _allowOversize);
+    void setAllowOversize(bool _allowOversize);
 
-  bool getGrouping();
+    bool getGrouping();
 
-  void setGrouping(bool _grouping);
+    void setGrouping(bool _grouping);
 
-  bool getShowEmpty();
+    bool getShowEmpty();
 
-  void setShowEmpty(bool _showEmpty);
+    void setShowEmpty(bool _showEmpty);
 
-  int getTileSize();
+    int getTileSize();
 
-  void setTileSize(int _tileSize);
+    void setTileSize(int _tileSize);
 
-  void renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> loc,
-                    int frameTime) override;
+    void renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> loc, int frameTime) override;
 
-  bool mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button,
-                  int x, int y) override;
+    bool mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button, int x, int y) override;
 
-  std::list<std::shared_ptr<CGameGraphicsObject>>
-  getProxiedObjects(std::shared_ptr<CGui> gui, int x, int y) override;
+    std::list<std::shared_ptr<CGameGraphicsObject>> getProxiedObjects(std::shared_ptr<CGui> gui, int x, int y) override;
 
-  int getSizeX(std::shared_ptr<CGui> gui) override;
+    int getSizeX(std::shared_ptr<CGui> gui) override;
 
-  int getSizeY(std::shared_ptr<CGui> gui) override;
+    int getSizeY(std::shared_ptr<CGui> gui) override;
 
-  std::string getCollection();
+    std::string getCollection();
 
-  void setCollection(std::string collection);
+    void setCollection(std::string collection);
 
-  std::string getCallback();
+    std::string getCallback();
 
-  void setCallback(std::string callback);
+    void setCallback(std::string callback);
 
-  std::string getRightClickCallback();
+    std::string getRightClickCallback();
 
-  void setRightClickCallback(std::string rightClickCallback);
+    void setRightClickCallback(std::string rightClickCallback);
 
-  std::string getSelect();
+    std::string getSelect();
 
-  void setSelect(std::string select);
+    void setSelect(std::string select);
 
-  int getXPrefferedSize() const;
+    int getXPrefferedSize() const;
 
-  void setXPrefferedSize(int xPrefferedSize);
+    void setXPrefferedSize(int xPrefferedSize);
 
-  int getYPrefferedSize() const;
+    int getYPrefferedSize() const;
 
-  void setYPrefferedSize(int yPrefferedSize);
+    void setYPrefferedSize(int yPrefferedSize);
 
-private:
-  CListView::collection_pointer invokeCollection(std::shared_ptr<CGui> gui);
+  private:
+    CListView::collection_pointer invokeCollection(std::shared_ptr<CGui> gui);
 
-  void invokeCallback(std::shared_ptr<CGui> gui, int i,
-                      std::shared_ptr<CGameObject> object);
+    void invokeCallback(std::shared_ptr<CGui> gui, int i, std::shared_ptr<CGameObject> object);
 
-  bool invokeRightClickCallback(std::shared_ptr<CGui> gui, int i,
-                                std::shared_ptr<CGameObject> object);
+    bool invokeRightClickCallback(std::shared_ptr<CGui> gui, int i, std::shared_ptr<CGameObject> object);
 
-  bool invokeSelect(std::shared_ptr<CGui> gui, int i,
-                    std::shared_ptr<CGameObject> object);
+    bool invokeSelect(std::shared_ptr<CGui> gui, int i, std::shared_ptr<CGameObject> object);
 
-  bool tryGetClickedObject(std::shared_ptr<CGui> gui, int x, int y, int &index,
-                           std::shared_ptr<CGameObject> &object);
+    bool tryGetClickedObject(std::shared_ptr<CGui> gui, int x, int y, int &index, std::shared_ptr<CGameObject> &object);
 
-  std::unordered_map<std::pair<int, int>, std::shared_ptr<CProxyGraphicsObject>>
-      proxyObjects;
+    std::unordered_map<std::pair<int, int>, std::shared_ptr<CProxyGraphicsObject>> proxyObjects;
 
-  void doShift(const std::shared_ptr<CGui> &gui, int val);
+    void doShift(const std::shared_ptr<CGui> &gui, int val);
 
-  int shiftIndex(const std::shared_ptr<CGui> &gui, int arg);
+    int shiftIndex(const std::shared_ptr<CGui> &gui, int arg);
 
-  int getRightArrowIndex(const std::shared_ptr<CGui> &gui);
+    int getRightArrowIndex(const std::shared_ptr<CGui> &gui);
 
-  int getLeftArrowIndex(const std::shared_ptr<CGui> &gui);
+    int getLeftArrowIndex(const std::shared_ptr<CGui> &gui);
 
-  // TODO: do not generate whole map, instead add callback arguement and stop
-  // when met
-  std::unordered_multimap<int, std::shared_ptr<CGameObject>>
-  calculateIndices(const std::shared_ptr<CGui> &gui);
+    // TODO: do not generate whole map, instead add callback arguement and stop
+    // when met
+    std::unordered_multimap<int, std::shared_ptr<CGameObject>> calculateIndices(const std::shared_ptr<CGui> &gui);
 
-  std::shared_ptr<SDL_Rect>
-  calculateIndexPosition(const std::shared_ptr<CGui> &gui,
-                         const std::shared_ptr<SDL_Rect> &loc, int index);
+    std::shared_ptr<SDL_Rect> calculateIndexPosition(const std::shared_ptr<CGui> &gui,
+                                                     const std::shared_ptr<SDL_Rect> &loc, int index);
 
-  // TODO: cache method calls // note to self, seems like no performance impact,
-  // even in debug
-  bool isOversized(const std::shared_ptr<CGui> &gui);
+    // TODO: cache method calls // note to self, seems like no performance impact,
+    // even in debug
+    bool isOversized(const std::shared_ptr<CGui> &gui);
 
-  auto getArrowCallback(bool left);
+    auto getArrowCallback(bool left);
 
-  void
-  addItemBox(const std::shared_ptr<CGui> &gui,
-             std::list<std::shared_ptr<CGameGraphicsObject>> &return_val) const;
+    void addItemBox(const std::shared_ptr<CGui> &gui,
+                    std::list<std::shared_ptr<CGameGraphicsObject>> &return_val) const;
 
-  void addItem(std::list<std::shared_ptr<CGameGraphicsObject>> &return_val,
-               std::unordered_multimap<int, std::shared_ptr<CGameObject>>
-                   indexedCollection,
-               int itemIndex) const;
+    void addItem(std::list<std::shared_ptr<CGameGraphicsObject>> &return_val,
+                 std::unordered_multimap<int, std::shared_ptr<CGameObject>> indexedCollection, int itemIndex) const;
 
-  void addSelectionBox(
-      const std::shared_ptr<CGui> &gui,
-      std::list<std::shared_ptr<CGameGraphicsObject>> &return_val) const;
+    void addSelectionBox(const std::shared_ptr<CGui> &gui,
+                         std::list<std::shared_ptr<CGameGraphicsObject>> &return_val) const;
 
-  void addCountBox(
-      const std::shared_ptr<CGui> &gui, int count,
-      std::list<std::shared_ptr<CGameGraphicsObject>> &return_val) const;
+    void addCountBox(const std::shared_ptr<CGui> &gui, int count,
+                     std::list<std::shared_ptr<CGameGraphicsObject>> &return_val) const;
 
-  int getItemTypesCount(const std::shared_ptr<CGui> &gui);
+    int getItemTypesCount(const std::shared_ptr<CGui> &gui);
 };

--- a/src/handler/CEventHandler.h
+++ b/src/handler/CEventHandler.h
@@ -28,58 +28,55 @@ class CTrigger;
 class CGameObject;
 
 class CGameEvent : public CGameObject {
-  V_META(CGameEvent, CGameObject, vstd::meta::empty())
-public:
-  class Type {
+    V_META(CGameEvent, CGameObject, vstd::meta::empty())
   public:
-    static std::string onEnter;
-    static std::string onTurn;
-    static std::string onCreate;
-    static std::string onDestroy;
-    static std::string onLeave;
-    static std::string onUse;
-    static std::string onEquip;
-    static std::string onUnequip;
-    static std::string inventoryChanged;
-    static std::string equippedChanged;
-  };
+    class Type {
+      public:
+        static std::string onEnter;
+        static std::string onTurn;
+        static std::string onCreate;
+        static std::string onDestroy;
+        static std::string onLeave;
+        static std::string onUse;
+        static std::string onEquip;
+        static std::string onUnequip;
+        static std::string inventoryChanged;
+        static std::string equippedChanged;
+    };
 
-  CGameEvent();
+    CGameEvent();
 
-  CGameEvent(std::string type);
+    CGameEvent(std::string type);
 
-  std::string getType() const;
+    std::string getType() const;
 
-private:
-  const std::string type;
+  private:
+    const std::string type;
 };
 
 class CGameEventCaused : public CGameEvent {
-  V_META(CGameEventCaused, CGameEvent, vstd::meta::empty())
-public:
-  CGameEventCaused();
+    V_META(CGameEventCaused, CGameEvent, vstd::meta::empty())
+  public:
+    CGameEventCaused();
 
-  CGameEventCaused(std::string type, std::shared_ptr<CGameObject> cause);
+    CGameEventCaused(std::string type, std::shared_ptr<CGameObject> cause);
 
-  std::shared_ptr<CGameObject> getCause() const;
+    std::shared_ptr<CGameObject> getCause() const;
 
-private:
-  std::shared_ptr<CGameObject> cause;
+  private:
+    std::shared_ptr<CGameObject> cause;
 };
 
 class CEventHandler : public CGameObject {
-  typedef std::unordered_multimap<std::pair<std::string, std::string>,
-                                  std::shared_ptr<CTrigger>>
-      TriggerMap;
+    typedef std::unordered_multimap<std::pair<std::string, std::string>, std::shared_ptr<CTrigger>> TriggerMap;
 
-public:
-  void gameEvent(std::shared_ptr<CMapObject> mapObject,
-                 std::shared_ptr<CGameEvent> event) const;
+  public:
+    void gameEvent(std::shared_ptr<CMapObject> mapObject, std::shared_ptr<CGameEvent> event) const;
 
-  void registerTrigger(std::shared_ptr<CTrigger> trigger);
+    void registerTrigger(std::shared_ptr<CTrigger> trigger);
 
-  std::set<std::shared_ptr<CTrigger>> getTriggers();
+    std::set<std::shared_ptr<CTrigger>> getTriggers();
 
-private:
-  TriggerMap triggers;
+  private:
+    TriggerMap triggers;
 };

--- a/src/handler/CFightHandler.h
+++ b/src/handler/CFightHandler.h
@@ -24,15 +24,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 class CCreature;
 
 class CFightHandler {
-public:
-  static bool fight(std::shared_ptr<CCreature> a, std::shared_ptr<CCreature> b);
+  public:
+    static bool fight(std::shared_ptr<CCreature> a, std::shared_ptr<CCreature> b);
 
-  static bool
-  fightMany(std::shared_ptr<CCreature> attacker,
-            const std::vector<std::shared_ptr<CCreature>> &opponents);
+    static bool fightMany(std::shared_ptr<CCreature> attacker,
+                          const std::vector<std::shared_ptr<CCreature>> &opponents);
 
-  static void defeatedCreature(const std::shared_ptr<CCreature> &a,
-                               const std::shared_ptr<CCreature> &b);
+    static void defeatedCreature(const std::shared_ptr<CCreature> &a, const std::shared_ptr<CCreature> &b);
 
-  static void applyEffects(const std::shared_ptr<CCreature> &cr);
+    static void applyEffects(const std::shared_ptr<CCreature> &cr);
 };

--- a/src/handler/CQuestHandler.h
+++ b/src/handler/CQuestHandler.h
@@ -18,6 +18,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 
 class CQuestHandler {
-public:
-  CQuestHandler();
+  public:
+    CQuestHandler();
 };

--- a/src/handler/CRngHandler.h
+++ b/src/handler/CRngHandler.h
@@ -27,31 +27,28 @@ class CGame;
 class CCreature;
 
 class CRngHandler : public CGameObject {
-public:
-  CRngHandler() = default;
+  public:
+    CRngHandler() = default;
 
-  explicit CRngHandler(const std::shared_ptr<CGame> &map);
+    explicit CRngHandler(const std::shared_ptr<CGame> &map);
 
-  std::set<std::shared_ptr<CItem>> getRandomLoot(int value) const;
+    std::set<std::shared_ptr<CItem>> getRandomLoot(int value) const;
 
-  std::set<std::shared_ptr<CCreature>> getRandomEncounter(int value) const;
+    std::set<std::shared_ptr<CCreature>> getRandomEncounter(int value) const;
 
-  void addRandomLoot(const std::shared_ptr<CCreature> &creature,
-                     const std::set<std::shared_ptr<CItem>> &items);
+    void addRandomLoot(const std::shared_ptr<CCreature> &creature, const std::set<std::shared_ptr<CItem>> &items);
 
-  void addRandomLoot(const std::shared_ptr<CCreature> &creature, int value);
+    void addRandomLoot(const std::shared_ptr<CCreature> &creature, int value);
 
-  void addRandomEncounter(const std::shared_ptr<CMap> &map, int x, int y, int z,
-                          int value);
+    void addRandomEncounter(const std::shared_ptr<CMap> &map, int x, int y, int z, int value);
 
-private:
-  std::set<std::shared_ptr<CItem>> calculateRandomLoot(int value) const;
+  private:
+    std::set<std::shared_ptr<CItem>> calculateRandomLoot(int value) const;
 
-  std::set<std::shared_ptr<CCreature>>
-  calculateRandomEncounter(int value) const;
+    std::set<std::shared_ptr<CCreature>> calculateRandomEncounter(int value) const;
 
-  std::weak_ptr<CGame> game;
+    std::weak_ptr<CGame> game;
 
-  std::unordered_multimap<int, std::string> itemPowerTable;
-  std::unordered_multimap<int, std::string> creaturePowerTable;
+    std::unordered_multimap<int, std::string> itemPowerTable;
+    std::unordered_multimap<int, std::string> creaturePowerTable;
 };

--- a/src/handler/CScriptHandler.cpp
+++ b/src/handler/CScriptHandler.cpp
@@ -19,84 +19,71 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <pybind11/eval.h>
 
 CScriptHandler::CScriptHandler() {
-  main_module = pybind11::module::import("__main__");
-  main_namespace = main_module.attr("__dict__");
+    main_module = pybind11::module::import("__main__");
+    main_namespace = main_module.attr("__dict__");
 }
 
 CScriptHandler::~CScriptHandler() = default;
 
-void CScriptHandler::execute_script(std::string script,
-                                    pybind11::object name_space) {
-  auto target = name_space.is_none() ? main_namespace : name_space;
-  pybind11::exec(script + "\n", target, target);
+void CScriptHandler::execute_script(std::string script, pybind11::object name_space) {
+    auto target = name_space.is_none() ? main_namespace : name_space;
+    pybind11::exec(script + "\n", target, target);
 }
 
-std::string
-CScriptHandler::build_command(std::initializer_list<std::string> list) {
-  std::string command;
-  unsigned int pos = 0;
-  for (auto it = list.begin(); it != list.end(); it++, pos++) {
-    std::string part = vstd::replace(*it, "\"", "\\\"");
-    if (pos == 0) {
-      command.append(part);
-      command.append("(");
-    } else {
-      command.append("\"");
-      command.append(part);
-      command.append("\"");
-      if (pos < list.size() - 1) {
-        command.append(",");
-      } else {
-        command.append(")");
-      }
+std::string CScriptHandler::build_command(std::initializer_list<std::string> list) {
+    std::string command;
+    unsigned int pos = 0;
+    for (auto it = list.begin(); it != list.end(); it++, pos++) {
+        std::string part = vstd::replace(*it, "\"", "\\\"");
+        if (pos == 0) {
+            command.append(part);
+            command.append("(");
+        } else {
+            command.append("\"");
+            command.append(part);
+            command.append("\"");
+            if (pos < list.size() - 1) {
+                command.append(",");
+            } else {
+                command.append(")");
+            }
+        }
     }
-  }
-  return command;
+    return command;
 }
 
-void CScriptHandler::add_function(std::string function_name,
-                                  std::string function_code,
+void CScriptHandler::add_function(std::string function_name, std::string function_code,
                                   std::initializer_list<std::string> args) {
-  std::string def =
-      vstd::join({"def ", function_name, "(", vstd::join(args, ","), "):"}, "");
-  std::stringstream stream;
-  stream << def << std::endl;
-  for (std::string line : vstd::split(function_code, '\n')) {
-    stream << "\t" << line << std::endl;
-  }
-  try {
-    PY_UNSAFE(execute_script(stream.str()));
-  } catch (...) {
-    add_function(function_name, "print('Compilation failure!')", args);
-  }
+    std::string def = vstd::join({"def ", function_name, "(", vstd::join(args, ","), "):"}, "");
+    std::stringstream stream;
+    stream << def << std::endl;
+    for (std::string line : vstd::split(function_code, '\n')) {
+        stream << "\t" << line << std::endl;
+    }
+    try {
+        PY_UNSAFE(execute_script(stream.str()));
+    } catch (...) {
+        add_function(function_name, "print('Compilation failure!')", args);
+    }
 }
 
-void CScriptHandler::add_class(std::string class_name,
-                               std::string function_code,
+void CScriptHandler::add_class(std::string class_name, std::string function_code,
                                std::initializer_list<std::string> bases) {
-  std::string def =
-      vstd::join({"class ", class_name, "(", vstd::join(bases, ","), "):"}, "");
-  std::stringstream stream;
-  stream << def << std::endl;
-  for (std::string line : vstd::split(function_code, '\n')) {
-    stream << "\t" << line << std::endl;
-  }
-  execute_script(stream.str());
+    std::string def = vstd::join({"class ", class_name, "(", vstd::join(bases, ","), "):"}, "");
+    std::stringstream stream;
+    stream << def << std::endl;
+    for (std::string line : vstd::split(function_code, '\n')) {
+        stream << "\t" << line << std::endl;
+    }
+    execute_script(stream.str());
 }
 
-std::string
-CScriptHandler::add_class(std::string function_code,
-                          std::initializer_list<std::string> bases) {
-  std::string name =
-      vstd::join({"CLASS", vstd::to_hex_hash(function_code)}, "");
-  add_class(name, function_code, bases);
-  return name;
+std::string CScriptHandler::add_class(std::string function_code, std::initializer_list<std::string> bases) {
+    std::string name = vstd::join({"CLASS", vstd::to_hex_hash(function_code)}, "");
+    add_class(name, function_code, bases);
+    return name;
 }
 
-void CScriptHandler::import(std::string name) {
-  execute_script(vstd::join({"import", name}, " "));
-}
+void CScriptHandler::import(std::string name) { execute_script(vstd::join({"import", name}, " ")); }
 
-void CScriptHandler::execute_command(std::initializer_list<std::string> list) {
-  execute_script(build_command(list));
-}
+void CScriptHandler::execute_command(std::initializer_list<std::string> list) { execute_script(build_command(list)); }

--- a/src/handler/CTooltipHandler.h
+++ b/src/handler/CTooltipHandler.h
@@ -21,6 +21,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 class CTooltipHandler : public CGameObject {
 
-public:
-  static std::string buildTooltip(std::shared_ptr<CGameObject> object);
+  public:
+    static std::string buildTooltip(std::shared_ptr<CGameObject> object);
 };

--- a/src/object/CBuilding.cpp
+++ b/src/object/CBuilding.cpp
@@ -20,7 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "handler/CEventHandler.h"
 
 CBuilding::CBuilding() {
-  //    this->setZValue ( 1 );
+    //    this->setZValue ( 1 );
 }
 
 CBuilding::~CBuilding() {}
@@ -30,17 +30,15 @@ bool CBuilding::isEnabled() { return enabled; }
 void CBuilding::setEnabled(bool enabled) { this->enabled = enabled; }
 
 void CBuilding::onEnter(std::shared_ptr<CGameEvent> event) {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "onEnter");
-      !override.is_none()) {
-    PY_SAFE(override(event); return;)
-  }
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "onEnter"); !override.is_none()) {
+        PY_SAFE(override(event); return;)
+    }
 }
 
 void CBuilding::onLeave(std::shared_ptr<CGameEvent> event) {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "onLeave");
-      !override.is_none()) {
-    PY_SAFE(override(event); return;)
-  }
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "onLeave"); !override.is_none()) {
+        PY_SAFE(override(event); return;)
+    }
 }

--- a/src/object/CBuilding.h
+++ b/src/object/CBuilding.h
@@ -21,22 +21,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 class CBuilding : public CMapObject, public Visitable {
 
-  V_META(CBuilding, CMapObject,
-         V_PROPERTY(CBuilding, bool, enabled, isEnabled, setEnabled))
+    V_META(CBuilding, CMapObject, V_PROPERTY(CBuilding, bool, enabled, isEnabled, setEnabled))
 
-public:
-  CBuilding();
+  public:
+    CBuilding();
 
-  virtual ~CBuilding();
+    virtual ~CBuilding();
 
-  bool isEnabled();
+    bool isEnabled();
 
-  void setEnabled(bool enabled);
+    void setEnabled(bool enabled);
 
-  virtual void onEnter(std::shared_ptr<CGameEvent>) override;
+    virtual void onEnter(std::shared_ptr<CGameEvent>) override;
 
-  virtual void onLeave(std::shared_ptr<CGameEvent>) override;
+    virtual void onLeave(std::shared_ptr<CGameEvent>) override;
 
-protected:
-  bool enabled = true;
+  protected:
+    bool enabled = true;
 };

--- a/src/object/CDialog.h
+++ b/src/object/CDialog.h
@@ -20,92 +20,87 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CGameObject.h"
 
 class CDialogOption : public CGameObject {
-  V_META(CDialogOption, CGameObject,
-         V_PROPERTY(CDialogOption, int, number, getNumber, setNumber),
-         V_PROPERTY(CDialogOption, std::string, nextStateId, getNextStateId,
-                    setNextStateId),
-         V_PROPERTY(CDialogOption, std::string, text, getText, setText),
-         V_PROPERTY(CDialogOption, std::string, condition, getCondition,
-                    setCondition),
-         V_PROPERTY(CDialogOption, std::string, action, getAction, setAction))
+    V_META(CDialogOption, CGameObject, V_PROPERTY(CDialogOption, int, number, getNumber, setNumber),
+           V_PROPERTY(CDialogOption, std::string, nextStateId, getNextStateId, setNextStateId),
+           V_PROPERTY(CDialogOption, std::string, text, getText, setText),
+           V_PROPERTY(CDialogOption, std::string, condition, getCondition, setCondition),
+           V_PROPERTY(CDialogOption, std::string, action, getAction, setAction))
 
-public:
-  int getNumber() const;
+  public:
+    int getNumber() const;
 
-  void setNumber(int number);
+    void setNumber(int number);
 
-  const std::string &getText() const;
+    const std::string &getText() const;
 
-  void setText(const std::string &text);
+    void setText(const std::string &text);
 
-  const std::string &getAction() const;
+    const std::string &getAction() const;
 
-  void setAction(const std::string &action);
+    void setAction(const std::string &action);
 
-private:
-  std::string nextStateId;
+  private:
+    std::string nextStateId;
 
-public:
-  const std::string &getNextStateId() const;
+  public:
+    const std::string &getNextStateId() const;
 
-  void setNextStateId(const std::string &nextStateId);
+    void setNextStateId(const std::string &nextStateId);
 
-private:
-  int number;
+  private:
+    int number;
 
-  std::string text;
-  std::string action;
-  std::string condition;
+    std::string text;
+    std::string action;
+    std::string condition;
 
-public:
-  const std::string &getCondition() const;
+  public:
+    const std::string &getCondition() const;
 
-  void setCondition(const std::string &condition);
+    void setCondition(const std::string &condition);
 };
 
 class CDialogState : public CGameObject {
-  V_META(CDialogState, CGameObject,
-         V_PROPERTY(CDialogState, std::set<std::shared_ptr<CDialogOption>>,
-                    options, getOptions, setOptions),
-         V_PROPERTY(CDialogState, std::string, stateId, getStateId, setStateId),
-         V_PROPERTY(CDialogState, std::string, text, getText, setText))
-public:
-  const std::string &getText() const;
+    V_META(CDialogState, CGameObject,
+           V_PROPERTY(CDialogState, std::set<std::shared_ptr<CDialogOption>>, options, getOptions, setOptions),
+           V_PROPERTY(CDialogState, std::string, stateId, getStateId, setStateId),
+           V_PROPERTY(CDialogState, std::string, text, getText, setText))
+  public:
+    const std::string &getText() const;
 
-  void setText(const std::string &text);
+    void setText(const std::string &text);
 
-  const std::set<std::shared_ptr<CDialogOption>> &getOptions() const;
+    const std::set<std::shared_ptr<CDialogOption>> &getOptions() const;
 
-  void setOptions(const std::set<std::shared_ptr<CDialogOption>> &options);
+    void setOptions(const std::set<std::shared_ptr<CDialogOption>> &options);
 
-private:
-  std::string stateId;
+  private:
+    std::string stateId;
 
-public:
-  const std::string &getStateId() const;
+  public:
+    const std::string &getStateId() const;
 
-  void setStateId(const std::string &stateId);
+    void setStateId(const std::string &stateId);
 
-private:
-  std::string text;
-  std::set<std::shared_ptr<CDialogOption>> options;
+  private:
+    std::string text;
+    std::set<std::shared_ptr<CDialogOption>> options;
 };
 
 class CDialog : public CGameObject {
-  V_META(CDialog, CGameObject,
-         V_PROPERTY(CDialog, std::set<std::shared_ptr<CDialogState>>, states,
-                    getStates, setStates))
-public:
-  const std::set<std::shared_ptr<CDialogState>> &getStates() const;
+    V_META(CDialog, CGameObject,
+           V_PROPERTY(CDialog, std::set<std::shared_ptr<CDialogState>>, states, getStates, setStates))
+  public:
+    const std::set<std::shared_ptr<CDialogState>> &getStates() const;
 
-  void setStates(const std::set<std::shared_ptr<CDialogState>> &states);
+    void setStates(const std::set<std::shared_ptr<CDialogState>> &states);
 
-  std::shared_ptr<CDialogState> getState(std::string state);
+    std::shared_ptr<CDialogState> getState(std::string state);
 
-  virtual void invokeAction(std::string action);
+    virtual void invokeAction(std::string action);
 
-  virtual bool invokeCondition(std::string action);
+    virtual bool invokeCondition(std::string action);
 
-private:
-  std::set<std::shared_ptr<CDialogState>> states;
+  private:
+    std::set<std::shared_ptr<CDialogState>> states;
 };

--- a/src/object/CEffect.h
+++ b/src/object/CEffect.h
@@ -22,49 +22,48 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 class CEffect : public CGameObject {
 
-  V_META(CEffect, CGameObject,
-         V_PROPERTY(CEffect, int, duration, getDuration, setDuration),
-         V_PROPERTY(CEffect, bool, cumulative, getCumulative, setCumulative))
+    V_META(CEffect, CGameObject, V_PROPERTY(CEffect, int, duration, getDuration, setDuration),
+           V_PROPERTY(CEffect, bool, cumulative, getCumulative, setCumulative))
 
-public:
-  CEffect();
+  public:
+    CEffect();
 
-  virtual ~CEffect();
+    virtual ~CEffect();
 
-  int getTimeLeft();
+    int getTimeLeft();
 
-  int getTimeTotal();
+    int getTimeTotal();
 
-  void apply(std::shared_ptr<CCreature> creature);
+    void apply(std::shared_ptr<CCreature> creature);
 
-  std::shared_ptr<Stats> getBonus();
+    std::shared_ptr<Stats> getBonus();
 
-  void setBonus(std::shared_ptr<Stats> value);
+    void setBonus(std::shared_ptr<Stats> value);
 
-  int getDuration();
+    int getDuration();
 
-  void setDuration(int duration);
+    void setDuration(int duration);
 
-  virtual void onEffect();
+    virtual void onEffect();
 
-  std::shared_ptr<CCreature> getCaster();
+    std::shared_ptr<CCreature> getCaster();
 
-  void setCaster(std::shared_ptr<CCreature> value);
+    void setCaster(std::shared_ptr<CCreature> value);
 
-  std::shared_ptr<CCreature> getVictim();
+    std::shared_ptr<CCreature> getVictim();
 
-  void setVictim(std::shared_ptr<CCreature> value);
+    void setVictim(std::shared_ptr<CCreature> value);
 
-  void setCumulative(bool value);
+    void setCumulative(bool value);
 
-  bool getCumulative();
+    bool getCumulative();
 
-private:
-  int timeLeft = 0;
-  int timeTotal = 0;
-  std::shared_ptr<Stats> bonus = std::make_shared<Stats>();
-  std::shared_ptr<CCreature> caster;
-  std::shared_ptr<CCreature> victim;
-  int duration = 0;
-  bool cumulative = false;
+  private:
+    int timeLeft = 0;
+    int timeTotal = 0;
+    std::shared_ptr<Stats> bonus = std::make_shared<Stats>();
+    std::shared_ptr<CCreature> caster;
+    std::shared_ptr<CCreature> victim;
+    int duration = 0;
+    bool cumulative = false;
 };

--- a/src/object/CEvent.cpp
+++ b/src/object/CEvent.cpp
@@ -27,17 +27,15 @@ bool CEvent::isEnabled() { return enabled; }
 void CEvent::setEnabled(bool enabled) { this->enabled = enabled; }
 
 void CEvent::onEnter(std::shared_ptr<CGameEvent> event) {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "onEnter");
-      !override.is_none()) {
-    PY_SAFE(override(event); return;)
-  }
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "onEnter"); !override.is_none()) {
+        PY_SAFE(override(event); return;)
+    }
 }
 
 void CEvent::onLeave(std::shared_ptr<CGameEvent> event) {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "onLeave");
-      !override.is_none()) {
-    PY_SAFE(override(event); return;)
-  }
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "onLeave"); !override.is_none()) {
+        PY_SAFE(override(event); return;)
+    }
 }

--- a/src/object/CEvent.h
+++ b/src/object/CEvent.h
@@ -21,20 +21,19 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 class CEvent : public CMapObject, public Visitable {
 
-  V_META(CEvent, CMapObject,
-         V_PROPERTY(CEvent, bool, enabled, isEnabled, setEnabled))
+    V_META(CEvent, CMapObject, V_PROPERTY(CEvent, bool, enabled, isEnabled, setEnabled))
 
-public:
-  CEvent();
+  public:
+    CEvent();
 
-  bool isEnabled();
+    bool isEnabled();
 
-  void setEnabled(bool enabled);
+    void setEnabled(bool enabled);
 
-  virtual void onEnter(std::shared_ptr<CGameEvent>) override;
+    virtual void onEnter(std::shared_ptr<CGameEvent>) override;
 
-  virtual void onLeave(std::shared_ptr<CGameEvent>) override;
+    virtual void onLeave(std::shared_ptr<CGameEvent>) override;
 
-private:
-  bool enabled = true;
+  private:
+    bool enabled = true;
 };

--- a/src/object/CGameObject.cpp
+++ b/src/object/CGameObject.cpp
@@ -23,11 +23,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <utility>
 
-std::function<bool(std::shared_ptr<CGameObject>, std::shared_ptr<CGameObject>)>
-    CGameObject::name_comparator =
-        [](std::shared_ptr<CGameObject> a, std::shared_ptr<CGameObject> b) {
-          return a->getType() == b->getType();
-        };
+std::function<bool(std::shared_ptr<CGameObject>, std::shared_ptr<CGameObject>)> CGameObject::name_comparator =
+    [](std::shared_ptr<CGameObject> a, std::shared_ptr<CGameObject> b) { return a->getType() == b->getType(); };
 
 CGameObject::~CGameObject() {}
 
@@ -39,41 +36,29 @@ std::shared_ptr<CGame> CGameObject::getGame() { return game; }
 
 void CGameObject::setGame(std::shared_ptr<CGame> map) { this->game = map; }
 
-void CGameObject::setStringProperty(std::string name, std::string value) {
-  this->setProperty(name, value);
-}
+void CGameObject::setStringProperty(std::string name, std::string value) { this->setProperty(name, value); }
 
-void CGameObject::setBoolProperty(std::string name, bool value) {
-  this->setProperty(name, value);
-}
+void CGameObject::setBoolProperty(std::string name, bool value) { this->setProperty(name, value); }
 
-void CGameObject::setNumericProperty(std::string name, int value) {
-  this->setProperty(name, value);
-}
+void CGameObject::setNumericProperty(std::string name, int value) { this->setProperty(name, value); }
 
 std::string CGameObject::getStringProperty(std::string name) {
-  return this->hasProperty(name) ? this->getProperty<std::string>(name) : "";
+    return this->hasProperty(name) ? this->getProperty<std::string>(name) : "";
 }
 
-bool CGameObject::getBoolProperty(std::string name) {
-  return this->hasProperty(name) && this->getProperty<bool>(name);
-}
+bool CGameObject::getBoolProperty(std::string name) { return this->hasProperty(name) && this->getProperty<bool>(name); }
 
 int CGameObject::getNumericProperty(std::string name) {
-  return this->hasProperty(name) ? this->getProperty<int>(name) : 0;
+    return this->hasProperty(name) ? this->getProperty<int>(name) : 0;
 }
 
 void CGameObject::incProperty(std::string name, int value) {
-  this->setNumericProperty(name, this->getNumericProperty(name) + value);
+    this->setNumericProperty(name, this->getNumericProperty(name) + value);
 }
 
-std::string CGameObject::to_string() {
-  return vstd::join({getType(), getName()}, ":");
-}
+std::string CGameObject::to_string() { return vstd::join({getType(), getName()}, ":"); }
 
-std::shared_ptr<CGameObject> CGameObject::_clone() {
-  return game->getObjectHandler()->clone<CGameObject>(this->ptr());
-}
+std::shared_ptr<CGameObject> CGameObject::_clone() { return game->getObjectHandler()->clone<CGameObject>(this->ptr()); }
 
 CTags CGameObject::getTags() { return tags; }
 
@@ -89,28 +74,22 @@ void CGameObject::setName(std::string name) { this->name = name; }
 
 bool CGameObject::hasTag(CTag tag) { return tags.contains(tag); }
 
-bool CGameObject::hasTag(const std::string &tag) {
-  return hasTag(CTags::fromString(tag));
-}
+bool CGameObject::hasTag(const std::string &tag) { return hasTag(CTags::fromString(tag)); }
 
 void CGameObject::addTag(CTag tag) { tags.insert(tag); }
 
-void CGameObject::addTag(const std::string &tag) {
-  addTag(CTags::fromString(tag));
-}
+void CGameObject::addTag(const std::string &tag) { addTag(CTags::fromString(tag)); }
 
 void CGameObject::removeTag(CTag tag) { tags.erase(tag); }
 
-void CGameObject::removeTag(const std::string &tag) {
-  removeTag(CTags::fromString(tag));
-}
+void CGameObject::removeTag(const std::string &tag) { removeTag(CTags::fromString(tag)); }
 
 std::string CGameObject::getAnimation() { return animation; }
 
 void CGameObject::setAnimation(std::string animation) {
-  // TODO: implement this in AOP way
-  graphicsObject.clear();
-  this->animation = animation;
+    // TODO: implement this in AOP way
+    graphicsObject.clear();
+    this->animation = animation;
 }
 
 std::string CGameObject::getLabel() { return label; }
@@ -119,35 +98,25 @@ void CGameObject::setLabel(std::string _label) { label = _label; }
 
 std::string CGameObject::getDescription() { return description; }
 
-void CGameObject::setDescription(std::string _description) {
-  description = _description;
-}
+void CGameObject::setDescription(std::string _description) { description = _description; }
 
 std::shared_ptr<CAnimation> CGameObject::getGraphicsObject() {
-  return graphicsObject.get([this]() {
-    std::shared_ptr<CAnimation> anim =
-        CAnimationProvider::getAnimation(getGame(), this->ptr<CGameObject>());
-    for (auto [key, val] :
-         getGame()
-             ->createObject<CMapStringInt>("mapObjectPriorities")
-             ->getValues()) {
-      if (val > anim->getPriority() && this->meta()->inherits(key)) {
-        anim->setPriority(val);
-      }
-    }
-    return anim;
-  });
+    return graphicsObject.get([this]() {
+        std::shared_ptr<CAnimation> anim = CAnimationProvider::getAnimation(getGame(), this->ptr<CGameObject>());
+        for (auto [key, val] : getGame()->createObject<CMapStringInt>("mapObjectPriorities")->getValues()) {
+            if (val > anim->getPriority() && this->meta()->inherits(key)) {
+                anim->setPriority(val);
+            }
+        }
+        return anim;
+    });
 }
 
-void CGameObject::connect(std::string signal,
-                          std::shared_ptr<CGameObject> object,
-                          std::string slot) {
-  connections.emplace_back(signal, object, slot);
+void CGameObject::connect(std::string signal, std::shared_ptr<CGameObject> object, std::string slot) {
+    connections.emplace_back(signal, object, slot);
 }
 
-bool CGameObject::hasProperty(std::string name) {
-  return this->meta()->has_property<CGameObject>(name, this->ptr());
-}
+bool CGameObject::hasProperty(std::string name) { return this->meta()->has_property<CGameObject>(name, this->ptr()); }
 
 void CGameObject::setTypeId(std::string _typeId) { typeId = _typeId; }
 

--- a/src/object/CInteraction.cpp
+++ b/src/object/CInteraction.cpp
@@ -23,34 +23,32 @@ CInteraction::CInteraction() {}
 
 CInteraction::~CInteraction() {}
 
-void CInteraction::onAction(std::shared_ptr<CCreature> first,
-                            std::shared_ptr<CCreature> second) {
-  vstd::logger::debug(first->to_string(), "used", this->to_string(), "against",
-                      second->to_string());
+void CInteraction::onAction(std::shared_ptr<CCreature> first, std::shared_ptr<CCreature> second) {
+    vstd::logger::debug(first->to_string(), "used", this->to_string(), "against", second->to_string());
 
-  first->takeMana(this->getManaCost());
+    first->takeMana(this->getManaCost());
 
-  this->performAction(first, second);
+    this->performAction(first, second);
 
-  if (effect) {
-    std::shared_ptr<CEffect> effect = this->effect->clone<CEffect>();
-    effect->setCaster(first);
-    if (this->configureEffect(effect)) {
-      if (effect->getAnimation().empty()) {
-        effect->setAnimation(getAnimation());
-      }
-      if (effect->getLabel().empty()) {
-        effect->setLabel(getLabel());
-      }
-      if (effect->hasTag(CTag::Buff)) {
-        effect->setVictim(first);
-        first->addEffect(effect);
-      } else {
-        effect->setVictim(second);
-        second->addEffect(effect);
-      }
+    if (effect) {
+        std::shared_ptr<CEffect> effect = this->effect->clone<CEffect>();
+        effect->setCaster(first);
+        if (this->configureEffect(effect)) {
+            if (effect->getAnimation().empty()) {
+                effect->setAnimation(getAnimation());
+            }
+            if (effect->getLabel().empty()) {
+                effect->setLabel(getLabel());
+            }
+            if (effect->hasTag(CTag::Buff)) {
+                effect->setVictim(first);
+                first->addEffect(effect);
+            } else {
+                effect->setVictim(second);
+                second->addEffect(effect);
+            }
+        }
     }
-  }
 }
 
 int CInteraction::getManaCost() const { return manaCost; }
@@ -59,24 +57,19 @@ void CInteraction::setManaCost(int value) { manaCost = value; }
 
 std::shared_ptr<CEffect> CInteraction::getEffect() const { return effect; }
 
-void CInteraction::setEffect(const std::shared_ptr<CEffect> value) {
-  effect = value;
-}
+void CInteraction::setEffect(const std::shared_ptr<CEffect> value) { effect = value; }
 
-void CInteraction::performAction(std::shared_ptr<CCreature> first,
-                                 std::shared_ptr<CCreature> second) {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "performAction");
-      !override.is_none()) {
-    PY_SAFE(override(first, second); return;)
-  }
+void CInteraction::performAction(std::shared_ptr<CCreature> first, std::shared_ptr<CCreature> second) {
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "performAction"); !override.is_none()) {
+        PY_SAFE(override(first, second); return;)
+    }
 }
 
 bool CInteraction::configureEffect(std::shared_ptr<CEffect> effect) {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "configureEffect");
-      !override.is_none()) {
-    PY_SAFE_RET_VAL(return override(effect).cast<bool>();, true)
-  }
-  return true;
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "configureEffect"); !override.is_none()) {
+        PY_SAFE_RET_VAL(return override(effect).cast<bool>();, true)
+    }
+    return true;
 }

--- a/src/object/CInteraction.h
+++ b/src/object/CInteraction.h
@@ -28,33 +28,29 @@ class CEffect;
 
 class CInteraction : public CGameObject {
 
-  V_META(CInteraction, CGameObject,
-         V_PROPERTY(CInteraction, std::shared_ptr<CEffect>, effect, getEffect,
-                    setEffect),
-         V_PROPERTY(CInteraction, int, manaCost, getManaCost, setManaCost))
+    V_META(CInteraction, CGameObject, V_PROPERTY(CInteraction, std::shared_ptr<CEffect>, effect, getEffect, setEffect),
+           V_PROPERTY(CInteraction, int, manaCost, getManaCost, setManaCost))
 
-public:
-  CInteraction();
+  public:
+    CInteraction();
 
-  ~CInteraction();
+    ~CInteraction();
 
-  void onAction(std::shared_ptr<CCreature> first,
-                std::shared_ptr<CCreature> second);
+    void onAction(std::shared_ptr<CCreature> first, std::shared_ptr<CCreature> second);
 
-  virtual void performAction(std::shared_ptr<CCreature>,
-                             std::shared_ptr<CCreature>);
+    virtual void performAction(std::shared_ptr<CCreature>, std::shared_ptr<CCreature>);
 
-  virtual bool configureEffect(std::shared_ptr<CEffect>);
+    virtual bool configureEffect(std::shared_ptr<CEffect>);
 
-  std::shared_ptr<CEffect> getEffect() const;
+    std::shared_ptr<CEffect> getEffect() const;
 
-  void setEffect(const std::shared_ptr<CEffect> value);
+    void setEffect(const std::shared_ptr<CEffect> value);
 
-  int getManaCost() const;
+    int getManaCost() const;
 
-  void setManaCost(int value);
+    void setManaCost(int value);
 
-private:
-  int manaCost = 0;
-  std::shared_ptr<CEffect> effect;
+  private:
+    int manaCost = 0;
+    std::shared_ptr<CEffect> effect;
 };

--- a/src/object/CItem.cpp
+++ b/src/object/CItem.cpp
@@ -25,36 +25,30 @@ CItem::CItem() {}
 CItem::~CItem() {}
 
 void CItem::onEnter(std::shared_ptr<CGameEvent> event) {
-  if (std::shared_ptr<CCreature> visitor = vstd::cast<CCreature>(
-          vstd::cast<CGameEventCaused>(event)->getCause())) {
-    // ensure the item added to the inventory shares the same control block
-    // as the one stored inside the map
-    auto item = vstd::cast<CItem>(getMap()->getObjectByName(getName()));
-    visitor->addItem(item);
-    getMap()->removeObject(item);
-  }
+    if (std::shared_ptr<CCreature> visitor = vstd::cast<CCreature>(vstd::cast<CGameEventCaused>(event)->getCause())) {
+        // ensure the item added to the inventory shares the same control block
+        // as the one stored inside the map
+        auto item = vstd::cast<CItem>(getMap()->getObjectByName(getName()));
+        visitor->addItem(item);
+        getMap()->removeObject(item);
+    }
 }
 
 void CItem::onLeave(std::shared_ptr<CGameEvent>) {}
 
 void CItem::onEquip(std::shared_ptr<CGameEvent> event) {
-  vstd::logger::debug(
-      vstd::cast<CGameEventCaused>(event)->getCause()->getType(), "equipped",
-      getType(), "\n");
+    vstd::logger::debug(vstd::cast<CGameEventCaused>(event)->getCause()->getType(), "equipped", getType(), "\n");
 }
 
 void CItem::onUnequip(std::shared_ptr<CGameEvent> event) {
-  vstd::logger::debug(
-      vstd::cast<CGameEventCaused>(event)->getCause()->getType(), "unequipped",
-      getType(), "\n");
+    vstd::logger::debug(vstd::cast<CGameEventCaused>(event)->getCause()->getType(), "unequipped", getType(), "\n");
 }
 
 void CItem::onUse(std::shared_ptr<CGameEvent> event) {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "onUse");
-      !override.is_none()) {
-    PY_SAFE(override(event); return;)
-  }
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "onUse"); !override.is_none()) {
+        PY_SAFE(override(event); return;)
+    }
 }
 
 int CItem::getPower() const { return power; }
@@ -66,8 +60,8 @@ CArmor::CArmor() {}
 std::shared_ptr<CInteraction> CItem::getInteraction() { return interaction; }
 
 void CItem::setInteraction(std::shared_ptr<CInteraction> interaction) {
-  this->interaction = interaction;
-  interaction->setManaCost(0);
+    this->interaction = interaction;
+    interaction->setManaCost(0);
 }
 
 CBelt::CBelt() {}
@@ -87,12 +81,11 @@ std::shared_ptr<Stats> CItem::getBonus() { return bonus; }
 void CItem::setBonus(std::shared_ptr<Stats> stats) { bonus = stats; }
 
 bool CItem::isDisposable() {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "isDisposable");
-      !override.is_none()) {
-    PY_SAFE_RET_VAL(return override().cast<bool>();, false)
-  }
-  return false;
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "isDisposable"); !override.is_none()) {
+        PY_SAFE_RET_VAL(return override().cast<bool>();, false)
+    }
+    return false;
 }
 
 CPotion::CPotion() {}
@@ -105,6 +98,4 @@ std::string CScroll::getText() const { return text; }
 
 void CScroll::setText(const std::string &value) { text = value; }
 
-void CScroll::onUse(std::shared_ptr<CGameEvent>) {
-  getMap()->getGame()->getGuiHandler()->showMessage(text);
-}
+void CScroll::onUse(std::shared_ptr<CGameEvent>) { getMap()->getGame()->getGuiHandler()->showMessage(text); }

--- a/src/object/CItem.h
+++ b/src/object/CItem.h
@@ -24,119 +24,114 @@ class CCreature;
 
 class CInteraction;
 
-class CItem : public CMapObject,
-              public Visitable,
-              public Wearable,
-              public Usable {
+class CItem : public CMapObject, public Visitable, public Wearable, public Usable {
 
-  V_META(CItem, CMapObject, V_PROPERTY(CItem, int, power, getPower, setPower),
-         V_PROPERTY(CItem, std::shared_ptr<Stats>, bonus, getBonus, setBonus),
-         V_PROPERTY(CItem, std::shared_ptr<CInteraction>, interaction,
-                    getInteraction, setInteraction))
+    V_META(CItem, CMapObject, V_PROPERTY(CItem, int, power, getPower, setPower),
+           V_PROPERTY(CItem, std::shared_ptr<Stats>, bonus, getBonus, setBonus),
+           V_PROPERTY(CItem, std::shared_ptr<CInteraction>, interaction, getInteraction, setInteraction))
 
-public:
-  CItem();
+  public:
+    CItem();
 
-  ~CItem() override;
+    ~CItem() override;
 
-  void onEquip(std::shared_ptr<CGameEvent> event) override;
+    void onEquip(std::shared_ptr<CGameEvent> event) override;
 
-  void onUnequip(std::shared_ptr<CGameEvent> event) override;
+    void onUnequip(std::shared_ptr<CGameEvent> event) override;
 
-  void onUse(std::shared_ptr<CGameEvent> event) override;
+    void onUse(std::shared_ptr<CGameEvent> event) override;
 
-  void onEnter(std::shared_ptr<CGameEvent> event) override;
+    void onEnter(std::shared_ptr<CGameEvent> event) override;
 
-  void onLeave(std::shared_ptr<CGameEvent>) override;
+    void onLeave(std::shared_ptr<CGameEvent>) override;
 
-  int getPower() const;
+    int getPower() const;
 
-  void setPower(int value);
+    void setPower(int value);
 
-  std::shared_ptr<Stats> getBonus();
+    std::shared_ptr<Stats> getBonus();
 
-  void setBonus(std::shared_ptr<Stats> stats);
+    void setBonus(std::shared_ptr<Stats> stats);
 
-  std::shared_ptr<CInteraction> getInteraction();
+    std::shared_ptr<CInteraction> getInteraction();
 
-  void setInteraction(std::shared_ptr<CInteraction> interaction);
+    void setInteraction(std::shared_ptr<CInteraction> interaction);
 
-  virtual bool isDisposable();
+    virtual bool isDisposable();
 
-protected:
-  std::shared_ptr<Stats> bonus = std::make_shared<Stats>();
-  std::shared_ptr<CInteraction> interaction;
-  int power = 0;
+  protected:
+    std::shared_ptr<Stats> bonus = std::make_shared<Stats>();
+    std::shared_ptr<CInteraction> interaction;
+    int power = 0;
 
-private:
-  int slot = 0;
+  private:
+    int slot = 0;
 };
 
 class CArmor : public CItem {
-  V_META(CArmor, CItem, vstd::meta::empty())
-public:
-  CArmor();
+    V_META(CArmor, CItem, vstd::meta::empty())
+  public:
+    CArmor();
 };
 
 class CBelt : public CItem {
-  V_META(CBelt, CItem, vstd::meta::empty())
-public:
-  CBelt();
+    V_META(CBelt, CItem, vstd::meta::empty())
+  public:
+    CBelt();
 };
 
 class CHelmet : public CItem {
-  V_META(CHelmet, CItem, vstd::meta::empty())
-public:
-  CHelmet();
+    V_META(CHelmet, CItem, vstd::meta::empty())
+  public:
+    CHelmet();
 };
 
 class CBoots : public CItem {
-  V_META(CBoots, CItem, vstd::meta::empty())
-public:
-  CBoots();
+    V_META(CBoots, CItem, vstd::meta::empty())
+  public:
+    CBoots();
 };
 
 class CGloves : public CItem {
-  V_META(CGloves, CItem, vstd::meta::empty())
-public:
-  CGloves();
+    V_META(CGloves, CItem, vstd::meta::empty())
+  public:
+    CGloves();
 };
 
 class CWeapon : public CItem {
-  V_META(CWeapon, CItem, vstd::meta::empty())
-public:
-  CWeapon();
+    V_META(CWeapon, CItem, vstd::meta::empty())
+  public:
+    CWeapon();
 };
 
 class CSmallWeapon : public CWeapon {
-  V_META(CSmallWeapon, CWeapon, vstd::meta::empty())
-public:
-  CSmallWeapon();
+    V_META(CSmallWeapon, CWeapon, vstd::meta::empty())
+  public:
+    CSmallWeapon();
 };
 
 class CScroll : public CItem {
 
-  V_META(CScroll, CItem,
-         V_PROPERTY(CScroll, std::string, text, getText, setText))
+    V_META(CScroll, CItem, V_PROPERTY(CScroll, std::string, text, getText, setText))
 
-public:
-  CScroll();
+  public:
+    CScroll();
 
-  std::string getText() const;
+    std::string getText() const;
 
-  void setText(const std::string &value);
+    void setText(const std::string &value);
 
-  void onUse(std::shared_ptr<CGameEvent>) override;
+    void onUse(std::shared_ptr<CGameEvent>) override;
 
-private:
-  std::string text;
+  private:
+    std::string text;
 };
 
 class CPotion : public CItem {
-  V_META(CPotion, CItem, vstd::meta::empty())
+    V_META(CPotion, CItem, vstd::meta::empty())
 
-public:
-  bool isDisposable() override;
+  public:
+    bool isDisposable() override;
 
-  CPotion();
+    CPotion();
 };

--- a/src/object/CMapObject.cpp
+++ b/src/object/CMapObject.cpp
@@ -26,51 +26,44 @@ CMapObject::CMapObject() {}
 CMapObject::~CMapObject() {}
 
 void CMapObject::move(int x, int y, int z) {
-  Coords target(posx + x, posy + y, posz + z);
-  auto map = getMap();
-  if (map) {
-    target = map->normalizeCoords(target);
-  }
-
-  if (dynamic_cast<Moveable *>(this) && map) {
-    auto current = map->normalizeCoords(Coords(posx, posy, posz));
-    auto delta = map->getShortestDelta(current, target);
-    bool is_registered = map->getObjectByName(getName()) == this->ptr<CMapObject>();
-    bool is_step_move = delta.z == 0 && std::abs(delta.x) + std::abs(delta.y) == 1;
-    if (is_registered && is_step_move && !map->canStep(target)) {
-      vstd::logger::debug(getName(), "cannot step on:", target.x, target.y,
-                          target.z);
-      return;
+    Coords target(posx + x, posy + y, posz + z);
+    auto map = getMap();
+    if (map) {
+        target = map->normalizeCoords(target);
     }
-    dynamic_cast<Moveable *>(this)->beforeMove();
-  }
 
-  Coords oldCoords(posx, posy, posz);
-  posx = target.x;
-  posy = target.y;
-  posz = target.z;
-  Coords newCoords(posx, posy, posz);
+    if (dynamic_cast<Moveable *>(this) && map) {
+        auto current = map->normalizeCoords(Coords(posx, posy, posz));
+        auto delta = map->getShortestDelta(current, target);
+        bool is_registered = map->getObjectByName(getName()) == this->ptr<CMapObject>();
+        bool is_step_move = delta.z == 0 && std::abs(delta.x) + std::abs(delta.y) == 1;
+        if (is_registered && is_step_move && !map->canStep(target)) {
+            vstd::logger::debug(getName(), "cannot step on:", target.x, target.y, target.z);
+            return;
+        }
+        dynamic_cast<Moveable *>(this)->beforeMove();
+    }
 
-  if (map) {
-    map->objectMoved(this->ptr<CMapObject>(), oldCoords, newCoords);
-  }
+    Coords oldCoords(posx, posy, posz);
+    posx = target.x;
+    posy = target.y;
+    posz = target.z;
+    Coords newCoords(posx, posy, posz);
 
-  if (dynamic_cast<Moveable *>(this) && map) {
-    dynamic_cast<Moveable *>(this)->afterMove();
-  }
+    if (map) {
+        map->objectMoved(this->ptr<CMapObject>(), oldCoords, newCoords);
+    }
+
+    if (dynamic_cast<Moveable *>(this) && map) {
+        dynamic_cast<Moveable *>(this)->afterMove();
+    }
 }
 
-void CMapObject::move(Coords coords) {
-  this->move(coords.x, coords.y, coords.z);
-}
+void CMapObject::move(Coords coords) { this->move(coords.x, coords.y, coords.z); }
 
-void CMapObject::moveTo(int x, int y, int z) {
-  move(x - posx, y - posy, z - posz);
-}
+void CMapObject::moveTo(int x, int y, int z) { move(x - posx, y - posy, z - posz); }
 
-void CMapObject::moveTo(Coords coords) {
-  this->moveTo(coords.x, coords.y, coords.z);
-}
+void CMapObject::moveTo(Coords coords) { this->moveTo(coords.x, coords.y, coords.z); }
 
 int CMapObject::getPosY() const { return posy; }
 
@@ -79,48 +72,40 @@ int CMapObject::getPosZ() const { return posz; }
 int CMapObject::getPosX() const { return posx; }
 
 void CMapObject::onTurn(std::shared_ptr<CGameEvent> event) {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "onTurn");
-      !override.is_none()) {
-    PY_SAFE(override(event); return;)
-  }
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "onTurn"); !override.is_none()) {
+        PY_SAFE(override(event); return;)
+    }
 }
 
 void CMapObject::onCreate(std::shared_ptr<CGameEvent> event) {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "onCreate");
-      !override.is_none()) {
-    PY_SAFE(override(event); return;)
-  }
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "onCreate"); !override.is_none()) {
+        PY_SAFE(override(event); return;)
+    }
 }
 
 void CMapObject::onDestroy(std::shared_ptr<CGameEvent> event) {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "onDestroy");
-      !override.is_none()) {
-    PY_SAFE(override(event); return;)
-  }
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "onDestroy"); !override.is_none()) {
+        PY_SAFE(override(event); return;)
+    }
 }
 
 Coords CMapObject::getCoords() { return Coords(posx, posy, posz); }
 
-void CMapObject::setCoords(Coords coords) {
-  this->moveTo(coords.x, coords.y, coords.z);
-}
+void CMapObject::setCoords(Coords coords) { this->moveTo(coords.x, coords.y, coords.z); }
 
 bool CMapObject::isAffiliatedWith(std::shared_ptr<CMapObject> object) {
-  return !vstd::is_empty(this->getAffiliation()) &&
-         !vstd::is_empty(object->getAffiliation()) &&
-         this->getAffiliation() == object->getAffiliation();
+    return !vstd::is_empty(this->getAffiliation()) && !vstd::is_empty(object->getAffiliation()) &&
+           this->getAffiliation() == object->getAffiliation();
 }
 
 void CMapObject::setPosX(int posx) { this->posx = posx; }
 
 std::string CMapObject::getAffiliation() { return affiliation; }
 
-void CMapObject::setAffiliation(const std::string &affiliation) {
-  CMapObject::affiliation = affiliation;
-}
+void CMapObject::setAffiliation(const std::string &affiliation) { CMapObject::affiliation = affiliation; }
 
 void CMapObject::setPosY(int posy) { this->posy = posy; }
 

--- a/src/object/CMapObject.h
+++ b/src/object/CMapObject.h
@@ -27,65 +27,62 @@ class CMap;
 class CCreature;
 
 class CMapObject : public CGameObject, public Creatable, public Turnable {
-  friend class CObjectHandler;
+    friend class CObjectHandler;
 
-  V_META(CMapObject, CGameObject,
-         V_PROPERTY(CMapObject, int, posx, getPosX, setPosX),
-         V_PROPERTY(CMapObject, int, posy, getPosY, setPosY),
-         V_PROPERTY(CMapObject, int, posz, getPosZ, setPosZ),
-         V_PROPERTY(CMapObject, bool, canStep, getCanStep, setCanStep),
-         V_PROPERTY(CMapObject, std::string, affiliation, getAffiliation,
-                    setAffiliation))
+    V_META(CMapObject, CGameObject, V_PROPERTY(CMapObject, int, posx, getPosX, setPosX),
+           V_PROPERTY(CMapObject, int, posy, getPosY, setPosY), V_PROPERTY(CMapObject, int, posz, getPosZ, setPosZ),
+           V_PROPERTY(CMapObject, bool, canStep, getCanStep, setCanStep),
+           V_PROPERTY(CMapObject, std::string, affiliation, getAffiliation, setAffiliation))
 
-public:
-  CMapObject();
+  public:
+    CMapObject();
 
-  virtual ~CMapObject();
+    virtual ~CMapObject();
 
-  void setPosX(int posx);
+    void setPosX(int posx);
 
-  void setPosY(int posy);
+    void setPosY(int posy);
 
-  void setPosZ(int posz);
+    void setPosZ(int posz);
 
-  std::string getAffiliation();
+    std::string getAffiliation();
 
-  void setAffiliation(const std::string &affiliation);
+    void setAffiliation(const std::string &affiliation);
 
-  int getPosX() const;
+    int getPosX() const;
 
-  int getPosY() const;
+    int getPosY() const;
 
-  int getPosZ() const;
+    int getPosZ() const;
 
-  virtual void onTurn(std::shared_ptr<CGameEvent>) override;
+    virtual void onTurn(std::shared_ptr<CGameEvent>) override;
 
-  virtual void onCreate(std::shared_ptr<CGameEvent>) override;
+    virtual void onCreate(std::shared_ptr<CGameEvent>) override;
 
-  virtual void onDestroy(std::shared_ptr<CGameEvent>) override;
+    virtual void onDestroy(std::shared_ptr<CGameEvent>) override;
 
-  Coords getCoords();
+    Coords getCoords();
 
-  void setCoords(Coords coords);
+    void setCoords(Coords coords);
 
-  virtual void move(int x, int y, int z);
+    virtual void move(int x, int y, int z);
 
-  void move(Coords coords);
+    void move(Coords coords);
 
-  void moveTo(int x, int y, int z);
+    void moveTo(int x, int y, int z);
 
-  void moveTo(Coords coords);
+    void moveTo(Coords coords);
 
-  bool isAffiliatedWith(std::shared_ptr<CMapObject> object);
+    bool isAffiliatedWith(std::shared_ptr<CMapObject> object);
 
-  bool getCanStep();
+    bool getCanStep();
 
-  void setCanStep(bool step);
+    void setCanStep(bool step);
 
-private:
-  int posx = 0;
-  int posy = 0;
-  int posz = 0;
-  bool canStep = true;
-  std::string affiliation;
+  private:
+    int posx = 0;
+    int posy = 0;
+    int posz = 0;
+    bool canStep = true;
+    std::string affiliation;
 };

--- a/src/object/CMarket.cpp
+++ b/src/object/CMarket.cpp
@@ -24,23 +24,23 @@ CMarket::CMarket() {}
 CMarket::~CMarket() {}
 
 void CMarket::add(std::shared_ptr<CItem> item) {
-  items.insert(item);
-  signal("itemsChanged");
+    items.insert(item);
+    signal("itemsChanged");
 }
 
 void CMarket::remove(std::shared_ptr<CItem> item) {
-  if (items.erase(item)) {
-    signal("itemsChanged");
-  }
+    if (items.erase(item)) {
+        signal("itemsChanged");
+    }
 }
 
 void CMarket::setItems(std::set<std::shared_ptr<CItem>> _items) {
-  while (items.size() > 0) { // TODO: extract this to macro
-    remove(*items.begin());
-  }
-  for (auto item : _items) {
-    add(item);
-  }
+    while (items.size() > 0) { // TODO: extract this to macro
+        remove(*items.begin());
+    }
+    for (auto item : _items) {
+        add(item);
+    }
 }
 
 std::set<std::shared_ptr<CItem>> CMarket::getItems() { return items; }
@@ -53,33 +53,31 @@ int CMarket::getBuy() const { return buy; }
 
 void CMarket::setBuy(int value) { buy = value; }
 
-bool CMarket::sellItem(std::shared_ptr<CCreature> cre,
-                       std::shared_ptr<CItem> item) {
-  int price = getSellCost(item);
-  vstd::fail_if(!vstd::ctn(items, item), "tried to sell item not on sell");
-  if (cre->getGold() < price) {
-    return false;
-  }
-  cre->addGold(-price);
-  cre->addItem(item);
-  remove(item);
-  return true;
+bool CMarket::sellItem(std::shared_ptr<CCreature> cre, std::shared_ptr<CItem> item) {
+    int price = getSellCost(item);
+    vstd::fail_if(!vstd::ctn(items, item), "tried to sell item not on sell");
+    if (cre->getGold() < price) {
+        return false;
+    }
+    cre->addGold(-price);
+    cre->addItem(item);
+    remove(item);
+    return true;
 }
 
 int CMarket::getSellCost(std::shared_ptr<CItem> item) {
-  return (int)(pow(2, item->getPower()) * 200.0 * ((double)getSell()) / 100.0);
+    return (int)(pow(2, item->getPower()) * 200.0 * ((double)getSell()) / 100.0);
 }
 
-void CMarket::buyItem(std::shared_ptr<CCreature> cre,
-                      std::shared_ptr<CItem> item) {
-  int price = getBuyCost(item);
-  std::set<std::shared_ptr<CItem>> items = cre->getInInventory();
-  vstd::fail_if(!vstd::ctn(items, item), "tried to sell not owned item");
-  cre->addGold(price);
-  add(item);
-  cre->removeItem(item);
+void CMarket::buyItem(std::shared_ptr<CCreature> cre, std::shared_ptr<CItem> item) {
+    int price = getBuyCost(item);
+    std::set<std::shared_ptr<CItem>> items = cre->getInInventory();
+    vstd::fail_if(!vstd::ctn(items, item), "tried to sell not owned item");
+    cre->addGold(price);
+    add(item);
+    cre->removeItem(item);
 }
 
 int CMarket::getBuyCost(std::shared_ptr<CItem> item) {
-  return (int)(pow(2, item->getPower()) * 200.0 * ((double)getBuy()) / 100.0);
+    return (int)(pow(2, item->getPower()) * 200.0 * ((double)getBuy()) / 100.0);
 }

--- a/src/object/CMarket.h
+++ b/src/object/CMarket.h
@@ -26,43 +26,40 @@ class CCreature;
 
 class CMarket : public CGameObject {
 
-  V_META(CMarket, CGameObject,
-         V_PROPERTY(CMarket, std::set<std::shared_ptr<CItem>>, items, getItems,
-                    setItems),
-         V_PROPERTY(CMarket, int, sell, getSell, setSell),
-         V_PROPERTY(CMarket, int, buy, getBuy, setBuy))
+    V_META(CMarket, CGameObject, V_PROPERTY(CMarket, std::set<std::shared_ptr<CItem>>, items, getItems, setItems),
+           V_PROPERTY(CMarket, int, sell, getSell, setSell), V_PROPERTY(CMarket, int, buy, getBuy, setBuy))
 
-public:
-  CMarket();
+  public:
+    CMarket();
 
-  ~CMarket();
+    ~CMarket();
 
-  void add(std::shared_ptr<CItem> item);
+    void add(std::shared_ptr<CItem> item);
 
-  void remove(std::shared_ptr<CItem> item);
+    void remove(std::shared_ptr<CItem> item);
 
-  bool sellItem(std::shared_ptr<CCreature> cre, std::shared_ptr<CItem> item);
+    bool sellItem(std::shared_ptr<CCreature> cre, std::shared_ptr<CItem> item);
 
-  void buyItem(std::shared_ptr<CCreature> cre, std::shared_ptr<CItem> item);
+    void buyItem(std::shared_ptr<CCreature> cre, std::shared_ptr<CItem> item);
 
-  void setItems(std::set<std::shared_ptr<CItem>> items);
+    void setItems(std::set<std::shared_ptr<CItem>> items);
 
-  std::set<std::shared_ptr<CItem>> getItems();
+    std::set<std::shared_ptr<CItem>> getItems();
 
-  int getSell() const;
+    int getSell() const;
 
-  void setSell(int value);
+    void setSell(int value);
 
-  int getBuy() const;
+    int getBuy() const;
 
-  void setBuy(int value);
+    void setBuy(int value);
 
-  int getSellCost(std::shared_ptr<CItem> item);
+    int getSellCost(std::shared_ptr<CItem> item);
 
-  int getBuyCost(std::shared_ptr<CItem> item);
+    int getBuyCost(std::shared_ptr<CItem> item);
 
-private:
-  std::set<std::shared_ptr<CItem>> items;
-  int sell = 100;
-  int buy = 80;
+  private:
+    std::set<std::shared_ptr<CItem>> items;
+    int sell = 100;
+    int buy = 80;
 };

--- a/src/object/CPlayer.cpp
+++ b/src/object/CPlayer.cpp
@@ -22,46 +22,41 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <utility>
 
 void CPlayer::checkQuests() {
-  auto set = quests;
-  for (const auto &quest : set) {
-    if (quest->isCompleted()) {
-      quest->onComplete();
-      quests.erase(quests.find(quest));
-      completedQuests.insert(quest);
+    auto set = quests;
+    for (const auto &quest : set) {
+        if (quest->isCompleted()) {
+            quest->onComplete();
+            quests.erase(quests.find(quest));
+            completedQuests.insert(quest);
+        }
     }
-  }
 }
 
 void CPlayer::addQuest(std::string questName) {
-  for (const auto &q : quests) {
-    if (q->getName() == questName) {
-      return;
+    for (const auto &q : quests) {
+        if (q->getName() == questName) {
+            return;
+        }
     }
-  }
-  for (const auto &q : completedQuests) {
-    if (q->getName() == questName) {
-      return;
+    for (const auto &q : completedQuests) {
+        if (q->getName() == questName) {
+            return;
+        }
     }
-  }
-  std::shared_ptr<CQuest> quest = getGame()->createObject<CQuest>(questName);
-  if (quest) {
-    quests.insert(quest);
-  }
+    std::shared_ptr<CQuest> quest = getGame()->createObject<CQuest>(questName);
+    if (quest) {
+        quests.insert(quest);
+    }
 }
 
 std::set<std::shared_ptr<CQuest>> CPlayer::getQuests() { return quests; }
 
-void CPlayer::setQuests(std::set<std::shared_ptr<CQuest>> _quests) {
-  this->quests = std::move(_quests);
-}
+void CPlayer::setQuests(std::set<std::shared_ptr<CQuest>> _quests) { this->quests = std::move(_quests); }
 
-std::set<std::shared_ptr<CQuest>> CPlayer::getCompletedQuests() {
-  return completedQuests;
-}
+std::set<std::shared_ptr<CQuest>> CPlayer::getCompletedQuests() { return completedQuests; }
 
-void CPlayer::setCompletedQuests(
-    std::set<std::shared_ptr<CQuest>> _completedQuests) {
-  completedQuests = std::move(_completedQuests);
+void CPlayer::setCompletedQuests(std::set<std::shared_ptr<CQuest>> _completedQuests) {
+    completedQuests = std::move(_completedQuests);
 }
 
 void CPlayer::incTurn() { turn++; }

--- a/src/object/CPlayer.h
+++ b/src/object/CPlayer.h
@@ -22,34 +22,32 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 class CQuest;
 
 class CPlayer : public CCreature {
-  V_META(CPlayer, CCreature,
-         V_PROPERTY(CPlayer, std::set<std::shared_ptr<CQuest>>, quests,
-                    getQuests, setQuests),
-         V_PROPERTY(CPlayer, std::set<std::shared_ptr<CQuest>>, completedQuests,
-                    getCompletedQuests, setCompletedQuests))
+    V_META(CPlayer, CCreature, V_PROPERTY(CPlayer, std::set<std::shared_ptr<CQuest>>, quests, getQuests, setQuests),
+           V_PROPERTY(CPlayer, std::set<std::shared_ptr<CQuest>>, completedQuests, getCompletedQuests,
+                      setCompletedQuests))
 
-public:
-  CPlayer() = default;
+  public:
+    CPlayer() = default;
 
-  ~CPlayer() override = default;
+    ~CPlayer() override = default;
 
-  void addQuest(std::string questName);
+    void addQuest(std::string questName);
 
-  std::set<std::shared_ptr<CQuest>> getQuests();
+    std::set<std::shared_ptr<CQuest>> getQuests();
 
-  void setQuests(std::set<std::shared_ptr<CQuest>> quests);
+    void setQuests(std::set<std::shared_ptr<CQuest>> quests);
 
-  std::set<std::shared_ptr<CQuest>> getCompletedQuests();
+    std::set<std::shared_ptr<CQuest>> getCompletedQuests();
 
-  void setCompletedQuests(std::set<std::shared_ptr<CQuest>> completedQuests);
+    void setCompletedQuests(std::set<std::shared_ptr<CQuest>> completedQuests);
 
-  void checkQuests();
+    void checkQuests();
 
-  void incTurn();
+    void incTurn();
 
-private:
-  std::set<std::shared_ptr<CQuest>> quests;
-  std::set<std::shared_ptr<CQuest>> completedQuests;
+  private:
+    std::set<std::shared_ptr<CQuest>> quests;
+    std::set<std::shared_ptr<CQuest>> completedQuests;
 
-  int turn = 0;
+    int turn = 0;
 };

--- a/src/object/CQuest.cpp
+++ b/src/object/CQuest.cpp
@@ -21,24 +21,20 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 CQuest::CQuest() {}
 
 bool CQuest::isCompleted() {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "isCompleted");
-      !override.is_none()) {
-    PY_SAFE_RET_VAL(return override().cast<bool>();, false)
-  }
-  return false;
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "isCompleted"); !override.is_none()) {
+        PY_SAFE_RET_VAL(return override().cast<bool>();, false)
+    }
+    return false;
 }
 
 void CQuest::onComplete() {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "onComplete");
-      !override.is_none()) {
-    PY_SAFE(override(); return;)
-  }
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "onComplete"); !override.is_none()) {
+        PY_SAFE(override(); return;)
+    }
 }
 
-void CQuest::setDescription(std::string description) {
-  this->description = description;
-}
+void CQuest::setDescription(std::string description) { this->description = description; }
 
 std::string CQuest::getDescription() { return description; }

--- a/src/object/CQuest.h
+++ b/src/object/CQuest.h
@@ -20,20 +20,18 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CGameObject.h"
 
 class CQuest : public CGameObject {
-  V_META(CQuest, CGameObject,
-         V_PROPERTY(CQuest, std::string, description, getDescription,
-                    setDescription))
-public:
-  CQuest();
+    V_META(CQuest, CGameObject, V_PROPERTY(CQuest, std::string, description, getDescription, setDescription))
+  public:
+    CQuest();
 
-  virtual bool isCompleted();
+    virtual bool isCompleted();
 
-  virtual void onComplete();
+    virtual void onComplete();
 
-  std::string getDescription();
+    std::string getDescription();
 
-  void setDescription(std::string description);
+    void setDescription(std::string description);
 
-private:
-  std::string description = "";
+  private:
+    std::string description = "";
 };

--- a/src/object/CTrigger.cpp
+++ b/src/object/CTrigger.cpp
@@ -21,13 +21,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 CTrigger::CTrigger() {}
 
-void CTrigger::trigger(std::shared_ptr<CGameObject> object,
-                       std::shared_ptr<CGameEvent> event) {
-  pybind11::gil_scoped_acquire gil;
-  if (auto override = CPythonOverrides::find_override(this, "trigger");
-      !override.is_none()) {
-    PY_SAFE(override(object, event); return;)
-  }
+void CTrigger::trigger(std::shared_ptr<CGameObject> object, std::shared_ptr<CGameEvent> event) {
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "trigger"); !override.is_none()) {
+        PY_SAFE(override(object, event); return;)
+    }
 }
 
 std::string CTrigger::getObject() { return object; }
@@ -38,7 +36,6 @@ std::string CTrigger::getEvent() { return event; }
 
 void CTrigger::setEvent(std::string event) { CTrigger::event = event; }
 
-void CCustomTrigger::trigger(std::shared_ptr<CGameObject> object,
-                             std::shared_ptr<CGameEvent> event) {
-  _trigger(object, event);
+void CCustomTrigger::trigger(std::shared_ptr<CGameObject> object, std::shared_ptr<CGameEvent> event) {
+    _trigger(object, event);
 }


### PR DESCRIPTION
### Motivation

- Normalize C/C++ source formatting across the engine to a consistent `clang-format` style. 
- Keep changes strictly formatting-only so no runtime behavior is intended to change. 
- Make future diffs easier to review by removing incidental whitespace/linebreak differences. 
- Apply formatting across core, GUI, handler, and object model files.

### Description

- Ran `clang-format -i` on all tracked C/C++ source and header files in the repository, producing formatting-only edits across many files (examples: `src/core/CFuture.cpp`, `src/gui/panel/CGamePanel.cpp`, `src/object/CPlayer.cpp`).
- No functional code changes were made; edits are limited to whitespace, indentation, line-wrapping and minor reflow of declarations and statements. 
- The changes were committed with message: `Run clang-format across C++ source tree` (commit `fba214c`).
- Only tracked C/C++ files were modified; submodules and generated artifacts were not touched.

### Testing

- Built the `_game` target and test binaries with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` and the build completed successfully. 
- Ran the unit-test runner with `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` and the `for_unit_tests` CTest passed. 
- Ran the full Python test suite with `python3 test.py` and it completed successfully (`126` tests run, `19` skipped, all passing). 
- Note: an initial run of `ctest` and `python3 test.py` failed prior to building `_game` due to the `for_unit_tests` executable being absent and `ModuleNotFoundError: No module named '_game'`, and those failures were resolved after building the project.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d36c694883268f022889e118b5cd)