### PR TITLE
[codex] Introduce game context services

### DIFF
--- a/TODO_WORKLOG.md
+++ b/TODO_WORKLOG.md
@@ -386,3 +386,36 @@
   - `git diff --check` -> no whitespace errors
   - `./scripts/run_coverage.sh` -> C++ tests passed, embedded `python3 test.py` passed, and report generation passed with `lines: 91.3% (8805 out of 9644)`
 - Blockers if unresolved: None.
+
+## Batch 25
+- Location: `src/core/CGameContext.h`, `src/core/CGameContext.cpp`, `src/core/CGame.h`,
+  `src/core/CGame.cpp`, `src/core/CModule.cpp`, `test.py`, `todo.txt`
+- Original TODO or summary: `CGame` still lazily constructed several runtime services directly, while `todo.txt`
+  tracked broad singleton/context work without an explicit service-owner seam.
+- Status: fixed
+- What was changed: Added `CGameContext` as the first explicit per-game runtime service context. `CGame` now owns a
+  `std::shared_ptr<CGameContext>` and keeps the existing `getObjectHandler()`, `getScriptHandler()`, and
+  `getRngHandler()` APIs by delegating to context-owned stable service instances. Added `CGame::getContext()` and a
+  minimal Python binding for `CGameContext` plus `CScriptHandler` so public regression coverage can exercise the new
+  seam. `CGuiHandler`, `CSlotConfig`, active map, and active GUI intentionally remain owned by `CGame` for now because
+  they are still tied to UI/session state or deserialized game configuration. Narrowed the context TODO to the
+  remaining global/static providers and UI/session services.
+- Why the change is correct: The loader still initializes object builders, JSON configs, and plugins through the same
+  `CGame` public getters, so object creation, JSON loading, plugin loading, and serialization continue to receive the
+  owning `CGame`. `CGameContext` stores only a `std::weak_ptr<CGame>` for services that need the game during lazy
+  construction, avoiding a new strong `CGame -> CGameContext -> CGame` cycle while leaving the existing
+  `CGameObject::getGame()` ownership model unchanged. The regression proves the context is non-null after
+  `CGameLoader.loadGame()`, service instances are stable and shared with existing `CGame` getters, configured object
+  creation remains per-game, and `startGameWithPlayer()` still creates map/player objects with the same owning game.
+- Validation performed:
+  - `git fetch origin main` -> updated `origin/main` from `99558a69` to `8e1060fe`
+  - `git rebase --autostash origin/main` -> completed cleanly and reapplied the local changes
+  - `clang-format -i src/core/CGameContext.h src/core/CGameContext.cpp src/core/CGame.h src/core/CGame.cpp src/core/CModule.cpp`
+  - `black -l 120 test.py` -> `1 file left unchanged`
+  - `python3 -m unittest test.GameTest.test_game_context_owns_runtime_services_and_preserves_creation` -> `Ran 1 test`, `OK`
+  - `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` -> completed successfully after CMake regenerated the build files
+  - `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` -> `1/1 Test #1: for_unit_tests ... Passed`
+  - `python3 test.py` -> all shards and serial tests passed on the rebased branch
+  - `./scripts/run_coverage.sh` -> C++ tests passed, embedded `python3 test.py` passed, and report generation passed with `lines: 92.00% (9040 out of 9826)`
+- Blockers if unresolved: None. A pre-rebase `python3 test.py` run wedged in a GUI shard and was terminated; the
+  isolated shard, full suite rerun, and final post-rebase full suite all passed.

--- a/src/core/CGame.cpp
+++ b/src/core/CGame.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "core/CGame.h"
+#include "core/CGameContext.h"
 #include "core/CLoader.h"
 #include "gui/CGui.h"
 
@@ -29,17 +30,20 @@ std::shared_ptr<CMap> CGame::getMap() const { return map; }
 
 void CGame::setMap(std::shared_ptr<CMap> map) { this->map = map; }
 
+std::shared_ptr<CGameContext> CGame::getContext() {
+    if (!context) {
+        context = std::make_shared<CGameContext>(this->ptr<CGame>());
+    }
+    return context;
+}
+
 std::shared_ptr<CGuiHandler> CGame::getGuiHandler() {
     return guiHandler.get([this]() { return std::make_shared<CGuiHandler>(this->ptr<CGame>()); });
 }
 
-std::shared_ptr<CScriptHandler> CGame::getScriptHandler() {
-    return scriptHandler.get([]() { return std::make_shared<CScriptHandler>(); });
-}
+std::shared_ptr<CScriptHandler> CGame::getScriptHandler() { return getContext()->getScriptHandler(); }
 
-std::shared_ptr<CObjectHandler> CGame::getObjectHandler() {
-    return objectHandler.get([]() { return std::make_shared<CObjectHandler>(); });
-}
+std::shared_ptr<CObjectHandler> CGame::getObjectHandler() { return getContext()->getObjectHandler(); }
 
 void CGame::loadPlugin(std::function<std::shared_ptr<CPlugin>()> plugin) { plugin()->load(this->ptr<CGame>()); }
 
@@ -51,6 +55,4 @@ std::shared_ptr<CSlotConfig> CGame::getSlotConfiguration() {
     return slotConfiguration.get([this]() { return createObject<CSlotConfig>("slotConfiguration"); });
 }
 
-std::shared_ptr<CRngHandler> CGame::getRngHandler() {
-    return rngHandler.get([this]() { return std::make_shared<CRngHandler>(this->ptr<CGame>()); });
-}
+std::shared_ptr<CRngHandler> CGame::getRngHandler() { return getContext()->getRngHandler(); }

--- a/src/core/CGame.h
+++ b/src/core/CGame.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -32,6 +32,8 @@ class CMap;
 
 class CGameObject;
 
+class CGameContext;
+
 class CGui;
 
 class CRngHandler;
@@ -52,6 +54,8 @@ class CGame : public CGameObject {
     std::shared_ptr<CMap> getMap() const;
 
     void setMap(std::shared_ptr<CMap> map);
+
+    std::shared_ptr<CGameContext> getContext();
 
     std::shared_ptr<CGuiHandler> getGuiHandler();
 
@@ -75,11 +79,9 @@ class CGame : public CGameObject {
 
   private:
     vstd::lazy<CGuiHandler> guiHandler;
-    vstd::lazy<CScriptHandler> scriptHandler;
     vstd::lazy<CSlotConfig> slotConfiguration;
-    vstd::lazy<CRngHandler> rngHandler;
 
-    vstd::lazy<CObjectHandler> objectHandler;
+    std::shared_ptr<CGameContext> context;
     std::shared_ptr<CMap> map;
     std::shared_ptr<CGui> _gui;
 

--- a/src/core/CGameContext.cpp
+++ b/src/core/CGameContext.cpp
@@ -1,0 +1,52 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "core/CGameContext.h"
+#include "core/CGame.h"
+#include "handler/CObjectHandler.h"
+#include "handler/CRngHandler.h"
+#include "handler/CScriptHandler.h"
+
+#include <stdexcept>
+#include <utility>
+
+CGameContext::CGameContext(std::shared_ptr<CGame> game) : game(std::move(game)) {}
+
+std::shared_ptr<CObjectHandler> CGameContext::getObjectHandler() {
+    if (!objectHandler) {
+        objectHandler = std::make_shared<CObjectHandler>();
+    }
+    return objectHandler;
+}
+
+std::shared_ptr<CScriptHandler> CGameContext::getScriptHandler() {
+    if (!scriptHandler) {
+        scriptHandler = std::make_shared<CScriptHandler>();
+    }
+    return scriptHandler;
+}
+
+std::shared_ptr<CRngHandler> CGameContext::getRngHandler() {
+    if (!rngHandler) {
+        auto owner = game.lock();
+        if (!owner) {
+            throw std::runtime_error("Cannot create CRngHandler without an active CGame.");
+        }
+        rngHandler = std::make_shared<CRngHandler>(owner);
+    }
+    return rngHandler;
+}

--- a/src/core/CGameContext.h
+++ b/src/core/CGameContext.h
@@ -1,0 +1,42 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <memory>
+
+class CGame;
+class CObjectHandler;
+class CRngHandler;
+class CScriptHandler;
+
+class CGameContext {
+  public:
+    explicit CGameContext(std::shared_ptr<CGame> game);
+
+    std::shared_ptr<CObjectHandler> getObjectHandler();
+
+    std::shared_ptr<CScriptHandler> getScriptHandler();
+
+    std::shared_ptr<CRngHandler> getRngHandler();
+
+  private:
+    std::weak_ptr<CGame> game;
+    std::shared_ptr<CObjectHandler> objectHandler;
+    std::shared_ptr<CScriptHandler> scriptHandler;
+    std::shared_ptr<CRngHandler> rngHandler;
+};

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -51,6 +51,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "../object/CTile.h"
 #include "../object/CTrigger.h"
 #include "CGame.h"
+#include "CGameContext.h"
 #include "CList.h"
 #include "CMap.h"
 #include "CProvider.h"
@@ -385,11 +386,21 @@ void init_game_module(py::module_ &m) {
 
     std::shared_ptr<CGameObject> (CGame::*createObject)(std::string) = &CGame::createObject<CGameObject>;
 
+    py::class_<CScriptHandler, std::shared_ptr<CScriptHandler>>(m, "CScriptHandler",
+                                                                "Python script execution service.");
+
+    py::class_<CGameContext, std::shared_ptr<CGameContext>>(m, "CGameContext",
+                                                            "Runtime service context owned by a game instance.")
+        .def("getObjectHandler", &CGameContext::getObjectHandler, "Return the object factory/registry handler.")
+        .def("getScriptHandler", &CGameContext::getScriptHandler, "Return the Python script execution service.")
+        .def("getRngHandler", &CGameContext::getRngHandler, "Return the random encounter/loot handler.");
+
     py::class_<CGame, CGameObject, std::shared_ptr<CGame>>(
         m, "CGame", "Top-level game container holding the active map, handlers, and GUI.")
         .def("getMap", &CGame::getMap, "Return the currently loaded map.")
         .def("changeMap", &CGame::changeMap, "Load and switch to another map.")
         .def("loadPlugin", &CGame::loadPlugin, "Load a plugin object into the game.")
+        .def("getContext", &CGame::getContext, "Return the runtime service context.")
         .def("getGuiHandler", &CGame::getGuiHandler, "Return the GUI handler service.")
         .def("getObjectHandler", &CGame::getObjectHandler, "Return the object factory/registry handler.")
         .def("getRngHandler", &CGame::getRngHandler, "Return the random encounter/loot handler.")

--- a/test.py
+++ b/test.py
@@ -2374,6 +2374,64 @@ class GameTest(unittest.TestCase):
         return True, json.dumps({"registered": sorted(created), "json": json_defined_types}, sort_keys=True)
 
     @game_test
+    def test_game_context_owns_runtime_services_and_preserves_creation(self):
+        game = load_game_module()
+
+        g = game.CGameLoader.loadGame()
+        context = g.getContext()
+        self.assertIsNotNone(context)
+        self.assertIs(context, g.getContext())
+
+        object_handler = context.getObjectHandler()
+        script_handler = context.getScriptHandler()
+        rng_handler = context.getRngHandler()
+
+        self.assertIs(object_handler, context.getObjectHandler())
+        self.assertIs(script_handler, context.getScriptHandler())
+        self.assertIs(rng_handler, context.getRngHandler())
+        self.assertIs(object_handler, g.getObjectHandler())
+        self.assertIs(rng_handler, g.getRngHandler())
+
+        other_game = game.CGameLoader.loadGame()
+        self.assertIsNot(context, other_game.getContext())
+        self.assertIsNot(object_handler, other_game.getObjectHandler())
+
+        object_handler.registerConfigJson(
+            "contextOwnedProbe",
+            json.dumps(
+                {
+                    "class": "CGameObject",
+                    "properties": {
+                        "label": "context owned",
+                    },
+                }
+            ),
+        )
+
+        probe = g.createObject("contextOwnedProbe")
+        self.assertIsNotNone(probe)
+        self.assertEqual("context owned", probe.getStringProperty("label"))
+        self.assertIs(g, probe.getGame())
+        self.assertIsNone(other_game.createObject("contextOwnedProbe"))
+
+        game.CGameLoader.startGameWithPlayer(g, "test", "Warrior")
+        game_map = g.getMap()
+        self.assertIsNotNone(game_map)
+        player = game_map.getPlayer()
+        self.assertIsNotNone(player)
+        self.assertEqual("CPlayer", player.getType())
+        self.assertIs(g, game_map.getGame())
+        self.assertIs(g, player.getGame())
+        self.assertIs(context, g.getContext())
+
+        report = {
+            "map": game_map.getType(),
+            "player": player.getType(),
+            "probe": probe.getStringProperty("label"),
+        }
+        return True, json.dumps(report, sort_keys=True)
+
+    @game_test
     def test_array_deserialize_skips_bad_entries_and_consumers_are_safe(self):
         game = load_game_module()
 

--- a/todo.txt
+++ b/todo.txt
@@ -2,7 +2,7 @@
 //TODO: weird fight bug after fight, player didnt return to position
 //TODO: drag & drop
 //TODO: resizing panels
-//TODO: registering singletons in context
+//TODO: migrate remaining global/static providers and UI/session services into CGameContext where safe
 //TODO: initiative
 //TODO: when lost fight in cave, panel pops out after return to position
 //TODO: encapsulate SDL_RenderCopy


### PR DESCRIPTION
## Summary
- Added `CGameContext` as a per-game runtime service context owned by `CGame`.
- Moved construction policy for `CObjectHandler`, `CScriptHandler`, and `CRngHandler` behind the context while preserving existing `CGame` getters.
- Kept `CGuiHandler`, slot configuration, active map, and active GUI in `CGame` for this first seam.
- Added Python binding and regression coverage for `CGame.getContext()` and context-owned service stability.

## Validation
- `git fetch origin main`
- `git rebase --autostash origin/main`
- `clang-format -i src/core/CGameContext.h src/core/CGameContext.cpp src/core/CGame.h src/core/CGame.cpp src/core/CModule.cpp`
- `black -l 120 test.py`
- `python3 -m unittest test.GameTest.test_game_context_owns_runtime_services_and_preserves_creation`
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py`
- `./scripts/run_coverage.sh` -> `TOTAL 9040/9826 lines covered (92.00%)`

## Notes
- Generated `coverage/` artifacts are intentionally not committed.
- A pre-rebase full Python run wedged in a GUI shard and was terminated; the isolated shard, full rerun, and final post-rebase full suite all passed.