### PR TITLE
Make resource listing robust when optional dirs are missing

### DIFF
--- a/src/core/CProvider.cpp
+++ b/src/core/CProvider.cpp
@@ -141,7 +141,20 @@ std::vector<std::string> CResourcesProvider::getFiles(const std::string &type) {
         vstd::logger::fatal("Unknown resource type:", type);
     }
 
-    std::filesystem::directory_iterator dir(folderName), end;
+    const auto resolvedFolderName = getPath(folderName);
+    std::error_code errorCode;
+    const bool directoryExists =
+        !resolvedFolderName.empty() && std::filesystem::is_directory(resolvedFolderName, errorCode);
+    if (!directoryExists) {
+        if (type == CResType::SAVE) {
+            vstd::logger::debug("Optional resource directory is missing:", folderName);
+        } else {
+            vstd::logger::warning("Resource directory is missing:", folderName);
+        }
+        return retValue;
+    }
+
+    std::filesystem::directory_iterator dir(resolvedFolderName), end;
     while (dir != end) {
         if (type == CResType::MAP || type == CResType::SAVE) {
             auto pt = dir->path().filename().stem().string();

--- a/test.py
+++ b/test.py
@@ -4826,6 +4826,28 @@ class GameTest(unittest.TestCase):
         return True, json.dumps(report, sort_keys=True)
 
     @game_test
+    def test_missing_save_resource_directory_lists_empty(self):
+        game = load_game_module()
+        provider = game.CResourcesProvider.getInstance()
+
+        save_path = Path.cwd() / "save"
+        backup_path = None
+        if save_path.exists():
+            backup_path = Path(tempfile.mkdtemp(prefix="save-backup-")) / "save"
+            shutil.move(str(save_path), str(backup_path))
+
+        try:
+            self.assertFalse(save_path.exists())
+            self.assertEqual([], list(provider.getFiles("SAVE")))
+        finally:
+            if backup_path is not None and backup_path.exists():
+                if save_path.exists():
+                    shutil.rmtree(save_path)
+                shutil.move(str(backup_path), str(save_path))
+
+        return True, json.dumps({"save": []}, sort_keys=True)
+
+    @game_test
     def test_headless_handlers_and_resources(self):
         game = load_game_module()
         g = game.CGameLoader.loadGame()


### PR DESCRIPTION
### Motivation
- `CResourcesProvider::getFiles` previously constructed a `std::filesystem::directory_iterator` directly from a literal folder name and could throw when optional folders (for example `save/`) were absent in fresh checkouts.
- The intent is to treat some resource directories as optional, return an empty list when they are missing, and otherwise surface a useful log message instead of raising an exception.

### Description
- Resolve the folder through the resource provider by calling `getPath(folderName)` and use the resolved path for iteration in `CResourcesProvider::getFiles` (file: `src/core/CProvider.cpp`).
- Check that the resolved path is a directory using `std::filesystem::is_directory(..., errorCode)` and return an empty `std::vector<std::string>` when it does not exist.
- Log missing `SAVE` directories at debug level as optional and log missing non-optional resource directories as warnings, preserving existing behavior for `MAP`, `CONFIG`, and `PLUGIN` listing and filters.
- Add a regression test that temporarily removes any existing `save/` directory and asserts that `provider.getFiles("SAVE")` returns an empty list without throwing (file: `test.py`).

### Testing
- Built the engine and unit-test target with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` and the build succeeded.
- Ran C++ tests with `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` and they passed (`for_unit_tests` passed).
- Ran the full Python test suite with `python3 test.py`; the first run failed due to a missing `Pillow` dependency for screenshot assertions, then `Pillow` was installed with `python3 -m pip install Pillow` and `python3 test.py` was rerun successfully (all tests passed, with GUI process tests skipped where appropriate).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a313063da288326b74a7e71cd245ab9)