### PR TITLE
[codex] Add dynamic C++ plugin loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,37 @@ endif ()
 
 pybind11_add_module(_game NO_EXTRAS ${GAME_SRC})
 configure_fon_cpp_target(_game)
-target_link_libraries(_game PRIVATE ${SDL2_LIBS} ${SDL2_IMAGE_LIBS} ${SDL2_TTF_LIBS})
+target_link_libraries(_game PRIVATE ${SDL2_LIBS} ${SDL2_IMAGE_LIBS} ${SDL2_TTF_LIBS} ${CMAKE_DL_LIBS})
+
+add_library(native_marker_plugin MODULE native_plugins/native_marker_plugin.cpp)
+target_compile_features(native_marker_plugin PRIVATE cxx_std_23)
+set_target_properties(native_marker_plugin PROPERTIES
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+    PREFIX ""
+    OUTPUT_NAME "native_marker_plugin"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins/native"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins/native"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins/native"
+)
+if (CMAKE_CONFIGURATION_TYPES)
+    foreach (config IN LISTS CMAKE_CONFIGURATION_TYPES)
+        string(TOUPPER "${config}" config_upper)
+        set_target_properties(native_marker_plugin PROPERTIES
+            LIBRARY_OUTPUT_DIRECTORY_${config_upper} "${CMAKE_BINARY_DIR}/plugins/native"
+            RUNTIME_OUTPUT_DIRECTORY_${config_upper} "${CMAKE_BINARY_DIR}/plugins/native"
+            ARCHIVE_OUTPUT_DIRECTORY_${config_upper} "${CMAKE_BINARY_DIR}/plugins/native"
+        )
+    endforeach ()
+endif ()
+target_include_directories(native_marker_plugin PRIVATE ${CMAKE_SOURCE_DIR}/src)
+if (MSVC)
+    target_compile_options(native_marker_plugin PRIVATE /W3 /permissive- /Zc:preprocessor /EHsc)
+    target_compile_definitions(native_marker_plugin PRIVATE NOMINMAX WIN32_LEAN_AND_MEAN)
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+    target_compile_options(native_marker_plugin PRIVATE -Wall -fvisibility=hidden)
+endif ()
+add_dependencies(_game native_marker_plugin)
 
 set_source_files_properties(
     ${CMAKE_SOURCE_DIR}/src/core/CModule.cpp
@@ -315,6 +345,11 @@ configure_file(play.py play.py)
 configure_file(mcp.py mcp.py)
 
 install(TARGETS _game DESTINATION fall-of-nouraajd)
+install(TARGETS native_marker_plugin
+    LIBRARY DESTINATION fall-of-nouraajd/plugins/native
+    RUNTIME DESTINATION fall-of-nouraajd/plugins/native
+    BUNDLE DESTINATION fall-of-nouraajd/plugins/native
+)
 install(DIRECTORY res/config DESTINATION fall-of-nouraajd)
 install(DIRECTORY res/fonts DESTINATION fall-of-nouraajd)
 install(DIRECTORY res/images DESTINATION fall-of-nouraajd)

--- a/native_plugins/native_marker_plugin.cpp
+++ b/native_plugins/native_marker_plugin.cpp
@@ -1,0 +1,68 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "plugin/FonPluginAbi.h"
+
+namespace {
+
+constexpr const char *DYNAMIC_MARKER_CONFIG = R"json({
+  "class": "CGameObject",
+  "properties": {
+    "label": "Dynamic native plugin marker",
+    "description": "Registered by a dynamic C++ plugin.",
+    "nativePluginLoaded": true,
+    "dynamicPluginLoaded": true
+  }
+})json";
+
+constexpr const char *DIRECT_MARKER_CONFIG = R"json({
+  "class": "CGameObject",
+  "properties": {
+    "label": "Direct dynamic plugin marker",
+    "description": "Registered by an explicit dynamic C++ plugin load.",
+    "nativePluginLoaded": true,
+    "dynamicPluginLoaded": true,
+    "directDynamicPluginLoaded": true
+  }
+})json";
+
+bool register_marker(const FonPluginHostV1 *host, const char *id, const char *config) {
+    if (host == nullptr || host->api_version != FON_PLUGIN_API_VERSION || host->game == nullptr ||
+        host->register_config_json == nullptr) {
+        return false;
+    }
+    if (host->log != nullptr) {
+        host->log(host->game, "registering dynamic native marker content");
+    }
+    return host->register_config_json(host->game, id, config);
+}
+
+} // namespace
+
+extern "C" FON_PLUGIN_EXPORT bool fon_plugin_load_v1(const FonPluginHostV1 *host) {
+    return register_marker(host, "dynamicNativePluginMarker", DYNAMIC_MARKER_CONFIG);
+}
+
+extern "C" FON_PLUGIN_EXPORT bool fon_plugin_load_direct_v1(const FonPluginHostV1 *host) {
+    return register_marker(host, "directDynamicPluginMarker", DIRECT_MARKER_CONFIG);
+}
+
+extern "C" FON_PLUGIN_EXPORT bool fon_plugin_load_bad_api_v1(const FonPluginHostV1 *host) {
+    return host != nullptr && host->api_version == FON_PLUGIN_API_VERSION + 1;
+}
+
+extern "C" FON_PLUGIN_EXPORT bool fon_plugin_load_false_v1(const FonPluginHostV1 *) { return false; }

--- a/res/plugins/manifest.json
+++ b/res/plugins/manifest.json
@@ -3,6 +3,11 @@
     {
       "kind": "cpp",
       "id": "CNativeContentPlugin"
+    },
+    {
+      "kind": "dynamic",
+      "id": "nativeMarkerDynamic",
+      "library": "plugins/native/native_marker_plugin"
     }
   ],
   "maps": {}

--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "handler/CRngHandler.h"
 #include "object/CCreature.h"
 #include "object/CPlayer.h"
+#include "plugin/FonPluginAbi.h"
 #include <pybind11/eval.h>
 #include <rdg.h>
 
@@ -31,8 +32,165 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <cctype>
 #include <utility>
 
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
 namespace {
 constexpr const char *PLUGIN_MANIFEST_PATH = "plugins/manifest.json";
+constexpr const char *DYNAMIC_PLUGIN_DEFAULT_ENTRY = "fon_plugin_load_v1";
+
+class CDynamicLibrary {
+  public:
+    explicit CDynamicLibrary(std::string path) : path(std::move(path)) {
+#if defined(_WIN32)
+        handle = LoadLibraryW(std::filesystem::path(this->path).wstring().c_str());
+#else
+        handle = dlopen(this->path.c_str(), RTLD_NOW | RTLD_LOCAL);
+#endif
+    }
+
+    ~CDynamicLibrary() {
+        if (!handle) {
+            return;
+        }
+#if defined(_WIN32)
+        FreeLibrary(handle);
+#else
+        dlclose(handle);
+#endif
+    }
+
+    CDynamicLibrary(const CDynamicLibrary &) = delete;
+    CDynamicLibrary &operator=(const CDynamicLibrary &) = delete;
+
+    bool isLoaded() const { return handle != nullptr; }
+
+    FonPluginLoadV1 loadSymbol(const std::string &symbolName) const {
+        if (!handle) {
+            return nullptr;
+        }
+
+#if defined(_WIN32)
+        auto symbol = GetProcAddress(handle, symbolName.c_str());
+        if (!symbol) {
+            vstd::logger::warning("Failed to find dynamic plugin symbol:", symbolName, "in:", path,
+                                  "error code:", static_cast<int>(GetLastError()));
+            return nullptr;
+        }
+        return reinterpret_cast<FonPluginLoadV1>(symbol);
+#else
+        dlerror();
+        auto symbol = dlsym(handle, symbolName.c_str());
+        const char *error = dlerror();
+        if (error != nullptr) {
+            vstd::logger::warning("Failed to find dynamic plugin symbol:", symbolName, "in:", path, "error:", error);
+            return nullptr;
+        }
+        return reinterpret_cast<FonPluginLoadV1>(symbol);
+#endif
+    }
+
+    const std::string &getPath() const { return path; }
+
+  private:
+    std::string path;
+#if defined(_WIN32)
+    HMODULE handle = nullptr;
+#else
+    void *handle = nullptr;
+#endif
+};
+
+std::string dynamic_library_suffix() {
+#if defined(_WIN32)
+    return ".dll";
+#elif defined(__APPLE__)
+    return ".dylib";
+#else
+    return ".so";
+#endif
+}
+
+std::vector<std::string> dynamic_library_candidates(const std::string &library) {
+    std::vector<std::string> candidates{library};
+    if (std::filesystem::path(library).extension().empty()) {
+        candidates.push_back(library + dynamic_library_suffix());
+    }
+    return candidates;
+}
+
+std::string resolve_dynamic_library_path(const std::string &library) {
+    auto provider = CResourcesProvider::getInstance();
+    for (const auto &candidate : dynamic_library_candidates(library)) {
+        auto resolved = provider->getPath(candidate);
+        if (!resolved.empty()) {
+            return std::filesystem::absolute(resolved).lexically_normal().string();
+        }
+        if (std::filesystem::exists(candidate)) {
+            return std::filesystem::absolute(candidate).lexically_normal().string();
+        }
+    }
+    return {};
+}
+
+CDynamicLibrary *load_dynamic_library(const std::string &path) {
+    static std::map<std::string, std::unique_ptr<CDynamicLibrary>> libraries;
+
+    auto existing = libraries.find(path);
+    if (existing != libraries.end()) {
+        return existing->second.get();
+    }
+
+    auto library = std::make_unique<CDynamicLibrary>(path);
+    if (!library->isLoaded()) {
+#if defined(_WIN32)
+        vstd::logger::warning("Failed to load dynamic plugin library:", path,
+                              "error code:", static_cast<int>(GetLastError()));
+#else
+        const char *error = dlerror();
+        vstd::logger::warning("Failed to load dynamic plugin library:", path,
+                              "error:", error == nullptr ? "<unknown>" : error);
+#endif
+        return nullptr;
+    }
+
+    auto inserted = libraries.emplace(path, std::move(library));
+    return inserted.first->second.get();
+}
+
+void dynamic_plugin_log(void *, const char *message) {
+    vstd::logger::info("Dynamic plugin:", message == nullptr ? "<null>" : message);
+}
+
+bool dynamic_plugin_register_config_json(void *opaqueGame, const char *id, const char *jsonText) {
+    if (opaqueGame == nullptr || id == nullptr || id[0] == '\0' || jsonText == nullptr) {
+        vstd::logger::warning("Dynamic plugin attempted to register config without a game, id, or json text");
+        return false;
+    }
+
+    auto *game = static_cast<CGame *>(opaqueGame);
+    auto parsed = CJsonUtil::parse_expected(jsonText, std::string("dynamic plugin config ") + id);
+    if (!parsed) {
+        CJsonUtil::log_parse_error(parsed.error());
+        return false;
+    }
+    if (!(*parsed)->is_object()) {
+        vstd::logger::warning("Dynamic plugin config is not an object:", id);
+        return false;
+    }
+
+    game->getObjectHandler()->registerConfig(id, *parsed);
+    return true;
+}
 
 bool read_bool_property(const json &properties, const std::string &key) {
     if (!properties.count(key)) {
@@ -125,7 +283,7 @@ std::shared_ptr<json> load_plugin_manifest() {
 }
 
 bool load_plugin_entry(const std::shared_ptr<CGame> &game, const json &entry,
-                       std::set<std::string> &loadedPythonPlugins) {
+                       std::set<std::string> &loadedPythonPlugins, std::set<std::string> &loadedDynamicPlugins) {
     if (!entry.is_object()) {
         vstd::logger::warning("Ignoring non-object plugin manifest entry");
         return false;
@@ -139,6 +297,20 @@ bool load_plugin_entry(const std::shared_ptr<CGame> &game, const json &entry,
     if (kind == "cpp") {
         const auto id = entry.value("id", std::string());
         return CPluginLoader::loadCppPlugin(game, id);
+    }
+
+    if (kind == "dynamic") {
+        const auto id = entry.value("id", std::string());
+        const auto library = entry.value("library", std::string());
+        const auto symbol = entry.value("entry", std::string(DYNAMIC_PLUGIN_DEFAULT_ENTRY));
+        if (id.empty() || library.empty()) {
+            vstd::logger::warning("Ignoring dynamic plugin manifest entry without id or library");
+            return false;
+        }
+        if (!loadedDynamicPlugins.insert(id).second) {
+            return true;
+        }
+        return CPluginLoader::loadDynamicPlugin(game, library, symbol);
     }
 
     if (kind == "python") {
@@ -158,7 +330,7 @@ bool load_plugin_entry(const std::shared_ptr<CGame> &game, const json &entry,
 }
 
 bool load_plugin_entries(const std::shared_ptr<CGame> &game, const json &entries,
-                         std::set<std::string> &loadedPythonPlugins) {
+                         std::set<std::string> &loadedPythonPlugins, std::set<std::string> &loadedDynamicPlugins) {
     if (!entries.is_array()) {
         vstd::logger::warning("Ignoring non-array plugin manifest section");
         return false;
@@ -166,7 +338,7 @@ bool load_plugin_entries(const std::shared_ptr<CGame> &game, const json &entries
 
     bool loadedAll = true;
     for (const auto &entry : entries) {
-        loadedAll = load_plugin_entry(game, entry, loadedPythonPlugins) && loadedAll;
+        loadedAll = load_plugin_entry(game, entry, loadedPythonPlugins, loadedDynamicPlugins) && loadedAll;
     }
     return loadedAll;
 }
@@ -509,13 +681,54 @@ bool CPluginLoader::loadCppPlugin(const std::shared_ptr<CGame> &game, const std:
     return false;
 }
 
+bool CPluginLoader::loadDynamicPlugin(const std::shared_ptr<CGame> &game, const std::string &library,
+                                      const std::string &entry) {
+    if (!game || library.empty()) {
+        vstd::logger::warning("Cannot load dynamic C++ plugin without a game and library path");
+        return false;
+    }
+
+    const auto symbolName = entry.empty() ? std::string(DYNAMIC_PLUGIN_DEFAULT_ENTRY) : entry;
+    const auto resolvedPath = resolve_dynamic_library_path(library);
+    if (resolvedPath.empty()) {
+        vstd::logger::warning("Failed to resolve dynamic C++ plugin library:", library);
+        return false;
+    }
+
+    auto *dynamicLibrary = load_dynamic_library(resolvedPath);
+    if (!dynamicLibrary) {
+        return false;
+    }
+
+    auto entrypoint = dynamicLibrary->loadSymbol(symbolName);
+    if (!entrypoint) {
+        return false;
+    }
+
+    FonPluginHostV1 host{FON_PLUGIN_API_VERSION, game.get(), dynamic_plugin_log, dynamic_plugin_register_config_json};
+    try {
+        if (!entrypoint(&host)) {
+            vstd::logger::warning("Dynamic C++ plugin entrypoint returned false:", library, symbolName);
+            return false;
+        }
+        return true;
+    } catch (const std::exception &exception) {
+        vstd::logger::warning("Failed to load dynamic C++ plugin:", library, symbolName, exception.what());
+    } catch (...) {
+        vstd::logger::warning("Failed to load dynamic C++ plugin:", library, symbolName);
+    }
+    return false;
+}
+
 bool CPluginLoader::loadGlobalPlugins(const std::shared_ptr<CGame> &game) {
     bool loadedAll = true;
     std::set<std::string> loadedPythonPlugins;
+    std::set<std::string> loadedDynamicPlugins;
 
     if (auto manifest = load_plugin_manifest()) {
         if (manifest->contains("global")) {
-            loadedAll = load_plugin_entries(game, (*manifest)["global"], loadedPythonPlugins) && loadedAll;
+            loadedAll = load_plugin_entries(game, (*manifest)["global"], loadedPythonPlugins, loadedDynamicPlugins) &&
+                        loadedAll;
         }
     }
 
@@ -531,12 +744,14 @@ bool CPluginLoader::loadGlobalPlugins(const std::shared_ptr<CGame> &game) {
 bool CPluginLoader::loadMapPlugins(const std::shared_ptr<CGame> &game, const std::string &mapName) {
     bool loadedAll = true;
     std::set<std::string> loadedPythonPlugins;
+    std::set<std::string> loadedDynamicPlugins;
 
     if (auto manifest = load_plugin_manifest()) {
         if (manifest->contains("maps")) {
             const auto &mapEntries = (*manifest)["maps"];
             if (mapEntries.is_object() && mapEntries.contains(mapName)) {
-                loadedAll = load_plugin_entries(game, mapEntries[mapName], loadedPythonPlugins) && loadedAll;
+                loadedAll = load_plugin_entries(game, mapEntries[mapName], loadedPythonPlugins, loadedDynamicPlugins) &&
+                            loadedAll;
             } else if (!mapEntries.is_object()) {
                 vstd::logger::warning("Ignoring non-object map plugin manifest section");
                 loadedAll = false;

--- a/src/core/CLoader.h
+++ b/src/core/CLoader.h
@@ -78,6 +78,9 @@ class CPluginLoader {
 
     static bool loadCppPlugin(const std::shared_ptr<CGame> &game, const std::string &type);
 
+    static bool loadDynamicPlugin(const std::shared_ptr<CGame> &game, const std::string &library,
+                                  const std::string &entry = "fon_plugin_load_v1");
+
     static bool loadGlobalPlugins(const std::shared_ptr<CGame> &game);
 
     static bool loadMapPlugins(const std::shared_ptr<CGame> &game, const std::string &mapName);

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -658,6 +658,8 @@ PYBIND11_MODULE(_game, m) {
     py::class_<CPluginLoader, std::shared_ptr<CPluginLoader>>(m, "CPluginLoader", "Helpers for loading plugins.")
         .def("loadPlugin", &CPluginLoader::loadPlugin, "Load a Python plugin resource into the game.")
         .def("loadCppPlugin", &CPluginLoader::loadCppPlugin, "Load a compiled C++ plugin type into the game.")
+        .def_static("loadDynamicPlugin", &CPluginLoader::loadDynamicPlugin, py::arg("game"), py::arg("library"),
+                    py::arg("entry") = "fon_plugin_load_v1", "Load a dynamic C++ plugin shared library into the game.")
         .def("loadGlobalPlugins", &CPluginLoader::loadGlobalPlugins, "Load configured global plugins.")
         .def("loadMapPlugins", &CPluginLoader::loadMapPlugins, "Load configured plugins for a map.");
 

--- a/src/core/CTypes.cpp
+++ b/src/core/CTypes.cpp
@@ -161,9 +161,7 @@ struct register_all_types {
                 CTypes::register_type<CMonsterFightController, CFightController, CGameObject>();
             }
             CTypes::register_type<CGameEvent, CGameObject>();
-            {
-                CTypes::register_type<CGameEventCaused, CGameEvent, CGameObject>();
-            }
+            { CTypes::register_type<CGameEventCaused, CGameEvent, CGameObject>(); }
             CTypes::register_type<CPlugin, CGameObject>();
             {
                 CTypes::register_type<CNativeContentPlugin, CPlugin, CGameObject>();
@@ -177,41 +175,27 @@ struct register_all_types {
             CTypes::register_type<CMapObject, CGameObject>();
             {
                 CTypes::register_type<CBuilding, CMapObject, CGameObject>();
-                {
-                    CTypes::register_type<CWrapper<CBuilding>, CBuilding, CMapObject, CGameObject>();
-                }
+                { CTypes::register_type<CWrapper<CBuilding>, CBuilding, CMapObject, CGameObject>(); }
                 CTypes::register_type<CEvent, CMapObject, CGameObject>();
-                {
-                    CTypes::register_type<CWrapper<CEvent>, CEvent, CMapObject, CGameObject>();
-                }
+                { CTypes::register_type<CWrapper<CEvent>, CEvent, CMapObject, CGameObject>(); }
                 CTypes::register_type<CItem, CMapObject, CGameObject>();
                 {
                     CTypes::register_type<CWeapon, CItem, CMapObject, CGameObject>();
-                    {
-                        CTypes::register_type<CSmallWeapon, CWeapon, CItem, CMapObject, CGameObject>();
-                    }
+                    { CTypes::register_type<CSmallWeapon, CWeapon, CItem, CMapObject, CGameObject>(); }
                     CTypes::register_type<CArmor, CItem, CMapObject, CGameObject>();
                     CTypes::register_type<CPotion, CItem, CMapObject, CGameObject>();
-                    {
-                        CTypes::register_type<CWrapper<CPotion>, CPotion, CItem, CMapObject, CGameObject>();
-                    }
+                    { CTypes::register_type<CWrapper<CPotion>, CPotion, CItem, CMapObject, CGameObject>(); }
                     CTypes::register_type<CHelmet, CItem, CMapObject, CGameObject>();
                     CTypes::register_type<CBoots, CItem, CMapObject, CGameObject>();
                     CTypes::register_type<CBelt, CItem, CMapObject, CGameObject>();
                     CTypes::register_type<CGloves, CItem, CMapObject, CGameObject>();
                     CTypes::register_type<CScroll, CItem, CMapObject, CGameObject>();
-                    {
-                        CTypes::register_type<CWrapper<CScroll>, CScroll, CItem, CMapObject, CGameObject>();
-                    }
+                    { CTypes::register_type<CWrapper<CScroll>, CScroll, CItem, CMapObject, CGameObject>(); }
                 }
-                {
-                    CTypes::register_type<CWrapper<CScroll>, CScroll, CItem, CMapObject, CGameObject>();
-                }
+                { CTypes::register_type<CWrapper<CScroll>, CScroll, CItem, CMapObject, CGameObject>(); }
 
                 CTypes::register_type<CCreature, CMapObject, CGameObject>();
-                {
-                    CTypes::register_type<CPlayer, CCreature, CMapObject, CGameObject>();
-                }
+                { CTypes::register_type<CPlayer, CCreature, CMapObject, CGameObject>(); }
             }
         }
 
@@ -219,40 +203,28 @@ struct register_all_types {
         CTypes::register_type<CGameObject>();
         {
             CTypes::register_type<CEffect, CGameObject>();
-            {
-                CTypes::register_type<CWrapper<CEffect>, CEffect, CGameObject>();
-            }
+            { CTypes::register_type<CWrapper<CEffect>, CEffect, CGameObject>(); }
 
             CTypes::register_type<CMarket, CGameObject>();
             CTypes::register_type<CDialog, CGameObject>();
-            {
-                CTypes::register_type<CWrapper<CDialog>, CDialog, CGameObject>();
-            }
+            { CTypes::register_type<CWrapper<CDialog>, CDialog, CGameObject>(); }
             CTypes::register_type<CDialogOption, CGameObject>();
             CTypes::register_type<CDialogState, CGameObject>();
 
             CTypes::register_type<CTrigger, CGameObject>();
-            {
-                CTypes::register_type<CWrapper<CTrigger>, CTrigger, CGameObject>();
-            }
+            { CTypes::register_type<CWrapper<CTrigger>, CTrigger, CGameObject>(); }
 
             CTypes::register_type<CQuest, CGameObject>();
-            {
-                CTypes::register_type<CWrapper<CQuest>, CQuest, CGameObject>();
-            }
+            { CTypes::register_type<CWrapper<CQuest>, CQuest, CGameObject>(); }
 
             CTypes::register_type<Stats, CGameObject>();
             CTypes::register_type<Damage, CGameObject>();
 
             CTypes::register_type<CTile, CGameObject>();
-            {
-                CTypes::register_type<CWrapper<CTile>, CTile, CGameObject>();
-            }
+            { CTypes::register_type<CWrapper<CTile>, CTile, CGameObject>(); }
 
             CTypes::register_type<CInteraction, CGameObject>();
-            {
-                CTypes::register_type<CWrapper<CInteraction>, CInteraction, CGameObject>();
-            }
+            { CTypes::register_type<CWrapper<CInteraction>, CInteraction, CGameObject>(); }
 
             CTypes::register_type<CController, CGameObject>();
             {

--- a/src/plugin/FonPluginAbi.h
+++ b/src/plugin/FonPluginAbi.h
@@ -1,0 +1,48 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#if defined(_WIN32)
+#define FON_PLUGIN_EXPORT __declspec(dllexport)
+#elif defined(__GNUC__) || defined(__clang__)
+#define FON_PLUGIN_EXPORT __attribute__((visibility("default")))
+#else
+#define FON_PLUGIN_EXPORT
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum { FON_PLUGIN_API_VERSION = 1 };
+
+typedef struct FonPluginHostV1 {
+    uint32_t api_version;
+    void *game;
+    void (*log)(void *game, const char *message);
+    bool (*register_config_json)(void *game, const char *id, const char *json_text);
+} FonPluginHostV1;
+
+typedef bool (*FonPluginLoadV1)(const FonPluginHostV1 *host);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test.py
+++ b/test.py
@@ -1770,6 +1770,49 @@ class GameTest(unittest.TestCase):
         return True, json.dumps(report, sort_keys=True)
 
     @game_test
+    def test_dynamic_plugin_manifest_registers_native_content(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        marker = g.createObject("dynamicNativePluginMarker")
+
+        self.assertIsNotNone(marker)
+        self.assertEqual("Dynamic native plugin marker", marker.getStringProperty("label"))
+        self.assertEqual("Registered by a dynamic C++ plugin.", marker.getStringProperty("description"))
+        self.assertTrue(marker.getBoolProperty("nativePluginLoaded"))
+        self.assertTrue(marker.getBoolProperty("dynamicPluginLoaded"))
+
+        report = {
+            "dynamic": marker.getBoolProperty("dynamicPluginLoaded"),
+            "marker": marker.getStringProperty("label"),
+        }
+        return True, json.dumps(report, sort_keys=True)
+
+    @game_test
+    def test_dynamic_plugin_direct_load_and_failures(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        sample_library = "plugins/native/native_marker_plugin"
+
+        self.assertTrue(game.CPluginLoader.loadDynamicPlugin(g, sample_library, "fon_plugin_load_direct_v1"))
+        marker = g.createObject("directDynamicPluginMarker")
+        self.assertIsNotNone(marker)
+        self.assertEqual("Direct dynamic plugin marker", marker.getStringProperty("label"))
+        self.assertTrue(marker.getBoolProperty("directDynamicPluginLoaded"))
+
+        self.assertFalse(game.CPluginLoader.loadDynamicPlugin(g, "plugins/native/definitely_missing_plugin"))
+        self.assertFalse(game.CPluginLoader.loadDynamicPlugin(g, sample_library, "fon_plugin_load_missing_v1"))
+        self.assertFalse(game.CPluginLoader.loadDynamicPlugin(g, sample_library, "fon_plugin_load_bad_api_v1"))
+        self.assertFalse(game.CPluginLoader.loadDynamicPlugin(g, sample_library, "fon_plugin_load_false_v1"))
+
+        report = {
+            "direct": marker.getBoolProperty("directDynamicPluginLoaded"),
+            "marker": marker.getStringProperty("label"),
+        }
+        return True, json.dumps(report, sort_keys=True)
+
+    @game_test
     def test_crafting_runtime_applies_recipe(self):
         import crafting
 


### PR DESCRIPTION
## What changed
- Added a small C ABI for dynamically loaded native plugins.
- Added platform-aware shared library loading through `CPluginLoader::loadDynamicPlugin` and manifest entries with `kind: "dynamic"`.
- Built and installed a sample native marker plugin used by regression coverage.
- Added Python tests for manifest-driven dynamic plugin loading, direct loading, and failure cases.

## Why
This extends the existing compiled plugin manifest support so plugin content can also be delivered from shared libraries without being linked into `_game` itself.

## Validation
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 -m unittest test.GameTest.test_cpp_clang_formatting test.GameTest.test_dynamic_plugin_direct_load_and_failures test.GameTest.test_dynamic_plugin_manifest_registers_native_content`
- `python3 test.py` (135 tests, 19 skipped)
- `./scripts/run_coverage.sh` (line coverage 90.6%)

## Notes
- Rebasing onto the updated `origin/main` produced an identical tree to the validated commit; the base now includes the prior native plugin manifest loader.