### PR TITLE
Enable unity build batching for game_core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,7 +527,8 @@ endif ()
 
 if (WIN32)
     set_target_properties(_game PROPERTIES UNITY_BUILD OFF)
-else()
+else ()
+    set_target_properties(game_core PROPERTIES UNITY_BUILD ON UNITY_BUILD_BATCH_SIZE 8)
     set_target_properties(_game PROPERTIES UNITY_BUILD ON UNITY_BUILD_BATCH_SIZE 8)
 endif ()
 


### PR DESCRIPTION
### Motivation
- `game_core` now owns `GAME_CORE_SRC`, so enable non-Windows unity batching for `game_core` (batch size 8) and avoid relying on `_game` for whole-project batching.

### Description
- On non-Windows platforms set `UNITY_BUILD ON` and `UNITY_BUILD_BATCH_SIZE 8` for the `game_core` target while preserving the existing `_game` unity properties and keeping the `set_source_files_properties(... PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)` block covering the listed `src/core/*` and `src/object/CCreature.cpp` files.

### Testing
- Ran the required validation: `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`, `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`, and `python3 test.py`; `python3 test.py` initially errored due to missing `PIL`/Pillow, installed it with `python3 -m pip install --user Pillow`, reran `python3 test.py`, and the full suite completed successfully (154 tests run, 21 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31526ee97483268d7471ad68dbf04d)