### PR TITLE
Handle empty GUI selection lists

### DIFF
--- a/res/game.py
+++ b/res/game.py
@@ -63,11 +63,23 @@ def new():
     CGameLoader.loadGui(g)
     selection = g.getGuiHandler().showSelection(list_string(g, ["NEW", "LOAD", "RANDOM"]))
     if selection == "NEW":
-        map = g.getGuiHandler().showSelection(list_string(g, CResourcesProvider.getInstance().getFiles("MAP")))
+        maps = CResourcesProvider.getInstance().getFiles("MAP")
+        if not maps:
+            g.getGuiHandler().showInfo("No maps are available.", True)
+            return
+        map = g.getGuiHandler().showSelection(list_string(g, maps))
+        if not map:
+            return
         player = choose_player_class(g)
         CGameLoader.startGameWithPlayer(g, map, player)
     elif selection == "LOAD":
-        save = g.getGuiHandler().showSelection(list_string(g, CResourcesProvider.getInstance().getFiles("SAVE")))
+        saves = CResourcesProvider.getInstance().getFiles("SAVE")
+        if not saves:
+            g.getGuiHandler().showInfo("No saved games are available.", True)
+            return
+        save = g.getGuiHandler().showSelection(list_string(g, saves))
+        if not save:
+            return
         CGameLoader.loadSavedGame(g, save)
     elif selection == "RANDOM":
         player = choose_player_class(g)

--- a/src/handler/CGuiHandler.cpp
+++ b/src/handler/CGuiHandler.cpp
@@ -121,15 +121,26 @@ void CGuiHandler::showLoot(std::shared_ptr<CCreature> creature, std::set<std::sh
 CGuiHandler::CGuiHandler(std::shared_ptr<CGame> game) : _game(game) {}
 
 std::string CGuiHandler::showSelection(std::shared_ptr<CListString> list) {
-    std::shared_ptr<CGamePanel> panel = _game.lock()->createObject<CGamePanel>("selectionPanel");
-    vstd::cast<CCenteredLayout>(panel->getLayout())->setH(vstd::str(75 * list->getValues().size()));
+    auto game = _game.lock();
+    if (!game || !game->getGui()) {
+        return "";
+    }
+
+    auto values = list ? list->getValues() : std::set<std::string>();
+    if (values.empty()) {
+        vstd::logger::warning("Selection requested with an empty option list.");
+        return "";
+    }
+
+    std::shared_ptr<CGamePanel> panel = game->createObject<CGamePanel>("selectionPanel");
+    vstd::cast<CCenteredLayout>(panel->getLayout())->setH(vstd::str(75 * values.size()));
 
     std::shared_ptr<std::string> selected;
 
     std::set<std::shared_ptr<CGameGraphicsObject>> widgets;
     int i = 0;
     // TODO: unify with CGameDialogPanel
-    for (auto item : list->getValues()) {
+    for (auto item : values) {
         std::string clickName = vstd::str("click") + vstd::str(i);
 
         panel->meta()->set_method<CGameGraphicsObject, void, std::shared_ptr<CGui>>(
@@ -137,12 +148,12 @@ std::string CGuiHandler::showSelection(std::shared_ptr<CListString> list) {
                 selected = std::make_shared<std::string>(item);
             });
 
-        std::shared_ptr<CButton> widget = _game.lock()->createObject<CButton>("CButton");
+        std::shared_ptr<CButton> widget = game->createObject<CButton>("CButton");
         widget->setClick(clickName);
         widget->setText(item);
 
-        std::shared_ptr<CLayout> layout = _game.lock()->createObject<CLayout>("CLayout");
-        int percentSize = 100.0 / list->getValues().size();
+        std::shared_ptr<CLayout> layout = game->createObject<CLayout>("CLayout");
+        int percentSize = 100.0 / values.size();
         layout->setX(vstd::str(0) + "%");
         layout->setY(vstd::str(percentSize * i) + "%");
         layout->setW(vstd::str(100) + "%");
@@ -154,7 +165,7 @@ std::string CGuiHandler::showSelection(std::shared_ptr<CListString> list) {
 
     panel->setChildren(widgets);
 
-    _game.lock()->getGui()->pushChild(panel);
+    game->getGui()->pushChild(panel);
 
     vstd::wait_until([&]() { return selected != nullptr; });
 

--- a/test.py
+++ b/test.py
@@ -4866,6 +4866,99 @@ class GameTest(unittest.TestCase):
         return True, json.dumps(resources, sort_keys=True)
 
     @game_test
+    def test_empty_selection_list_returns_without_waiting(self):
+        game = load_game_module()
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.loadGui(g)
+
+        empty_selection = g.createObject("CListString")
+        started_at = time.monotonic()
+        selected = g.getGuiHandler().showSelection(empty_selection)
+
+        self.assertEqual("", selected)
+        self.assertLess(time.monotonic() - started_at, 1.0)
+        return True, json.dumps({"selected": selected})
+
+    def test_new_game_load_with_no_saves_reports_message(self):
+        game = load_game_module()
+
+        class FakeListString:
+            def __init__(self):
+                self.values = []
+
+            def addValue(self, value):
+                self.values.append(value)
+
+            def getValues(self):
+                return set(self.values)
+
+        class FakeGuiHandler:
+            def __init__(self):
+                self.messages = []
+                self.selections = []
+
+            def showSelection(self, list_string):
+                self.selections.append(sorted(list_string.getValues()))
+                return "LOAD"
+
+            def showInfo(self, message, centered):
+                self.messages.append((message, centered))
+
+        class FakeGame:
+            def __init__(self):
+                self.gui_handler = FakeGuiHandler()
+
+            def createObject(self, type_id):
+                if type_id != "CListString":
+                    raise AssertionError(f"unexpected fake object type: {type_id}")
+                return FakeListString()
+
+            def getGuiHandler(self):
+                return self.gui_handler
+
+        fake_game = FakeGame()
+
+        class FakeGameLoader:
+            loaded_save = None
+
+            @staticmethod
+            def loadGame():
+                return fake_game
+
+            @staticmethod
+            def loadGui(g):
+                pass
+
+            @staticmethod
+            def loadSavedGame(g, save):
+                FakeGameLoader.loaded_save = save
+
+        class FakeResourcesProvider:
+            @staticmethod
+            def getInstance():
+                return FakeResourcesProvider()
+
+            def getFiles(self, kind):
+                return [] if kind == "SAVE" else ["nouraajd"]
+
+        original_loader = game.CGameLoader
+        original_provider = game.CResourcesProvider
+        original_event_loop = game.event_loop
+        try:
+            game.CGameLoader = FakeGameLoader
+            game.CResourcesProvider = FakeResourcesProvider
+            game.event_loop = types.SimpleNamespace(instance=lambda: None)
+            game.new()
+        finally:
+            game.CGameLoader = original_loader
+            game.CResourcesProvider = original_provider
+            game.event_loop = original_event_loop
+
+        self.assertEqual([["LOAD", "NEW", "RANDOM"]], fake_game.gui_handler.selections)
+        self.assertEqual([("No saved games are available.", True)], fake_game.gui_handler.messages)
+        self.assertIsNone(FakeGameLoader.loaded_save)
+
+    @game_test
     def test_blocking_modal_gui_helpers_drive_panels(self):
         game = load_game_module()
         drain_sdl_events()


### PR DESCRIPTION
### Motivation
- `CGuiHandler::showSelection` previously used `list->getValues().size()` and created widgets before checking for emptiness, which could cause division-by-zero and an indefinite `wait_until` when a list (e.g. save or map list) was empty.
- The new-game / load flow in `res/game.py` passed selections through without handling an empty response, leading to downstream callers attempting to load non-existent resources.

### Description
- Add an early-return path in `CGuiHandler::showSelection` that verifies the `game`, `game->getGui()`, and the selection `values` and returns an empty-string sentinel when unavailable or empty, avoiding widget creation, division by zero, and blocking waits (changes in `src/handler/CGuiHandler.cpp`).
- Use a local `values` set for layout sizing and iteration and replace repeated `_game.lock()` calls with the validated `game` pointer when creating widgets and layouts (changes in `src/handler/CGuiHandler.cpp`).
- Update `res/game.py` new/load flow to check `CResourcesProvider.getInstance().getFiles("MAP"/"SAVE")` and show an informational message with `showInfo(...)` and return early if no maps/saves exist, and to handle the empty-string return from `showSelection`.
- Add two regression tests in `test.py`: one verifying `showSelection` on an empty `CListString` returns promptly and another verifying the new-game LOAD path shows a message and does not attempt to load when there are no saves.

### Testing
- Built native module and unit-test binary with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` and ran C++ unit tests with `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`, which passed.
- Ran the two targeted Python tests with `python3 test.py GameTest.test_empty_selection_list_returns_without_waiting GameTest.test_new_game_load_with_no_saves_reports_message`, which passed.
- Ran the full Python test suite with `python3 test.py`, which initially failed due to missing `Pillow` (`ModuleNotFoundError: No module named 'PIL'`), then installed Pillow via `python3 -m pip install --user Pillow` and re-ran the full suite; the full test run completed successfully (152 tests, 21 skipped) including `XvfbGameplayTest.test_keyboard_gameplay_under_xvfb`.
- Summary of validation commands executed: `cmake --build ...`, `ctest ...`, `python3 test.py <targeted tests>`, `python3 -m pip install --user Pillow`, and `python3 test.py` (all now passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31306b23b48326a90cb8e15a32ace2)