### PR TITLE
[codex] Optimize Windows build and test speed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: build
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -105,7 +107,13 @@ jobs:
     runs-on: windows-2022
     env:
       CONFIGURE_BUILD_DIRS: cmake-build-release
+      GAME_TEST_TIMINGS_FILE: test/test-timings-windows.json
+      GAME_WINDOWS_FAST_BUILD: "1"
+      GAME_WINDOWS_INSTALL_FAST_TOOLS: "1"
+      GAME_WINDOWS_REQUIRE_FAST_TOOLS: "1"
+      SCCACHE_DIR: ${{ github.workspace }}\.sccache
       VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
+      VCPKG_INSTALLED_DIR: ${{ github.workspace }}\vcpkg_installed\fast
       VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}\cmake\triplets
       VCPKG_TARGET_TRIPLET: x64-windows-release
     steps:
@@ -118,44 +126,107 @@ jobs:
         run: python -m pip install --upgrade black pybind11 pillow
       - name: submodules
         run: git submodule update --init --recursive
+      - name: Set up MSVC command prompt
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
       - name: Set up vcpkg
         shell: pwsh
         run: |
-          if (-not $env:VCPKG_ROOT) {
-            $env:VCPKG_ROOT = $env:VCPKG_INSTALLATION_ROOT
+          $candidateRoots = @()
+          if ($env:VCPKG_INSTALLATION_ROOT) {
+            $candidateRoots += $env:VCPKG_INSTALLATION_ROOT
           }
-          if (-not $env:VCPKG_ROOT) {
-            throw "VCPKG_ROOT and VCPKG_INSTALLATION_ROOT are not set"
+          $candidateRoots += "C:\vcpkg"
+          if ($env:VCPKG_ROOT) {
+            $candidateRoots += $env:VCPKG_ROOT
           }
-          "VCPKG_ROOT=$env:VCPKG_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+          $vcpkgRoot = $candidateRoots |
+            Where-Object { $_ -and (Test-Path (Join-Path $_ "vcpkg.exe")) } |
+            Select-Object -First 1
+          if (-not $vcpkgRoot) {
+            throw "No usable vcpkg.exe was found in VCPKG_INSTALLATION_ROOT, C:\vcpkg, or VCPKG_ROOT"
+          }
+
+          "Using vcpkg at $vcpkgRoot"
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Enable vcpkg x-gha binary cache
         uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Cache sccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ runner.os }}-sccache-${{ hashFiles('**/CMakeLists.txt', 'configure.bat') }}
+          restore-keys: ${{ runner.os }}-sccache-
+      - name: Cache Python test timings
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.GAME_TEST_TIMINGS_FILE }}
+          key: ${{ runner.os }}-test-timings-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-test-timings-
+      - name: Configure Windows parallelism
+        shell: pwsh
+        run: |
+          $buildJobs = [Math]::Max(1, [Environment]::ProcessorCount)
+          $testJobs = 1
+          "CMAKE_BUILD_PARALLEL_LEVEL=$buildJobs" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "GAME_TEST_JOBS=$testJobs" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "Windows build jobs: $buildJobs"
+          "Windows Python test jobs: $testJobs"
       - name: Install native deps
         shell: pwsh
         run: |
           & "$env:VCPKG_ROOT\vcpkg.exe" install `
             --triplet "$env:VCPKG_TARGET_TRIPLET" `
-            --overlay-triplets "$env:VCPKG_OVERLAY_TRIPLETS"
-      - name: configure, test, and package
+            --overlay-triplets "$env:VCPKG_OVERLAY_TRIPLETS" `
+            "--x-install-root=$env:VCPKG_INSTALLED_DIR"
+      - name: Configure
         shell: cmd
         run: |
           call configure.bat
           if errorlevel 1 exit /b 1
-          cmake --build cmake-build-release --config Release --target _game for_unit_tests
+      - name: Build test targets
+        shell: cmd
+        run: |
+          cmake --build cmake-build-release --target _game for_unit_tests --parallel %CMAKE_BUILD_PARALLEL_LEVEL%
           if errorlevel 1 exit /b 1
-          ctest --test-dir cmake-build-release -C Release --output-on-failure -R for_unit_tests
+      - name: sccache stats after build
+        if: always()
+        shell: cmd
+        run: |
+          where sccache >nul 2>nul
+          if errorlevel 1 exit /b 0
+          if not errorlevel 1 sccache --show-stats
+      - name: test (c++)
+        shell: cmd
+        run: |
+          ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
           if errorlevel 1 exit /b 1
+      - name: test (python)
+        shell: cmd
+        run: |
           set GAME_BUILD_DIR=cmake-build-release
           set GAME_BUILD_CONFIG=Release
-          set PATH=%CD%\cmake-build-release\Release;%CD%\vcpkg_installed\%VCPKG_TARGET_TRIPLET%\bin;%PATH%
+          set PATH=%CD%\cmake-build-release;%CD%\cmake-build-release\Release;%VCPKG_INSTALLED_DIR%\%VCPKG_TARGET_TRIPLET%\bin;%PATH%
           python test.py
           if errorlevel 1 exit /b 1
-          cmake --build cmake-build-release --config Release --target package
+      - name: package
+        shell: cmd
+        run: |
+          cmake --build cmake-build-release --target package --parallel %CMAKE_BUILD_PARALLEL_LEVEL%
           if errorlevel 1 exit /b 1
+      - name: sccache stats after package
+        if: always()
+        shell: cmd
+        run: |
+          where sccache >nul 2>nul
+          if errorlevel 1 exit /b 0
+          if not errorlevel 1 sccache --show-stats
       - name: publish
         uses: actions/upload-artifact@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ project(fall-of-nouraajd)
 set(GAME_DEFAULT_ENABLE_UNITY_BUILD OFF)
 set(GAME_DEFAULT_ENABLE_PCH OFF)
 set(GAME_DEFAULT_UNITY_BATCH_SIZE "8")
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_BUILD_TYPE STREQUAL "Release")
+if ((CMAKE_SYSTEM_NAME STREQUAL "Linux" OR WIN32) AND CMAKE_BUILD_TYPE STREQUAL "Release")
     set(GAME_DEFAULT_ENABLE_UNITY_BUILD ON)
     set(GAME_DEFAULT_ENABLE_PCH ON)
     set(GAME_DEFAULT_UNITY_BATCH_SIZE "16")
@@ -93,7 +93,7 @@ function(configure_cpp_target target_name)
         target_compile_definitions(${target_name} PRIVATE SDL_MAIN_HANDLED)
     endif ()
     if (MSVC)
-        target_compile_options(${target_name} PRIVATE /W3 /bigobj /permissive- /Zc:preprocessor /EHsc)
+        target_compile_options(${target_name} PRIVATE /W3 /bigobj /MP /permissive- /Zc:preprocessor /EHsc)
         target_compile_definitions(${target_name} PRIVATE
             _USE_MATH_DEFINES
             NOMINMAX

--- a/configure.bat
+++ b/configure.bat
@@ -1,6 +1,16 @@
 @echo off
 setlocal EnableExtensions EnableDelayedExpansion
 
+if not defined GAME_WINDOWS_FAST_BUILD set "GAME_WINDOWS_FAST_BUILD=0"
+if not defined GAME_WINDOWS_REQUIRE_FAST_TOOLS set "GAME_WINDOWS_REQUIRE_FAST_TOOLS=0"
+if not defined GAME_WINDOWS_INSTALL_FAST_TOOLS (
+    if "!GAME_WINDOWS_FAST_BUILD!"=="1" (
+        set "GAME_WINDOWS_INSTALL_FAST_TOOLS=1"
+    ) else (
+        set "GAME_WINDOWS_INSTALL_FAST_TOOLS=0"
+    )
+)
+
 where cmake >nul 2>nul
 if errorlevel 1 (
     echo CMake was not found on PATH.
@@ -14,6 +24,8 @@ if errorlevel 1 (
     echo Install Python 3 and make sure it is available on PATH.
     exit /b 1
 )
+
+call :add_python_user_scripts_to_path
 
 for /f "usebackq delims=" %%i in (`python -c "import sys; print(sys.executable)"`) do set "PYTHON_EXECUTABLE=%%i"
 for /f "usebackq delims=" %%i in (`python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"`) do set "PYTHON_VERSION=%%i"
@@ -32,11 +44,24 @@ if not "!PYTHON_VERSION!"=="3.12" (
     exit /b 1
 )
 
-if not defined VCPKG_ROOT (
-    if defined VCPKG_INSTALLATION_ROOT set "VCPKG_ROOT=!VCPKG_INSTALLATION_ROOT!"
+if defined VCPKG_INSTALLATION_ROOT (
+    if exist "!VCPKG_INSTALLATION_ROOT!\vcpkg.exe" (
+        if not defined VCPKG_ROOT (
+            set "VCPKG_ROOT=!VCPKG_INSTALLATION_ROOT!"
+        ) else (
+            echo !VCPKG_ROOT! | findstr /I /C:"\VC\vcpkg" >nul 2>nul
+            if not errorlevel 1 set "VCPKG_ROOT=!VCPKG_INSTALLATION_ROOT!"
+        )
+    )
+)
+if defined VCPKG_ROOT (
+    echo !VCPKG_ROOT! | findstr /I /C:"\VC\vcpkg" >nul 2>nul
+    if not errorlevel 1 (
+        if exist "C:\vcpkg\vcpkg.exe" set "VCPKG_ROOT=C:\vcpkg"
+    )
 )
 if not defined VCPKG_ROOT (
-    if exist "C:\vcpkg" set "VCPKG_ROOT=C:\vcpkg"
+    if exist "C:\vcpkg\vcpkg.exe" set "VCPKG_ROOT=C:\vcpkg"
 )
 if not defined VCPKG_ROOT (
     set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
@@ -61,8 +86,50 @@ if not exist "!VCPKG_TOOLCHAIN_FILE!" (
     exit /b 1
 )
 
+if "!GAME_WINDOWS_FAST_BUILD!"=="1" (
+    if not defined CONFIGURE_BUILD_DIRS set "CONFIGURE_BUILD_DIRS=cmake-build-release"
+    if not defined VCPKG_TARGET_TRIPLET set "VCPKG_TARGET_TRIPLET=x64-windows-release"
+    if not defined VCPKG_INSTALLED_DIR set "VCPKG_INSTALLED_DIR=%CD%\vcpkg_installed\fast"
+
+    call :ensure_fast_tool ninja ninja Ninja-build.Ninja
+    if errorlevel 1 (
+        if "!GAME_WINDOWS_REQUIRE_FAST_TOOLS!"=="1" exit /b 1
+    )
+
+    call :ensure_fast_tool sccache sccache Mozilla.sccache
+    if errorlevel 1 (
+        if "!GAME_WINDOWS_REQUIRE_FAST_TOOLS!"=="1" exit /b 1
+    )
+)
+
+if not defined CMAKE_GENERATOR (
+    if "!GAME_WINDOWS_FAST_BUILD!"=="1" (
+        where ninja >nul 2>nul
+        if not errorlevel 1 set "CMAKE_GENERATOR=Ninja"
+    )
+)
 if not defined CMAKE_GENERATOR set "CMAKE_GENERATOR=Visual Studio 17 2022"
-if not defined CMAKE_GENERATOR_PLATFORM set "CMAKE_GENERATOR_PLATFORM=x64"
+
+if /I "!CMAKE_GENERATOR!"=="Ninja" (
+    set "CMAKE_GENERATOR_PLATFORM="
+    call :ensure_msvc_env
+    if errorlevel 1 exit /b 1
+) else (
+    if not defined CMAKE_GENERATOR_PLATFORM set "CMAKE_GENERATOR_PLATFORM=x64"
+)
+
+if "!GAME_WINDOWS_FAST_BUILD!"=="1" (
+    if not defined SCCACHE_EXECUTABLE (
+        for /f "usebackq delims=" %%i in (`where sccache 2^>nul`) do (
+            if not defined SCCACHE_EXECUTABLE set "SCCACHE_EXECUTABLE=%%i"
+        )
+    )
+    if defined SCCACHE_EXECUTABLE (
+        set "CMAKE_C_COMPILER_LAUNCHER=!SCCACHE_EXECUTABLE!"
+        set "CMAKE_CXX_COMPILER_LAUNCHER=!SCCACHE_EXECUTABLE!"
+    )
+)
+
 if not defined VCPKG_TARGET_TRIPLET set "VCPKG_TARGET_TRIPLET=x64-windows"
 if not defined VCPKG_INSTALLED_DIR set "VCPKG_INSTALLED_DIR=%CD%\vcpkg_installed"
 if not defined VCPKG_OVERLAY_TRIPLETS set "VCPKG_OVERLAY_TRIPLETS="
@@ -77,8 +144,86 @@ for %%d in (!CONFIGURE_BUILD_DIRS!) do (
 
 exit /b 0
 
+:add_python_user_scripts_to_path
+for /f "usebackq delims=" %%i in (`python -c "import site; from pathlib import Path; print(Path(site.getuserbase()) / 'Scripts')" 2^>nul`) do set "PYTHON_USER_SCRIPTS=%%i"
+if defined PYTHON_USER_SCRIPTS (
+    if exist "!PYTHON_USER_SCRIPTS!" set "PATH=!PYTHON_USER_SCRIPTS!;!PATH!"
+)
+exit /b 0
+
+:ensure_fast_tool
+set "TOOL_NAME=%~1"
+set "CHOCO_PACKAGE=%~2"
+set "WINGET_ID=%~3"
+where !TOOL_NAME! >nul 2>nul
+if not errorlevel 1 exit /b 0
+
+if not "!GAME_WINDOWS_INSTALL_FAST_TOOLS!"=="1" (
+    echo !TOOL_NAME! was not found; continuing without installing it.
+    exit /b 1
+)
+
+echo !TOOL_NAME! was not found; attempting to install it for the Windows fast build.
+where choco >nul 2>nul
+if not errorlevel 1 (
+    choco install -y !CHOCO_PACKAGE! --no-progress
+    call :add_python_user_scripts_to_path
+    where !TOOL_NAME! >nul 2>nul
+    if not errorlevel 1 exit /b 0
+)
+
+where winget >nul 2>nul
+if not errorlevel 1 (
+    winget install --id !WINGET_ID! --exact --silent --accept-package-agreements --accept-source-agreements
+    call :add_python_user_scripts_to_path
+    where !TOOL_NAME! >nul 2>nul
+    if not errorlevel 1 exit /b 0
+)
+
+if /I "!TOOL_NAME!"=="ninja" (
+    python -m pip install --user ninja
+    call :add_python_user_scripts_to_path
+    where ninja >nul 2>nul
+    if not errorlevel 1 exit /b 0
+)
+
+echo Could not install !TOOL_NAME!. Install it manually, or set GAME_WINDOWS_INSTALL_FAST_TOOLS=0 to fall back when possible.
+exit /b 1
+
+:ensure_msvc_env
+where cl >nul 2>nul
+if not errorlevel 1 exit /b 0
+
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist "!VSWHERE!" (
+    for /f "usebackq delims=" %%i in (`"!VSWHERE!" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2^>nul`) do (
+        if not defined VS_INSTALL_DIR set "VS_INSTALL_DIR=%%i"
+    )
+)
+if defined VS_INSTALL_DIR (
+    if exist "!VS_INSTALL_DIR!\Common7\Tools\VsDevCmd.bat" (
+        call "!VS_INSTALL_DIR!\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64 >nul
+    )
+)
+
+where cl >nul 2>nul
+if errorlevel 1 (
+    echo MSVC cl.exe was not found. Run configure.bat from a Visual Studio Developer Command Prompt or install VS C++ tools.
+    exit /b 1
+)
+exit /b 0
+
 :configure
 set "BUILD_DIR=%~1"
+set "CMAKE_GENERATOR_PLATFORM_ARG="
+set "CMAKE_BUILD_TYPE_ARG="
+set "CMAKE_COMPILER_LAUNCHER_ARGS="
+set "GAME_FAST_CMAKE_ARGS="
+
+if defined CMAKE_GENERATOR_PLATFORM set "CMAKE_GENERATOR_PLATFORM_ARG=-A !CMAKE_GENERATOR_PLATFORM!"
+if /I "!CMAKE_GENERATOR!"=="Ninja" set "CMAKE_BUILD_TYPE_ARG=-DCMAKE_BUILD_TYPE=Release"
+if defined CMAKE_C_COMPILER_LAUNCHER set "CMAKE_COMPILER_LAUNCHER_ARGS=-DCMAKE_C_COMPILER_LAUNCHER=!CMAKE_C_COMPILER_LAUNCHER! -DCMAKE_CXX_COMPILER_LAUNCHER=!CMAKE_CXX_COMPILER_LAUNCHER!"
+if "!GAME_WINDOWS_FAST_BUILD!"=="1" set "GAME_FAST_CMAKE_ARGS=-DGAME_ENABLE_UNITY_BUILD=ON -DGAME_ENABLE_PCH=ON -DGAME_UNITY_BATCH_SIZE=16"
 
 if exist "!BUILD_DIR!\CMakeCache.txt" (
     findstr /C:"CMAKE_GENERATOR:INTERNAL=!CMAKE_GENERATOR!" "!BUILD_DIR!\CMakeCache.txt" >nul 2>nul
@@ -87,11 +232,13 @@ if exist "!BUILD_DIR!\CMakeCache.txt" (
         del /q "!BUILD_DIR!\CMakeCache.txt" 2>nul
         rmdir /s /q "!BUILD_DIR!\CMakeFiles" 2>nul
     ) else (
-        findstr /C:"CMAKE_GENERATOR_PLATFORM:INTERNAL=!CMAKE_GENERATOR_PLATFORM!" "!BUILD_DIR!\CMakeCache.txt" >nul 2>nul
-        if errorlevel 1 (
-            echo Recreating !BUILD_DIR! because it was configured for a different platform.
-            del /q "!BUILD_DIR!\CMakeCache.txt" 2>nul
-            rmdir /s /q "!BUILD_DIR!\CMakeFiles" 2>nul
+        if defined CMAKE_GENERATOR_PLATFORM (
+            findstr /C:"CMAKE_GENERATOR_PLATFORM:INTERNAL=!CMAKE_GENERATOR_PLATFORM!" "!BUILD_DIR!\CMakeCache.txt" >nul 2>nul
+            if errorlevel 1 (
+                echo Recreating !BUILD_DIR! because it was configured for a different platform.
+                del /q "!BUILD_DIR!\CMakeCache.txt" 2>nul
+                rmdir /s /q "!BUILD_DIR!\CMakeFiles" 2>nul
+            )
         )
     )
     if exist "!BUILD_DIR!\CMakeCache.txt" (
@@ -117,7 +264,10 @@ cmake -B ./!BUILD_DIR! -S . ^
     -U "_Python3_*" ^
     -U "PYBIND11_PYTHON_*" ^
     -G "!CMAKE_GENERATOR!" ^
-    -A "!CMAKE_GENERATOR_PLATFORM!" ^
+    !CMAKE_GENERATOR_PLATFORM_ARG! ^
+    !CMAKE_BUILD_TYPE_ARG! ^
+    !CMAKE_COMPILER_LAUNCHER_ARGS! ^
+    !GAME_FAST_CMAKE_ARGS! ^
     -DCMAKE_TOOLCHAIN_FILE="!VCPKG_TOOLCHAIN_FILE!" ^
     -DVCPKG_INSTALLED_DIR="!VCPKG_INSTALLED_DIR!" ^
     -DVCPKG_TARGET_TRIPLET="!VCPKG_TARGET_TRIPLET!" ^

--- a/test.py
+++ b/test.py
@@ -51,6 +51,19 @@ def resolve_test_output_dir():
 
 
 TEST_OUTPUT_DIR = resolve_test_output_dir()
+
+
+def resolve_test_timings_file():
+    timings_file = os.environ.get("GAME_TEST_TIMINGS_FILE")
+    if not timings_file:
+        return TEST_OUTPUT_DIR / "test-timings.json"
+    path = Path(timings_file)
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+    return path
+
+
+TEST_TIMINGS_FILE = resolve_test_timings_file()
 runtime_dir_id = os.getuid() if hasattr(os, "getuid") else os.getpid()
 XDG_RUNTIME_DIR = Path(tempfile.gettempdir()) / f"xdg-runtime-{runtime_dir_id}"
 
@@ -107,6 +120,20 @@ SERIAL_TEST_NAMES = {
     "GameTest.test_missing_save_resource_directory_lists_empty",
     "XvfbGameplayTest.test_keyboard_gameplay_under_xvfb",
 }
+SERIAL_TEST_PREFIXES = ("McpServerTest.test_stdio_map_walkthrough_",)
+DEFAULT_TEST_DURATIONS = {
+    "McpServerTest.test_stdio_map_walkthrough_nouraajd": 45.0,
+    "McpServerTest.test_stdio_map_walkthrough_ritual": 45.0,
+    "McpServerTest.test_stdio_map_walkthrough_siege": 30.0,
+    "McpServerTest.test_stdio_map_walkthrough_test": 20.0,
+    "XvfbGameplayTest.test_keyboard_gameplay_under_xvfb": 90.0,
+    "GameTest.test_map_walkthrough_nouraajd": 25.0,
+    "GameTest.test_map_walkthrough_ritual": 20.0,
+    "GameTest.test_map_walkthrough_siege": 15.0,
+    "GameTest.test_map_walkthrough_test": 10.0,
+    "GameTest.test_playthrough": 20.0,
+    "GameTest.test_campaign_transitions_preserve_player_and_start_siege": 20.0,
+}
 
 
 def parse_positive_int(value, name):
@@ -133,6 +160,7 @@ class ProgressTextTestResult(unittest.TextTestResult):
         self.total_tests = 0
         self.test_index = 0
         self._test_start_times = {}
+        self.test_durations = {}
 
     def startTest(self, test):
         self.test_index += 1
@@ -142,33 +170,49 @@ class ProgressTextTestResult(unittest.TextTestResult):
 
     def addSuccess(self, test):
         unittest.TestResult.addSuccess(self, test)
-        self._write_progress(test, "ok", self._duration(test))
+        duration = self._duration(test)
+        self._record_duration(test, duration)
+        self._write_progress(test, "ok", duration)
 
     def addFailure(self, test, err):
         unittest.TestResult.addFailure(self, test, err)
-        self._write_progress(test, "FAIL", self._duration(test))
+        duration = self._duration(test)
+        self._record_duration(test, duration)
+        self._write_progress(test, "FAIL", duration)
 
     def addError(self, test, err):
         unittest.TestResult.addError(self, test, err)
-        self._write_progress(test, "ERROR", self._duration(test))
+        duration = self._duration(test)
+        self._record_duration(test, duration)
+        self._write_progress(test, "ERROR", duration)
 
     def addSkip(self, test, reason):
         unittest.TestResult.addSkip(self, test, reason)
-        self._write_progress(test, "skip", self._duration(test), reason)
+        duration = self._duration(test)
+        self._record_duration(test, duration)
+        self._write_progress(test, "skip", duration, reason)
 
     def addExpectedFailure(self, test, err):
         unittest.TestResult.addExpectedFailure(self, test, err)
-        self._write_progress(test, "expected-failure", self._duration(test))
+        duration = self._duration(test)
+        self._record_duration(test, duration)
+        self._write_progress(test, "expected-failure", duration)
 
     def addUnexpectedSuccess(self, test):
         unittest.TestResult.addUnexpectedSuccess(self, test)
-        self._write_progress(test, "UNEXPECTED-SUCCESS", self._duration(test))
+        duration = self._duration(test)
+        self._record_duration(test, duration)
+        self._write_progress(test, "UNEXPECTED-SUCCESS", duration)
 
     def _duration(self, test):
         started_at = self._test_start_times.pop(id(test), None)
         if started_at is None:
             return None
         return time.monotonic() - started_at
+
+    def _record_duration(self, test, duration):
+        if duration is not None:
+            self.test_durations[self._subprocess_name(test)] = duration
 
     def _write_progress(self, test, status, duration=None, detail=None):
         total = self.total_tests or "?"
@@ -185,13 +229,23 @@ class ProgressTextTestResult(unittest.TextTestResult):
             return f"test.{test_id[len('__main__.'):]}"
         return test_id
 
+    @staticmethod
+    def _subprocess_name(test):
+        test_id = test.id()
+        for prefix in (f"{__name__}.", "__main__."):
+            if test_id.startswith(prefix):
+                return test_id[len(prefix) :]
+        return test_id
+
 
 class ProgressTextTestRunner(unittest.TextTestRunner):
     resultclass = ProgressTextTestResult
 
     def run(self, test):
         self._total_tests = test.countTestCases()
-        return super().run(test)
+        result = super().run(test)
+        write_test_timings(TEST_TIMINGS_FILE, result.test_durations)
+        return result
 
     def _makeResult(self):
         result = super()._makeResult()
@@ -8650,23 +8704,31 @@ class McpServerTest(unittest.TestCase):
         discovered_maps = discover_maps()
         self.assertEqual(set(discovered_maps), set(self.MCP_WALKTHROUGHS))
 
-        results = {}
-        failed = {}
-        for map_name in discovered_maps:
-            success, log = self._run_mcp_walkthrough(map_name)
-            results[map_name] = log
-            if not success:
-                failed[map_name] = log
-
         summary = {
             "discovered_maps": discovered_maps,
             "walkthroughs": self.MCP_WALKTHROUGHS,
-            "failed": failed,
-            "results": results,
         }
         TEST_OUTPUT_DIR.mkdir(exist_ok=True)
         (TEST_OUTPUT_DIR / "mcp_walkthroughs.json").write_text(json.dumps(summary, indent=2, sort_keys=True))
-        self.assertEqual({}, failed, json.dumps(summary, sort_keys=True))
+
+    def test_stdio_map_walkthrough_nouraajd(self):
+        self._assert_mcp_walkthrough("nouraajd")
+
+    def test_stdio_map_walkthrough_ritual(self):
+        self._assert_mcp_walkthrough("ritual")
+
+    def test_stdio_map_walkthrough_siege(self):
+        self._assert_mcp_walkthrough("siege")
+
+    def test_stdio_map_walkthrough_test(self):
+        self._assert_mcp_walkthrough("test")
+
+    def _assert_mcp_walkthrough(self, map_name):
+        discovered_maps = discover_maps()
+        self.assertIn(map_name, discovered_maps)
+        self.assertIn(map_name, self.MCP_WALKTHROUGHS)
+        success, log = self._run_mcp_walkthrough(map_name)
+        self.assertTrue(success, json.dumps(log, sort_keys=True))
 
     def _run_mcp_walkthrough(self, map_name):
         proc = None
@@ -9101,6 +9163,51 @@ def selected_unittest_args(unittest_argv):
     return [arg for arg in unittest_argv[1:] if not arg.startswith("-")]
 
 
+def load_test_timings(path):
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    timings = {}
+    if isinstance(data, dict):
+        for test_name, duration in data.items():
+            try:
+                timings[test_name] = max(float(duration), 0.001)
+            except (TypeError, ValueError):
+                continue
+    return timings
+
+
+def write_test_timings(path, timings):
+    if not timings:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = load_test_timings(path)
+    existing.update({test_name: round(float(duration), 6) for test_name, duration in timings.items()})
+    path.write_text(json.dumps(dict(sorted(existing.items())), indent=2, sort_keys=True), encoding="utf-8")
+
+
+def test_duration_weight(test_name, timings):
+    if test_name in timings:
+        return timings[test_name]
+    if test_name in DEFAULT_TEST_DURATIONS:
+        return DEFAULT_TEST_DURATIONS[test_name]
+    if test_name.startswith("McpServerTest.test_stdio_map_walkthrough_"):
+        return 30.0
+    if test_name.startswith("XvfbGameplayProcessTest."):
+        return 10.0
+    if "walkthrough" in test_name:
+        return 8.0
+    if test_name.startswith("McpServerTest."):
+        return 6.0
+    return 1.0
+
+
+def is_serial_test_name(test_name):
+    return test_name in SERIAL_TEST_NAMES or any(test_name.startswith(prefix) for prefix in SERIAL_TEST_PREFIXES)
+
+
 def runner_jobs(cli_jobs, unittest_argv):
     if GAME_TEST_WORKER:
         return 1
@@ -9145,15 +9252,24 @@ def discover_unittest_test_names(unittest_argv):
     return [subprocess_test_name(test) for test in tests]
 
 
-def shard_test_names(test_names, jobs):
+def shard_test_names(test_names, jobs, timings=None):
     groups = [[] for _ in range(min(jobs, len(test_names)))]
-    for index, test_name in enumerate(test_names):
-        groups[index % len(groups)].append(test_name)
+    group_weights = [0.0 for _ in groups]
+    timings = timings or {}
+    weighted_tests = sorted(
+        ((test_duration_weight(test_name, timings), index, test_name) for index, test_name in enumerate(test_names)),
+        key=lambda item: (-item[0], item[1]),
+    )
+    for weight, _, test_name in weighted_tests:
+        group_index = min(range(len(groups)), key=lambda index: group_weights[index])
+        groups[group_index].append(test_name)
+        group_weights[group_index] += weight
     return groups
 
 
 def run_test_subprocess(test_names, shard_name):
     output_dir = TEST_OUTPUT_DIR / "workers" / shard_name
+    timings_file = output_dir / "test-timings.json"
     env = os.environ.copy()
     env.update(
         {
@@ -9161,6 +9277,7 @@ def run_test_subprocess(test_names, shard_name):
             "GAME_TEST_JOBS": "1",
             "GAME_TEST_OUTPUT_DIR": str(output_dir),
             "GAME_TEST_SHARD": shard_name,
+            "GAME_TEST_TIMINGS_FILE": str(timings_file),
             "PYTHONUNBUFFERED": "1",
         }
     )
@@ -9170,13 +9287,14 @@ def run_test_subprocess(test_names, shard_name):
 
 
 def run_sharded_tests(test_names, jobs):
-    serial_tests = [test_name for test_name in test_names if test_name in SERIAL_TEST_NAMES]
-    parallel_tests = [test_name for test_name in test_names if test_name not in SERIAL_TEST_NAMES]
+    serial_tests = [test_name for test_name in test_names if is_serial_test_name(test_name)]
+    parallel_tests = [test_name for test_name in test_names if not is_serial_test_name(test_name)]
+    timings = load_test_timings(TEST_TIMINGS_FILE)
     failures = []
 
     processes = []
     if parallel_tests:
-        for index, group in enumerate(shard_test_names(parallel_tests, jobs), start=1):
+        for index, group in enumerate(shard_test_names(parallel_tests, jobs, timings), start=1):
             processes.append((f"{index}", run_test_subprocess(group, f"{index}")))
 
     for shard_name, proc in processes:
@@ -9194,6 +9312,11 @@ def run_sharded_tests(test_names, jobs):
         for shard_name, return_code in failures:
             print(f"[test shard {shard_name}] failed with exit code {return_code}", file=sys.stderr, flush=True)
         return 1
+
+    combined_timings = {}
+    for timings_path in (TEST_OUTPUT_DIR / "workers").glob("*/test-timings.json"):
+        combined_timings.update(load_test_timings(timings_path))
+    write_test_timings(TEST_TIMINGS_FILE, combined_timings)
     return 0
 
 


### PR DESCRIPTION
## Summary
- enable faster Windows Release builds with MSVC /MP, unity builds, and precompiled headers
- add Windows fast-mode configure support that can provision Ninja and sccache and isolates release-triplet vcpkg dependencies
- split Windows CI steps, cache sccache/test timings, and add duration-aware Python test sharding
- split MCP map walkthrough coverage into per-map tests so long sessions shard independently

## Validation
- black -l 120 test.py
- python -m py_compile test.py
- ctest --test-dir cmake-build-release -C Release --output-on-failure -R for_unit_tests
- targeted Python sharding/MCP checks
- tests/security/test_configure_supply_chain.py
- tests/security/test_python_plugin_sandbox.py
- tests/security/test_layout_no_script_eval.py
- wsl.exe bash -lc "cd /mnt/c/Users/andrz/OneDrive/Pulpit/git/fall-of-nouraajd && ./scripts/run_coverage.sh" (91.94% line coverage)

Note: local MSBuild compile validation was blocked by this shell exposing duplicate Path/PATH environment variables before cl.exe could launch; generated Visual Studio projects were inspected and contain the expected /MP, unity, PCH, and fast vcpkg-root settings.