### PR TITLE
[codex] Fix list view animation ownership

### DIFF
--- a/src/gui/object/CMapGraphicsObject.cpp
+++ b/src/gui/object/CMapGraphicsObject.cpp
@@ -10,17 +10,7 @@
 namespace {
 std::shared_ptr<CAnimation> clone_proxy_animation(const std::shared_ptr<CGui> &gui,
                                                   const std::shared_ptr<CAnimation> &cached) {
-    std::shared_ptr<CAnimation> animation;
-    if (vstd::cast<CDynamicAnimation>(cached)) {
-        animation = std::make_shared<CDynamicAnimation>();
-    } else if (vstd::cast<CStaticAnimation>(cached)) {
-        animation = std::make_shared<CStaticAnimation>();
-    } else if (vstd::cast<CSelectionBox>(cached)) {
-        animation = std::make_shared<CSelectionBox>();
-    } else {
-        animation = gui->getGame()->createObject<CAnimation>(cached->meta()->name());
-    }
-    animation->setGame(gui->getGame());
+    auto animation = gui->getGame()->createObject<CAnimation>(cached->meta()->name());
     animation->setPriority(cached->getPriority());
     return animation;
 }

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -18,14 +18,27 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CListView.h"
 #include "core/CGame.h"
 #include "core/CMap.h"
+#include "core/CProvider.h"
 #include "core/CScript.h"
 #include "core/CUtil.h"
+#include "gui/CAnimation.h"
 #include "gui/CGui.h"
 #include "gui/CLayout.h"
 #include "gui/CTextureCache.h"
 #include "gui/object/CProxyGraphicsObject.h"
 #include "gui/object/CWidget.h"
 #include "handler/CEventHandler.h"
+
+namespace {
+std::shared_ptr<CAnimation> createListItemAnimation(const std::shared_ptr<CGui> &gui,
+                                                    const std::shared_ptr<CGameObject> &object) {
+    auto cached = object->getGraphicsObject();
+    auto animation = CAnimationProvider::getAnimation(gui->getGame(), object);
+    animation->setPriority(cached->getPriority());
+    animation->setLayout(std::make_shared<CParentLayout>());
+    return animation;
+}
+} // namespace
 
 void CListView::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> loc, int frameTime) {}
 
@@ -209,7 +222,7 @@ std::list<std::shared_ptr<CGameGraphicsObject>> CListView::getProxiedObjects(std
             addItemBox(gui, return_val);
         }
         if (isItemPresent) {
-            addItem(return_val, indexedCollection, itemIndex);
+            addItem(gui, return_val, indexedCollection, itemIndex);
         }
         if (invokeSelect(gui, itemIndex, isItemPresent ? indexedCollection.find(itemIndex)->second : nullptr)) {
             addSelectionBox(gui, return_val);
@@ -243,25 +256,27 @@ void CListView::addSelectionBox(const std::shared_ptr<CGui> &gui,
     return_val.push_back(selectionBox); // TODO: cache
 }
 
-void CListView::addItem(std::list<std::shared_ptr<CGameGraphicsObject>> &return_val,
+void CListView::addItem(const std::shared_ptr<CGui> &gui, std::list<std::shared_ptr<CGameGraphicsObject>> &return_val,
                         std::unordered_multimap<int, std::shared_ptr<CGameObject>> indexedCollection,
                         int itemIndex) const {
     auto self = const_cast<CListView *>(this)->ptr<CListView>();
     auto object = indexedCollection.find(itemIndex)->second;
-    std::shared_ptr<CGameGraphicsObject> objectGraphic = object->getGraphicsObject()->withCallback(
-        [self, itemIndex, object](std::shared_ptr<CGui> gui, SDL_EventType type, int button, int, int) {
-            if (type != SDL_MOUSEBUTTONDOWN) {
-                return false;
-            }
-            if (button == SDL_BUTTON_LEFT) {
-                self->invokeCallback(gui, itemIndex, object);
-                return true;
-            }
-            if (button == SDL_BUTTON_RIGHT) {
-                return self->invokeRightClickCallback(gui, itemIndex, object);
-            }
-            return false;
-        });
+    std::shared_ptr<CGameGraphicsObject> objectGraphic =
+        createListItemAnimation(gui, object)
+            ->withCallback(
+                [self, itemIndex, object](std::shared_ptr<CGui> gui, SDL_EventType type, int button, int, int) {
+                    if (type != SDL_MOUSEBUTTONDOWN) {
+                        return false;
+                    }
+                    if (button == SDL_BUTTON_LEFT) {
+                        self->invokeCallback(gui, itemIndex, object);
+                        return true;
+                    }
+                    if (button == SDL_BUTTON_RIGHT) {
+                        return self->invokeRightClickCallback(gui, itemIndex, object);
+                    }
+                    return false;
+                });
     objectGraphic->setPriority(2);
     return_val.push_back(objectGraphic);
 }

--- a/src/gui/panel/CListView.h
+++ b/src/gui/panel/CListView.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -174,7 +174,7 @@ class CListView : public CProxyTargetGraphicsObject {
     void addItemBox(const std::shared_ptr<CGui> &gui,
                     std::list<std::shared_ptr<CGameGraphicsObject>> &return_val) const;
 
-    void addItem(std::list<std::shared_ptr<CGameGraphicsObject>> &return_val,
+    void addItem(const std::shared_ptr<CGui> &gui, std::list<std::shared_ptr<CGameGraphicsObject>> &return_val,
                  std::unordered_multimap<int, std::shared_ptr<CGameObject>> indexedCollection, int itemIndex) const;
 
     void addSelectionBox(const std::shared_ptr<CGui> &gui,


### PR DESCRIPTION
## Summary

Fixes proxy/list animation ownership so UI list cells render their own animation instances instead of reusing an object's cached graphics object. This prevents the fight panel enemy selector from stealing the selected enemy's large portrait.

## Validation

- `cmake --build cmake-build-release --config Release --target _game for_unit_tests`
- `ctest --test-dir cmake-build-release -C Release --output-on-failure -R for_unit_tests`
- Visual Studio `clang-format --dry-run --Werror` on touched files
- `python test.py` was run; it failed on Windows because SDL2 event injection could not load SDL2, and its clang-format PATH check could not see the VS clang-format binary from the embedded Python environment.