### PR TITLE
Optimize Linux native build fanout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,15 @@ project(fall-of-nouraajd)
 
 set(FON_DEFAULT_ENABLE_UNITY_BUILD OFF)
 set(FON_DEFAULT_ENABLE_PCH OFF)
+set(FON_DEFAULT_UNITY_BATCH_SIZE "8")
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_BUILD_TYPE STREQUAL "Release")
     set(FON_DEFAULT_ENABLE_UNITY_BUILD ON)
     set(FON_DEFAULT_ENABLE_PCH ON)
+    set(FON_DEFAULT_UNITY_BATCH_SIZE "16")
 endif ()
 option(FON_ENABLE_UNITY_BUILD "Enable unity builds for large shared game targets." ${FON_DEFAULT_ENABLE_UNITY_BUILD})
-set(FON_UNITY_BATCH_SIZE "8" CACHE STRING "Number of source files per unity build translation unit.")
+set(FON_UNITY_BATCH_SIZE "${FON_DEFAULT_UNITY_BATCH_SIZE}" CACHE STRING
+    "Number of source files per unity build translation unit.")
 option(FON_ENABLE_PCH "Enable precompiled headers for large shared game targets." ${FON_DEFAULT_ENABLE_PCH})
 
 if (WIN32)
@@ -225,27 +228,8 @@ function(add_native_plugin target_name source_file)
 endfunction()
 
 add_native_plugin(native_marker_plugin native_plugins/native_marker_plugin.cpp)
-add_native_plugin(native_gameplay_effects native_plugins/native_gameplay_effects.cpp)
-add_native_plugin(native_gameplay_interactions native_plugins/native_gameplay_interactions.cpp)
-add_native_plugin(native_gameplay_items native_plugins/native_gameplay_items.cpp)
-add_native_plugin(native_gameplay_tiles native_plugins/native_gameplay_tiles.cpp)
-add_native_plugin(native_gameplay_map_content native_plugins/native_gameplay_map_content.cpp)
-add_native_plugin(native_gameplay_controllers native_plugins/native_gameplay_controllers.cpp)
-add_native_plugin(native_gameplay_creatures native_plugins/native_gameplay_creatures.cpp)
+add_native_plugin(native_gameplay native_plugins/native_gameplay.cpp)
 add_dependencies(_game ${NATIVE_PLUGIN_TARGETS})
-
-set_source_files_properties(
-    ${CMAKE_SOURCE_DIR}/src/core/CModule.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/CTypes.cpp
-    ${CMAKE_SOURCE_DIR}/src/object/CCreature.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/CSerialization.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/CMap.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/CLoader.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/CController.cpp
-    ${CMAKE_SOURCE_DIR}/src/object/CInteraction.cpp
-    ${CMAKE_SOURCE_DIR}/src/object/CItem.cpp
-    PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
-)
 
 configure_file(res/config/armors.json config/armors.json)
 configure_file(res/config/panels.json config/panels.json)

--- a/native_plugins/native_gameplay.cpp
+++ b/native_plugins/native_gameplay.cpp
@@ -1,0 +1,46 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "plugin/NativePlugin.h"
+
+extern "C" NATIVE_PLUGIN_EXPORT bool native_gameplay_effects_load_v1(const NativePluginHostV1 *host) {
+    return native_plugin::register_effects(host);
+}
+
+extern "C" NATIVE_PLUGIN_EXPORT bool native_gameplay_interactions_load_v1(const NativePluginHostV1 *host) {
+    return native_plugin::register_interactions(host);
+}
+
+extern "C" NATIVE_PLUGIN_EXPORT bool native_gameplay_items_load_v1(const NativePluginHostV1 *host) {
+    return native_plugin::register_items(host);
+}
+
+extern "C" NATIVE_PLUGIN_EXPORT bool native_gameplay_tiles_load_v1(const NativePluginHostV1 *host) {
+    return native_plugin::register_tiles(host);
+}
+
+extern "C" NATIVE_PLUGIN_EXPORT bool native_gameplay_map_content_load_v1(const NativePluginHostV1 *host) {
+    return native_plugin::register_map_content(host);
+}
+
+extern "C" NATIVE_PLUGIN_EXPORT bool native_gameplay_controllers_load_v1(const NativePluginHostV1 *host) {
+    return native_plugin::register_controllers(host);
+}
+
+extern "C" NATIVE_PLUGIN_EXPORT bool native_gameplay_creatures_load_v1(const NativePluginHostV1 *host) {
+    return native_plugin::register_creatures(host);
+}

--- a/res/plugins/manifest.json
+++ b/res/plugins/manifest.json
@@ -12,44 +12,44 @@
     {
       "kind": "dynamic",
       "id": "nativeGameplayEffects",
-      "library": "plugins/native/native_gameplay_effects",
-      "entry": "native_plugin_load_v1"
+      "library": "plugins/native/native_gameplay",
+      "entry": "native_gameplay_effects_load_v1"
     },
     {
       "kind": "dynamic",
       "id": "nativeGameplayInteractions",
-      "library": "plugins/native/native_gameplay_interactions",
-      "entry": "native_plugin_load_v1"
+      "library": "plugins/native/native_gameplay",
+      "entry": "native_gameplay_interactions_load_v1"
     },
     {
       "kind": "dynamic",
       "id": "nativeGameplayItems",
-      "library": "plugins/native/native_gameplay_items",
-      "entry": "native_plugin_load_v1"
+      "library": "plugins/native/native_gameplay",
+      "entry": "native_gameplay_items_load_v1"
     },
     {
       "kind": "dynamic",
       "id": "nativeGameplayTiles",
-      "library": "plugins/native/native_gameplay_tiles",
-      "entry": "native_plugin_load_v1"
+      "library": "plugins/native/native_gameplay",
+      "entry": "native_gameplay_tiles_load_v1"
     },
     {
       "kind": "dynamic",
       "id": "nativeGameplayMapContent",
-      "library": "plugins/native/native_gameplay_map_content",
-      "entry": "native_plugin_load_v1"
+      "library": "plugins/native/native_gameplay",
+      "entry": "native_gameplay_map_content_load_v1"
     },
     {
       "kind": "dynamic",
       "id": "nativeGameplayControllers",
-      "library": "plugins/native/native_gameplay_controllers",
-      "entry": "native_plugin_load_v1"
+      "library": "plugins/native/native_gameplay",
+      "entry": "native_gameplay_controllers_load_v1"
     },
     {
       "kind": "dynamic",
       "id": "nativeGameplayCreatures",
-      "library": "plugins/native/native_gameplay_creatures",
-      "entry": "native_plugin_load_v1"
+      "library": "plugins/native/native_gameplay",
+      "entry": "native_gameplay_creatures_load_v1"
     }
   ],
   "maps": {}


### PR DESCRIPTION
## What changed
- Increased the Linux Release unity batch default from 8 to 16.
- Removed the previous game_core unity exclusion list after verifying those files compile and run correctly inside unity files.
- Collapsed the seven gameplay native plugin modules into one native_gameplay module with separate exported entry points.
- Updated the native plugin manifest to load the same gameplay domains from the aggregate module.

## Why
This reduces Linux build fanout: fewer game_core translation units, fewer native plugin targets, and fewer dynamic plugin shared-library links while preserving explicit manifest entries and runtime coverage.

## Validation
- cmake -S . -B cmake-build-release -DCMAKE_BUILD_TYPE=Release -U FON_ENABLE_UNITY_BUILD -U FON_ENABLE_PCH -U FON_UNITY_BATCH_SIZE
- /usr/bin/time -p cmake --build cmake-build-release --target _game for_unit_tests -j8
- ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
- python3 test.py GameTest.test_dynamic_domain_plugins_register_gameplay_classes GameTest.test_dynamic_domain_plugins_serialize_clone_and_load_gameplay_content GameTest.test_load GameTest.test_playthrough GameTest.test_dynamic_plugin_manifest_registers_native_content
- python3 test.py

## Benchmark
Clean Release build of `_game for_unit_tests`, Ninja, `-j8`, no ccache:
- origin/main: 225.53s, 39 build steps
- this branch: 187.72s, 16 build steps
- improvement: 37.81s faster, about 16.8% wall-clock reduction

## Notes
- Coverage was not rerun for this follow-up because it only changes CMake/native plugin packaging and the manifest.