### PR TITLE
Skip null entries during array deserialization

### DIFF
--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -508,6 +508,16 @@ void init_game_module(py::module_ &m) {
             },
             "Register a class constructor under a class name.")
         .def("createObject", createObjectByType, "Create an object by configured type id.")
+        .def(
+            "registerConfigJson",
+            [](CObjectHandler &self, const std::string &name, const std::string &config) {
+                auto parsed = CJsonUtil::from_string(config, "registerConfigJson:" + name);
+                if (!parsed) {
+                    throw std::runtime_error("Failed to parse object config json for " + name);
+                }
+                self.registerConfig(name, parsed);
+            },
+            "Register object configuration from a JSON string.")
         .def("getAllTypes", &CObjectHandler::getAllTypes, "Return all configured object type ids.")
         .def("getAllSubTypes", &CObjectHandler::getAllSubTypes,
              "Return configured type ids whose class inherits the given base class.");
@@ -672,6 +682,7 @@ void init_game_module(py::module_ &m) {
 
     py::class_<CFightHandler, std::shared_ptr<CFightHandler>>(m, "CFightHandler", "Combat resolution service.")
         .def("fight", &CFightHandler::fight, "Run a fight between two creatures.")
+        .def_static("applyEffects", &CFightHandler::applyEffects, "Apply active effects to a creature.")
         .def(
             "fightMany",
             [](std::shared_ptr<CCreature> attacker, const py::iterable &opponents) {
@@ -814,6 +825,11 @@ void init_game_module(py::module_ &m) {
         .def("addItem", addItemByName, "Create and add an item by type id.")
         .def("addItem", addItemByObject, "Add an existing item object.")
         .def("addItems", &CCreature::addItems, "Add all items from a set to inventory.")
+        .def("setItems", &CCreature::setItems, "Replace inventory items.")
+        .def("getItems", &CCreature::getItems, "Return inventory items.")
+        .def("setEffects", &CCreature::setEffects, "Replace active effects.")
+        .def("getEffects", &CCreature::getEffects, "Return active effects.")
+        .def("getActions", &CCreature::getActions, "Return available actions.")
         .def("removeItem", removeItem,
              "Remove the first inventory item matching predicate(item). Optional second arg allows quest removal.")
         .def("removeQuestItem", removeQuestItem, "Remove first matching quest item predicate from inventory.")

--- a/src/core/CSerialization.cpp
+++ b/src/core/CSerialization.cpp
@@ -27,6 +27,20 @@ std::shared_ptr<CSerializerBase> CSerialization::serializer(std::pair<std::type_
 }
 
 namespace {
+thread_local std::string array_deserialize_context;
+
+class ScopedArrayDeserializeContext {
+  public:
+    explicit ScopedArrayDeserializeContext(std::string context) : previous(array_deserialize_context) {
+        array_deserialize_context = std::move(context);
+    }
+
+    ~ScopedArrayDeserializeContext() { array_deserialize_context = previous; }
+
+  private:
+    std::string previous;
+};
+
 class CGameObjectPointerSerializer : public CSerializerBase {
   public:
     std::any serialize(std::any object) final {
@@ -160,6 +174,15 @@ void CSerialization::setOtherProperty(std::type_index serializedId, std::type_in
         (*CTypes::serializers())[std::make_pair(serializedId, deserializedId)];
     std::any result;
     try {
+        std::string context = "property '" + key + "'";
+        if (object) {
+            context += " on ";
+            context += vstd::is_empty(object->getTypeId()) ? object->meta()->name() : object->getTypeId();
+            if (!vstd::is_empty(object->getName())) {
+                context += " named '" + object->getName() + "'";
+            }
+        }
+        ScopedArrayDeserializeContext arrayContext(context);
         result = vstd::not_null(serializer, "No serializer!")->deserialize(object->getGame(), value);
     } catch (const std::exception &ex) {
         throw std::runtime_error("Failed to deserialize property '" + key + "': " + ex.what());
@@ -308,7 +331,10 @@ std::set<std::shared_ptr<CGameObject>> array_deserialize(const std::shared_ptr<C
         auto deserialized = CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(
             map, CJsonUtil::alias(object, (*object)[i]));
         if (!deserialized) {
-            vstd::logger::warning("Failed to deserialize object in array at index:", i);
+            vstd::logger::warning("Failed to deserialize object in array",
+                                  array_deserialize_context.empty() ? "property <unknown>" : array_deserialize_context,
+                                  "index", i, "- skipping null entry");
+            continue;
         }
         objects.insert(deserialized);
     }

--- a/src/handler/CFightHandler.cpp
+++ b/src/handler/CFightHandler.cpp
@@ -353,6 +353,10 @@ void CFightHandler::applyEffects(const std::shared_ptr<CCreature> &cr) {
     auto effects = cr->getEffects();
 
     for (const auto &effect : effects) {
+        if (!effect) {
+            vstd::logger::warning("Skipping null effect while expiring effects for", cr->to_string());
+            continue;
+        }
         if (effect->getTimeLeft() == 0) {
             vstd::logger::debug(cr->to_string(), "is now free from", effect->to_string());
             cr->removeEffect(effect);
@@ -361,6 +365,10 @@ void CFightHandler::applyEffects(const std::shared_ptr<CCreature> &cr) {
         }
     }
     for (const auto &effect : effects) {
+        if (!effect) {
+            vstd::logger::warning("Skipping null effect while applying effects for", cr->to_string());
+            continue;
+        }
         vstd::logger::debug(cr->to_string(), "suffers from", effect->to_string());
         effect->apply(cr);
         if (!cr->isAlive()) {

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -26,7 +26,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 bool visitablePredicate(std::shared_ptr<CMapObject> object) { return vstd::cast<Visitable>(object).operator bool(); };
 
-void CCreature::setActions(std::set<std::shared_ptr<CInteraction>> value) { actions = value; }
+void CCreature::setActions(std::set<std::shared_ptr<CInteraction>> value) {
+    actions.clear();
+    for (const auto &action : value) {
+        addAction(action);
+    }
+}
 
 std::set<std::shared_ptr<CInteraction>> CCreature::getActions() { return actions; }
 
@@ -110,6 +115,10 @@ void CCreature::setEquipped(CItemMap value) {
 
 void CCreature::addItems(std::set<std::shared_ptr<CItem>> items) {
     for (std::shared_ptr<CItem> it : items) {
+        if (!it) {
+            vstd::logger::warning("Skipping null item while adding inventory to", to_string());
+            continue;
+        }
         this->items.insert(it);
         signal("inventoryChanged");
     }
@@ -175,7 +184,8 @@ CInteractionMap CCreature::getLevelling() { return levelling; }
 void CCreature::setLevelling(CInteractionMap value) { levelling = value; }
 
 void CCreature::setItems(std::set<std::shared_ptr<CItem>> value) {
-    items = value; // TODO: rethink inventory changed here
+    items.clear(); // TODO: rethink inventory changed here
+    addItems(value);
 }
 
 std::set<std::shared_ptr<CItem>> CCreature::getItems() { return items; }
@@ -225,6 +235,10 @@ void CCreature::addAction(std::shared_ptr<CInteraction> action) {
 }
 
 void CCreature::addEffect(std::shared_ptr<CEffect> effect) {
+    if (!effect) {
+        vstd::logger::warning("Skipping null effect for", to_string());
+        return;
+    }
     if (vstd::ctn(effects, effect, CGameObject::name_comparator)) {
         vstd::logger::debug(effect->to_string(), "skipping already present effect for", this->to_string());
     } else {
@@ -497,7 +511,12 @@ void CCreature::onLeave(std::shared_ptr<CGameEvent>) {}
 
 void CCreature::onDestroy(std::shared_ptr<CGameEvent>) { effects.clear(); }
 
-void CCreature::setEffects(const std::set<std::shared_ptr<CEffect>> &value) { effects = value; }
+void CCreature::setEffects(const std::set<std::shared_ptr<CEffect>> &value) {
+    effects.clear();
+    for (const auto &effect : value) {
+        addEffect(effect);
+    }
+}
 
 std::shared_ptr<CController> CCreature::getController() {
     return controller ? controller : std::make_shared<CController>();
@@ -569,10 +588,14 @@ std::shared_ptr<Stats> CCreature::getStats() {
         ret->addBonus(getLevelStats());
     }
     for (auto [slot, item] : getEquipped()) {
-        ret->addBonus(item->getBonus());
+        if (item) {
+            ret->addBonus(item->getBonus());
+        }
     }
     for (auto effect : getEffects()) {
-        ret->addBonus(effect->getBonus());
+        if (effect) {
+            ret->addBonus(effect->getBonus());
+        }
     }
     return ret;
 }

--- a/src/object/CMarket.cpp
+++ b/src/object/CMarket.cpp
@@ -24,6 +24,10 @@ CMarket::CMarket() {}
 CMarket::~CMarket() {}
 
 void CMarket::add(std::shared_ptr<CItem> item) {
+    if (!item) {
+        vstd::logger::warning("Skipping null market item");
+        return;
+    }
     items.insert(item);
     signal("itemsChanged");
 }

--- a/test.py
+++ b/test.py
@@ -1955,6 +1955,61 @@ class GameTest(unittest.TestCase):
         return True, json.dumps(report, sort_keys=True)
 
     @game_test
+    def test_array_deserialize_skips_bad_entries_and_consumers_are_safe(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        handler = g.getObjectHandler()
+        handler.registerConfigJson(
+            "ArrayDeserializeRegressionCreature",
+            json.dumps(
+                {
+                    "class": "CCreature",
+                    "properties": {
+                        "actions": [{"ref": "Strike"}, {"ref": "DefinitelyMissingInteraction"}],
+                        "effects": [{"class": "CEffect"}, {"class": "DefinitelyMissingEffectClass"}],
+                        "items": [{"ref": "LifePotion"}, {"ref": "DefinitelyMissingItem"}],
+                    },
+                }
+            ),
+        )
+
+        creature = g.createObject("ArrayDeserializeRegressionCreature")
+        self.assertIsNotNone(creature)
+
+        actions = list(creature.getActions())
+        effects = list(creature.getEffects())
+        items = list(creature.getItems())
+
+        self.assertTrue(actions)
+        self.assertTrue(effects)
+        self.assertTrue(items)
+        self.assertNotIn(None, actions)
+        self.assertNotIn(None, effects)
+        self.assertNotIn(None, items)
+        self.assertEqual(["Strike"], sorted(action.getTypeId() for action in actions))
+        self.assertEqual(["LifePotion"], sorted(item.getTypeId() for item in items))
+
+        # High-risk consumers should tolerate nulls defensively even if a caller bypasses deserialization.
+        creature.setItems({None, g.createObject("ManaPotion")})
+        creature.addItems({None, g.createObject("LesserLifePotion")})
+        creature.setEffects({None, g.createObject("CEffect")})
+        game.CFightHandler.applyEffects(creature)
+
+        self.assertNotIn(None, list(creature.getItems()))
+        self.assertNotIn(None, list(creature.getEffects()))
+        self.assertEqual(2, len(creature.getItems()))
+
+        return True, json.dumps(
+            {
+                "actions": sorted(action.getTypeId() for action in actions),
+                "effects": len(effects),
+                "items": sorted(item.getTypeId() for item in items),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_dynamic_domain_plugins_serialize_clone_and_load_gameplay_content(self):
         game = load_game_module()
         g = game.CGameLoader.loadGame()


### PR DESCRIPTION
### Motivation
- Arrays deserializing object refs/types logged failures but still inserted null pointers into returned sets, causing later consumers to crash when dereferencing null entries.  
- The goal is to choose a consistent policy: skip bad array entries (preserve valid entries) and make failures easier to diagnose by including the owning property/source context and index in warnings.  
- Also add defensive checks in known high-risk consumers so callers that bypass deserialization are tolerated without crashes.

### Description
- Make `array_deserialize` skip null deserializations and log a clear warning that includes the owning `property/object` context and the array `index` when available by introducing a `thread_local std::string array_deserialize_context` and `ScopedArrayDeserializeContext`. (changes in `src/core/CSerialization.cpp`).
- Set the context for array deserialization in `CSerialization::setOtherProperty` so warnings include `property 'name' on <type|typeId> named '<name>'` when applicable. (changes in `src/core/CSerialization.cpp`).
- Add defensive null filtering/guards in high-risk consumers: `CCreature` methods (`setActions`, `addItems`, `setItems`, `addEffect`, `setEffects`, `getStats` null checks), `CMarket::add`, and `CFightHandler::applyEffects` to skip nulls and log warnings rather than crash. (changes in `src/object/CCreature.cpp`, `src/object/CMarket.cpp`, `src/handler/CFightHandler.cpp`).
- Extend Python bindings to help tests and callers: add `CObjectHandler.registerConfigJson`, expose `CCreature` `setItems/getItems/setEffects/getEffects/getActions`, and expose `CFightHandler.applyEffects` to exercise behavior from Python tests. (changes in `src/core/CModule.cpp`).
- Add a regression test that registers an object config with arrays containing a bad `ref`/`class` and asserts: no `None`/nullptr entries in resulting sets, valid entries preserved, and consumer code (effects/items handling) does not crash. (changes in `test.py`).

### Testing
- Built native targets with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`, which completed successfully.  
- Ran C++ unit tests with `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`, which passed.  
- Ran the focused Python regression test with `python3 test.py -k array_deserialize` and it passed; the new test verifies skipped null entries and safe consumers.  
- Ran full Python test suite and `./scripts/run_coverage.sh`; initial `python3 test.py` failed due to missing `Pillow` (screenshot assertions); after installing `pillow` the targeted `Xvfb` playback test passed, but the coverage run reported a failure due to a long-running UI test timing out (`test_full_nouraajd_quest_walkthrough_ui` exceeded the wrapper timeout) so the coverage script exited non-zero.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31308bba1c8326a3765ba68f4581c7)