### PR TITLE
Document bugfix test coverage requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ The Python tests require the compiled `_game` module for most runtime paths. Tes
 
 When validation cannot be run, do not imply that it passed. Report the exact command that was skipped or failed and the reason.
 
-Every bug fix must include at least one corresponding automated test (unit, integration, or regression) that fails before the fix and passes after it.
+Every bug fix must include at least one corresponding automated test (unit, integration, or regression) that fails before the fix and passes after it. Treat this as required bugfix test coverage; do not mark a bug fix complete without a regression test covering the fixed behavior.
 
 ## Coverage
 


### PR DESCRIPTION
### Motivation
- Clarify that every bug fix must include regression-oriented automated test coverage and cannot be marked complete without a regression test that demonstrates the fix.

### Description
- Update `AGENTS.md` to extend the existing bugfix-test requirement with the sentence: "Treat this as required bugfix test coverage; do not mark a bug fix complete without a regression test covering the fixed behavior." in the Required validation section.

### Testing
- Ran `git diff --check` which succeeded; no build or test workflows were executed because this is a documentation-only change and the full validation commands `cmake --build ... for_unit_tests`, `ctest --test-dir ... -R for_unit_tests`, and `python3 test.py` were intentionally skipped for this edit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a312eaf4bcc8326ada287811c1bc0d9)