### PR TITLE
[codex] Implement player-value features

### DIFF
--- a/res/config/crafting.json
+++ b/res/config/crafting.json
@@ -27,6 +27,17 @@
         "gold": 35,
         "unlockFlag": "CAN_CRAFT_SCROLLS"
     },
+    "scribe_emergency_portal_scroll": {
+        "station": "scribeDesk",
+        "inputs": [
+            { "item": "Scroll", "count": 1 },
+            { "item": "LesserManaPotion", "count": 2 }
+        ],
+        "output": { "item": "TownPortalScroll", "count": 1 },
+        "gold": 20,
+        "successChance": 85,
+        "unlockFlag": "CAN_CRAFT_SCROLLS"
+    },
     "blend_greater_life_potion": {
         "station": "alchemyTable",
         "inputs": [
@@ -44,5 +55,25 @@
         "output": { "item": "GreaterManaPotion", "count": 1 },
         "gold": 45,
         "successChance": 90
+    },
+    "brew_full_life_potion": {
+        "station": "alchemyTable",
+        "inputs": [
+            { "item": "GreaterLifePotion", "count": 2 }
+        ],
+        "output": { "item": "FullLifePotion", "count": 1 },
+        "gold": 90,
+        "successChance": 85,
+        "unlockFlag": "CAN_BREW_GREATER_POTIONS"
+    },
+    "brew_full_mana_potion": {
+        "station": "alchemyTable",
+        "inputs": [
+            { "item": "GreaterManaPotion", "count": 2 }
+        ],
+        "output": { "item": "FullManaPotion", "count": 1 },
+        "gold": 90,
+        "successChance": 85,
+        "unlockFlag": "CAN_BREW_GREATER_POTIONS"
     }
 }

--- a/res/config/panels.json
+++ b/res/config/panels.json
@@ -260,6 +260,21 @@
           }
         },
         {
+          "class": "CWidget",
+          "properties": {
+            "layout": {
+              "class": "CLayout",
+              "properties": {
+                "h": "14%",
+                "w": "80%",
+                "x": "10%",
+                "y": "66%"
+              }
+            },
+            "render": "renderCombatStatus"
+          }
+        },
+        {
           "class": "CListView",
           "properties": {
             "callback": "interactionsCallback",

--- a/res/game.py
+++ b/res/game.py
@@ -3,6 +3,15 @@ from _game import *
 set_logger_sink("disabled", None)
 
 
+PLAYER_CLASS_SUMMARIES = {
+    "Assasin": "agile striker with poison and stun tricks",
+    "Inquisitor": "durable zealot who exposes corruption",
+    "Sorcerer": "high-mana caster with escalating spells",
+    "Warrior": "armored front-liner with reliable melee pressure",
+    "Wayfarer": "mobile scout with route and mark bonuses",
+}
+
+
 def register(context):
     def register_wrapper(f):
         context.getObjectHandler().registerType(f.__name__, f)
@@ -15,8 +24,8 @@ def trigger(context, event, object):
     def trigger_wrapper(f):
         context.getObjectHandler().registerType(f.__name__, f)
         trigger = context.createObject(f.__name__)
-        trigger.setStringProperty('object', object)
-        trigger.setStringProperty('event', event)
+        trigger.setStringProperty("object", object)
+        trigger.setStringProperty("event", event)
         map = context.getMap()
         if map:
             map.getEventHandler().registerTrigger(trigger)
@@ -32,19 +41,36 @@ def list_string(g, list):
     return return_list
 
 
+def player_class_options(g):
+    options = {}
+    for player_type in sorted(g.getObjectHandler().getAllSubTypes("CPlayer")):
+        player = g.createObject(player_type)
+        label = player.getStringProperty("label") or player_type
+        summary = PLAYER_CLASS_SUMMARIES.get(player_type, "adventurer")
+        option = f"{label} - {summary}"
+        options[option] = player_type
+    return options
+
+
+def choose_player_class(g):
+    options = player_class_options(g)
+    selection = g.getGuiHandler().showSelection(list_string(g, list(options.keys())))
+    return options.get(selection, selection)
+
+
 def new():
     g = CGameLoader.loadGame()
     CGameLoader.loadGui(g)
     selection = g.getGuiHandler().showSelection(list_string(g, ["NEW", "LOAD", "RANDOM"]))
     if selection == "NEW":
         map = g.getGuiHandler().showSelection(list_string(g, CResourcesProvider.getInstance().getFiles("MAP")))
-        player = g.getGuiHandler().showSelection(list_string(g, g.getObjectHandler().getAllSubTypes("CPlayer")))
+        player = choose_player_class(g)
         CGameLoader.startGameWithPlayer(g, map, player)
     elif selection == "LOAD":
         save = g.getGuiHandler().showSelection(list_string(g, CResourcesProvider.getInstance().getFiles("SAVE")))
         CGameLoader.loadSavedGame(g, save)
     elif selection == "RANDOM":
-        player = g.getGuiHandler().showSelection(list_string(g, g.getObjectHandler().getAllSubTypes("CPlayer")))
+        player = choose_player_class(g)
         CGameLoader.startRandomGameWithPlayer(g, player)
     while event_loop.instance().run():
         pass

--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -26,6 +26,12 @@
         },
         {
           "ref": "LesserLifePotion"
+        },
+        {
+          "ref": "LesserManaPotion"
+        },
+        {
+          "ref": "Scroll"
         }
       ]
     }

--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -455,12 +455,21 @@ def load(self, context):
     @register(context)
     class ChangeMap(CEvent):
         def onEnter(self, event):
-            self.getMap().getGame().changeMap("map2")
+            self.getMap().getGame().changeMap("ritual")
 
     @register(context)
     class MainQuest(CQuest):
         def isCompleted(self):
             return _quest_system_from(self).get_state("main") == "gooby_slain"
+
+        def getObjective(self):
+            return "Follow Sergeant Rolf's trail, recover his skull, then slay Gooby beneath Nouraajd."
+
+        def getReward(self):
+            return "Unlocks the deeper Marumi Baso threat."
+
+        def getHint(self):
+            return "Search the cave outside town for the first sign of Rolf."
 
         def onComplete(self):
             self.getGame().getGuiHandler().showMessage("Gooby lies butchered, and weary townsfolk dare a ragged cheer.")
@@ -469,6 +478,15 @@ def load(self, context):
     class RolfQuest(CQuest):
         def isCompleted(self):
             return _quest_system_from(self).get_state("rolf") == "skull_recovered"
+
+        def getObjective(self):
+            return "Recover Sergeant Rolf's skull from the Pritscher cave."
+
+        def getReward(self):
+            return "Starts the Gooby hunt."
+
+        def getHint(self):
+            return "The cave entrance lies beyond Nouraajd's roads."
 
         def onComplete(self):
             self.getGame().getGuiHandler().showMessage(
@@ -480,6 +498,15 @@ def load(self, context):
         def isCompleted(self):
             return _quest_system_from(self).is_letter_delivered()
 
+        def getObjective(self):
+            return "Carry Mayor Irvin's sealed letter to Father Beren at the chapel."
+
+        def getReward(self):
+            return "Unlocks scribe-desk scroll crafting."
+
+        def getHint(self):
+            return "Ask at town hall, then visit the chapel."
+
         def onComplete(self):
             pass
 
@@ -487,6 +514,15 @@ def load(self, context):
     class RetrieveRelicQuest(CQuest):
         def isCompleted(self):
             return _quest_system_from(self).is_relic_returned()
+
+        def getObjective(self):
+            return "Recover the holy relic from the catacombs and return it to Father Beren."
+
+        def getReward(self):
+            return "Unlocks stronger alchemy recipes."
+
+        def getHint(self):
+            return "The catacombs hide the relic Beren needs."
 
         def onComplete(self):
             pass
@@ -496,6 +532,15 @@ def load(self, context):
         def isCompleted(self):
             return _quest_system_from(self).is_cave_purged()
 
+        def getObjective(self):
+            return "Use the returned relic to cleanse the OctoBogz cave, then report to Beren."
+
+        def getReward(self):
+            return "Opens the road to the ritual chapel."
+
+        def getHint(self):
+            return "Clear the OctoBogz lair after the relic is back in Beren's hands."
+
         def onComplete(self):
             pass
 
@@ -504,6 +549,20 @@ def load(self, context):
         def isCompleted(self):
             return _quest_system_from(self).victor_has_ended()
 
+        def getObjective(self):
+            state = _quest_system_from(self).get_state("victor")
+            if state == "encounter_active":
+                return "Defeat the cultists in the courtyard before Victor's daughter is taken."
+            if state in ("met_victor", "records_reviewed", "courtyard_known"):
+                return "Follow Victor's clue from the tavern and town hall to the marked courtyard."
+            return "Find Victor's missing daughter."
+
+        def getReward(self):
+            return "500 gold, healing, and Victor's remaining potions if you reach the courtyard in time."
+
+        def getHint(self):
+            return "The tavern rumor and town-hall records point to the courtyard."
+
         def onComplete(self):
             pass
 
@@ -511,6 +570,15 @@ def load(self, context):
     class OctoBogzQuest(CQuest):
         def isCompleted(self):
             return _quest_system_from(self).is_octobogz_contract_completed()
+
+        def getObjective(self):
+            return "Destroy the OctoBogz in the cave east of Nouraajd."
+
+        def getReward(self):
+            return "1000 gold and the Shadow Blade."
+
+        def getHint(self):
+            return "The travelers in Nouraajd know the route."
 
         def onComplete(self):
             game = self.getGame()
@@ -523,6 +591,15 @@ def load(self, context):
     class AmuletQuest(CQuest):
         def isCompleted(self):
             return _quest_system_from(self).is_amulet_returned()
+
+        def getObjective(self):
+            return "Recover the old woman's stolen amulet from the goblin thief."
+
+        def getReward(self):
+            return "50 gold."
+
+        def getHint(self):
+            return "The thief lurks near the village edge."
 
         def onComplete(self):
             pass
@@ -764,6 +841,10 @@ def load(self, context):
                 return
             player.removeItem(self._is_letter_to_beren, True)
             quest_system.mark_letter_delivered(player)
+            player.setBoolProperty("CAN_CRAFT_SCROLLS", True)
+            self.getGame().getGuiHandler().showMessage(
+                "Beren opens the chapel scriptorium to you; town portal scrolls can now be crafted."
+            )
             if not quest_system.is_relic_returned():
                 self._ensure_quest("retrieveRelicQuest")
 
@@ -775,6 +856,10 @@ def load(self, context):
                 return
             player.removeItem(lambda it: it.getName() == "holyRelic", True)
             quest_system.mark_relic_returned()
+            player.setBoolProperty("CAN_BREW_GREATER_POTIONS", True)
+            self.getGame().getGuiHandler().showMessage(
+                "Relic dust settles into the alchemist's notes; stronger draughts are now possible."
+            )
             if game_map.getBoolProperty("OCTOBOGZ_SLAIN"):
                 game_map.setBoolProperty("OCTOBOGZ_CLEARED", True)
             if not quest_system.is_cave_purged():
@@ -785,8 +870,9 @@ def load(self, context):
             if self.can_finish_cleanse():
                 quest_system.mark_cave_purged()
                 self.getGame().getGuiHandler().showMessage(
-                    "For a breath, the town is spared and the OctoBogz lie quiet."
+                    "For a breath, the town is spared. Beren points you toward the abandoned ritual chapel."
                 )
+                self.getGame().changeMap("ritual")
             else:
                 self.getGame().getGuiHandler().showMessage("The cave still writhes with OctoBogz corruption.")
 

--- a/res/maps/ritual/script.py
+++ b/res/maps/ritual/script.py
@@ -110,6 +110,20 @@ def load(self, context):
             game_map = self.getGame().getMap()
             return game_map.getBoolProperty("leader_defeated") and not game_map.getBoolProperty("captive_lost")
 
+        def getObjective(self):
+            game_map = self.getGame().getMap()
+            if not game_map.getBoolProperty("anchors_destroyed"):
+                return "Break all three ritual anchors before the final chant finishes."
+            if not game_map.getBoolProperty("leader_defeated"):
+                return "Defeat the ritual leader now that the anchors are broken."
+            return "Reach the captive and decide the chapel's fate."
+
+        def getReward(self):
+            return "Opens the road to the siege map if the captive survives."
+
+        def getHint(self):
+            return "The witness and chapel records describe where the anchors stand."
+
         def onComplete(self):
             pass
 
@@ -117,6 +131,16 @@ def load(self, context):
     class DestroyAnchorsQuest(CQuest):
         def isCompleted(self):
             return self.getGame().getMap().getBoolProperty("anchors_destroyed")
+
+        def getObjective(self):
+            count = self.getGame().getMap().getNumericProperty("anchors_destroyed_count")
+            return f"Destroy the north, crypt, and sanctum anchors ({count}/3 destroyed)."
+
+        def getReward(self):
+            return "Summons the exposed ritual leader."
+
+        def getHint(self):
+            return "One anchor is in the chapel, one in the crypt, and one near the sanctum glass."
 
         def onComplete(self):
             pass
@@ -127,6 +151,17 @@ def load(self, context):
             game_map = self.getGame().getMap()
             return game_map.getBoolProperty("captive_freed") or game_map.getBoolProperty("captive_lost")
 
+        def getObjective(self):
+            if self.getGame().getMap().getBoolProperty("captive_lost"):
+                return "The captive was lost to the rite."
+            return "Free the captive after the leader falls."
+
+        def getReward(self):
+            return "300 gold and a Life Potion if the captive survives."
+
+        def getHint(self):
+            return "The stained-glass prison opens only after the anchors and leader are gone."
+
         def onComplete(self):
             pass
 
@@ -135,6 +170,15 @@ def load(self, context):
         def isCompleted(self):
             game_map = self.getGame().getMap()
             return game_map.getBoolProperty("good_ending") or game_map.getBoolProperty("bad_ending")
+
+        def getObjective(self):
+            return "Resolve whether the chapel becomes a rescue or a warning."
+
+        def getReward(self):
+            return "Continues the campaign to the siege if you save the captive."
+
+        def getHint(self):
+            return "Return to the captive once the sanctum is quiet."
 
         def onComplete(self):
             pass
@@ -166,7 +210,11 @@ def load(self, context):
 
         def need_more_work(self):
             game_map = self.getGame().getMap()
-            return not self.can_free_captive() and not game_map.getBoolProperty("captive_lost") and not self.is_captive_freed()
+            return (
+                not self.can_free_captive()
+                and not game_map.getBoolProperty("captive_lost")
+                and not self.is_captive_freed()
+            )
 
         def free_captive(self):
             game_map = self.getGame().getMap()
@@ -183,8 +231,9 @@ def load(self, context):
                 player.addItem("LifePotion")
                 game_map.setBoolProperty("reward_claimed", True)
                 self.getGame().getGuiHandler().showMessage(
-                    "You earn 300 gold and a Life Potion for saving the captive."
+                    "You earn 300 gold and a Life Potion. The rescued captive points toward a siege beyond the marsh."
                 )
+            self.getGame().changeMap("siege")
 
     @trigger(context, "onTurn", "ritualTurnAnchor")
     class RitualTurnTrigger(CTrigger):

--- a/res/maps/siege/config.json
+++ b/res/maps/siege/config.json
@@ -1,4 +1,16 @@
 {
+  "siegeStart": {
+    "class": "SiegeStartEvent"
+  },
+  "defendSiegeQuest": {
+    "class": "DefendSiegeQuest",
+    "properties": {
+      "description": "Defend the gatehouse from the Pritscher siege.",
+      "objective": "Seal every siege gate with charged wands.",
+      "reward": "500 gold and campaign completion.",
+      "hint": "Pritz mages carry extra wands."
+    }
+  },
   "siegePritz": {
     "ref": "Pritz",
     "properties": {

--- a/res/maps/siege/map.json
+++ b/res/maps/siege/map.json
@@ -59,6 +59,17 @@
           "width": 32,
           "x": 800,
           "y": -32
+        },
+        {
+          "height": 32,
+          "id": 24,
+          "name": "siegeStart",
+          "rotation": 0,
+          "type": "siegeStart",
+          "visible": true,
+          "width": 32,
+          "x": 384,
+          "y": 384
         }
       ],
       "opacity": 1,

--- a/res/maps/siege/script.py
+++ b/res/maps/siege/script.py
@@ -1,11 +1,69 @@
 def load(self, context):
     from game import CTag
     from game import CEvent
+    from game import CQuest
     from game import CTrigger
     from game import register
     from game import trigger
     from game import randint
     from game import logger
+
+    SPAWN_POINTS = ("spawnPoint1", "spawnPoint2", "spawnPoint3", "spawnPoint4")
+
+    def destroyed_gate_count(game_map):
+        count = 0
+        for name in SPAWN_POINTS:
+            gate = game_map.getObjectByName(name)
+            if gate and gate.getBoolProperty("destroyed"):
+                count += 1
+        return count
+
+    def ensure_siege_quest(player):
+        for quest in player.getQuests():
+            if quest.getName() == "defendSiegeQuest" or quest.getTypeId() == "defendSiegeQuest":
+                return
+        player.addQuest("defendSiegeQuest")
+
+    @register(context)
+    class SiegeStartEvent(CEvent):
+        def onEnter(self, event):
+            if not event.getCause().isPlayer():
+                return
+            game_map = self.getMap()
+            if game_map.getBoolProperty("siege_initialized"):
+                return
+            game_map.setBoolProperty("siege_initialized", True)
+            player = game_map.getPlayer()
+            ensure_siege_quest(player)
+            player.addItem("magicWand")
+            game_map.getGame().getGuiHandler().showMessage(
+                "The road ends at a besieged gatehouse. Seal each breach with mage-wands before the attackers "
+                "overrun it."
+            )
+
+    @register(context)
+    class DefendSiegeQuest(CQuest):
+        def isCompleted(self):
+            return destroyed_gate_count(self.getGame().getMap()) == len(SPAWN_POINTS)
+
+        def getObjective(self):
+            sealed = destroyed_gate_count(self.getGame().getMap())
+            return f"Seal every siege gate with charged wands ({sealed}/{len(SPAWN_POINTS)} sealed)."
+
+        def getReward(self):
+            return "500 gold and final campaign completion."
+
+        def getHint(self):
+            return "Pritz mages carry extra wands; defeat them if you run out."
+
+        def onComplete(self):
+            player = self.getGame().getMap().getPlayer()
+            if self.getGame().getMap().getBoolProperty("siege_reward_claimed"):
+                return
+            player.addGold(500)
+            self.getGame().getMap().setBoolProperty("siege_reward_claimed", True)
+            self.getGame().getMap().setBoolProperty("campaign_completed", True)
+            self.getGame().getGuiHandler().showMessage("The last breach is sealed. Nouraajd survives the night.")
 
     @register(context)
     class SpawnPoint(CEvent):

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -578,7 +578,10 @@ PYBIND11_MODULE(_game, m) {
         py::class_<CQuest, CWrapper<CQuest>, std::shared_ptr<CQuest>, CGameObject>(m, "CQuest", "Base quest class.");
     cquest.def(py::init_alias<>())
         .def("isCompleted", &CQuest::isCompleted, "Return whether quest objectives are completed.")
-        .def("onComplete", &CQuest::onComplete, "Handle quest completion callback.");
+        .def("onComplete", &CQuest::onComplete, "Handle quest completion callback.")
+        .def("getObjective", &CQuest::getObjective, "Return current quest objective text.")
+        .def("getReward", &CQuest::getReward, "Return quest reward text.")
+        .def("getHint", &CQuest::getHint, "Return optional quest hint text.");
     m.attr("CQuestBase") = cquest;
 
     auto cdialog = py::class_<CDialog, CWrapper<CDialog>, std::shared_ptr<CDialog>, CGameObject>(
@@ -740,7 +743,9 @@ PYBIND11_MODULE(_game, m) {
 
     py::class_<CPlayer, CCreature, std::shared_ptr<CPlayer>>(m, "CPlayer", "Player-controlled creature.")
         .def("addQuest", &CPlayer::addQuest, "Add a quest to the player quest log.")
-        .def("getQuests", &CPlayer::getQuests, "Return the player's active quests.");
+        .def("getQuests", &CPlayer::getQuests, "Return the player's active quests.")
+        .def("getCompletedQuests", &CPlayer::getCompletedQuests, "Return the player's completed quests.")
+        .def("checkQuests", &CPlayer::checkQuests, "Move completed quests into the completed quest log.");
 
     py::class_<CListString, CGameObject, std::shared_ptr<CListString>>(m, "CListString", "String list wrapper object.")
         .def("addValue", &CListString::addValue, "Append a value to the list.")
@@ -781,6 +786,7 @@ PYBIND11_MODULE(_game, m) {
     py::class_<CGameFightPanel, CGamePanel, std::shared_ptr<CGameFightPanel>>(m, "CGameFightPanel", "Fight panel.")
         .def("getEnemy", &CGameFightPanel::getEnemy, "Return current enemy creature.")
         .def("setEnemy", &CGameFightPanel::setEnemy, "Set current enemy creature.")
+        .def("getCombatStatus", &CGameFightPanel::getCombatStatus, "Return current combat status text.")
         .def(
             "setEnemies",
             [](CGameFightPanel &self, const py::iterable &creatures) {
@@ -826,7 +832,8 @@ PYBIND11_MODULE(_game, m) {
     py::class_<CGameInventoryPanel, CGamePanel, std::shared_ptr<CGameInventoryPanel>>(m, "CGameInventoryPanel",
                                                                                       "Inventory panel.");
 
-    py::class_<CGameQuestPanel, CGamePanel, std::shared_ptr<CGameQuestPanel>>(m, "CGameQuestPanel", "Quest log panel.");
+    py::class_<CGameQuestPanel, CGamePanel, std::shared_ptr<CGameQuestPanel>>(m, "CGameQuestPanel", "Quest log panel.")
+        .def("getText", &CGameQuestPanel::getText, "Return rendered quest journal text.");
 
     py::class_<CGameTextPanel, CGamePanel, std::shared_ptr<CGameTextPanel>>(m, "CGameTextPanel", "Text display panel.");
 

--- a/src/core/CWrapper.h
+++ b/src/core/CWrapper.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -215,6 +215,36 @@ template <> class CWrapper<CQuest> : public CQuest {
         } catch (const py::error_already_set &) {
             PYTHON_LOG;
             PyErr_Clear();
+        }
+    }
+
+    std::string getObjective() override final {
+        try {
+            PYBIND11_OVERRIDE(std::string, CQuest, getObjective);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+            return CQuest::getObjective();
+        }
+    }
+
+    std::string getReward() override final {
+        try {
+            PYBIND11_OVERRIDE(std::string, CQuest, getReward);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+            return CQuest::getReward();
+        }
+    }
+
+    std::string getHint() override final {
+        try {
+            PYBIND11_OVERRIDE(std::string, CQuest, getHint);
+        } catch (const py::error_already_set &) {
+            PYTHON_LOG;
+            PyErr_Clear();
+            return CQuest::getHint();
         }
     }
 };

--- a/src/gui/CAnimation.cpp
+++ b/src/gui/CAnimation.cpp
@@ -138,12 +138,18 @@ CAnimation::CAnimation() { setLayout(std::make_shared<CParentLayout>()); }
 
 bool CAnimation::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button, int x, int y) {
     if (type == SDL_MOUSEBUTTONDOWN && button == SDL_BUTTON_RIGHT) {
+        if (hasCallback) {
+            bool handled = callback(gui, type, button, x, y);
+            if (handled) {
+                return true;
+            }
+        }
         if (object && (!object->getLabel().empty() || !object->getDescription().empty())) {
             std::shared_ptr<SDL_Rect> absPos = getLayout()->getRect(this->ptr<CAnimation>());
             gui->getGame()->getGuiHandler()->showTooltip(CTooltipHandler::buildTooltip(object), absPos->x + x,
                                                          absPos->y + y);
         }
-        return hasCallback ? callback(gui, type, button, x, y) : true;
+        return !hasCallback;
     }
     return callback(gui, type, button, x, y);
 }

--- a/src/gui/panel/CGameFightPanel.cpp
+++ b/src/gui/panel/CGameFightPanel.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "core/CMap.h"
 #include "gui/CAnimation.h"
+#include "gui/CTextManager.h"
 #include "gui/CTextureCache.h"
 #include "gui/object/CProxyTargetGraphicsObject.h"
 #include "gui/object/CStatsGraphicsObject.h"
@@ -193,4 +194,23 @@ void CGameFightPanel::enemiesCallback(std::shared_ptr<CGui> gui, int index,
 
 bool CGameFightPanel::enemiesSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
     return object && enemy.lock() && enemy.lock() == object;
+}
+
+std::string CGameFightPanel::getCombatStatus(std::shared_ptr<CGui> gui) {
+    if (!gui || !gui->getGame() || !gui->getGame()->getMap()) {
+        return "";
+    }
+    auto status = gui->getGame()->getMap()->getStringProperty("combatStatus");
+    if (!status.empty()) {
+        return status;
+    }
+    if (enemy.lock()) {
+        return "Choose an action.\nEnemy: " + enemy.lock()->getLabel();
+    }
+    return "Choose an action.";
+}
+
+void CGameFightPanel::renderCombatStatus(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int frameTime) {
+    (void)frameTime;
+    gui->getTextManager()->drawText(getCombatStatus(gui), rect->x, rect->y, rect->w);
 }

--- a/src/gui/panel/CGameFightPanel.h
+++ b/src/gui/panel/CGameFightPanel.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -38,6 +38,7 @@ class CGameFightPanel : public CGamePanel {
            V_METHOD(CGameFightPanel, enemiesCollection, CListView::collection_pointer, std::shared_ptr<CGui>),
            V_METHOD(CGameFightPanel, enemiesCallback, void, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
            V_METHOD(CGameFightPanel, enemiesSelect, bool, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
+           V_METHOD(CGameFightPanel, renderCombatStatus, void, std::shared_ptr<CGui>, std::shared_ptr<SDL_Rect>, int),
            V_METHOD(CGameFightPanel, getEnemy, std::shared_ptr<CCreature>))
 
   public:
@@ -50,6 +51,10 @@ class CGameFightPanel : public CGamePanel {
     void setEnemy(std::shared_ptr<CCreature> en);
 
     void setEnemies(const std::vector<std::shared_ptr<CCreature>> &value);
+
+    std::string getCombatStatus(std::shared_ptr<CGui> gui);
+
+    void renderCombatStatus(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int frameTime);
 
   private:
     std::vector<std::shared_ptr<CCreature>> enemies;

--- a/src/gui/panel/CGameInventoryPanel.cpp
+++ b/src/gui/panel/CGameInventoryPanel.cpp
@@ -49,14 +49,13 @@ void CGameInventoryPanel::inventoryCallback(std::shared_ptr<CGui> gui, int index
 bool CGameInventoryPanel::inventoryRightClickCallback(std::shared_ptr<CGui> gui, int index,
                                                       std::shared_ptr<CGameObject> _newSelection) {
     auto newSelection = vstd::cast<CItem>(_newSelection);
-    if (!newSelection || newSelection->hasTag(CTag::Quest)) {
+    if (!newSelection) {
         return false;
     }
     selectedEquipped.reset();
     selectedInventory.reset();
-    gui->getGame()->getMap()->getPlayer()->useItem(newSelection);
     refreshViews();
-    return true;
+    return false;
 }
 
 bool CGameInventoryPanel::inventorySelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {

--- a/src/gui/panel/CGameQuestPanel.cpp
+++ b/src/gui/panel/CGameQuestPanel.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -19,6 +19,45 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CMap.h"
 #include "gui/CGui.h"
 #include "gui/CTextManager.h"
+#include "object/CQuest.h"
+
+namespace {
+void append_quest_line(std::string &text, const std::shared_ptr<CQuest> &quest, bool completed) {
+    if (!quest) {
+        return;
+    }
+
+    text += completed ? "[Completed] " : "[Active] ";
+    text += quest->getDescription();
+    text += "\n";
+
+    const auto objective = quest->getObjective();
+    if (!objective.empty()) {
+        text += "  Objective: ";
+        text += objective;
+        text += "\n";
+    }
+
+    const auto reward = quest->getReward();
+    if (!reward.empty()) {
+        text += "  Reward: ";
+        text += reward;
+        text += "\n";
+    }
+
+    const auto hint = quest->getHint();
+    if (!completed && !hint.empty()) {
+        text += "  Hint: ";
+        text += hint;
+        text += "\n";
+    }
+
+    if (completed) {
+        text += "  Status: Completed\n";
+    }
+    text += "\n";
+}
+} // namespace
 
 void CGameQuestPanel::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int i) {
     gui->getTextManager()->drawText(getText(gui), rect->x, rect->y, rect->w);
@@ -27,13 +66,13 @@ void CGameQuestPanel::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SD
 std::string CGameQuestPanel::getText(std::shared_ptr<CGui> ptr) {
     std::string text = "";
     for (auto quest : ptr->getGame()->getMap()->getPlayer()->getCompletedQuests()) {
-        text += quest->getDescription();
-        text += "(completed)";
-        text += "\n";
+        append_quest_line(text, quest, true);
     }
     for (auto quest : ptr->getGame()->getMap()->getPlayer()->getQuests()) {
-        text += quest->getDescription();
-        text += "\n";
+        append_quest_line(text, quest, false);
+    }
+    if (text.empty()) {
+        text = "No active quests.\n";
     }
     return text;
 }

--- a/src/handler/CFightHandler.cpp
+++ b/src/handler/CFightHandler.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -44,6 +44,81 @@ auto encounter_state(const std::shared_ptr<CCreature> &attacker, const encounter
 
 bool is_present(const std::shared_ptr<CCreature> &creature) {
     return creature && creature->getMap() && creature->getMap()->getObjectByName(creature->getName());
+}
+
+std::string combat_name(const std::shared_ptr<CCreature> &creature) {
+    if (!creature) {
+        return "Unknown";
+    }
+    const auto label = creature->getLabel();
+    return label.empty() ? creature->getName() : label;
+}
+
+int initiative_score(const std::shared_ptr<CCreature> &creature) {
+    if (!creature) {
+        return 0;
+    }
+    return creature->getStats()->getAgility() * 2 + creature->getLevel();
+}
+
+encounter_type build_turn_order(const std::shared_ptr<CCreature> &attacker, const encounter_type &opponents) {
+    encounter_type order;
+    if (attacker && attacker->isAlive() && is_present(attacker)) {
+        order.push_back(attacker);
+    }
+    for (const auto &opponent : opponents) {
+        if (opponent && opponent->isAlive() && is_present(opponent)) {
+            order.push_back(opponent);
+        }
+    }
+    std::stable_sort(order.begin(), order.end(), [attacker](const auto &left, const auto &right) {
+        if (left == right) {
+            return false;
+        }
+        const auto leftScore = initiative_score(left);
+        const auto rightScore = initiative_score(right);
+        if (leftScore != rightScore) {
+            return leftScore > rightScore;
+        }
+        if (left == attacker) {
+            return true;
+        }
+        if (right == attacker) {
+            return false;
+        }
+        return combat_name(left) < combat_name(right);
+    });
+    return order;
+}
+
+std::string format_turn_order(const encounter_type &turnOrder) {
+    std::string text = "Initiative: ";
+    bool first = true;
+    for (const auto &creature : turnOrder) {
+        if (!first) {
+            text += " > ";
+        }
+        text += combat_name(creature);
+        text += " (";
+        text += vstd::str(initiative_score(creature));
+        text += ")";
+        first = false;
+    }
+    return text;
+}
+
+void update_combat_status(const std::shared_ptr<CCreature> &attacker, const encounter_type &opponents,
+                          const std::string &message) {
+    if (!attacker || !attacker->getMap()) {
+        return;
+    }
+    const auto turnOrder = build_turn_order(attacker, opponents);
+    auto status = message;
+    if (!status.empty()) {
+        status += "\n";
+    }
+    status += format_turn_order(turnOrder);
+    attacker->getMap()->setStringProperty("combatStatus", status);
 }
 
 encounter_type sanitize_opponents(const std::shared_ptr<CCreature> &attacker, const encounter_type &opponents) {
@@ -137,45 +212,56 @@ bool CFightHandler::fightMany(std::shared_ptr<CCreature> attacker,
         if (SDL_HasEvent(SDL_QUIT)) {
             break;
         }
-        current = resolve_target(attacker, opponents, current);
+        update_combat_status(attacker, opponents, "Combat round " + vstd::str(turn + 1) + " begins.");
         auto before = encounter_state(attacker, opponents);
+        const auto turnOrder = build_turn_order(attacker, opponents);
 
-        applyEffects(attacker);
-        if (!attacker->isAlive()) {
-            // TODO: who was the caster? we should gratify him
-            defeat_attacker(attacker, opponents, current);
-            resolved = true;
-            break;
-        }
-
-        if (!CTags::isTagPresent(attacker->getEffects(), CTag::Stun)) {
-            attacker->getFightController()->control(attacker, current);
-            remove_dead_opponents(attacker, opponents);
-            if (!attacker->isAlive()) {
-                defeat_attacker(attacker, opponents, current);
-                resolved = true;
+        for (const auto &actor : turnOrder) {
+            if (resolved || !attacker->isAlive() || opponents.empty()) {
                 break;
             }
-            if (opponents.empty()) {
-                resolved = true;
-                break;
-            }
-            current = resolve_target(attacker, opponents, current);
-        }
 
-        for (size_t i = 0; i < opponents.size() && attacker->isAlive();) {
-            auto opponent = opponents[i];
-            if (!opponent || !is_present(opponent)) {
-                opponents.erase(opponents.begin() + i);
-                if (opponents.empty()) {
+            if (actor == attacker) {
+                current = resolve_target(attacker, opponents, current);
+                update_combat_status(attacker, opponents,
+                                     combat_name(attacker) + " acts against " + combat_name(current) + ".");
+
+                applyEffects(attacker);
+                if (!attacker->isAlive()) {
+                    // TODO: who was the caster? we should gratify him
+                    defeat_attacker(attacker, opponents, current);
                     resolved = true;
                     break;
                 }
-                current = resolve_target(attacker, opponents, current);
+
+                if (!CTags::isTagPresent(attacker->getEffects(), CTag::Stun)) {
+                    attacker->getFightController()->control(attacker, current);
+                    remove_dead_opponents(attacker, opponents);
+                    if (!attacker->isAlive()) {
+                        defeat_attacker(attacker, opponents, current);
+                        resolved = true;
+                        break;
+                    }
+                    if (opponents.empty()) {
+                        resolved = true;
+                        break;
+                    }
+                    current = resolve_target(attacker, opponents, current);
+                } else {
+                    update_combat_status(attacker, opponents, combat_name(attacker) + " is stunned.");
+                }
                 continue;
             }
-            applyEffects(opponent);
-            if (!opponent->isAlive()) {
+
+            auto opponentIt = std::find(opponents.begin(), opponents.end(), actor);
+            if (opponentIt == opponents.end() || !actor || !is_present(actor)) {
+                continue;
+            }
+
+            update_combat_status(attacker, opponents,
+                                 combat_name(actor) + " acts against " + combat_name(attacker) + ".");
+            applyEffects(actor);
+            if (!actor->isAlive()) {
                 if (remove_dead_opponents(attacker, opponents)) {
                     if (opponents.empty()) {
                         resolved = true;
@@ -185,14 +271,16 @@ bool CFightHandler::fightMany(std::shared_ptr<CCreature> attacker,
                 }
                 continue;
             }
-            if (!CTags::isTagPresent(opponent->getEffects(), CTag::Stun)) {
-                opponent->getFightController()->control(opponent, attacker);
+            if (!CTags::isTagPresent(actor->getEffects(), CTag::Stun)) {
+                actor->getFightController()->control(actor, attacker);
                 if (!attacker->isAlive()) {
                     remove_dead_opponents(attacker, opponents);
-                    defeat_attacker(attacker, opponents, opponent);
+                    defeat_attacker(attacker, opponents, actor);
                     resolved = true;
                     break;
                 }
+            } else {
+                update_combat_status(attacker, opponents, combat_name(actor) + " is stunned.");
             }
             if (remove_dead_opponents(attacker, opponents)) {
                 if (opponents.empty()) {
@@ -200,9 +288,7 @@ bool CFightHandler::fightMany(std::shared_ptr<CCreature> attacker,
                     break;
                 }
                 current = resolve_target(attacker, opponents, current);
-                continue;
             }
-            ++i;
         }
 
         if (resolved || !attacker->isAlive()) {
@@ -220,6 +306,13 @@ bool CFightHandler::fightMany(std::shared_ptr<CCreature> attacker,
     attacker->getFightController()->end(attacker, current);
     for (const auto &opponent : allOpponents) {
         opponent->getFightController()->end(opponent, attacker);
+    }
+
+    if (resolved) {
+        const auto message = attacker->isAlive() && is_present(attacker)
+                                 ? combat_name(attacker) + " survives the encounter."
+                                 : "The encounter is resolved.";
+        update_combat_status(attacker, opponents, message);
     }
 
     return resolved;

--- a/src/object/CQuest.cpp
+++ b/src/object/CQuest.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -35,6 +35,36 @@ void CQuest::onComplete() {
     }
 }
 
+std::string CQuest::getObjective() {
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "getObjective"); !override.is_none()) {
+        PY_SAFE_RET_VAL(return override().cast<std::string>();, objective)
+    }
+    return objective;
+}
+
+std::string CQuest::getReward() {
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "getReward"); !override.is_none()) {
+        PY_SAFE_RET_VAL(return override().cast<std::string>();, reward)
+    }
+    return reward;
+}
+
+std::string CQuest::getHint() {
+    pybind11::gil_scoped_acquire gil;
+    if (auto override = CPythonOverrides::find_override(this, "getHint"); !override.is_none()) {
+        PY_SAFE_RET_VAL(return override().cast<std::string>();, hint)
+    }
+    return hint;
+}
+
 void CQuest::setDescription(std::string description) { this->description = description; }
 
 std::string CQuest::getDescription() { return description; }
+
+void CQuest::setObjective(std::string objective) { this->objective = objective; }
+
+void CQuest::setReward(std::string reward) { this->reward = reward; }
+
+void CQuest::setHint(std::string hint) { this->hint = hint; }

--- a/src/object/CQuest.h
+++ b/src/object/CQuest.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -20,7 +20,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CGameObject.h"
 
 class CQuest : public CGameObject {
-    V_META(CQuest, CGameObject, V_PROPERTY(CQuest, std::string, description, getDescription, setDescription))
+    V_META(CQuest, CGameObject, V_PROPERTY(CQuest, std::string, description, getDescription, setDescription),
+           V_PROPERTY(CQuest, std::string, objective, getObjective, setObjective),
+           V_PROPERTY(CQuest, std::string, reward, getReward, setReward),
+           V_PROPERTY(CQuest, std::string, hint, getHint, setHint))
   public:
     CQuest();
 
@@ -28,10 +31,25 @@ class CQuest : public CGameObject {
 
     virtual void onComplete();
 
+    virtual std::string getObjective();
+
+    virtual std::string getReward();
+
+    virtual std::string getHint();
+
     std::string getDescription();
 
     void setDescription(std::string description);
 
+    void setObjective(std::string objective);
+
+    void setReward(std::string reward);
+
+    void setHint(std::string hint);
+
   private:
     std::string description = "";
+    std::string objective = "";
+    std::string reward = "";
+    std::string hint = "";
 };

--- a/test.py
+++ b/test.py
@@ -1851,6 +1851,41 @@ class GameTest(unittest.TestCase):
         return True, ""
 
     @game_test
+    def test_crafting_unlocks_follow_story_progression(self):
+        import crafting
+
+        g, game_map, player = load_game_map_with_player("nouraajd")
+        runtime = crafting.get_runtime()
+
+        self.assertNotIn(
+            "craft_town_portal_scroll",
+            {recipe["id"] for recipe in runtime.available_recipes(player, "scribeDesk")},
+        )
+        town_hall = g.createObject("townHallDialog")
+        beren = g.createObject("berenDialog")
+        town_hall.give_letter()
+        beren.deliver_letter()
+        scribe_recipes = {recipe["id"] for recipe in runtime.available_recipes(player, "scribeDesk")}
+        self.assertIn("craft_town_portal_scroll", scribe_recipes)
+        self.assertIn("scribe_emergency_portal_scroll", scribe_recipes)
+
+        game_map.removeObjectByName("catacombs")
+        beren.return_relic()
+        alchemy_recipes = {recipe["id"] for recipe in runtime.available_recipes(player, "alchemyTable")}
+        self.assertIn("brew_full_life_potion", alchemy_recipes)
+        self.assertIn("brew_full_mana_potion", alchemy_recipes)
+
+        return True, json.dumps(
+            {
+                "alchemy_recipes": sorted(alchemy_recipes),
+                "can_brew_greater": player.getBoolProperty("CAN_BREW_GREATER_POTIONS"),
+                "can_craft_scrolls": player.getBoolProperty("CAN_CRAFT_SCROLLS"),
+                "scribe_recipes": sorted(scribe_recipes),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_potions_are_not_consumed_at_full_resources(self):
         g, _game_map, player = load_game_map_with_player("nouraajd", "Sorcerer")
 
@@ -2761,6 +2796,11 @@ class GameTest(unittest.TestCase):
         for image_name in ("inquisitor.png", "wayfarer.png"):
             self.assertTrue((build_dir / "images" / "players" / image_name).exists(), image_name)
 
+        menu_options = game.player_class_options(g)
+        self.assertIn("Warrior", menu_options.values())
+        self.assertTrue(any(option.startswith("Warrior - ") for option in menu_options))
+        self.assertTrue(any(option.startswith("Inquisitor - ") for option in menu_options))
+
         required_types = (
             "ExposeCorruption",
             "SanctifiedWard",
@@ -2833,6 +2873,46 @@ class GameTest(unittest.TestCase):
         one_side_took_damage = attacker.getHpRatio() < attacker_hp_before or defender.getHpRatio() < defender_hp_before
         self.assertTrue(one_side_took_damage)
         return True, ""
+
+    @game_test
+    def test_combat_initiative_status_uses_agility_order(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGame(g, "empty")
+        attacker = g.createObject("Warrior")
+        attacker.name = "slowWarrior"
+        attacker.baseStats.agility = 1
+        attacker.baseStats.hit = 0
+        attacker.baseStats.dmgMin = 0
+        attacker.baseStats.dmgMax = 0
+        attacker.setFightController(g.createObject("CFightController"))
+        attacker.moveTo(0, 0, 0)
+        g.getMap().addObject(attacker)
+
+        defender = g.createObject("GoblinThief")
+        defender.name = "quickGoblin"
+        defender.baseStats.agility = 50
+        defender.baseStats.hit = 0
+        defender.baseStats.dmgMin = 0
+        defender.baseStats.dmgMax = 0
+        defender.setFightController(g.createObject("CFightController"))
+        defender.moveTo(1, 0, 0)
+        g.getMap().addObject(defender)
+
+        result = game.CFightHandler.fightMany(attacker, [defender])
+        status = g.getMap().getStringProperty("combatStatus")
+        self.assertFalse(result)
+        self.assertIn("Initiative:", status)
+        initiative_line = status.split("Initiative:", 1)[1]
+        self.assertLess(initiative_line.index("Goblin Thief"), initiative_line.index("Warrior"))
+
+        gui = g.createObject("gui")
+        panel = g.createObject("CGameFightPanel")
+        panel.setEnemy(defender)
+        self.assertIn("Initiative:", panel.getCombatStatus(gui))
+
+        return True, json.dumps({"resolved": result, "status": status}, sort_keys=True)
 
     @game_test
     def test_shadow_bolt_can_configure_its_effect(self):
@@ -5517,6 +5597,78 @@ class GameTest(unittest.TestCase):
             "gooby_spawned": [gooby.getCoords().x, gooby.getCoords().y, gooby.getCoords().z],
         }
         return success, json.dumps(log, sort_keys=True)
+
+    @game_test
+    def test_campaign_transitions_preserve_player_and_start_siege(self):
+        game = load_game_module()
+
+        g, game_map, player = load_game_map_with_player("nouraajd")
+        town_hall = g.createObject("townHallDialog")
+        beren = g.createObject("berenDialog")
+
+        town_hall.give_letter()
+        beren.deliver_letter()
+        game_map.removeObjectByName("catacombs")
+        beren.return_relic()
+        game_map.removeObjectByName("cave2")
+        beren.finish_cleanse()
+        pump_event_loop(10)
+
+        self.assertEqual("ritual", g.getMap().mapName)
+        self.assertTrue(g.getMap().getPlayer() == player)
+
+        ritual_map = g.getMap()
+        ritual_map.setBoolProperty("anchors_destroyed", True)
+        ritual_map.setBoolProperty("leader_defeated", True)
+        captured = g.createObject("capturedSoulDialog")
+        captured.free_captive()
+        pump_event_loop(10)
+
+        self.assertEqual("siege", g.getMap().mapName)
+        self.assertTrue(g.getMap().getPlayer() == player)
+        self.assertIn("defendSiegeQuest", quest_names(player))
+        self.assertGreaterEqual(player.countItems("magicWand"), 1)
+
+        return True, json.dumps(
+            {
+                "current_map": g.getMap().mapName,
+                "player_name": player.getName(),
+                "quests": quest_names(player),
+                "wands": player.countItems("magicWand"),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
+    def test_quest_journal_shows_objectives_rewards_and_hints(self):
+        game = load_game_module()
+
+        g, game_map, player = load_game_map_with_player("nouraajd")
+        player.addQuest("rolfQuest")
+        game.CGameLoader.loadGui(g)
+        quest_panel = g.createObject("questPanel")
+        text = quest_panel.getText(g.getGui())
+
+        self.assertIn("[Active] Unravel the fate of Sergeant Rolf.", text)
+        self.assertIn("Objective: Recover Sergeant Rolf's skull", text)
+        self.assertIn("Reward: Starts the Gooby hunt.", text)
+        self.assertIn("Hint: The cave entrance lies beyond Nouraajd's roads.", text)
+
+        g_completed, completed_map, completed_player = load_game_map_with_player("nouraajd")
+        completed_player.addQuest("rolfQuest")
+        completed_map.removeObjectByName("cave1")
+        completed_player.checkQuests()
+        game.CGameLoader.loadGui(g_completed)
+        completed_panel = g_completed.createObject("questPanel")
+        text_after_completion = completed_panel.getText(g_completed.getGui())
+        self.assertIn("[Completed] Unravel the fate of Sergeant Rolf.", text_after_completion)
+        self.assertIn("Status: Completed", text_after_completion)
+        self.assertIn("[Active] Vanquish the Dreaded Gooby", text_after_completion)
+
+        return True, json.dumps(
+            {"before": text, "after": text_after_completion},
+            sort_keys=True,
+        )
 
     @game_test
     def test_nouraajd_quest_state_machine(self):

--- a/test.py
+++ b/test.py
@@ -4177,6 +4177,48 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_inventory_right_click_inspects_scroll_without_opening_it(self):
+        game = load_game_module()
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.loadGui(g)
+        game.CGameLoader.startGameWithPlayer(g, "nouraajd", "Warrior")
+        player = g.getMap().getPlayer()
+        player.addItem("letterFromRolf")
+
+        inventory_panel = g.getGuiHandler().openPanel("inventoryPanel")
+        pump_event_loop(5)
+        inventory_list = next(
+            list_view
+            for list_view in collect_gui_children(inventory_panel, "CListView")
+            if list_view.getCollection() == "inventoryCollection"
+        )
+        inventory_list.setTileSize(50)
+        inventory_list.setXPrefferedSize(8)
+        inventory_list.setYPrefferedSize(8)
+        inventory_list.refresh()
+
+        target_graphic = None
+        for y in range(8):
+            for x in range(8):
+                for graphic in inventory_list.getProxiedObjects(g.getGui(), x, y):
+                    obj = graphic.getObject() if hasattr(graphic, "getObject") else None
+                    if obj and obj.getTypeId() == "letterFromRolf":
+                        target_graphic = graphic
+                        break
+                if target_graphic:
+                    break
+            if target_graphic:
+                break
+
+        self.assertIsNotNone(target_graphic)
+        target_graphic.mouseEvent(g.getGui(), SDL_MOUSEBUTTONDOWN, SDL_BUTTON_RIGHT, 1, 1)
+        pump_event_loop(2)
+        self.assertTrue(gui_contains_class(g, "CTooltip"))
+        self.assertFalse(gui_contains_class(g, "CGameTextPanel"))
+
+        return True, json.dumps({"rolf_letters": player.countItems("letterFromRolf")}, sort_keys=True)
+
+    @game_test
     def test_fight_panel_callbacks_and_list_views(self):
         game = load_game_module()
         drain_sdl_events()


### PR DESCRIPTION
## Summary
- connect Nouraajd, ritual, and siege into a continuous campaign path with preserved player state and siege rewards
- expand the quest journal with objectives, rewards, hints, and completed quest status
- add combat initiative/status feedback, richer class selection copy, and unlock-gated crafting progression

## Validation
- `cmake --build cmake-build-release --config Release --target _game for_unit_tests` passed
- `ctest --test-dir cmake-build-release -C Release --output-on-failure -R for_unit_tests` passed
- focused feature regressions passed
- `python test.py` completed with 4 local environment/tooling failures: SDL2 event injection unavailable for two GUI tests, `clang-format` missing, and `black` missing; 20 Xvfb/Linux GUI tests skipped on Windows
- coverage script could not run in this Windows/Git Bash environment because the coverage build requires Ninja/compiler tooling not available on PATH