### PR TITLE
Restrict CScript accessor expressions

### DIFF
--- a/src/core/CScript.cpp
+++ b/src/core/CScript.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -18,8 +18,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CScript.h"
 #include "core/CGame.h"
 #include "handler/CScriptHandler.h"
+#include "vlogger.h"
 
 std::shared_ptr<CGameObject> CScript::invoke(std::shared_ptr<CGame> game, std::shared_ptr<CGameObject> self) {
+    if (!isSafeAccessorExpression(script)) {
+        vstd::logger::error("CScript: rejected unsafe accessor expression", script);
+        return nullptr;
+    }
     return game->getScriptHandler()->call_created_function<std::shared_ptr<CGameObject>, std::shared_ptr<CGameObject>>(
         "return " + script, {"self"}, self);
 }

--- a/src/core/CScript.h
+++ b/src/core/CScript.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -18,10 +18,45 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 
 #include "object/CGameObject.h"
+#include "vstring.h"
+
+#include <cctype>
 
 class CScript : public CGameObject {
     V_META(CScript, CGameObject, V_PROPERTY(CScript, std::string, script, getScript, setScript))
   public:
+    static bool isSafeAccessorExpression(const std::string &expression) {
+        const std::string trimmed = vstd::trim(expression);
+        std::size_t pos = 0;
+
+        auto consumeIdentifier = [&trimmed, &pos]() {
+            if (pos >= trimmed.size() ||
+                (!std::isalpha(static_cast<unsigned char>(trimmed[pos])) && trimmed[pos] != '_')) {
+                return false;
+            }
+            ++pos;
+            while (pos < trimmed.size() &&
+                   (std::isalnum(static_cast<unsigned char>(trimmed[pos])) || trimmed[pos] == '_')) {
+                ++pos;
+            }
+            return true;
+        };
+
+        if (!consumeIdentifier() || trimmed.substr(0, pos) != "self") {
+            return false;
+        }
+        while (pos < trimmed.size()) {
+            if (trimmed[pos++] != '.' || !consumeIdentifier()) {
+                return false;
+            }
+            if (pos + 1 >= trimmed.size() || trimmed[pos] != '(' || trimmed[pos + 1] != ')') {
+                return false;
+            }
+            pos += 2;
+        }
+        return true;
+    }
+
     template <fn::GameObjectDerived T>
     std::shared_ptr<T> invoke(std::shared_ptr<CGame> game, std::shared_ptr<CGameObject> self) {
         return vstd::cast<T>(invoke(game, self));

--- a/tests/unit/test_coords.cpp
+++ b/tests/unit/test_coords.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CJsonUtil.h"
 #include "core/CPathFinder.h"
 #include "core/CSerialization.h"
+#include "core/CScript.h"
 #include "core/CUtil.h"
 #include "gui/CSdlResources.h"
 #include "handler/CScriptHandler.h"
@@ -648,6 +649,21 @@ void test_vstd_string_helpers() {
     expect_true(vstd::camel("hello world") == "Hello World ", "camel should title-case space-separated words");
 }
 
+void test_script_rejects_executable_expressions() {
+    expect_true(CScript::isSafeAccessorExpression("self.getGui().getGame().getMap().getPlayer()"),
+                "safe accessor validation should accept existing panel refresh target expressions");
+    expect_true(CScript::isSafeAccessorExpression(" self.getParent().getMarket() "),
+                "safe accessor validation should trim existing accessor expressions");
+    expect_true(!CScript::isSafeAccessorExpression("(__import__('os').system('id > /tmp/pwned'), self)[1]"),
+                "safe accessor validation should reject Python side-effect expressions");
+    expect_true(!CScript::isSafeAccessorExpression("self.getGui().getGame().getMap().getPlayer().__class__"),
+                "safe accessor validation should reject attribute access without a zero-argument call");
+    expect_true(!CScript::isSafeAccessorExpression("self.getGui(__import__('os'))"),
+                "safe accessor validation should reject method arguments");
+    expect_true(!CScript::isSafeAccessorExpression("game.getMap()"),
+                "safe accessor validation should only allow expressions rooted at self");
+}
+
 void test_script_handler_executes_commands_and_wraps_functions() {
     CScriptHandler handler;
 
@@ -879,6 +895,7 @@ int main() {
     test_vstd_queue_collection_and_function_helpers();
     test_vstd_allocation_random_and_value_helpers();
     test_vstd_string_helpers();
+    test_script_rejects_executable_expressions();
     test_script_handler_executes_commands_and_wraps_functions();
     test_random_dungeon_cell_flags_and_validation();
     test_random_dungeon_layout_variants_generate_accessible_maps();


### PR DESCRIPTION
### Motivation
- Prevent execution of arbitrary Python expressions coming from JSON-configured `CScript` objects used as GUI refresh/visible targets, which allowed attacker-controlled side-effectful Python to run during GUI initialization.
- Preserve existing bundled resource expressions (e.g. `self.getGui().getGame().getMap().getPlayer()`) while blocking malicious constructs that perform imports, function calls with arguments, indexing, or non-`self` roots.

### Description
- Add `CScript::isSafeAccessorExpression(const std::string&)` which validates that the script is a `self`-rooted chain of zero-argument accessor calls (identifier, dot, identifier, `()`), allowing whitespace trimming and rejecting anything else. (file: `src/core/CScript.h`)
- Update `CScript::invoke` to call the validator and, on failure, log an error and return `nullptr` instead of compiling/executing the Python code. (file: `src/core/CScript.cpp`)
- Add a new unit test `test_script_rejects_executable_expressions` that asserts acceptance of existing accessor expressions and rejection of side-effectful or non-self expressions, and wire it into the test runner. (file: `tests/unit/test_coords.cpp`)
- Changes are limited to the three files above to keep the fix narrow and preserve existing behavior for valid bundled configs.

### Testing
- Built native targets and unit tests with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` which completed successfully. (succeeded)
- Ran native unit tests via `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` which passed. (succeeded)
- Ran the Python/integration test suite with `python3 test.py` which ran all tests (132 total, 19 skipped) and passed. (succeeded)
- Generated coverage with `./scripts/run_coverage.sh` producing line coverage `91.10%`. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032d8a3ce48326921d8751a44e39d0)