### PR TITLE
Fix non-square TMX tile layer indexing and add regression test

### DIFF
--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -487,16 +487,20 @@ void CMapLoader::handleTileLayer(const std::shared_ptr<CMap> &map, const std::ve
     const auto game = map->getGame();
     int level = vstd::to_int(layerProperties["level"].get<std::string>()).first;
 
-    int yLayer = layer["width"].get<int>();
-    int xLayer = layer["height"].get<int>();
+    int width = layer["width"].get<int>();
+    int height = layer["height"].get<int>();
 
-    for (int y = 0; y < yLayer; ++y) {
-        for (int x = 0; x < xLayer; ++x) {
-            int id = layerData[x + y * xLayer].get<int>();
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            int id = layerData[x + y * width].get<int>();
             if (id == 0) {
                 continue;
             }
             id--;
+            if (id < 0 || id >= static_cast<int>(tileTypes.size()) || tileTypes[id].empty()) {
+                vstd::logger::warning("Skipping invalid tile id", id + 1, "at", x, y, "level", level);
+                continue;
+            }
             map->addTile(game->createObject<CTile>(tileTypes[id]), x, y, level);
         }
     }

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -459,6 +459,7 @@ void init_game_module(py::module_ &m) {
 
     bool (CMap::*canStep)(Coords) = &CMap::canStep;
     int (CMap::*getMovementCost)(Coords) = &CMap::getMovementCost;
+    std::shared_ptr<CTile> (CMap::*getTile)(int, int, int) = &CMap::getTile;
     void (CMap::*addObject)(const std::shared_ptr<CMapObject> &) = &CMap::addObject;
 
     py::class_<CMap, CGameObject, std::shared_ptr<CMap>>(
@@ -479,6 +480,7 @@ void init_game_module(py::module_ &m) {
         .def("canStep", canStep, "Return whether coordinates are walkable.")
         .def("getMovementCost", getMovementCost,
              "Return movement cost at coordinates. One-step turns treat every tile as cost 1.")
+        .def("getTile", getTile, "Return the tile at coordinates, creating the layer default when missing.")
         .def("dumpPaths", &CMap::dumpPaths, "Write pathfinding diagnostics to a file path.")
         .def("getEntryX", &CMap::getEntryX, "Return map entry X coordinate.")
         .def("getEntryY", &CMap::getEntryY, "Return map entry Y coordinate.")
@@ -618,7 +620,9 @@ void init_game_module(py::module_ &m) {
 
     auto ctile =
         py::class_<CTile, CWrapper<CTile>, std::shared_ptr<CTile>, CGameObject>(m, "CTile", "Base tile class.");
-    ctile.def(py::init_alias<>()).def("onStep", &CTile::onStep, "Handle a creature stepping on this tile.");
+    ctile.def(py::init_alias<>())
+        .def("onStep", &CTile::onStep, "Handle a creature stepping on this tile.")
+        .def("getTileType", &CTile::getTileType, "Return this tile's terrain type.");
     m.attr("CTileBase") = ctile;
 
     py::class_<CItem, CMapObject, std::shared_ptr<CItem>>(m, "CItem", "Base inventory/equipment item.");

--- a/test.py
+++ b/test.py
@@ -1268,18 +1268,6 @@ def validate_tiled_layer(
                 )
             )
 
-        if width is not None and height is not None and width != height:
-            issues.append(
-                map_validation_issue(
-                    path,
-                    "loader_assumption",
-                    f"{prefix} is rectangular ({width}x{height}), but the current handleTileLayer() implementation swaps width and height and is only safe for square layers.",
-                    field="width",
-                    layer_name=layer_name,
-                    layer_index=layer_index,
-                )
-            )
-
         for cell_index, gid in enumerate(data):
             if not is_integral_json_number(gid) or int(gid) < 0:
                 issues.append(
@@ -1772,6 +1760,70 @@ class GameTest(unittest.TestCase):
         self.assertIsNone(g.createObject("DefinitelyMissingType"))
         self.assertIsNone(g.getMap().getObjectByName("DefinitelyMissingObject"))
         g.getMap().removeObjectByName("DefinitelyMissingObject")
+        return True, ""
+
+    @game_test
+    def test_non_square_tmx_tile_layer_preserves_row_major_tile_positions(self):
+        game = load_game_module()
+        map_name = "unit_non_square_tmx"
+        map_dir = Path.cwd() / "maps" / map_name
+        map_dir.mkdir(parents=True, exist_ok=True)
+        (map_dir / "config.json").write_text("{}")
+        (map_dir / "script.py").write_text("")
+        (map_dir / "map.json").write_text(
+            json.dumps(
+                {
+                    "type": "map",
+                    "orientation": "orthogonal",
+                    "width": 3,
+                    "height": 2,
+                    "tilewidth": 32,
+                    "tileheight": 32,
+                    "properties": {"x": "0", "y": "0", "z": "0"},
+                    "tilesets": [
+                        {
+                            "firstgid": 1,
+                            "tileproperties": {
+                                "0": {"type": "GrassTile"},
+                                "1": {"type": "WaterTile"},
+                                "2": {"type": "MountainTile"},
+                            },
+                        }
+                    ],
+                    "layers": [
+                        {
+                            "type": "tilelayer",
+                            "name": "ground",
+                            "width": 3,
+                            "height": 2,
+                            "properties": {
+                                "level": "0",
+                                "default": "GrassTile",
+                                "outOfBounds": "WaterTile",
+                                "xBound": "3",
+                                "yBound": "2",
+                            },
+                            "data": [1, 2, 3, 3, 2, 99],
+                        }
+                    ],
+                }
+            )
+        )
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGame(g, map_name)
+        game_map = g.getMap()
+
+        expected_tile_types = {
+            (0, 0): "grass",
+            (1, 0): "water",
+            (2, 0): "mountain",
+            (0, 1): "mountain",
+            (1, 1): "water",
+            (2, 1): "grass",
+        }
+        for (x_pos, y_pos), tile_type in expected_tile_types.items():
+            self.assertEqual(tile_type, game_map.getTile(x_pos, y_pos, 0).getTileType())
         return True, ""
 
     @game_test


### PR DESCRIPTION
### Motivation
- The TMX tile-layer loader treated `width` and `height` swapped and used incorrect indexing which transposed non-square layers and corrupted tile placement.
- Tile IDs were indexed without bounds checks which could crash or read invalid entries for malformed maps.
- Tests and Python bindings were missing to assert exact tile placement for non-square map fixtures.

### Description
- Corrected `CMapLoader::handleTileLayer` to use `width`/`height`, iterate `for (y = 0; y < height)` then `for (x = 0; x < width)`, and index `layerData[x + y * width]` (file: `src/core/CLoader.cpp`).
- Added bounds validation for local tile ids and log+skip behavior for invalid ids instead of indexing out of range (file: `src/core/CLoader.cpp`).
- Exported `CMap.getTile(...)` and `CTile.getTileType()` to Python so tests can assert exact tile types (file: `src/core/CModule.cpp`).
- Removed the previous map-validation assumption that rectangular tile layers are unsafe and added a 3x2 non-square TMX regression test that verifies row-major tile placement and that an out-of-range GID is skipped (file: `test.py`).

### Testing
- Ran `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` which completed successfully.
- Ran `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` and the C++ unit test target `for_unit_tests` passed.
- Ran `python3 test.py` which initially failed due to missing Pillow (`ModuleNotFoundError: No module named 'PIL'`), installed Pillow with `python3 -m pip install --user Pillow`, then re-ran `python3 test.py` and the full Python test suite passed (headless/Xvfb tests were skipped or guarded as expected in the environment).
- Ran `./scripts/run_coverage.sh` which built the coverage targets successfully but the Python coverage run failed in the slower coverage environment because an Xvfb gameplay scenario timed out (`test_full_nouraajd_quest_walkthrough_ui`), so the coverage workflow reported failure and requires follow-up investigation in the coverage environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3130554f4c83269add12ef128bc4dc)