### PR TITLE
Harden resource loading against cwd script injection

### DIFF
--- a/src/core/CProvider.cpp
+++ b/src/core/CProvider.cpp
@@ -20,11 +20,70 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CJsonUtil.h"
 #include "gui/CAnimation.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
 namespace {
 
 bool isConfigResourcePath(const std::string &path) {
     const std::filesystem::path resourcePath(path);
     return !resourcePath.has_parent_path() || resourcePath.parent_path() == std::filesystem::path("config");
+}
+
+std::filesystem::path providerModulePathAnchor() { return std::filesystem::path(); }
+
+std::filesystem::path getModuleResourceRoot() {
+#ifdef _WIN32
+    HMODULE moduleHandle = nullptr;
+    if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           reinterpret_cast<LPCSTR>(&providerModulePathAnchor), &moduleHandle) == 0) {
+        return {};
+    }
+
+    std::string buffer(MAX_PATH, '\0');
+    DWORD length = 0;
+    while (true) {
+        length = GetModuleFileNameA(moduleHandle, buffer.data(), static_cast<DWORD>(buffer.size()));
+        if (length == 0) {
+            return {};
+        }
+        if (length < buffer.size() - 1) {
+            buffer.resize(length);
+            break;
+        }
+        buffer.resize(buffer.size() * 2, '\0');
+    }
+    return std::filesystem::path(buffer).parent_path();
+#else
+    Dl_info info{};
+    if (dladdr(reinterpret_cast<void *>(&providerModulePathAnchor), &info) == 0 || info.dli_fname == nullptr) {
+        return {};
+    }
+    return std::filesystem::path(info.dli_fname).parent_path();
+#endif
+}
+
+std::list<std::string> buildResourceSearchPath() {
+    std::list<std::string> paths;
+    auto moduleRoot = getModuleResourceRoot();
+    if (!moduleRoot.empty()) {
+        paths.push_back(std::filesystem::weakly_canonical(moduleRoot).string());
+    }
+    return paths;
+}
+
+bool isWithinResourceRoot(const std::filesystem::path &candidate, const std::filesystem::path &root) {
+    auto candidateIt = candidate.begin();
+    auto rootIt = root.begin();
+    for (; rootIt != root.end(); ++rootIt, ++candidateIt) {
+        if (candidateIt == candidate.end() || *candidateIt != *rootIt) {
+            return false;
+        }
+    }
+    return true;
 }
 
 } // namespace
@@ -59,7 +118,7 @@ void CConfigurationProvider::loadConfig(const std::string &path) {
     this->insert(std::make_pair(path, CResourcesProvider::getInstance()->loadJson(path)));
 }
 
-std::list<std::string> CResourcesProvider::searchPath = {""};
+std::list<std::string> CResourcesProvider::searchPath = buildResourceSearchPath();
 
 std::shared_ptr<CResourcesProvider> CResourcesProvider::getInstance() {
     static std::shared_ptr<CResourcesProvider> instance = std::make_shared<CResourcesProvider>();
@@ -112,10 +171,20 @@ std::shared_ptr<json> CResourcesProvider::loadJson(std::string path) {
 }
 
 std::string CResourcesProvider::getPath(std::string path) {
-    for (auto it : searchPath) {
-        auto p = std::filesystem::path(it) / std::filesystem::path(path);
-        if (std::filesystem::exists(p)) {
-            return p.string();
+    const std::filesystem::path requestedPath(std::move(path));
+    if (requestedPath.is_absolute()) {
+        return {};
+    }
+
+    for (const auto &root : searchPath) {
+        if (root.empty()) {
+            continue;
+        }
+
+        auto resourceRoot = std::filesystem::weakly_canonical(root);
+        auto candidate = std::filesystem::weakly_canonical(resourceRoot / requestedPath);
+        if (isWithinResourceRoot(candidate, resourceRoot) && std::filesystem::exists(candidate)) {
+            return candidate.string();
         }
     }
     return {};
@@ -154,13 +223,15 @@ std::vector<std::string> CResourcesProvider::getFiles(const std::string &type) {
         return retValue;
     }
 
-    std::filesystem::directory_iterator dir(resolvedFolderName), end;
+    const auto folderPath = std::filesystem::path(resolvedFolderName);
+    const auto resourceRoot = folderPath.parent_path();
+    std::filesystem::directory_iterator dir(folderPath), end;
     while (dir != end) {
         if (type == CResType::MAP || type == CResType::SAVE) {
             auto pt = dir->path().filename().stem().string();
             retValue.push_back(pt);
         } else {
-            auto pt = dir->path().string();
+            auto pt = std::filesystem::relative(dir->path(), resourceRoot).generic_string();
             if (vstd::ends_with(pt, vstd::join({".", suffix}, ""))) {
                 retValue.push_back(pt);
             }

--- a/test.py
+++ b/test.py
@@ -5610,6 +5610,24 @@ class GameTest(unittest.TestCase):
             self.assertIn(needle, provider.load(resource_path), resource_path)
             resolved[resource_path] = full_path
 
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            malicious_plugins = tmp_path / "plugins"
+            malicious_plugins.mkdir()
+            (malicious_plugins / "aardvark.py").write_text(
+                "def load(context):\n    raise RuntimeError('untrusted cwd plugin executed')\n",
+                encoding="utf-8",
+            )
+
+            original_cwd = Path.cwd()
+            try:
+                os.chdir(tmp_path)
+                self.assertFalse(provider.getPath("plugins/aardvark.py"))
+                self.assertNotIn("plugins/aardvark.py", provider.getFiles("PLUGIN"))
+                game.CGameLoader.loadGame()
+            finally:
+                os.chdir(original_cwd)
+
         return True, json.dumps(resolved, sort_keys=True)
 
     @game_test


### PR DESCRIPTION
### Motivation
- The startup loader previously enumerated and executed Python plugins by scanning a relative `scripts`/`plugins` directory using the process current working directory, allowing a malicious cwd resource to execute arbitrary Python at program start. 
- The change aims to restrict resource discovery to a trusted location and prevent resolved resource paths from escaping that root, eliminating the local cwd execution vector while preserving intended plugin/config loading.

### Description
- Anchor resource lookup to the engine/module install location by deriving a trusted resource root from the loaded `_game` module (using `dladdr` on POSIX and `GetModuleHandleEx` on Windows) and initialize `CResourcesProvider::searchPath` from that root. (`src/core/CProvider.cpp`)
- Harden `CResourcesProvider::getPath` to reject absolute requested paths and to canonicalize candidate paths and verify they remain within the trusted resource root before returning them. (`src/core/CProvider.cpp`)
- Update `CResourcesProvider::getFiles` to resolve resource directories through the hardened `getPath` and return stable resource-relative paths (so enumeration no longer depends on cwd). (`src/core/CProvider.cpp`)
- Link the `_game` module with `${CMAKE_DL_LIBS}` so runtime module-address lookup via `dladdr` works portably. (`CMakeLists.txt`) 
- Add a regression test that creates a temporary attacker-controlled `plugins/aardvark.py` in a temporary cwd, asserts it is not resolvable or enumerated by the provider, and calls `CGameLoader.loadGame()` to confirm the malicious plugin is ignored. (`test.py`) 

### Testing
- Built the engine and for-unit-tests with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`, which completed successfully. 
- Ran the native test executable with `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`, and the unit test target passed. 
- Ran the full Python test suite `python3 test.py`; an initial run failed due to missing `PIL` (Pillow), then `pillow` was installed and `python3 test.py` completed successfully (132 tests passed, 19 skipped). 
- Executed the coverage workflow `./scripts/run_coverage.sh`, which completed and produced line coverage of `91.05%`, exceeding the 90% threshold.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b6fadc9c8326b299a00dbb25888b)