### PR TITLE
Fix map object creation initialization order

### DIFF
--- a/res/maps/test/map.json
+++ b/res/maps/test/map.json
@@ -131,6 +131,23 @@
           "width": 32,
           "x": 384,
           "y": 224
+        },
+        {
+          "height": 32,
+          "id": 25,
+          "name": "initializationProbe",
+          "properties": {
+            "marker": "configured-before-create"
+          },
+          "propertytypes": {
+            "marker": "string"
+          },
+          "rotation": 0,
+          "type": "InitializationProbe",
+          "visible": true,
+          "width": 32,
+          "x": 96,
+          "y": 128
         }
       ],
       "opacity": 1,

--- a/res/maps/test/script.py
+++ b/res/maps/test/script.py
@@ -7,13 +7,22 @@ def load(self, context):
     @register(context)
     class ChangeMap(CEvent):
         def onEnter(self, event):
-            pass #self.getMap().getGame().changeMap("test")
+            pass  # self.getMap().getGame().changeMap("test")
+
+    @register(context)
+    class InitializationProbe(CEvent):
+        def onCreate(self, event):
+            coords = self.getCoords()
+            self.setStringProperty("observedMarker", self.getStringProperty("marker"))
+            self.setNumericProperty("observedX", coords.x)
+            self.setNumericProperty("observedY", coords.y)
+            self.setNumericProperty("observedZ", coords.z)
 
     @trigger(context, "onEnter", "market1")
     class MarketTrigger(CTrigger):
         def trigger(self, object, event):
             if event.getCause().isPlayer():
-                object.getGame().getGuiHandler().showTrade(object.getObjectProperty('market'))
+                object.getGame().getGuiHandler().showTrade(object.getObjectProperty("market"))
 
     # TODO: replace with onLoad event
     @trigger(context, "onTurn", "triggerAnchor")

--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -519,12 +519,14 @@ void CMapLoader::handleObjectLayer(const std::shared_ptr<CMap> &map, const json 
         if (!vstd::is_empty(objectName)) {
             mapObject->setName(objectName);
         }
-        map->addObject(mapObject);
         const json &objectProperties = object.count("properties") ? object["properties"] : json();
         for (auto &[key, value] : objectProperties.items()) {
             CSerialization::setProperty(mapObject, key, CJsonUtil::clone(value));
         }
-        mapObject->moveTo(xPos, yPos, level);
+        mapObject->setPosX(xPos);
+        mapObject->setPosY(yPos);
+        mapObject->setPosZ(level);
+        map->addObject(mapObject);
         vstd::logger::debug("Loaded object:", mapObject->to_string());
     }
 }

--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -239,6 +239,7 @@ void CMap::addObject(const std::shared_ptr<CMapObject> &mapObject) {
         creature->addExp(0);
     }
     mapObjects.insert(std::make_pair(mapObject->getName(), mapObject));
+    mapObjectsCache.insert(std::make_pair(normalizeCoords(mapObject->getCoords()), mapObject->getName()));
     bumpNavigationRevision();
     getEventHandler()->gameEvent(mapObject, std::make_shared<CGameEvent>(CGameEvent::Type::onCreate));
     signal("objectChanged", mapObject->getCoords());

--- a/test.py
+++ b/test.py
@@ -4612,6 +4612,31 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_map_object_properties_and_coordinates_are_available_during_on_create(self):
+        _g, game_map = load_game_map("test")
+        probe = game_map.getObjectByName("initializationProbe")
+
+        self.assertIsNotNone(probe)
+        self.assertEqual("configured-before-create", probe.getStringProperty("observedMarker"))
+        self.assertEqual(3, probe.getNumericProperty("observedX"))
+        self.assertEqual(4, probe.getNumericProperty("observedY"))
+        self.assertEqual(0, probe.getNumericProperty("observedZ"))
+        self.assertEqual({probe.getName()}, {obj.getName() for obj in game_map.getObjectsAtCoords(probe.getCoords())})
+
+        return True, json.dumps(
+            {
+                "coords": [
+                    probe.getNumericProperty("observedX"),
+                    probe.getNumericProperty("observedY"),
+                    probe.getNumericProperty("observedZ"),
+                ],
+                "marker": probe.getStringProperty("observedMarker"),
+                "objects_at_coords": sorted(obj.getName() for obj in game_map.getObjectsAtCoords(probe.getCoords())),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_python_wrapper_exceptions_are_caught_by_native_bridges(self):
         game = load_game_module()
         g = game.CGameLoader.loadGame()


### PR DESCRIPTION
### Motivation
- Object instances created from Tiled were being inserted via `CMap::addObject` before their `properties` and coordinates were applied, causing `onCreate` handlers to observe default coordinates and missing properties.
- The goal is to ensure loaded objects have their name, configured properties, and initial normalized coordinates applied before `onCreate` dispatch, and to keep `mapObjectsCache` consistent.

### Description
- Refactored `CMapLoader::handleObjectLayer` to apply Tiled `name`, configured `properties`, and initial coordinates using `setPosX`/`setPosY`/`setPosZ` before calling `CMap::addObject`, avoiding `moveTo` prior to insertion (`src/core/CLoader.cpp`).
- Changed `CMap::addObject` to insert the new object into `mapObjectsCache` at `normalizeCoords(mapObject->getCoords())` immediately upon insertion, so the cache contains exactly one entry for the inserted object at its initial coordinates (`src/core/CMap.cpp`).
- Added a test map object `initializationProbe` to `res/maps/test/map.json` and a small map plugin class `InitializationProbe` that records observed properties and coords during `onCreate` (`res/maps/test/script.py`).
- Added a Python regression test `test_map_object_properties_and_coordinates_are_available_during_on_create` that asserts the probe saw its configured property and correct coordinates during `onCreate` and that `getObjectsAtCoords` returns the probe at the expected position (`test.py`).

### Testing
- Built the native target with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` and the build completed successfully.
- Ran C++ unit tests with `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` which passed (for_unit_tests passed).
- Ran the full Python test suite with `python3 test.py`, encountered an environment `ModuleNotFoundError: No module named 'PIL'` for xvfb screenshot checks, installed Pillow via `python3 -m pip install --user Pillow`, and re-ran `python3 test.py`.
- After installing Pillow the full Python suite completed successfully (151 tests run, 21 skipped) and the new regression test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31304eec2c83268d39441ea732ad8b)