### PR TITLE
Fix empty-string deserialization

### DIFF
--- a/src/core/CSerialization.cpp
+++ b/src/core/CSerialization.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -127,25 +127,15 @@ void CSerialization::setBooleanProperty(const std::shared_ptr<CGameObject> &obje
 
 void CSerialization::setStringProperty(const std::shared_ptr<CGameObject> &object, const std::string &key,
                                        const std::string &value) {
-    if (!vstd::trim(value).empty()) {
-        auto val = vstd::to_int(value);
-        if (val.second) {
-            setNumericProperty(object, key, val.first);
-        } else if (value == "true") {
-            setBooleanProperty(object, key, true);
-        } else if (value == "false") {
-            setBooleanProperty(object, key, false);
-        } else {
-            // TODO: make method that checks if object is JSON
-            std::shared_ptr<json> d = CJsonUtil::from_string(value);
-            if (d && d->is_number() && vstd::str(d->get<double>()) != value) {
-                object->setStringProperty(key, value);
-            } else if (!d || d->is_string()) {
-                object->setStringProperty(key, value);
-            } else {
-                setProperty(object, key, d);
-            }
-        }
+    auto coerced = coerceStringProperty(getProperty(object, key), value);
+    if (std::holds_alternative<std::string>(coerced)) {
+        object->setStringProperty(key, std::get<std::string>(coerced));
+    } else if (std::holds_alternative<int>(coerced)) {
+        setNumericProperty(object, key, std::get<int>(coerced));
+    } else if (std::holds_alternative<bool>(coerced)) {
+        setBooleanProperty(object, key, std::get<bool>(coerced));
+    } else if (std::holds_alternative<std::shared_ptr<json>>(coerced)) {
+        setProperty(object, key, std::get<std::shared_ptr<json>>(coerced));
     }
 }
 

--- a/src/core/CSerialization.h
+++ b/src/core/CSerialization.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -19,6 +19,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "core/CConcepts.h"
 #include "core/CGlobal.h"
+#include "core/CJsonUtil.h"
+
+#include <variant>
 
 class CGame;
 
@@ -198,6 +201,37 @@ class CSerialization {
 
     static void setProperty(const std::shared_ptr<json> &conf, const std::string &propertyName,
                             const std::any &propertyValue);
+
+    using CoercedStringProperty = std::variant<std::monostate, std::string, int, bool, std::shared_ptr<json>>;
+
+    static CoercedStringProperty coerceStringProperty(std::type_index property, const std::string &value) {
+        if (property == std::type_index(typeid(std::string))) {
+            return value;
+        }
+        if (vstd::trim(value).empty()) {
+            return std::monostate();
+        }
+
+        auto val = vstd::to_int(value);
+        if (val.second) {
+            return val.first;
+        }
+        if (value == "true") {
+            return true;
+        }
+        if (value == "false") {
+            return false;
+        }
+
+        auto parsed = CJsonUtil::from_string(value);
+        if (parsed && parsed->is_number() && vstd::str(parsed->get<double>()) != value) {
+            return value;
+        }
+        if (!parsed || parsed->is_string()) {
+            return value;
+        }
+        return parsed;
+    }
 
     static std::string generateName(const std::shared_ptr<CGameObject> &object);
 

--- a/tests/unit/test_coords.cpp
+++ b/tests/unit/test_coords.cpp
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CTags.h"
 #include "core/CJsonUtil.h"
 #include "core/CPathFinder.h"
+#include "core/CSerialization.h"
 #include "core/CUtil.h"
 #include "gui/CSdlResources.h"
 #include "handler/CScriptHandler.h"
@@ -94,6 +95,26 @@ void expect_true(bool condition, const char *message) {
         std::cerr << "FAIL: " << message << "\n";
         ++failures;
     }
+}
+
+void test_string_deserialization_preserves_empty_and_whitespace() {
+    auto empty_value = CSerialization::coerceStringProperty(std::type_index(typeid(std::string)), "");
+    expect_true(std::holds_alternative<std::string>(empty_value) && std::get<std::string>(empty_value).empty(),
+                "string deserialization should preserve intentionally empty strings");
+
+    auto blank_value = CSerialization::coerceStringProperty(std::type_index(typeid(std::string)), "   ");
+    expect_true(std::holds_alternative<std::string>(blank_value) && std::get<std::string>(blank_value) == "   ",
+                "string deserialization should preserve whitespace-only strings");
+}
+
+void test_string_deserialization_coerces_non_string_targets() {
+    auto numeric_value = CSerialization::coerceStringProperty(std::type_index(typeid(int)), "42");
+    expect_true(std::holds_alternative<int>(numeric_value) && std::get<int>(numeric_value) == 42,
+                "numeric string deserialization should preserve numeric coercion for numeric targets");
+
+    auto bool_value = CSerialization::coerceStringProperty(std::type_index(typeid(bool)), "true");
+    expect_true(std::holds_alternative<bool>(bool_value) && std::get<bool>(bool_value),
+                "boolean string deserialization should preserve boolean coercion for boolean targets");
 }
 
 void test_happy_path_add_and_distance() {
@@ -831,6 +852,8 @@ void test_random_dungeon_layout_variants_generate_accessible_maps() {
 int main() {
     pybind11::scoped_interpreter guard{};
 
+    test_string_deserialization_preserves_empty_and_whitespace();
+    test_string_deserialization_coerces_non_string_targets();
     test_happy_path_add_and_distance();
     test_edge_case_adjacent_or_same();
     test_comparison_and_ordering();


### PR DESCRIPTION
### Motivation
- Configuration strings set to `""` or whitespace were being ignored during deserialization because `setStringProperty` skipped blank values, preventing authors from intentionally setting empty or whitespace-only string properties.
- The change preserves exact string values when the destination property type is `std::string` while keeping existing numeric/bool/JSON coercion for non-string targets.

### Description
- Add `CoercedStringProperty` (a `std::variant`) and a helper `coerceStringProperty(std::type_index, const std::string&)` that encapsulates the coercion rules and preserves exact values for `std::string` targets. (see `src/core/CSerialization.h`).
- Replace the previous ad-hoc logic in `setStringProperty` with a call to `coerceStringProperty`, then dispatch to `setNumericProperty`, `setBooleanProperty`, `setProperty` (JSON/object) or `object->setStringProperty` according to the variant result. (see `src/core/CSerialization.cpp`).
- Add unit tests exercising: intentionally empty string, whitespace-only string, numeric-string -> numeric coercion for numeric targets, and bool-string -> bool coercion for bool targets. (see `tests/unit/test_coords.cpp`).
- Include necessary header additions (`CJsonUtil` and `<variant>`) and update copyright year in modified files.

### Testing
- Built the unit target with `cmake --build cmake-build-release --target for_unit_tests -j$(nproc)` and the full engine with `_game` successfully, and linking completed without errors.
- Ran `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` and the `for_unit_tests` executable passed.
- Ran the full Python test suite with `python3 test.py`; the suite executed many tests successfully but several xvfb screenshot tests errored due to missing Pillow (`ModuleNotFoundError: No module named 'PIL'`), causing the overall Python run to fail in this environment.
- Ran coverage with `./scripts/run_coverage.sh`; the instrumented build and `ctest` passed, but the instrumented Python test run encountered the same missing-Pillow limitation and could not fully complete coverage collection.

Files changed:
- `src/core/CSerialization.h`
- `src/core/CSerialization.cpp`
- `tests/unit/test_coords.cpp`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a313079f300832681d0c385b867b70e)