### PR TITLE
Prevent layout dimensions from executing Python

### DIFF
--- a/src/gui/CLayout.cpp
+++ b/src/gui/CLayout.cpp
@@ -17,10 +17,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "CLayout.h"
-#include "core/CGame.h"
 #include "core/CUtil.h"
 #include "gui/object/CProxyGraphicsObject.h"
-#include "handler/CScriptHandler.h"
 
 std::shared_ptr<SDL_Rect> CLayout::getParentRect(std::shared_ptr<CGameGraphicsObject> object) {
     return object->getParent() ? object->getParent()->getLayout()->getRect(object->getParent())
@@ -60,16 +58,14 @@ void CLayout::setVertical(std::string vertical) { CLayout::vertical = vertical; 
 
 std::string CLayout::getVertical() { return vertical; }
 
-std::pair<CLayout::TYPE, int> CLayout::parseValue(std::shared_ptr<CGameGraphicsObject> object, std::string value) {
+std::pair<CLayout::TYPE, int> CLayout::parseValue(std::string value) {
     if (vstd::ends_with(value, "%") && vstd::is_int(value.substr(0, value.length() - 1))) {
         return std::make_pair(PERCENT, vstd::to_int(value.substr(0, value.length() - 1)).first);
     } else if (vstd::is_int(value)) {
         return std::make_pair(SIMPLE, vstd::to_int(value).first);
     }
-    // TODO: rethink parsing and validating script and script output
-    return std::make_pair(
-        SIMPLE, object->getGame()->getScriptHandler()->call_created_function<int, std::shared_ptr<CGameGraphicsObject>>(
-                    value, {"self"}, object));
+    vstd::logger::error("Invalid layout value:", value);
+    return std::make_pair(SIMPLE, 0);
 }
 
 int CLayout::parseValue(std::pair<TYPE, int> value, int parentValue) {
@@ -82,17 +78,15 @@ int CLayout::parseValue(std::pair<TYPE, int> value, int parentValue) {
     return vstd::fail_if(true, "Should not happen!");
 }
 
-int CLayout::parseValue(std::shared_ptr<CGameGraphicsObject> object, std::string value, int parentValue) {
-    return parseValue(parseValue(object, value), parentValue);
-}
+int CLayout::parseValue(std::string value, int parentValue) { return parseValue(parseValue(value), parentValue); }
 
 std::shared_ptr<SDL_Rect> CLayout::getRect(std::shared_ptr<CGameGraphicsObject> object) {
     auto parent = getParentRect(object);
 
-    int x = parseValue(object, getX(), parent->w);
-    int y = parseValue(object, getY(), parent->h);
-    int w = horizontal == "PARENT" ? parent->w : parseValue(object, getW(), parent->w);
-    int h = vertical == "PARENT" ? parent->h : parseValue(object, getH(), parent->h);
+    int x = parseValue(getX(), parent->w);
+    int y = parseValue(getY(), parent->h);
+    int w = horizontal == "PARENT" ? parent->w : parseValue(getW(), parent->w);
+    int h = vertical == "PARENT" ? parent->h : parseValue(getH(), parent->h);
 
     if (horizontal == "LEFT" || horizontal == "PARENT") {
         x = 0;

--- a/src/gui/CLayout.h
+++ b/src/gui/CLayout.h
@@ -32,11 +32,11 @@ class CLayout : public CGameObject {
   private:
     enum TYPE { SIMPLE, PERCENT };
 
-    std::pair<TYPE, int> parseValue(std::shared_ptr<CGameGraphicsObject> object, std::string value);
+    std::pair<TYPE, int> parseValue(std::string value);
 
     int parseValue(std::pair<TYPE, int> value, int parentValue);
 
-    int parseValue(std::shared_ptr<CGameGraphicsObject> object, std::string value, int parentValue);
+    int parseValue(std::string value, int parentValue);
 
   protected:
     static std::shared_ptr<SDL_Rect> getParentRect(std::shared_ptr<CGameGraphicsObject> object);

--- a/tests/security/test_layout_no_script_eval.py
+++ b/tests/security/test_layout_no_script_eval.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# fall-of-nouraajd c++ dark fantasy game
+# Copyright (C) 2026  Andrzej Lis
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class LayoutScriptEvaluationTest(unittest.TestCase):
+    def test_layout_dimensions_do_not_compile_resource_strings_as_python(self):
+        layout_cpp = (REPO_ROOT / "src/gui/CLayout.cpp").read_text()
+
+        self.assertNotIn("handler/CScriptHandler.h", layout_cpp)
+        self.assertNotIn("call_created_function", layout_cpp)
+        self.assertNotRegex(layout_cpp, re.compile(r"getScriptHandler\s*\("))
+
+    def test_invalid_layout_dimensions_fall_back_to_zero(self):
+        layout_cpp = (REPO_ROOT / "src/gui/CLayout.cpp").read_text()
+        parse_value = re.search(
+            r"std::pair<CLayout::TYPE, int> CLayout::parseValue\(std::string value\) \{(?P<body>.*?)\n\}",
+            layout_cpp,
+            re.DOTALL,
+        )
+
+        self.assertIsNotNone(parse_value)
+        body = parse_value.group("body")
+        self.assertIn('vstd::logger::error("Invalid layout value:", value);', body)
+        self.assertIn("return std::make_pair(SIMPLE, 0);", body)
+        self.assertNotIn("object->getGame()", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Layout dimension fields (`x`, `y`, `w`, `h`) were changed to string-backed properties that fell back to compiling and executing arbitrary Python when a value was neither an integer nor a percent, creating an RCE sink during normal GUI layout evaluation.
- The intent of this change is to remove that implicit code-execution path and ensure resource/config strings cannot be compiled or executed as Python during layout calculation.

### Description
- Removed the `CScriptHandler` fallback and the dynamic `call_created_function` invocation so `CLayout::parseValue` only accepts integer pixels or integer percentages and does not execute scripts.
- Changed the parsing helpers signatures so `parseValue` accepts only the raw `std::string` value and `getRect()` resolves `x`, `y`, `w`, and `h` through the non-executing parser.
- Invalid or unknown layout strings are now logged with `vstd::logger::error` and treated as zero (`return std::make_pair(SIMPLE, 0)`) instead of compiling/returning script output.
- Added a security regression test `tests/security/test_layout_no_script_eval.py` that asserts `CLayout.cpp` no longer includes `handler/CScriptHandler.h`, does not reference `call_created_function`/`getScriptHandler`, and that invalid values fall back to `0`.

### Testing
- Ran the security unit tests with `python3 -m unittest tests.security.test_layout_no_script_eval` and the test passed.
- Ran all security tests with `python3 -m unittest discover -s tests/security` and they passed.
- Built tests with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` and executed the native test runner via `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`, which passed.`
- Executed the full Python integration/test suite with `python3 test.py` (132 tests, 19 skipped) and it completed successfully (all tests OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0346f0805883269df3bac06cd40176)