### PR TITLE
Clarify method naming conventions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,8 @@ General:
 
 Python:
 
-- Use `snake_case` for functions, methods, and local variables.
+- Use `camelCase` for functions and methods, including methods exposed to or called from C++/JSON.
+- Use `snake_case` for local variables.
 - Use `UPPER_SNAKE_CASE` for global flags and constant-like values.
 - Use `CamelCase` for classes.
 - Trigger classes decorated with `@trigger` must use `CamelCase` and end with `Trigger`.
@@ -190,8 +191,7 @@ Python:
 C++:
 
 - Use `CamelCase` for class names.
-- Existing engine methods exposed to Python may keep their current `CamelCase` names.
-- New Python-only methods should use `snake_case`.
+- Use `camelCase` for all methods, including methods exposed to Python.
 
 JSON/resource IDs:
 


### PR DESCRIPTION
### Motivation
- Ensure consistent cross-language naming by specifying that methods (both C++ and Python) use `camelCase` and clarifying that Python local variables remain `snake_case`.

### Description
- Update `AGENTS.md` to use `camelCase` for Python functions and methods (including those exposed to or called from C++/JSON), to keep local variables as `snake_case`, and to require `camelCase` for all C++ methods; the changes are limited to the `Python` and `C++` style subsections of `AGENTS.md`.

### Testing
- Ran `git diff --check` which reported no issues; the full build-and-test validation (`cmake` build, `ctest` for `for_unit_tests`, and `python3 test.py`) was not executed in this change and should be run by maintainers or CI using the repository's required validation commands when merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a312b934fe883268d5fc8cdf55b39ad)