### PR TITLE
Use system pybind11 during Linux configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,21 +33,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_SOURCE_DIR}/cmake")
 file(GLOB_RECURSE GAME_SRC ${CMAKE_SOURCE_DIR}/src/**.cpp ${CMAKE_SOURCE_DIR}/src/**.h)
 
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
-find_package(pybind11 CONFIG QUIET)
-if (NOT pybind11_FOUND)
-    execute_process(
-        COMMAND ${Python3_EXECUTABLE} -m pybind11 --cmakedir
-        OUTPUT_VARIABLE pybind11_cmake_dir
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-    )
-    if (pybind11_cmake_dir)
-        list(APPEND CMAKE_PREFIX_PATH ${pybind11_cmake_dir})
-        find_package(pybind11 CONFIG REQUIRED)
-    else ()
-        message(FATAL_ERROR "pybind11 was not found. Install pybind11 or set pybind11_DIR.")
-    endif ()
-endif ()
+find_package(pybind11 CONFIG REQUIRED)
 find_package(SDL2 CONFIG QUIET)
 if (NOT SDL2_FOUND AND NOT TARGET SDL2::SDL2)
     find_package(SDL2 REQUIRED)

--- a/configure.sh
+++ b/configure.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+set -euo pipefail
 
 sudo apt-get update
 sudo apt-get install -y build-essential cmake ninja-build ccache clang-format \
-    python3 python3-dev \
+    python3 python3-dev pybind11-dev python3-pil \
     libboost-dev \
     libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
     nlohmann-json3-dev \
@@ -12,8 +13,12 @@ git submodule update --init --recursive
 mkdir -p cmake-build-debug
 mkdir -p cmake-build-release
 
-python3 -m pip install --upgrade pybind11 pillow
-PYBIND11_DIR="$(python3 -m pybind11 --cmakedir)"
+PYBIND11_CONFIG="$(dpkg-query -L pybind11-dev | awk '/\/pybind11Config.cmake$/ { print; exit }')"
+if [[ -z "${PYBIND11_CONFIG}" ]]; then
+    echo "pybind11Config.cmake was not found in the pybind11-dev package" >&2
+    exit 1
+fi
+PYBIND11_DIR="$(dirname "${PYBIND11_CONFIG}")"
 
 cmake -G Ninja -B ./cmake-build-debug -S . \
     -DCMAKE_BUILD_TYPE=Debug \

--- a/tests/security/test_configure_supply_chain.py
+++ b/tests/security/test_configure_supply_chain.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# fall-of-nouraajd c++ dark fantasy game
+# Copyright (C) 2026  Andrzej Lis
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class ConfigureSupplyChainTest(unittest.TestCase):
+    def test_linux_configure_uses_os_pybind11_package(self):
+        configure_script = (REPO_ROOT / "configure.sh").read_text()
+
+        self.assertIn("pybind11-dev", configure_script)
+        self.assertNotRegex(configure_script, re.compile(r"python3\s+-m\s+pip\s+install[^\n]*\bpybind11\b"))
+        self.assertIn("dpkg-query -L pybind11-dev", configure_script)
+        self.assertIn("pybind11Config.cmake was not found in the pybind11-dev package", configure_script)
+        self.assertIn('-Dpybind11_DIR="${PYBIND11_DIR}"', configure_script)
+        self.assertNotIn("python3 -m pybind11 --cmakedir", configure_script)
+
+    def test_cmake_does_not_auto_load_pybind11_python_package(self):
+        cmake_lists = (REPO_ROOT / "CMakeLists.txt").read_text()
+
+        self.assertIn("find_package(pybind11 CONFIG REQUIRED)", cmake_lists)
+        self.assertNotIn("COMMAND ${Python3_EXECUTABLE} -m pybind11 --cmakedir", cmake_lists)
+        self.assertNotIn("list(APPEND CMAKE_PREFIX_PATH ${pybind11_cmake_dir})", cmake_lists)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- The Linux `configure.sh` previously installed an unpinned `pybind11` from PyPI and executed `python3 -m pybind11 --cmakedir`, which allows upstream Python/CMake code to run during configure and creates a supply-chain risk for release builds.
- The goal is to remove the mutable PyPI dependency at configure time and ensure the build uses the OS-provided `pybind11` packaging (static, distro-managed CMake config) to avoid executing untrusted package code.

### Description

- Replaced the `pip` install path in `configure.sh` with OS packages by installing `pybind11-dev` and `python3-pil` and added `set -euo pipefail` for fail-fast shell behavior.
- Resolve `PYBIND11_DIR` by locating `pybind11Config.cmake` from the `pybind11-dev` package (`dpkg-query`/`awk`) and fail if it cannot be found, instead of running `python3 -m pybind11 --cmakedir`.
- Simplified CMake pybind11 lookup by requiring the config package with `find_package(pybind11 CONFIG REQUIRED)` and removed the code path that executed the active Python interpreter to extend `CMAKE_PREFIX_PATH` from the reported Python package CMake dir.
- Added a regression test `tests/security/test_configure_supply_chain.py` that asserts `configure.sh` no longer uses `python3 -m pip install pybind11` or `python3 -m pybind11 --cmakedir` and that the root `CMakeLists.txt` uses `find_package(pybind11 CONFIG REQUIRED)`.

### Testing

- Ran the new security test: `python3 tests/security/test_configure_supply_chain.py`, which passed.
- Ran formatting check: `python3 -m black --check -l 120 tests/security/test_configure_supply_chain.py`, which passed after formatting the new test file with `black`.
- Built native targets: `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`, which completed successfully and produced build artifacts.
- Ran C++ unit tests: `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`, which passed (for_unit_tests passed).
- Ran full Python/integration test suite: `python3 test.py`; an initial run failed due to formatting of the new test but after formatting and re-running, the full test suite completed successfully (all tests passed, with expected skips).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02fb4b656c83269bd07e16020a32f7)