### PR TITLE
Add display-only minimap HUD

### DIFF
--- a/res/config/graphics.json
+++ b/res/config/graphics.json
@@ -36,6 +36,12 @@
             "priority": 1
           },
           "ref": "sideBar"
+        },
+        {
+          "properties": {
+            "priority": 1
+          },
+          "ref": "minimapGraphics"
         }
       ],
       "layout": {
@@ -55,6 +61,26 @@
     "properties": {
       "layout": {
         "class": "CParentLayout"
+      }
+    }
+  },
+  "minimapGraphics": {
+    "class": "CMinimapGraphicsObject",
+    "properties": {
+      "layout": {
+        "class": "CLayout",
+        "properties": {
+          "h": 220,
+          "w": 220,
+          "x": 1700,
+          "y": 820
+        }
+      },
+      "visible": {
+        "class": "CScript",
+        "properties": {
+          "script": "self.getGui().getGame().getMap().getPlayer()"
+        }
       }
     }
   },

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -109,7 +109,7 @@ run_phase "configure" cmake "${cmake_args[@]}"
 run_phase "build _game and for_unit_tests" cmake --build "${BUILD_DIR}" --target _game for_unit_tests -j"${COVERAGE_JOBS}"
 run_phase "coverage data cleanup" find "${BUILD_DIR}" -name '*.gcda' -delete
 run_phase "ctest" ctest --test-dir "${BUILD_DIR}" --output-on-failure
-run_phase "python test suite" env GAME_BUILD_DIR="${BUILD_DIR}" python3 test.py
+run_phase "python test suite" env GAME_BUILD_DIR="${BUILD_DIR}" FON_COVERAGE_RUN=1 python3 test.py
 run_phase "report generation" generate_report
 
 total_elapsed=$((SECONDS - SCRIPT_START))

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "../gui/CAnimation.h"
 #include "../gui/CGui.h"
 #include "../gui/object/CMapGraphicsObject.h"
+#include "../gui/object/CMinimapGraphicsObject.h"
 #include "../gui/object/CSideBar.h"
 #include "../gui/object/CStatsGraphicsObject.h"
 #include "../gui/panel/CCreatureView.h"
@@ -398,7 +399,26 @@ void init_game_module(py::module_ &m) {
             "Dispatch a mouse button event to this object.");
 
     py::class_<CGui, CGameGraphicsObject, std::shared_ptr<CGui>>(m, "CGui", "Game GUI root object.")
-        .def("getGame", &CGui::getGame, "Return the owning game.");
+        .def("getGame", &CGui::getGame, "Return the owning game.")
+        .def(
+            "read_pixels",
+            [](const CGui &self) {
+                SDL_Renderer *renderer = self.getRenderer();
+                if (!renderer) {
+                    throw std::runtime_error("CGui has no SDL renderer");
+                }
+                int width = 0;
+                int height = 0;
+                if (SDL_GetRendererOutputSize(renderer, &width, &height) != 0) {
+                    throw std::runtime_error(SDL_GetError());
+                }
+                std::string pixels(static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 4, '\0');
+                if (SDL_RenderReadPixels(renderer, nullptr, SDL_PIXELFORMAT_RGBA32, pixels.data(), width * 4) != 0) {
+                    throw std::runtime_error(SDL_GetError());
+                }
+                return py::make_tuple(py::bytes(pixels), width, height);
+            },
+            "Read the current SDL renderer pixels as RGBA bytes, width, and height.");
 
     py::class_<CAnimation, CGameGraphicsObject, std::shared_ptr<CAnimation>>(m, "CAnimation",
                                                                              "Base animation graphics object.")
@@ -440,6 +460,9 @@ void init_game_module(py::module_ &m) {
         m, "CStatsGraphicsObject");
 
     py::class_<CSideBar, CGameGraphicsObject, std::shared_ptr<CSideBar>>(m, "CSideBar");
+
+    py::class_<CMinimapGraphicsObject, CGameGraphicsObject, std::shared_ptr<CMinimapGraphicsObject>>(
+        m, "CMinimapGraphicsObject", "Display-only current-level minimap graphics object.");
 
     py::class_<CProxyTargetGraphicsObject, CGameGraphicsObject, std::shared_ptr<CProxyTargetGraphicsObject>>(
         m, "CProxyTargetGraphicsObject", "Graphics object that proxies child graphics for cells.")

--- a/src/core/CTypes.cpp
+++ b/src/core/CTypes.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "../gui/CTooltip.h"
 #include "../gui/object/CConsoleGraphicsObject.h"
 #include "../gui/object/CMapGraphicsObject.h"
+#include "../gui/object/CMinimapGraphicsObject.h"
 #include "../gui/object/CProxyGraphicsObject.h"
 #include "../gui/object/CSideBar.h"
 #include "../gui/object/CStatsGraphicsObject.h"
@@ -282,6 +283,7 @@ struct register_all_types {
                 CTypes::register_type<CConsoleGraphicsObject, CGameGraphicsObject, CGameObject>();
                 CTypes::register_type<CProxyGraphicsObject, CGameGraphicsObject, CGameObject>();
                 CTypes::register_type<CSideBar, CGameGraphicsObject, CGameObject>();
+                CTypes::register_type<CMinimapGraphicsObject, CGameGraphicsObject, CGameObject>();
             }
         }
 

--- a/src/gui/object/CMinimapGraphicsObject.cpp
+++ b/src/gui/object/CMinimapGraphicsObject.cpp
@@ -1,0 +1,381 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "CMinimapGraphicsObject.h"
+#include "core/CMap.h"
+#include "core/CUtil.h"
+#include "gui/CGui.h"
+#include "gui/CSdlResources.h"
+#include "object/CCreature.h"
+#include "object/CPlayer.h"
+#include "object/CTile.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cmath>
+#include <functional>
+#include <limits>
+#include <map>
+#include <optional>
+#include <string>
+
+namespace {
+constexpr SDL_Color MINIMAP_BACKGROUND{7, 9, 10, 255};
+constexpr SDL_Color MINIMAP_DEFAULT{39, 44, 41, 255};
+constexpr SDL_Color MINIMAP_UNKNOWN{62, 63, 58, 255};
+constexpr SDL_Color MINIMAP_GRASS{45, 111, 55, 255};
+constexpr SDL_Color MINIMAP_GROUND{86, 72, 48, 255};
+constexpr SDL_Color MINIMAP_ROAD{118, 103, 72, 255};
+constexpr SDL_Color MINIMAP_WATER{29, 86, 148, 255};
+constexpr SDL_Color MINIMAP_MOUNTAIN{83, 86, 91, 255};
+constexpr SDL_Color MINIMAP_LAVA{190, 62, 38, 255};
+constexpr SDL_Color MINIMAP_BEACH{176, 163, 108, 255};
+constexpr SDL_Color MINIMAP_DESERT{177, 137, 64, 255};
+constexpr SDL_Color MINIMAP_SNOW{188, 204, 209, 255};
+constexpr SDL_Color MINIMAP_SWAMP{45, 84, 65, 255};
+constexpr SDL_Color MINIMAP_WASTELAND{96, 79, 67, 255};
+constexpr SDL_Color MINIMAP_PLAYER{255, 255, 0, 255};
+constexpr SDL_Color MINIMAP_CREATURE{255, 0, 0, 255};
+constexpr SDL_Color MINIMAP_OBJECT{255, 170, 0, 255};
+constexpr SDL_Color MINIMAP_VIEWPORT{255, 255, 255, 255};
+
+struct LevelBounds {
+    int minX = 0;
+    int minY = 0;
+    int maxX = 0;
+    int maxY = 0;
+};
+
+struct MinimapScale {
+    std::shared_ptr<SDL_Rect> rect;
+    LevelBounds bounds;
+    double scaleX = 1.0;
+    double scaleY = 1.0;
+};
+
+bool z_matches(Coords coords, int z) { return coords.z == z; }
+
+void hash_combine(std::size_t &seed, std::size_t value) { seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2); }
+
+SDL_Color tile_color(const std::string &tileType) {
+    if (tileType == "GrassTile" || tileType == "grass") {
+        return MINIMAP_GRASS;
+    }
+    if (tileType == "GroundTile" || tileType == "ground") {
+        return MINIMAP_GROUND;
+    }
+    if (tileType == "RoadTile" || tileType == "road") {
+        return MINIMAP_ROAD;
+    }
+    if (tileType == "WaterTile" || tileType == "water") {
+        return MINIMAP_WATER;
+    }
+    if (tileType == "MountainTile" || tileType == "mountain") {
+        return MINIMAP_MOUNTAIN;
+    }
+    if (tileType == "LavaTile" || tileType == "lava") {
+        return MINIMAP_LAVA;
+    }
+    if (tileType == "BeachTile" || tileType == "beach") {
+        return MINIMAP_BEACH;
+    }
+    if (tileType == "DesertTile" || tileType == "desert") {
+        return MINIMAP_DESERT;
+    }
+    if (tileType == "SnowTile" || tileType == "snow") {
+        return MINIMAP_SNOW;
+    }
+    if (tileType == "SwampTile" || tileType == "swamp") {
+        return MINIMAP_SWAMP;
+    }
+    if (tileType == "WastelandTile" || tileType == "wasteland") {
+        return MINIMAP_WASTELAND;
+    }
+    if (tileType.empty()) {
+        return MINIMAP_DEFAULT;
+    }
+    return MINIMAP_UNKNOWN;
+}
+
+std::string tile_type(const std::shared_ptr<CTile> &tile) {
+    const auto &tileType = tile->getTileType();
+    return tileType.empty() ? tile->getTypeId() : tileType;
+}
+
+void include_coords(LevelBounds &bounds, bool &hasBounds, Coords coords) {
+    if (!hasBounds) {
+        bounds.minX = coords.x;
+        bounds.maxX = coords.x;
+        bounds.minY = coords.y;
+        bounds.maxY = coords.y;
+        hasBounds = true;
+        return;
+    }
+    bounds.minX = std::min(bounds.minX, coords.x);
+    bounds.maxX = std::max(bounds.maxX, coords.x);
+    bounds.minY = std::min(bounds.minY, coords.y);
+    bounds.maxY = std::max(bounds.maxY, coords.y);
+}
+
+std::optional<LevelBounds> get_level_bounds(const std::shared_ptr<CMap> &map, int z) {
+    const auto xBounds = map->getXBounds();
+    const auto yBounds = map->getYBounds();
+    if (vstd::ctn(xBounds, z) && vstd::ctn(yBounds, z)) {
+        return LevelBounds{0, 0, xBounds.at(z), yBounds.at(z)};
+    }
+
+    LevelBounds bounds;
+    bool hasBounds = false;
+    if (auto player = map->getPlayer()) {
+        include_coords(bounds, hasBounds, player->getCoords());
+    }
+    for (const auto &tile : map->getTiles()) {
+        if (tile && z_matches(tile->getCoords(), z)) {
+            include_coords(bounds, hasBounds, tile->getCoords());
+        }
+    }
+    for (const auto &object : map->getObjects()) {
+        if (object && z_matches(object->getCoords(), z)) {
+            include_coords(bounds, hasBounds, object->getCoords());
+        }
+    }
+    if (!hasBounds) {
+        return std::nullopt;
+    }
+    return bounds;
+}
+
+MinimapScale make_scale(std::shared_ptr<SDL_Rect> rect, LevelBounds bounds) {
+    const int levelWidth = std::max(1, bounds.maxX - bounds.minX + 1);
+    const int levelHeight = std::max(1, bounds.maxY - bounds.minY + 1);
+    const double scale =
+        std::min(rect->w / static_cast<double>(levelWidth), rect->h / static_cast<double>(levelHeight));
+    const int drawW = std::max(1, static_cast<int>(std::floor(levelWidth * scale)));
+    const int drawH = std::max(1, static_cast<int>(std::floor(levelHeight * scale)));
+    auto drawRect = CUtil::rect(rect->x + (rect->w - drawW) / 2, rect->y + (rect->h - drawH) / 2, drawW, drawH);
+    return MinimapScale{drawRect, bounds, scale, scale};
+}
+
+int cell_left(const MinimapScale &scale, int x) {
+    return scale.rect->x + static_cast<int>(std::floor((x - scale.bounds.minX) * scale.scaleX));
+}
+
+int cell_top(const MinimapScale &scale, int y) {
+    return scale.rect->y + static_cast<int>(std::floor((y - scale.bounds.minY) * scale.scaleY));
+}
+
+int cell_right(const MinimapScale &scale, int x) {
+    return scale.rect->x + static_cast<int>(std::ceil((x - scale.bounds.minX + 1) * scale.scaleX));
+}
+
+int cell_bottom(const MinimapScale &scale, int y) {
+    return scale.rect->y + static_cast<int>(std::ceil((y - scale.bounds.minY + 1) * scale.scaleY));
+}
+
+std::shared_ptr<SDL_Rect> cell_rect(const MinimapScale &scale, Coords coords) {
+    const int x = std::clamp(cell_left(scale, coords.x), scale.rect->x, scale.rect->x + scale.rect->w - 1);
+    const int y = std::clamp(cell_top(scale, coords.y), scale.rect->y, scale.rect->y + scale.rect->h - 1);
+    const int right = std::clamp(cell_right(scale, coords.x), x + 1, scale.rect->x + scale.rect->w);
+    const int bottom = std::clamp(cell_bottom(scale, coords.y), y + 1, scale.rect->y + scale.rect->h);
+    return CUtil::rect(x, y, right - x, bottom - y);
+}
+
+void fill_rect(SDL_Renderer *renderer, const std::shared_ptr<SDL_Rect> &rect, SDL_Color color) {
+    CUtil::setRenderDrawColor(renderer, color);
+    SDL_SAFE(SDL_RenderFillRect(renderer, rect.get()));
+}
+
+void fill_rect(SDL_Surface *surface, const std::shared_ptr<SDL_Rect> &rect, SDL_Color color) {
+    const auto mappedColor = SDL_MapRGBA(surface->format, color.r, color.g, color.b, color.a);
+    SDL_SAFE(SDL_FillRect(surface, rect.get(), mappedColor));
+}
+
+template <typename T> void draw_cell(T *target, const MinimapScale &scale, Coords coords, SDL_Color color) {
+    fill_rect(target, cell_rect(scale, coords), color);
+}
+
+template <typename T> void draw_default_terrain(T *target, const MinimapScale &scale, SDL_Color color) {
+    for (int y = scale.bounds.minY; y <= scale.bounds.maxY; ++y) {
+        for (int x = scale.bounds.minX; x <= scale.bounds.maxX; ++x) {
+            draw_cell(target, scale, Coords(x, y, 0), color);
+        }
+    }
+}
+
+std::string default_tile_type(const std::shared_ptr<CMap> &map, int z) {
+    const auto defaultTiles = map->getDefaultTiles();
+    if (vstd::ctn(defaultTiles, z)) {
+        return defaultTiles.at(z);
+    }
+    return "";
+}
+
+SDL_Color default_tile_color(const std::shared_ptr<CMap> &map, int z) { return tile_color(default_tile_type(map, z)); }
+
+template <typename T> void draw_terrain(T *target, const std::shared_ptr<CMap> &map, int z, const MinimapScale &scale) {
+    draw_default_terrain(target, scale, default_tile_color(map, z));
+    for (const auto &tile : map->getTiles()) {
+        if (!tile || !z_matches(tile->getCoords(), z)) {
+            continue;
+        }
+        draw_cell(target, scale, tile->getCoords(), tile_color(tile_type(tile)));
+    }
+}
+
+std::size_t terrain_signature(const std::shared_ptr<CMap> &map, int z, const LevelBounds &bounds, int width,
+                              int height) {
+    std::size_t seed = 0;
+    const std::hash<int> intHash;
+    const std::hash<std::string> stringHash;
+    hash_combine(seed, intHash(z));
+    hash_combine(seed, intHash(bounds.minX));
+    hash_combine(seed, intHash(bounds.minY));
+    hash_combine(seed, intHash(bounds.maxX));
+    hash_combine(seed, intHash(bounds.maxY));
+    hash_combine(seed, intHash(width));
+    hash_combine(seed, intHash(height));
+    hash_combine(seed, stringHash(default_tile_type(map, z)));
+    for (const auto &tile : map->getTiles()) {
+        if (!tile || !z_matches(tile->getCoords(), z)) {
+            continue;
+        }
+        const auto coords = tile->getCoords();
+        hash_combine(seed, intHash(coords.x));
+        hash_combine(seed, intHash(coords.y));
+        hash_combine(seed, intHash(coords.z));
+        hash_combine(seed, stringHash(tile_type(tile)));
+    }
+    return seed;
+}
+
+fn::sdl::TexturePtr build_terrain_texture(SDL_Renderer *renderer, const std::shared_ptr<CMap> &map, int z,
+                                          const std::shared_ptr<SDL_Rect> &rect, LevelBounds bounds) {
+    if (rect->w <= 0 || rect->h <= 0) {
+        return nullptr;
+    }
+    fn::sdl::SurfacePtr surface(
+        SDL_SAFE(SDL_CreateRGBSurfaceWithFormat(0, rect->w, rect->h, 32, SDL_PIXELFORMAT_RGBA32)));
+    if (!surface) {
+        return nullptr;
+    }
+
+    auto localRect = CUtil::rect(0, 0, rect->w, rect->h);
+    fill_rect(surface.get(), localRect, MINIMAP_BACKGROUND);
+    draw_terrain(surface.get(), map, z, make_scale(localRect, bounds));
+
+    fn::sdl::TexturePtr texture(SDL_SAFE(SDL_CreateTextureFromSurface(renderer, surface.get())));
+    if (texture) {
+        SDL_SAFE(SDL_SetTextureBlendMode(texture.get(), SDL_BLENDMODE_NONE));
+    }
+    return texture;
+}
+
+bool in_bounds(const LevelBounds &bounds, Coords coords) {
+    return coords.x >= bounds.minX && coords.x <= bounds.maxX && coords.y >= bounds.minY && coords.y <= bounds.maxY;
+}
+
+std::shared_ptr<SDL_Rect> marker_rect(const MinimapScale &scale, Coords coords, int size) {
+    const auto terrainCell = cell_rect(scale, coords);
+    const int markerWidth = std::min(size, scale.rect->w);
+    const int markerHeight = std::min(size, scale.rect->h);
+    const int centerX = terrainCell->x + terrainCell->w / 2;
+    const int centerY = terrainCell->y + terrainCell->h / 2;
+    auto marker = CUtil::centeredRect(centerX, centerY, markerWidth, markerHeight);
+    marker->x = std::clamp(marker->x, scale.rect->x, scale.rect->x + scale.rect->w - marker->w);
+    marker->y = std::clamp(marker->y, scale.rect->y, scale.rect->y + scale.rect->h - marker->h);
+    return marker;
+}
+
+void draw_marker(SDL_Renderer *renderer, const MinimapScale &scale, Coords coords, int size, SDL_Color color) {
+    if (in_bounds(scale.bounds, coords)) {
+        fill_rect(renderer, marker_rect(scale, coords, size), color);
+    }
+}
+
+void draw_viewport(SDL_Renderer *renderer, const std::shared_ptr<CGui> &gui, const MinimapScale &scale, Coords player) {
+    const int tileCountX = gui->getTileCountX();
+    const int tileCountY = gui->getTileCountY();
+    const int minX = std::max(scale.bounds.minX, player.x - tileCountX / 2);
+    const int minY = std::max(scale.bounds.minY, player.y - tileCountY / 2);
+    const int maxX = std::min(scale.bounds.maxX, player.x - tileCountX / 2 + tileCountX - 1);
+    const int maxY = std::min(scale.bounds.maxY, player.y - tileCountY / 2 + tileCountY - 1);
+    if (minX > maxX || minY > maxY) {
+        return;
+    }
+
+    const int x = std::clamp(cell_left(scale, minX), scale.rect->x, scale.rect->x + scale.rect->w - 1);
+    const int y = std::clamp(cell_top(scale, minY), scale.rect->y, scale.rect->y + scale.rect->h - 1);
+    const int right = std::clamp(cell_right(scale, maxX), x + 1, scale.rect->x + scale.rect->w);
+    const int bottom = std::clamp(cell_bottom(scale, maxY), y + 1, scale.rect->y + scale.rect->h);
+    auto viewport = CUtil::rect(x, y, right - x, bottom - y);
+
+    CUtil::setRenderDrawColor(renderer, MINIMAP_VIEWPORT);
+    SDL_SAFE(SDL_RenderDrawRect(renderer, viewport.get()));
+}
+} // namespace
+
+void CMinimapGraphicsObject::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int) {
+    auto game = gui->getGame();
+    if (!game) {
+        return;
+    }
+    auto map = game->getMap();
+    if (!map) {
+        return;
+    }
+    auto player = map->getPlayer();
+    if (!player) {
+        return;
+    }
+
+    auto renderer = gui->getRenderer();
+    const Coords playerCoords = player->getCoords();
+    const auto maybeBounds = get_level_bounds(map, playerCoords.z);
+    if (!maybeBounds) {
+        fill_rect(renderer, rect, MINIMAP_BACKGROUND);
+        return;
+    }
+    const auto scale = make_scale(rect, *maybeBounds);
+    const auto signature = terrain_signature(map, playerCoords.z, *maybeBounds, rect->w, rect->h);
+    if (!terrainTexture || terrainRenderer != renderer || terrainSignature != signature) {
+        terrainTexture = build_terrain_texture(renderer, map, playerCoords.z, rect, *maybeBounds);
+        terrainRenderer = renderer;
+        terrainSignature = signature;
+    }
+    if (terrainTexture) {
+        SDL_SAFE(SDL_RenderCopy(renderer, terrainTexture.get(), nullptr, rect.get()));
+    } else {
+        fill_rect(renderer, rect, MINIMAP_BACKGROUND);
+        draw_terrain(renderer, map, playerCoords.z, scale);
+    }
+
+    for (const auto &object : map->getObjects()) {
+        if (!object || object == player || !z_matches(object->getCoords(), playerCoords.z)) {
+            continue;
+        }
+        if (vstd::cast<CCreature>(object)) {
+            draw_marker(renderer, scale, object->getCoords(), 3, MINIMAP_CREATURE);
+        } else {
+            draw_marker(renderer, scale, object->getCoords(), 3, MINIMAP_OBJECT);
+        }
+    }
+
+    draw_marker(renderer, scale, playerCoords, 5, MINIMAP_PLAYER);
+    draw_viewport(renderer, gui, scale, playerCoords);
+}
+
+bool CMinimapGraphicsObject::mouseEvent(std::shared_ptr<CGui>, SDL_EventType, int, int, int) { return false; }

--- a/src/gui/object/CMinimapGraphicsObject.h
+++ b/src/gui/object/CMinimapGraphicsObject.h
@@ -1,0 +1,36 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "CGameGraphicsObject.h"
+#include "gui/CSdlResources.h"
+
+#include <cstddef>
+
+class CMinimapGraphicsObject : public CGameGraphicsObject {
+    V_META(CMinimapGraphicsObject, CGameGraphicsObject, vstd::meta::empty())
+
+    fn::sdl::TexturePtr terrainTexture;
+    SDL_Renderer *terrainRenderer = nullptr;
+    std::size_t terrainSignature = 0;
+
+  public:
+    void renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int frameTime) override;
+
+    bool mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button, int x, int y) override;
+};

--- a/test.py
+++ b/test.py
@@ -221,10 +221,15 @@ SDL_PIXELFORMAT_RGBA32 = 376840196
 GUI_WIDTH = 1920
 GUI_HEIGHT = 1080
 GUI_TILE_SIZE = 50
+MINIMAP_RECT = (1700, 820, 220, 220)
+MINIMAP_PLAYER_RGB = (255, 255, 0)
+MINIMAP_VIEWPORT_RGB = (255, 255, 255)
+XVFB_GAMEPLAY_CHILD_TIMEOUT = 300 if os.environ.get("FON_COVERAGE_RUN") == "1" else 90
 XVFB_GAMEPLAY_CHILD_TESTS = (
     "test_keyboard_input_moves_player",
     "test_mouse_click_moves_player",
     "test_screenshot_readback_has_rendered_pixels",
+    "test_screenshot_minimap_has_rendered_pixels",
     "test_screenshot_after_keyboard_move_has_rendered_pixels",
     "test_screenshot_after_mouse_move_has_rendered_pixels",
     "test_screenshot_after_save_hotkey_has_rendered_pixels",
@@ -268,6 +273,59 @@ def load_sdl_library():
         except OSError:
             continue
     raise AssertionError("Could not load SDL2 for gameplay event injection.")
+
+
+def sdl_x11_video_driver_available():
+    env = os.environ.copy()
+    env.update(
+        {
+            "SDL_VIDEODRIVER": "x11",
+            "SDL_AUDIODRIVER": "dummy",
+            "SDL_RENDER_DRIVER": "software",
+            "LIBGL_ALWAYS_SOFTWARE": "1",
+        }
+    )
+    script = r"""
+import ctypes
+import ctypes.util
+import sys
+
+for library_name in (ctypes.util.find_library("SDL2"), "libSDL2-2.0.so.0", "libSDL2.so"):
+    if not library_name:
+        continue
+    try:
+        sdl = ctypes.CDLL(library_name)
+        break
+    except OSError:
+        pass
+else:
+    sys.stderr.write("Could not load SDL2.")
+    sys.exit(1)
+
+sdl.SDL_Init.argtypes = [ctypes.c_uint32]
+sdl.SDL_Init.restype = ctypes.c_int
+sdl.SDL_GetError.restype = ctypes.c_char_p
+if sdl.SDL_Init(0x20) != 0:
+    error = sdl.SDL_GetError()
+    sys.stderr.write(error.decode("utf-8", errors="replace") if error else "SDL_Init failed.")
+    sys.exit(1)
+sdl.SDL_Quit()
+"""
+    try:
+        completed = subprocess.run(
+            ["xvfb-run", "-a", "--server-args=-screen 0 1920x1080x24", sys.executable, "-c", script],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "SDL x11 initialization under xvfb timed out."
+    if completed.returncode == 0:
+        return True, ""
+    message = (completed.stderr or completed.stdout or "SDL x11 initialization under xvfb failed.").strip()
+    return False, message
 
 
 def push_sdl_key_event(keycode, scancode, event_type=SDL_KEYDOWN):
@@ -391,14 +449,28 @@ def drain_sdl_events():
         pass
 
 
-def capture_sdl_screenshot(path):
+def capture_sdl_screenshot(path, gui=None):
     import ctypes
     from PIL import Image
+
+    if gui is not None and hasattr(gui, "read_pixels"):
+        pixels, width, height = gui.read_pixels()
+        data = bytes(pixels)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        Image.frombytes("RGBA", (width, height), data).save(path)
+        return data, width, height
 
     sdl = load_sdl_library()
     sdl.SDL_GetKeyboardFocus.restype = ctypes.c_void_p
     sdl.SDL_GetMouseFocus.restype = ctypes.c_void_p
     window = sdl.SDL_GetKeyboardFocus() or sdl.SDL_GetMouseFocus()
+    if not window:
+        sdl.SDL_GetWindowFromID.argtypes = [ctypes.c_uint32]
+        sdl.SDL_GetWindowFromID.restype = ctypes.c_void_p
+        for window_id in range(1, 256):
+            window = sdl.SDL_GetWindowFromID(window_id)
+            if window:
+                break
     if not window:
         raise AssertionError("Could not find the focused SDL window for screenshot capture.")
 
@@ -458,11 +530,34 @@ def screenshot_pixel_summary(data):
     return {"unique_rgb": len(unique_rgb), "non_black_pixels": non_black_pixels}
 
 
+def screenshot_pixel_rgb(data, width, x, y):
+    offset = (y * width + x) * 4
+    return tuple(data[offset : offset + 3])
+
+
+def screenshot_rect_summary(data, width, rect):
+    x, y, w, h = rect
+    unique_rgb = set()
+    non_black_pixels = 0
+    color_counts = {}
+    for row in range(y, y + h):
+        for col in range(x, x + w):
+            rgb = screenshot_pixel_rgb(data, width, col, row)
+            unique_rgb.add(rgb)
+            color_counts[rgb] = color_counts.get(rgb, 0) + 1
+            if rgb != (0, 0, 0):
+                non_black_pixels += 1
+    return {"unique_rgb": len(unique_rgb), "non_black_pixels": non_black_pixels, "color_counts": color_counts}
+
+
 def assert_screenshot_has_rendered_pixels(test_case, g, name):
     from PIL import Image
 
     screenshot_path = TEST_OUTPUT_DIR / f"{name}.png"
-    data, width, height = capture_sdl_screenshot(screenshot_path)
+    try:
+        data, width, height = capture_sdl_screenshot(screenshot_path, g.getGui())
+    except RuntimeError as exc:
+        test_case.skipTest(f"SDL renderer is not available for screenshot readback: {exc}")
     summary = screenshot_pixel_summary(data)
 
     test_case.assertEqual(".png", screenshot_path.suffix)
@@ -475,6 +570,31 @@ def assert_screenshot_has_rendered_pixels(test_case, g, name):
     test_case.assertGreater(summary["unique_rgb"], 8)
     test_case.assertGreater(summary["non_black_pixels"], width * height // 100)
     assert_rendered_map_proxy_cells(test_case, g)
+    return summary
+
+
+def assert_minimap_has_rendered_pixels(test_case, g, name):
+    from PIL import Image
+
+    screenshot_path = TEST_OUTPUT_DIR / f"{name}.png"
+    try:
+        data, width, height = capture_sdl_screenshot(screenshot_path, g.getGui())
+    except RuntimeError as exc:
+        test_case.skipTest(f"SDL renderer is not available for screenshot readback: {exc}")
+    summary = screenshot_rect_summary(data, width, MINIMAP_RECT)
+
+    test_case.assertEqual((GUI_WIDTH, GUI_HEIGHT), (width, height))
+    test_case.assertTrue(screenshot_path.exists())
+    test_case.assertGreater(screenshot_path.stat().st_size, 0)
+    with Image.open(screenshot_path) as image:
+        image.load()
+        test_case.assertEqual((width, height), image.size)
+
+    minimap_area = MINIMAP_RECT[2] * MINIMAP_RECT[3]
+    test_case.assertGreater(summary["unique_rgb"], 3)
+    test_case.assertGreater(summary["non_black_pixels"], minimap_area * 9 // 10)
+    test_case.assertGreater(summary["color_counts"].get(MINIMAP_PLAYER_RGB, 0), 0)
+    test_case.assertGreater(summary["color_counts"].get(MINIMAP_VIEWPORT_RGB, 0), 0)
     return summary
 
 
@@ -2741,6 +2861,40 @@ class GameTest(unittest.TestCase):
                 "empty_after_east_move": sum(count == 0 for count in east_counts),
                 "empty_after_west_move": sum(count == 0 for count in west_counts),
             }
+        )
+
+    @game_test
+    def test_gui_includes_display_only_minimap_layout(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.loadGui(g)
+        game.CGameLoader.startGameWithPlayer(g, "test", "Warrior")
+        pump_event_loop()
+
+        gui_tree = json.loads(game.jsonify(g.getGui()))
+        children = gui_tree.get("properties", {}).get("children") or []
+        minimap = next((child for child in children if child.get("class") == "CMinimapGraphicsObject"), None)
+        self.assertIsNotNone(minimap, "The root GUI should include the minimap HUD child.")
+
+        minimap_props = minimap.get("properties", {})
+        layout = minimap_props.get("layout", {})
+        layout_props = layout.get("properties", {})
+        self.assertEqual(1, minimap_props.get("priority"))
+        self.assertEqual("CLayout", layout.get("class"))
+        self.assertEqual(
+            {"x": 1700, "y": 820, "w": 220, "h": 220},
+            {key: int(layout_props.get(key)) for key in ("x", "y", "w", "h")},
+        )
+        self.assertEqual("CScript", minimap_props.get("visible", {}).get("class"))
+
+        return True, json.dumps(
+            {
+                "class": minimap.get("class"),
+                "priority": minimap_props.get("priority"),
+                "layout": {key: layout_props.get(key) for key in ("x", "y", "w", "h")},
+            },
+            sort_keys=True,
         )
 
     @game_test
@@ -7026,6 +7180,9 @@ class XvfbGameplayTest(unittest.TestCase):
             self.skipTest("xvfb-run is not available.")
         if shutil.which("xauth") is None:
             self.skipTest("xauth is not available for xvfb-run.")
+        available, reason = sdl_x11_video_driver_available()
+        if not available:
+            self.skipTest(f"SDL x11 video driver is not available under xvfb: {reason}")
 
         env = os.environ.copy()
         env.update(
@@ -7054,7 +7211,7 @@ class XvfbGameplayTest(unittest.TestCase):
                     env=env,
                     capture_output=True,
                     text=True,
-                    timeout=90,
+                    timeout=XVFB_GAMEPLAY_CHILD_TIMEOUT,
                 )
             except subprocess.TimeoutExpired as exc:
                 stdout = exc.stdout or ""
@@ -7279,6 +7436,12 @@ class XvfbGameplayProcessTest(unittest.TestCase):
     def test_screenshot_readback_has_rendered_pixels(self):
         _, g, _, _ = create_xvfb_gameplay_session(self)
         assert_screenshot_has_rendered_pixels(self, g, "xvfb_gameplay_screenshot")
+
+    def test_screenshot_minimap_has_rendered_pixels(self):
+        _, g, _, _ = create_xvfb_gameplay_session(self)
+        summary = assert_minimap_has_rendered_pixels(self, g, "xvfb_minimap_screenshot")
+        self.assertTrue(gui_contains_class(g, "CMinimapGraphicsObject"))
+        self.assertGreaterEqual(summary["color_counts"].get(MINIMAP_PLAYER_RGB, 0), 20)
 
     def test_screenshot_after_keyboard_move_has_rendered_pixels(self):
         _, g, game_map, player = create_xvfb_gameplay_session(self)


### PR DESCRIPTION
## What changed

- Added `CMinimapGraphicsObject`, a direct SDL-rendered display-only minimap HUD for the current z-level.
- Configured the minimap in `res/config/graphics.json` at `x=1700, y=820, w=220, h=220`.
- Registered and exposed the minimap type through the C++ type registry and pybind module.
- Added renderer pixel readback support for GUI screenshot assertions.
- Added regression coverage for serialized GUI layout and Xvfb-rendered minimap pixels.
- Adjusted the coverage test runner to give Xvfb child tests a longer timeout under coverage.

## Why

The HUD gives players a whole-level view without adding click behavior, fog of war, or thousands of proxy child graphics objects. Terrain rendering uses explicit map tiles and avoids sweeping the level through `CMap::getTile()`, so rendering does not materialize missing default tiles.

## Validation

- `clang-format -i src/core/CTypes.cpp src/core/CModule.cpp src/gui/object/CMinimapGraphicsObject.cpp src/gui/object/CMinimapGraphicsObject.h`
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `env BLACK_CACHE_DIR=/tmp/fon-black-cache python3 test.py` - 156 tests passed, 22 skipped
- `COVERAGE_FRESH_CONFIGURE=1 PATH=/tmp/fon-coverage-bin:/usr/bin:/bin ./scripts/run_coverage.sh` - 91.53% line coverage

## Known limitations

- Display-only v1: no click-to-move, fog/discovery memory, labels, or tooltips.
- Only the player's current z-level is shown.
