### PR TITLE
Optimize proxy graphics refresh

### DIFF
--- a/src/gui/object/CMapGraphicsObject.cpp
+++ b/src/gui/object/CMapGraphicsObject.cpp
@@ -42,58 +42,78 @@ std::shared_ptr<CAnimation> CMapGraphicsObject::syncProxyAnimation(std::shared_p
 
 std::list<std::shared_ptr<CGameGraphicsObject>> CMapGraphicsObject::getProxiedObjects(std::shared_ptr<CGui> gui, int x,
                                                                                       int y) {
-    return vstd::with<std::list<std::shared_ptr<CGameGraphicsObject>>>(gui->getGame()->getMap(), [&](auto map) {
-        std::list<std::shared_ptr<CGameGraphicsObject>> return_val;
+    auto game = gui->getGame();
+    auto map = game->getMap();
+    if (!map) {
+        return {};
+    }
+    if (cachedMap.lock() != map) {
+        proxyAnimations.clear();
+        cachedMap = map;
+        hasCachedProxyZ = false;
+    }
 
-        std::shared_ptr<CPlayer> player = gui->getGame()->getMap()->getPlayer();
-        auto proxyCoords = Coords(x, y, player->getCoords().z);
-        auto actualCoords = map->normalizeCoords(guiToMap(gui, Coords(x, y, player->getCoords().z)));
-        auto &slot = proxyAnimations[proxyCoords];
+    std::list<std::shared_ptr<CGameGraphicsObject>> return_val;
+    std::shared_ptr<CPlayer> player = map->getPlayer();
+    auto playerCoords = player->getCoords();
+    if (!hasCachedProxyZ || cachedProxyZ != playerCoords.z) {
+        proxyAnimations.clear();
+        cachedProxyZ = playerCoords.z;
+        hasCachedProxyZ = true;
+    }
 
-        std::shared_ptr<CTile> tile = map->getTile(actualCoords.x, actualCoords.y, actualCoords.z);
+    auto proxyCoords = Coords(x, y, playerCoords.z);
+    int tileCountX = gui->getTileCountX();
+    int tileCountY = gui->getTileCountY();
+    auto rawCoords = Coords(playerCoords.x - tileCountX / 2 + x, playerCoords.y - tileCountY / 2 + y, playerCoords.z);
+    auto actualCoords = map->normalizeCoords(rawCoords);
+    auto &slot = proxyAnimations[proxyCoords];
 
-        return_val.push_back(
-            syncProxyAnimation(gui, tile, slot.tile)
-                ->withCallback([actualCoords](std::shared_ptr<CGui> gui, SDL_EventType type, int button, int, int) {
-                    if (type == SDL_MOUSEBUTTONDOWN && button == SDL_BUTTON_LEFT) {
-                        auto controller =
-                            vstd::cast<CPlayerController>(gui->getGame()->getMap()->getPlayer()->getController());
-                        if (!controller) {
-                            return false;
-                        }
-                        auto player = gui->getGame()->getMap()->getPlayer();
-                        controller->setTarget(player, actualCoords);
-                        if (!gui->getMap()->isMoving()) {
-                            while (!controller->isCompleted(player)) {
-                                gui->getGame()->getMap()->move();
-                            }
-                        }
-                        return true;
+    std::shared_ptr<CTile> tile = map->getTile(actualCoords.x, actualCoords.y, actualCoords.z);
+    return_val.push_back(
+        syncProxyAnimation(gui, tile, slot.tile)
+            ->withCallback([actualCoords](std::shared_ptr<CGui> gui, SDL_EventType type, int button, int, int) {
+                if (type == SDL_MOUSEBUTTONDOWN && button == SDL_BUTTON_LEFT) {
+                    auto game = gui->getGame();
+                    auto map = game->getMap();
+                    auto player = map->getPlayer();
+                    auto controller = vstd::cast<CPlayerController>(player->getController());
+                    if (!controller) {
+                        return false;
                     }
-                    return false;
-                }));
+                    controller->setTarget(player, actualCoords);
+                    if (!map->isMoving()) {
+                        while (!controller->isCompleted(player)) {
+                            map->move();
+                        }
+                    }
+                    return true;
+                }
+                return false;
+            }));
 
-        auto objects = map->getObjectsAtCoords(actualCoords);
+    auto objects = map->getObjectsAtCoords(actualCoords);
+    if (slot.objects.size() != objects.size()) {
         slot.objects.resize(objects.size());
-        std::size_t objectIndex = 0;
-        for (const auto &ob : objects) {
-            return_val.push_back(syncProxyAnimation(gui, ob, slot.objects[objectIndex]));
-            objectIndex++;
-        }
+    }
+    std::size_t objectIndex = 0;
+    for (const auto &ob : objects) {
+        return_val.push_back(syncProxyAnimation(gui, ob, slot.objects[objectIndex]));
+        objectIndex++;
+    }
 
-        if (map->getBoolProperty("showCoordinates")) {
-            showCoordinates(gui, return_val, actualCoords);
-        }
+    if (map->getBoolProperty("showCoordinates")) {
+        showCoordinates(gui, return_val, actualCoords);
+    }
 
-        auto playerController = vstd::cast<CPlayerController>(player->getController());
-        auto path = playerController ? playerController->isOnPath(player, actualCoords)
-                                     : std::make_pair(false, Coords::UNDEFINED);
-        if (path.first) {
-            showFootprint(gui, path.second, return_val);
-        }
+    auto playerController = vstd::cast<CPlayerController>(player->getController());
+    auto path =
+        playerController ? playerController->isOnPath(player, actualCoords) : std::make_pair(false, Coords::UNDEFINED);
+    if (path.first) {
+        showFootprint(gui, path.second, return_val);
+    }
 
-        return return_val;
-    });
+    return return_val;
 }
 
 void CMapGraphicsObject::showCoordinates(std::shared_ptr<CGui> &gui,
@@ -221,4 +241,28 @@ void CMapGraphicsObject::refreshObject(Coords coords) {
 
     auto translated = mapToGui(gui, normalized);
     CProxyTargetGraphicsObject::refreshObject(translated.x, translated.y);
+}
+
+void CMapGraphicsObject::onProxyGridResized(int sizeX, int sizeY) {
+    auto gui = getGui();
+    auto map = gui->getGame()->getMap();
+    if (!map) {
+        proxyAnimations.clear();
+        cachedMap.reset();
+        hasCachedProxyZ = false;
+        return;
+    }
+    auto player = map->getPlayer();
+    pruneProxyAnimationCache(sizeX, sizeY, player->getCoords().z);
+}
+
+void CMapGraphicsObject::pruneProxyAnimationCache(int sizeX, int sizeY, int z) {
+    for (auto it = proxyAnimations.begin(); it != proxyAnimations.end();) {
+        const auto &coords = it->first;
+        if (coords.x < 0 || coords.x >= sizeX || coords.y < 0 || coords.y >= sizeY || coords.z != z) {
+            it = proxyAnimations.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }

--- a/src/gui/object/CMapGraphicsObject.h
+++ b/src/gui/object/CMapGraphicsObject.h
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/object/CProxyTargetGraphicsObject.h"
 
 class CProxyGraphicsObject;
+class CMap;
 
 class CMapGraphicsObject : public CProxyTargetGraphicsObject {
     V_META(CMapGraphicsObject, CProxyTargetGraphicsObject, V_METHOD(CMapGraphicsObject, initialize),
@@ -51,6 +52,9 @@ class CMapGraphicsObject : public CProxyTargetGraphicsObject {
     };
 
     std::unordered_map<Coords, ProxyAnimationSlot> proxyAnimations;
+    std::weak_ptr<CMap> cachedMap;
+    int cachedProxyZ = 0;
+    bool hasCachedProxyZ = false;
 
     Coords guiToMap(std::shared_ptr<CGui> gui, Coords coords);
 
@@ -65,4 +69,8 @@ class CMapGraphicsObject : public CProxyTargetGraphicsObject {
 
     void showFootprint(std::shared_ptr<CGui> &gui, Coords::Direction dir,
                        std::list<std::shared_ptr<CGameGraphicsObject>> &return_val) const;
+
+    void onProxyGridResized(int sizeX, int sizeY) override;
+
+    void pruneProxyAnimationCache(int sizeX, int sizeY, int z);
 };

--- a/src/gui/object/CProxyGraphicsObject.cpp
+++ b/src/gui/object/CProxyGraphicsObject.cpp
@@ -16,18 +16,38 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "gui/object/CProxyGraphicsObject.h"
-#include "core/CController.h"
-#include "core/CLoader.h"
-#include "gui/CLayout.h"
-#include "gui/object/CMapGraphicsObject.h"
 #include "gui/object/CProxyTargetGraphicsObject.h"
-#include "gui/panel/CGameInventoryPanel.h"
+
+#include <set>
+
+namespace {
+bool hasSameProxyChildren(const std::list<std::shared_ptr<CGameGraphicsObject>> &objects,
+                          const std::set<std::shared_ptr<CGameGraphicsObject>, priority_comparator> &children) {
+    if (objects.size() != children.size()) {
+        return false;
+    }
+    for (const auto &object : objects) {
+        auto current = children.find(object);
+        if (current == children.end() || (*current)->getPriority() != object->getPriority() ||
+            (*current)->meta()->name() != object->meta()->name()) {
+            return false;
+        }
+    }
+    return true;
+}
+} // namespace
 
 CProxyGraphicsObject::CProxyGraphicsObject(int x, int y) : x(x), y(y) {}
 
 void CProxyGraphicsObject::refresh() {
     vstd::with<void>(getGui(), [this](auto gui) {
-        auto objects = vstd::cast<CProxyTargetGraphicsObject>(getParent())->getProxiedObjects(gui, x, y);
+        auto target = vstd::cast<CProxyTargetGraphicsObject>(getParent());
+        auto objects = target->getProxiedObjects(gui, x, y);
+
+        if (hasSameProxyChildren(objects, children)) {
+            return;
+        }
+
         setChildren(std::set<std::shared_ptr<CGameGraphicsObject>>(objects.begin(), objects.end()));
     });
 }

--- a/src/gui/object/CProxyTargetGraphicsObject.cpp
+++ b/src/gui/object/CProxyTargetGraphicsObject.cpp
@@ -51,6 +51,7 @@ void CProxyTargetGraphicsObject::refresh() {
         }
 
         if (xDiff != 0 || yDiff != 0) {
+            onProxyGridResized(currentSizeX, currentSizeY);
             refreshAll();
         }
     });
@@ -66,28 +67,44 @@ void CProxyTargetGraphicsObject::addProxyObject(std::shared_ptr<CGui> gui, int &
 }
 
 void CProxyTargetGraphicsObject::removeProxyObject(int &x, int &y) {
-    removeChild(proxyObjects[x][y]);
-    proxyObjects[x].erase(y);
-    if (proxyObjects[x].empty()) {
-        proxyObjects.erase(x);
+    auto xIt = proxyObjects.find(x);
+    if (xIt == proxyObjects.end()) {
+        return;
+    }
+    auto yIt = xIt->second.find(y);
+    if (yIt == xIt->second.end()) {
+        return;
+    }
+    removeChild(yIt->second);
+    xIt->second.erase(yIt);
+    if (xIt->second.empty()) {
+        proxyObjects.erase(xIt);
     }
 }
 
 void CProxyTargetGraphicsObject::refreshAll() {
-    for (auto [_x, map_x] : proxyObjects) {
-        for (auto [no, val] : map_x) {
+    for (auto &[_x, map_x] : proxyObjects) {
+        for (auto &[no, val] : map_x) {
             val->refresh();
         }
     }
 }
 
 void CProxyTargetGraphicsObject::refreshObject(int x, int y) {
-    int sizeX = getSizeX(getGui());
-    int sizeY = getSizeY(getGui());
+    auto gui = getGui();
+    int sizeX = getSizeX(gui);
+    int sizeY = getSizeY(gui);
     if (x < 0 || x >= sizeX || y < 0 || y >= sizeY) {
         vstd::logger::warning("Ignoring proxy refresh outside target bounds:", x, y, "size:", sizeX, sizeY);
-    } else {
-        proxyObjects[x][y]->refresh();
+        return;
+    }
+    auto xIt = proxyObjects.find(x);
+    if (xIt == proxyObjects.end()) {
+        return;
+    }
+    auto yIt = xIt->second.find(y);
+    if (yIt != xIt->second.end()) {
+        yIt->second->refresh();
     }
 }
 
@@ -103,3 +120,5 @@ std::list<std::shared_ptr<CGameGraphicsObject>> CProxyTargetGraphicsObject::getP
 std::string CProxyTargetGraphicsObject::getProxyLayout() { return proxyLayout; }
 
 void CProxyTargetGraphicsObject::setProxyLayout(std::string _layout) { proxyLayout = std::move(_layout); }
+
+void CProxyTargetGraphicsObject::onProxyGridResized(int sizeX, int sizeY) {}

--- a/src/gui/object/CProxyTargetGraphicsObject.h
+++ b/src/gui/object/CProxyTargetGraphicsObject.h
@@ -38,6 +38,9 @@ class CProxyTargetGraphicsObject : public CGameGraphicsObject {
     std::map<int, std::map<int, std::shared_ptr<CProxyGraphicsObject>>> proxyObjects;
     std::string proxyLayout = "CProxyGraphicsLayout";
 
+  protected:
+    virtual void onProxyGridResized(int sizeX, int sizeY);
+
   public:
     std::string getProxyLayout();
 

--- a/test.py
+++ b/test.py
@@ -2434,6 +2434,103 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_map_proxy_refresh_reuses_children_and_updates_changed_cells(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.loadGui(g)
+        game.CGameLoader.startGameWithPlayer(g, "test", "Warrior")
+        pump_event_loop()
+
+        gui = g.getGui()
+        game_map = g.getMap()
+        player = game_map.getPlayer()
+        map_graph = next(child for child in collect_gui_children(gui, "CMapGraphicsObject"))
+
+        def represented_object(graphic):
+            try:
+                return graphic.getObject()
+            except AttributeError:
+                return None
+
+        def proxy_with_object(object_name):
+            for proxy in map_graph.getChildren():
+                for child in proxy.getChildren():
+                    represented = represented_object(child)
+                    if represented and represented.getName() == object_name:
+                        return proxy
+            return None
+
+        def proxy_has_type_id(proxy, type_id):
+            return any(
+                represented and represented.getTypeId() == type_id
+                for represented in (represented_object(child) for child in proxy.getChildren())
+            )
+
+        def has_footprint_overlay():
+            for proxy in map_graph.getChildren():
+                for child in proxy.getChildren():
+                    represented = represented_object(child)
+                    if represented and represented.getStringProperty("animation") == "images/footprint":
+                        return True
+            return False
+
+        player_proxy = proxy_with_object(player.getName())
+        self.assertIsNotNone(player_proxy)
+        player_graphic = next(child for child in player_proxy.getChildren() if represented_object(child) == player)
+        player_graphic.setNumericProperty("proxyReuseMarker", 17)
+        map_graph.refreshObject(player.getCoords())
+        player_proxy = proxy_with_object(player.getName())
+        refreshed_player_graphic = next(
+            child for child in player_proxy.getChildren() if represented_object(child) == player
+        )
+        self.assertEqual(17, refreshed_player_graphic.getNumericProperty("proxyReuseMarker"))
+
+        player_coords = player.getCoords()
+        marker = g.createObject("CEvent")
+        marker.setStringProperty("name", "mapProxyRefreshMarker")
+        marker.moveTo(player_coords.x, player_coords.y, player_coords.z)
+        game_map.addObject(marker)
+        pump_event_loop(5)
+        self.assertIsNotNone(proxy_with_object("mapProxyRefreshMarker"))
+
+        game_map.removeObject(marker)
+        pump_event_loop(5)
+        self.assertIsNone(proxy_with_object("mapProxyRefreshMarker"))
+
+        game_map.replaceTile("LavaTile", player_coords)
+        pump_event_loop(5)
+        self.assertTrue(proxy_has_type_id(proxy_with_object(player.getName()), "LavaTile"))
+
+        game_map.setBoolProperty("showCoordinates", True)
+        map_graph.refreshObject(player_coords)
+        self.assertTrue(
+            any(child.getType() == "CTextWidget" for child in proxy_with_object(player.getName()).getChildren())
+        )
+
+        target, _, _ = find_adjacent_walkable_direction(game_map, player_coords)
+        get_player_controller(player).setTarget(player, target)
+        map_graph.refreshAll()
+        self.assertTrue(has_footprint_overlay())
+
+        map_graph.refreshObject(game.Coords(-1, player_coords.y, player_coords.z))
+        self.assertEqual(0, sum(count == 0 for count in get_map_proxy_child_counts(g)))
+
+        gui.setNumericProperty("width", 100)
+        gui.setNumericProperty("height", 100)
+        map_graph.refresh()
+        self.assertEqual(9, len(map_graph.getChildren()))
+
+        return True, json.dumps(
+            {
+                "marker_removed": proxy_with_object("mapProxyRefreshMarker") is None,
+                "proxy_count_after_resize": len(map_graph.getChildren()),
+                "footprint_overlay": has_footprint_overlay(),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_inventory_panel_refreshes_only_after_event_loop_drains(self):
         game = load_game_module()
 


### PR DESCRIPTION
## What changed
- Skips proxy child replacement when a refreshed cell resolves to the same child graphics objects.
- Caches hot map/player/tile-count lookups in map proxy refresh and prunes stale proxy animation cache entries on map/z/grid changes.
- Avoids accidental proxy map insertion during targeted refresh/removal.
- Adds a headless regression test for child reuse, changed cells, overlays, wrapping refresh, and GUI resize.

## Why
Repeated unchanged map refreshes were rebuilding child sets and mutating parent links across visible proxy cells. The patch keeps the same rendering semantics while avoiding work in the unchanged path.

## Validation
- cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)
- ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
- python3 test.py
- ./scripts/run_coverage.sh, line coverage 91.2%
- callgrind toggle collection around CProxyTargetGraphicsObject::refreshAll(): 318,315,889 Ir before vs 25,832,982 Ir after for 30 unchanged refreshAll iterations over 121 proxy cells

## Known limitations / follow-up
- No overlay caching was added; coordinate labels and footprint overlays remain freshly built to avoid stale UI state.
- A dedicated in-repo microbenchmark would make future proxy refresh profiling easier to repeat.