### PR TITLE
docs: require tests for every bug fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,8 @@ The Python tests require the compiled `_game` module for most runtime paths. Tes
 
 When validation cannot be run, do not imply that it passed. Report the exact command that was skipped or failed and the reason.
 
+Every bug fix must include at least one corresponding automated test (unit, integration, or regression) that fails before the fix and passes after it.
+
 ## Coverage
 
 Run coverage when a change touches:


### PR DESCRIPTION
### Motivation
- Ensure every bug fix is accompanied by automated test coverage so regressions are prevented and fixes are verifiable.

### Description
- Added a sentence to `AGENTS.md` under the "Required validation" section requiring that every bug fix include at least one corresponding automated test (unit, integration, or regression) that fails before the fix and passes after it.

### Testing
- No automated tests were run because this is a documentation-only change and does not modify code or test behavior; the required validation workflow was intentionally skipped: `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`, `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`, and `python3 test.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f5353e8c8326b10ab001158941ff)