### PR TITLE
Block MCP access to logger sink configuration

### DIFF
--- a/mcp.py
+++ b/mcp.py
@@ -43,6 +43,12 @@ LOG_LEVELS = {
     "alert": 1,
     "emergency": 0,
 }
+MCP_EXCLUDED_EXPORTS = {
+    "load",
+    "register",
+    "set_logger_sink",
+    "trigger",
+}
 
 logger = logging.getLogger(SERVER_NAME)
 
@@ -189,7 +195,7 @@ class EngineMcpServer:
                 continue
             if not callable(value):
                 continue
-            if name in {"load", "register", "trigger"}:
+            if name in MCP_EXCLUDED_EXPORTS:
                 continue
             if name not in self.exports:
                 self.exports[name] = ExportedCallable(

--- a/test.py
+++ b/test.py
@@ -8138,6 +8138,9 @@ class McpServerTest(unittest.TestCase):
         def top_level():
             return "top-level"
 
+        def set_logger_sink(sink_name, path=None):
+            return sink_name, path
+
         class Dialog:
             def invoke(self, action):
                 return action
@@ -8154,6 +8157,7 @@ class McpServerTest(unittest.TestCase):
             append = list.append
 
         module.top_level = top_level
+        module.set_logger_sink = set_logger_sink
         module.Dialog = Dialog
         module.NativeLike = NativeLike
 
@@ -8165,6 +8169,7 @@ class McpServerTest(unittest.TestCase):
         self.assertIn("Dialog.class_invoke", server.exports)
         self.assertIn("Dialog.static_invoke", server.exports)
         self.assertNotIn("NativeLike.append", server.exports)
+        self.assertNotIn("set_logger_sink", server.exports)
         self.assertEqual(server.exports["Dialog.invoke"].source, "game.Dialog")
 
     def test_export_module_includes_pybind_class_methods(self):


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated MCP clients from redirecting native logging to arbitrary filesystem paths by stopping automatic export of the sensitive `set_logger_sink` callable.

### Description

- Add a central exclusion set `MCP_EXCLUDED_EXPORTS` and include `set_logger_sink` so it is not auto-exported to MCP clients via `_export_module_callables`.
- Replace the inline name check with a check against `MCP_EXCLUDED_EXPORTS` in `EngineMcpServer._export_module_callables` to centralize excluded exports.
- Extend `McpServerTest.test_export_module_includes_python_class_methods` in `test.py` with a stub `set_logger_sink` and an assertion that `set_logger_sink` is not present in `server.exports` to regress the fix.

### Testing

- Ran the focused unit test `python3 test.py McpServerTest.test_export_module_includes_python_class_methods`, which passed. 
- Built the native extension and unit test target with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` and ran `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`, which passed. 
- Executed the full Python test suite `python3 test.py` (installed `Pillow` when the environment lacked it) and the suite passed. 
- Ran coverage with `./scripts/run_coverage.sh`, producing line coverage of 91.10%.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b6fb0ecc832697c98802a1547629)