### PR TITLE
[codex] Add native C++ plugin manifest loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ configure_file(res/plugins/object.py plugins/object.py)
 configure_file(res/plugins/crafting.py plugins/crafting.py)
 configure_file(res/plugins/potion.py plugins/potion.py)
 configure_file(res/plugins/tile.py plugins/tile.py)
+configure_file(res/plugins/manifest.json plugins/manifest.json)
 
 configure_file(res/images/interactions/backstab.png images/interactions/backstab.png COPYONLY)
 configure_file(res/images/interactions/deathstrike.png images/interactions/deathstrike.png COPYONLY)

--- a/res/plugins/manifest.json
+++ b/res/plugins/manifest.json
@@ -1,0 +1,9 @@
+{
+  "global": [
+    {
+      "kind": "cpp",
+      "id": "CNativeContentPlugin"
+    }
+  ],
+  "maps": {}
+}

--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -32,6 +32,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <utility>
 
 namespace {
+constexpr const char *PLUGIN_MANIFEST_PATH = "plugins/manifest.json";
+
 bool read_bool_property(const json &properties, const std::string &key) {
     if (!properties.count(key)) {
         return false;
@@ -113,6 +115,61 @@ bool is_valid_slot_name(const std::string &name) {
 }
 
 std::string build_saved_map_config_key(const std::string &slotName) { return "__save_slot__/" + slotName; }
+
+std::shared_ptr<json> load_plugin_manifest() {
+    auto provider = CResourcesProvider::getInstance();
+    if (provider->getPath(PLUGIN_MANIFEST_PATH).empty()) {
+        return nullptr;
+    }
+    return provider->loadJson(PLUGIN_MANIFEST_PATH);
+}
+
+bool load_plugin_entry(const std::shared_ptr<CGame> &game, const json &entry,
+                       std::set<std::string> &loadedPythonPlugins) {
+    if (!entry.is_object()) {
+        vstd::logger::warning("Ignoring non-object plugin manifest entry");
+        return false;
+    }
+
+    std::string kind = entry.value("kind", std::string());
+    if (kind.empty()) {
+        kind = entry.value("type", std::string());
+    }
+
+    if (kind == "cpp") {
+        const auto id = entry.value("id", std::string());
+        return CPluginLoader::loadCppPlugin(game, id);
+    }
+
+    if (kind == "python") {
+        const auto path = entry.value("path", std::string());
+        if (path.empty()) {
+            vstd::logger::warning("Ignoring Python plugin manifest entry without path");
+            return false;
+        }
+        if (!loadedPythonPlugins.insert(path).second) {
+            return true;
+        }
+        return CPluginLoader::loadPlugin(game, path);
+    }
+
+    vstd::logger::warning("Ignoring plugin manifest entry with unknown kind:", kind);
+    return false;
+}
+
+bool load_plugin_entries(const std::shared_ptr<CGame> &game, const json &entries,
+                         std::set<std::string> &loadedPythonPlugins) {
+    if (!entries.is_array()) {
+        vstd::logger::warning("Ignoring non-array plugin manifest section");
+        return false;
+    }
+
+    bool loadedAll = true;
+    for (const auto &entry : entries) {
+        loadedAll = load_plugin_entry(game, entry, loadedPythonPlugins) && loadedAll;
+    }
+    return loadedAll;
+}
 } // namespace
 
 void CMapLoader::loadFromTmx(const std::shared_ptr<CMap> &map, const std::shared_ptr<json> &mapc) {
@@ -164,7 +221,7 @@ std::shared_ptr<CMap> CMapLoader::loadNewMap(const std::shared_ptr<CGame> &game,
         std::shared_ptr<CMap> map = game->getObjectHandler()->createObject<CMap>(game);
         game->setMap(map);
         game->getObjectHandler()->registerConfig(getConfigPaths(mapName));
-        CPluginLoader::loadPlugin(game, getScriptPath(mapName));
+        CPluginLoader::loadMapPlugins(game, mapName);
         loadFromTmx(map, mapc);
         map->setMapName(mapName);
         return map;
@@ -185,7 +242,7 @@ std::shared_ptr<CMap> CMapLoader::loadSavedMap(const std::shared_ptr<CGame> &gam
         const auto mapName = (*save)["properties"]["mapName"].get<std::string>();
 
         game->getObjectHandler()->registerConfig(getConfigPaths(mapName));
-        CPluginLoader::loadPlugin(game, getScriptPath(mapName));
+        CPluginLoader::loadMapPlugins(game, mapName);
         game->getObjectHandler()->registerConfig(getConfigPaths(mapName)); // TODO: duplicate?
 
         game->getObjectHandler()->registerConfig(saveConfigKey, save);
@@ -404,11 +461,8 @@ void CGameLoader::initObjectHandler(const std::shared_ptr<CObjectHandler> &handl
     }
 }
 
-void CGameLoader::initScriptHandler(const std::shared_ptr<CScriptHandler> &handler,
-                                    const std::shared_ptr<CGame> &game) {
-    for (const std::string &script : CResourcesProvider::getInstance()->getFiles(CResType::PLUGIN)) {
-        CPluginLoader::loadPlugin(game, script);
-    }
+void CGameLoader::initScriptHandler(const std::shared_ptr<CScriptHandler> &, const std::shared_ptr<CGame> &game) {
+    CPluginLoader::loadGlobalPlugins(game);
 }
 
 void CGameLoader::loadGui(const std::shared_ptr<CGame> &game) {
@@ -421,11 +475,78 @@ void CGameLoader::loadGui(const std::shared_ptr<CGame> &game) {
         [game](SDL_Event *event) { return game->getGui()->event(event); });
 }
 
-void CPluginLoader::loadPlugin(const std::shared_ptr<CGame> &game, const std::string &path) {
-    PY_SAFE(std::string code = CResourcesProvider::getInstance()->load(path); pybind11::dict plugin_namespace;
-            plugin_namespace["__builtins__"] = pybind11::module::import("builtins");
-            plugin_namespace["__file__"] = path;
-            plugin_namespace["__name__"] = vstd::join({"plugin_", vstd::to_hex_hash(path)}, "");
-            pybind11::exec(code + "\n", plugin_namespace, plugin_namespace);
-            plugin_namespace["load"](pybind11::none(), pybind11::cast(game));)
+bool CPluginLoader::loadPlugin(const std::shared_ptr<CGame> &game, const std::string &path) {
+    bool loaded = false;
+    PY_SAFE_RET_VAL(std::string code = CResourcesProvider::getInstance()->load(path); pybind11::dict plugin_namespace;
+                    plugin_namespace["__builtins__"] = pybind11::module::import("builtins");
+                    plugin_namespace["__file__"] = path;
+                    plugin_namespace["__name__"] = vstd::join({"plugin_", vstd::to_hex_hash(path)}, "");
+                    pybind11::exec(code + "\n", plugin_namespace, plugin_namespace);
+                    plugin_namespace["load"](pybind11::none(), pybind11::cast(game)); loaded = true;, false)
+    return loaded;
+}
+
+bool CPluginLoader::loadCppPlugin(const std::shared_ptr<CGame> &game, const std::string &type) {
+    if (!game || type.empty()) {
+        vstd::logger::warning("Cannot load C++ plugin without a game and type id");
+        return false;
+    }
+
+    auto plugin = game->createObject<CPlugin>(type);
+    if (!plugin) {
+        vstd::logger::warning("Failed to create C++ plugin:", type);
+        return false;
+    }
+
+    try {
+        plugin->load(game);
+        return true;
+    } catch (const std::exception &exception) {
+        vstd::logger::warning("Failed to load C++ plugin:", type, exception.what());
+    } catch (...) {
+        vstd::logger::warning("Failed to load C++ plugin:", type);
+    }
+    return false;
+}
+
+bool CPluginLoader::loadGlobalPlugins(const std::shared_ptr<CGame> &game) {
+    bool loadedAll = true;
+    std::set<std::string> loadedPythonPlugins;
+
+    if (auto manifest = load_plugin_manifest()) {
+        if (manifest->contains("global")) {
+            loadedAll = load_plugin_entries(game, (*manifest)["global"], loadedPythonPlugins) && loadedAll;
+        }
+    }
+
+    for (const std::string &script : CResourcesProvider::getInstance()->getFiles(CResType::PLUGIN)) {
+        if (!loadedPythonPlugins.contains(script)) {
+            loadedAll = loadPlugin(game, script) && loadedAll;
+        }
+    }
+
+    return loadedAll;
+}
+
+bool CPluginLoader::loadMapPlugins(const std::shared_ptr<CGame> &game, const std::string &mapName) {
+    bool loadedAll = true;
+    std::set<std::string> loadedPythonPlugins;
+
+    if (auto manifest = load_plugin_manifest()) {
+        if (manifest->contains("maps")) {
+            const auto &mapEntries = (*manifest)["maps"];
+            if (mapEntries.is_object() && mapEntries.contains(mapName)) {
+                loadedAll = load_plugin_entries(game, mapEntries[mapName], loadedPythonPlugins) && loadedAll;
+            } else if (!mapEntries.is_object()) {
+                vstd::logger::warning("Ignoring non-object map plugin manifest section");
+                loadedAll = false;
+            }
+        }
+    }
+
+    const auto scriptPath = getScriptPath(mapName);
+    if (!loadedPythonPlugins.contains(scriptPath)) {
+        loadedAll = loadPlugin(game, scriptPath) && loadedAll;
+    }
+    return loadedAll;
 }

--- a/src/core/CLoader.h
+++ b/src/core/CLoader.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -74,7 +74,13 @@ class CGameLoader {
 
 class CPluginLoader {
   public:
-    static void loadPlugin(const std::shared_ptr<CGame> &game, const std::string &path);
+    static bool loadPlugin(const std::shared_ptr<CGame> &game, const std::string &path);
+
+    static bool loadCppPlugin(const std::shared_ptr<CGame> &game, const std::string &type);
+
+    static bool loadGlobalPlugins(const std::shared_ptr<CGame> &game);
+
+    static bool loadMapPlugins(const std::shared_ptr<CGame> &game, const std::string &mapName);
 };
 
 class CRandomMapGenerator {

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -655,6 +655,12 @@ PYBIND11_MODULE(_game, m) {
         .def("loadNewMap", &CMapLoader::loadNewMap, "Load a map without changing the active player.")
         .def("save", &CMapLoader::save, "Save the current map state to a named save slot.");
 
+    py::class_<CPluginLoader, std::shared_ptr<CPluginLoader>>(m, "CPluginLoader", "Helpers for loading plugins.")
+        .def("loadPlugin", &CPluginLoader::loadPlugin, "Load a Python plugin resource into the game.")
+        .def("loadCppPlugin", &CPluginLoader::loadCppPlugin, "Load a compiled C++ plugin type into the game.")
+        .def("loadGlobalPlugins", &CPluginLoader::loadGlobalPlugins, "Load configured global plugins.")
+        .def("loadMapPlugins", &CPluginLoader::loadMapPlugins, "Load configured plugins for a map.");
+
     auto cplugin = py::class_<CPlugin, CWrapper<CPlugin>, std::shared_ptr<CPlugin>, CGameObject>(m, "CPlugin",
                                                                                                  "Base plugin class.");
     cplugin.def(py::init_alias<>()).def("load", &CPlugin::load, "Load plugin content into a game.");

--- a/src/core/CPlugin.cpp
+++ b/src/core/CPlugin.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -16,5 +16,16 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "CPlugin.h"
+#include "core/CGame.h"
+#include "handler/CObjectHandler.h"
 
-void CPlugin::load(std::shared_ptr<CGame> game) {}
+void CPlugin::load(std::shared_ptr<CGame>) {}
+
+void CNativeContentPlugin::load(std::shared_ptr<CGame> game) {
+    auto config = std::make_shared<json>();
+    (*config)["class"] = "CGameObject";
+    (*config)["properties"]["label"] = "Native plugin marker";
+    (*config)["properties"]["description"] = "Registered by a compiled C++ plugin.";
+    (*config)["properties"]["nativePluginLoaded"] = true;
+    game->getObjectHandler()->registerConfig("nativePluginMarker", config);
+}

--- a/src/core/CPlugin.h
+++ b/src/core/CPlugin.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -29,4 +29,10 @@ class CPlugin : public CGameObject {
     V_META(CPlugin, CGameObject, vstd::meta::empty())
   public:
     virtual void load(std::shared_ptr<CGame> game);
+};
+
+class CNativeContentPlugin : public CPlugin {
+    V_META(CNativeContentPlugin, CPlugin, vstd::meta::empty())
+  public:
+    void load(std::shared_ptr<CGame> game) override;
 };

--- a/src/core/CTypes.cpp
+++ b/src/core/CTypes.cpp
@@ -166,6 +166,7 @@ struct register_all_types {
             }
             CTypes::register_type<CPlugin, CGameObject>();
             {
+                CTypes::register_type<CNativeContentPlugin, CPlugin, CGameObject>();
                 CTypes::register_type<CWrapper<CPlugin>, CPlugin, CGameObject>();
             }
         }

--- a/test.py
+++ b/test.py
@@ -1750,6 +1750,26 @@ class GameTest(unittest.TestCase):
         return True, ""
 
     @game_test
+    def test_cpp_plugin_manifest_registers_native_content(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        marker = g.createObject("nativePluginMarker")
+
+        self.assertIsNotNone(marker)
+        self.assertEqual("Native plugin marker", marker.getStringProperty("label"))
+        self.assertEqual("Registered by a compiled C++ plugin.", marker.getStringProperty("description"))
+        self.assertTrue(marker.getBoolProperty("nativePluginLoaded"))
+        self.assertTrue(game.CPluginLoader.loadCppPlugin(g, "CNativeContentPlugin"))
+        self.assertFalse(game.CPluginLoader.loadCppPlugin(g, "DefinitelyMissingPlugin"))
+
+        report = {
+            "marker": marker.getStringProperty("label"),
+            "native": marker.getBoolProperty("nativePluginLoaded"),
+        }
+        return True, json.dumps(report, sort_keys=True)
+
+    @game_test
     def test_crafting_runtime_applies_recipe(self):
         import crafting
 


### PR DESCRIPTION
## What changed

- Added manifest-driven plugin loading from `plugins/manifest.json`.
- Added support for compiled C++ plugins through `CPluginLoader::loadCppPlugin` while keeping the existing Python plugin scan as the fallback.
- Routed global and map plugin loading through the unified loader.
- Added a built-in `CNativeContentPlugin` that registers a native marker config, plus a regression test covering manifest-loaded native plugin content.
- Exposed `CPluginLoader` to Python bindings for tools/tests.

## Why

Python plugins already use `CPlugin` as the extension contract, but native plugins could not be loaded through the same runtime path. This adds a conservative compiled-in C++ plugin path alongside Python plugins without introducing dynamic library ABI risk.

## Validation

- `clang-format -i src/core/CPlugin.h src/core/CPlugin.cpp src/core/CLoader.h src/core/CLoader.cpp src/core/CTypes.cpp src/core/CModule.cpp`
- `black -l 120 test.py`
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py` passed: 133 tests, 19 skipped
- `./scripts/run_coverage.sh` passed: line coverage 90.8%
- Post-cleanup sanity: rebuilt `_game`/`for_unit_tests` and reran `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`

## Known limitations / follow-up

- This intentionally implements compiled-in C++ plugins only. Runtime `.so`/`.dll` plugin loading remains future work because the engine currently exposes C++ object and pybind11 ABI boundaries that should not be crossed casually.