### PR TITLE
Fix play.py trusted workdir bootstrap

### DIFF
--- a/play.py
+++ b/play.py
@@ -40,9 +40,8 @@ def _insert_extension_paths(build_dir: Path) -> None:
         _insert_path(build_dir / config)
 
 
-def _ensure_workdir(build_dir: Path | None) -> None:
-    if build_dir and not (Path.cwd() / "config").exists():
-        os.chdir(build_dir)
+def _ensure_workdir(trusted_dir: Path) -> None:
+    os.chdir(trusted_dir)
 
 
 def _bootstrap() -> None:
@@ -53,7 +52,7 @@ def _bootstrap() -> None:
     if build_dir:
         _insert_path(build_dir)
         _insert_extension_paths(build_dir)
-    _ensure_workdir(build_dir)
+    _ensure_workdir(build_dir or res_dir)
 
 
 _bootstrap()

--- a/test.py
+++ b/test.py
@@ -6203,6 +6203,39 @@ class XvfbGameplayProcessTest(unittest.TestCase):
         self.assertEqual(marker, loaded.getMap().getStringProperty("xvfb_save_marker"))
 
 
+class PlayBootstrapTest(unittest.TestCase):
+    def _load_play_function(self, function_name):
+        module = ast.parse((REPO_ROOT / "play.py").read_text())
+        function_node = next(
+            node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == function_name
+        )
+        isolated_module = ast.Module(body=[function_node], type_ignores=[])
+        ast.fix_missing_locations(isolated_module)
+        namespace = {"os": os, "Path": Path}
+        exec(compile(isolated_module, str(REPO_ROOT / "play.py"), "exec"), namespace)
+        return namespace[function_name]
+
+    def test_ensure_workdir_switches_to_trusted_dir_even_when_cwd_has_config(self):
+        ensure_workdir = self._load_play_function("_ensure_workdir")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            attacker_cwd = tmp / "attacker"
+            trusted_dir = tmp / "trusted-build"
+            attacker_cwd.mkdir()
+            trusted_dir.mkdir()
+            (attacker_cwd / "config").mkdir()
+            (attacker_cwd / "plugins").mkdir()
+
+            original_cwd = Path.cwd()
+            try:
+                os.chdir(attacker_cwd)
+                ensure_workdir(trusted_dir)
+                self.assertEqual(trusted_dir, Path.cwd())
+            finally:
+                os.chdir(original_cwd)
+
+
 class McpServerTest(unittest.TestCase):
     def make_stub_server(self):
         server = mcp.EngineMcpServer(repo_root=REPO_ROOT, build_dir=build_dir)


### PR DESCRIPTION
### Motivation
- Prevent launcher-enabled current-working-directory resource hijacking that allowed attacker-controlled `config/` and `plugins/` in CWD to be treated as the resource root and cause arbitrary plugin execution.
- Ensure the launcher always uses a repository-trusted resource root (build dir when present, otherwise `res`) before the native engine enumerates and loads configs/plugins.

### Description
- Change `_ensure_workdir` in `play.py` to unconditionally `chdir` into the trusted directory and make `_bootstrap` call it with `build_dir or res_dir`, removing the prior CWD `config/` existence check (`play.py`).
- Add a focused regression test `PlayBootstrapTest.test_ensure_workdir_switches_to_trusted_dir_even_when_cwd_has_config` to `test.py` that isolates `_ensure_workdir` via AST and verifies it moves away from an attacker-like CWD containing `config/` and `plugins/` (`test.py`).
- Modified files: `play.py` and `test.py`.

### Testing
- Ran formatting with `black -l 120 play.py test.py` which completed successfully.
- Built native artifacts and unit tests with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` and `ctest --test-dir cmake-build-release -R for_unit_tests`, both of which passed.
- Executed the new regression test with `python3 test.py PlayBootstrapTest.test_ensure_workdir_switches_to_trusted_dir_even_when_cwd_has_config`, which passed.
- Ran the full Python test suite with `python3 test.py`; most tests passed but the full run failed due to a missing runtime dependency (`PIL`/Pillow) causing xvfb screenshot tests to error, so full-suite failures are environmental and unrelated to the patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b63bee9088326a06470806735f7e2)