### PR TITLE
Harden Python plugin loader path validation

### DIFF
--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -329,6 +329,35 @@ bool load_plugin_entry(const std::shared_ptr<CGame> &game, const json &entry,
     return false;
 }
 
+bool is_allowed_python_plugin_path(const std::string &path) {
+    auto normalizedPath = std::filesystem::path(path).lexically_normal();
+    if (normalizedPath.empty() || normalizedPath.is_absolute()) {
+        return false;
+    }
+
+    std::vector<std::string> parts;
+    for (const auto &part : normalizedPath) {
+        const auto token = part.string();
+        if (token.empty() || token == ".") {
+            continue;
+        }
+        if (token == "..") {
+            return false;
+        }
+        parts.push_back(token);
+    }
+
+    if (parts.size() >= 2 && parts[0] == "plugins") {
+        return normalizedPath.extension() == ".py";
+    }
+
+    if (parts.size() == 3 && parts[0] == "maps" && parts[2] == "script.py") {
+        return true;
+    }
+
+    return false;
+}
+
 bool load_plugin_entries(const std::shared_ptr<CGame> &game, const json &entries,
                          std::set<std::string> &loadedPythonPlugins, std::set<std::string> &loadedDynamicPlugins) {
     if (!entries.is_array()) {
@@ -650,6 +679,10 @@ void CGameLoader::loadGui(const std::shared_ptr<CGame> &game) {
 }
 
 bool CPluginLoader::loadPlugin(const std::shared_ptr<CGame> &game, const std::string &path) {
+    if (!is_allowed_python_plugin_path(path)) {
+        vstd::logger::warning("Rejected plugin path outside allowed resource locations:", path);
+        return false;
+    }
     bool loaded = false;
     PY_SAFE_RET_VAL(std::string code = CResourcesProvider::getInstance()->load(path); pybind11::dict plugin_namespace;
                     plugin_namespace["__builtins__"] = pybind11::module::import("builtins");

--- a/test.py
+++ b/test.py
@@ -2025,6 +2025,30 @@ class GameTest(unittest.TestCase):
             save_path.unlink(missing_ok=True)
 
     @game_test
+    def test_python_plugin_loader_rejects_non_resource_paths(self):
+        game = load_game_module()
+        g = game.CGameLoader.loadGame()
+
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as tmp:
+            tmp.write("def load(context, game):\n    pass\n")
+            absolute_path = tmp.name
+
+        try:
+            self.assertFalse(game.CPluginLoader.loadPlugin(g, absolute_path))
+            self.assertFalse(game.CPluginLoader.loadPlugin(g, "../res/plugins/effect.py"))
+            self.assertFalse(game.CPluginLoader.loadPlugin(g, "maps/nouraajd/not_script.py"))
+            self.assertTrue(game.CPluginLoader.loadPlugin(g, "plugins/effect.py"))
+
+            report = {
+                "absolute_path_rejected": absolute_path,
+                "relative_parent_rejected": "../res/plugins/effect.py",
+                "non_script_map_rejected": "maps/nouraajd/not_script.py",
+            }
+            return True, json.dumps(report, sort_keys=True)
+        finally:
+            os.unlink(absolute_path)
+
+    @game_test
     def test_crafting_runtime_applies_recipe(self):
         import crafting
 


### PR DESCRIPTION
### Motivation
- Prevent arbitrary Python code execution via the plugin loader by disallowing attacker-controlled absolute or traversal paths and limiting plugin manifest entries to safe resource locations.

### Description
- Add `is_allowed_python_plugin_path()` in `src/core/CLoader.cpp` to validate plugin paths and allow only `plugins/**/*.py` and `maps/<map>/script.py` while rejecting absolute paths and `..` traversal segments.
- Call the new validator at the start of `CPluginLoader::loadPlugin()` to reject disallowed paths before any file load or `exec` occurs.
- Add a regression test `test_python_plugin_loader_rejects_non_resource_paths` in `test.py` that verifies absolute paths, traversal-like relative paths, and non-script map paths are rejected while a normal `plugins/effect.py` still loads.
- Files changed: `src/core/CLoader.cpp`, `test.py`.

### Testing
- Built the native module and unit test target with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`, which completed successfully.
- Ran unit tests via `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`, which passed (`for_unit_tests` passed).
- Ran the new regression test directly with `python3 test.py GameTest.test_python_plugin_loader_rejects_non_resource_paths`, which passed (OK).
- Ran the full Python test suite with `python3 test.py`, which exercised many tests including the new one but failed in Xvfb screenshot tests because the environment is missing the `PIL` (Pillow) dependency; failure observed was `ModuleNotFoundError: No module named 'PIL'`, so full GUI screenshot tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b63c0e31483269d40ca9ad3807434)