### PR TITLE
Harden MCP callable and handle exports

### DIFF
--- a/mcp.py
+++ b/mcp.py
@@ -185,6 +185,7 @@ class EngineMcpServer:
                 continue
             if inspect.isclass(value):
                 self._export_class_python_methods(value, source=source)
+                continue
             if not callable(value):
                 continue
             if name in {"load", "register", "trigger"}:
@@ -892,6 +893,13 @@ class EngineMcpServer:
             raise ProtocolError(-32602, "engine_handle_call `args` must be an array")
         if not isinstance(call_kwargs, dict):
             raise ProtocolError(-32602, "engine_handle_call `kwargs` must be an object")
+        if method.startswith("_"):
+            result = {"error": f"Method `{method}` is not exported for handle calls"}
+            return {
+                "content": [{"type": "text", "text": json.dumps(result, ensure_ascii=False)}],
+                "structuredContent": result,
+                "isError": True,
+            }
         if handle not in self.handles:
             result = {"error": f"Unknown handle: {handle}"}
             return {

--- a/test.py
+++ b/test.py
@@ -7780,12 +7780,11 @@ class McpServerTest(unittest.TestCase):
         server._export_module_callables(module, source="game")
 
         self.assertIn("top_level", server.exports)
-        self.assertIn("Dialog", server.exports)
+        self.assertNotIn("Dialog", server.exports)
         self.assertIn("Dialog.invoke", server.exports)
         self.assertIn("Dialog.class_invoke", server.exports)
         self.assertIn("Dialog.static_invoke", server.exports)
         self.assertNotIn("NativeLike.append", server.exports)
-        self.assertEqual(server.exports["Dialog"].source, "game")
         self.assertEqual(server.exports["Dialog.invoke"].source, "game.Dialog")
 
     def test_export_module_includes_pybind_class_methods(self):
@@ -7835,6 +7834,27 @@ class McpServerTest(unittest.TestCase):
 
         self.assertEqual(handle["__type__"], "Dialog")
         self.assertEqual(handle["pythonMethods"], [{"name": "invoke", "signature": "(self, action)"}])
+
+    def test_engine_handle_call_rejects_private_methods(self):
+        server = self.make_stub_server()
+
+        class Dialog:
+            def invoke(self, action):
+                return action
+
+        handle = server._serialize_result(Dialog())
+        response = server._engine_handle_call(
+            {
+                "handle": handle["__handle__"],
+                "method": "__getattribute__",
+                "args": ["invoke"],
+            }
+        )
+
+        self.assertTrue(response["isError"])
+        self.assertEqual(
+            response["structuredContent"], {"error": "Method `__getattribute__` is not exported for handle calls"}
+        )
 
     def test_initialize_response_preserves_request_id(self):
         server = self.make_stub_server()


### PR DESCRIPTION
### Motivation
Prevent unauthenticated MCP clients from obtaining Python class objects and using handle-dispatch introspection (e.g. `__getattribute__`) to reach globals/builtins and execute arbitrary code by closing two attack paths introduced by the export/handle changes.

### Description
Stop exporting module-level class objects as direct MCP call targets (skip adding the class object to `exports` after exporting its public methods) and reject private/dunder method names in `_engine_handle_call` by returning an error for `method` values that start with `_`; update `test.py` to assert classes are not exported and add a regression test that `engine_handle_call` rejects `__getattribute__`.

### Testing
Built the extension and ran native unit tests with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` and `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` (passed), ran targeted Python unit tests via `python3 -m unittest` for the changed MCP tests (passed), and ran the full Python test suite `python3 test.py` (initial run failed due to missing Pillow, installed with `python3 -m pip install --user Pillow`, then reran `python3 test.py` and it passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a055f9279f08326a56c76100663065e)