### PR TITLE
Restrict MCP builtin method exports

### DIFF
--- a/mcp.py
+++ b/mcp.py
@@ -95,6 +95,9 @@ class ProtocolError(Exception):
         self.data = data
 
 
+MCP_ALLOWED_BUILTIN_CLASS_METHODS = frozenset({"event_loop.instance"})
+
+
 class EngineMcpServer:
     def __init__(
         self,
@@ -213,9 +216,9 @@ class EngineMcpServer:
         for name, value in inspect.getmembers(cls):
             if name.startswith("_"):
                 continue
-            if self._python_callable(value) is None:
-                continue
             export_name = f"{class_name}.{name}"
+            if self._python_callable(value, qualified_name=export_name) is None:
+                continue
             if export_name in self.exports:
                 continue
             self.exports[export_name] = ExportedCallable(
@@ -234,7 +237,7 @@ class EngineMcpServer:
             return "(signature unavailable)"
 
     @staticmethod
-    def _python_callable(value: Any) -> Any | None:
+    def _python_callable(value: Any, qualified_name: str | None = None) -> Any | None:
         if inspect.isfunction(value):
             return value
         function = getattr(value, "__func__", None)
@@ -247,7 +250,12 @@ class EngineMcpServer:
             and getattr(value, "__self__", None) is not None
         ):
             return value
-        if callable(value) and inspect.isbuiltin(value) and getattr(value, "__self__", None) is not None:
+        if (
+            callable(value)
+            and inspect.isbuiltin(value)
+            and getattr(value, "__self__", None) is not None
+            and qualified_name in MCP_ALLOWED_BUILTIN_CLASS_METHODS
+        ):
             return value
         return None
 

--- a/test.py
+++ b/test.py
@@ -8314,10 +8314,18 @@ class McpServerTest(unittest.TestCase):
         class NativeLike:
             append = list.append
 
+        class CPluginLoader:
+            loadDynamicPlugin = staticmethod(len)
+
+        class event_loop:
+            instance = staticmethod(len)
+
         module.top_level = top_level
         module.set_logger_sink = set_logger_sink
         module.Dialog = Dialog
         module.NativeLike = NativeLike
+        module.CPluginLoader = CPluginLoader
+        module.event_loop = event_loop
 
         server._export_module_callables(module, source="game")
 
@@ -8326,6 +8334,8 @@ class McpServerTest(unittest.TestCase):
         self.assertIn("Dialog.invoke", server.exports)
         self.assertIn("Dialog.class_invoke", server.exports)
         self.assertIn("Dialog.static_invoke", server.exports)
+        self.assertIn("event_loop.instance", server.exports)
+        self.assertNotIn("CPluginLoader.loadDynamicPlugin", server.exports)
         self.assertNotIn("NativeLike.append", server.exports)
         self.assertNotIn("set_logger_sink", server.exports)
         self.assertEqual(server.exports["Dialog.invoke"].source, "game.Dialog")
@@ -8340,6 +8350,7 @@ class McpServerTest(unittest.TestCase):
         self.assertIn("CGameLoader.startGameWithPlayer", server.exports)
         self.assertIn("event_loop.instance", server.exports)
         self.assertIn("CGuiHandler.openPanel", server.exports)
+        self.assertNotIn("CPluginLoader.loadDynamicPlugin", server.exports)
 
     def test_engine_call_resolves_handle_arguments_for_python_methods(self):
         server = self.make_stub_server()


### PR DESCRIPTION
### Motivation
- A recent change broadened the MCP export predicate to include pybind-built-in/static methods, which can expose dangerous native loader functions (for example `CPluginLoader.loadDynamicPlugin`) to unauthenticated `engine_call` and allow attacker-controlled native code execution via supplied library paths.
- The intent of this change is to preserve safe, intended exports (notably `event_loop.instance`) while preventing broad exposure of pybind/native built-in methods to the MCP surface.

### Description
- Add a strict allow-list `MCP_ALLOWED_BUILTIN_CLASS_METHODS = frozenset({"event_loop.instance"})` and require the fully-qualified export name to be allowed before accepting `inspect.isbuiltin` class members in `_python_callable` in `mcp.py`.
- Change `_export_class_python_methods` to pass the computed `export_name` as `qualified_name` to `_python_callable`, and update `_python_callable` to accept the optional `qualified_name` parameter so built-in acceptances are scoped.
- Add regression coverage in `test.py` by stubbing a built-in-style `CPluginLoader.loadDynamicPlugin` and an `event_loop.instance` to assert the unsafe loader is not exported while `event_loop.instance` remains exported.
- Only `mcp.py` and `test.py` were modified to implement the fix and the corresponding test coverage.

### Testing
- Ran `python3 -m py_compile mcp.py test.py` and the focused unit tests `python3 -m unittest test.McpServerTest.test_export_module_includes_python_class_methods` and `python3 -m unittest test.McpServerTest.test_export_module_includes_pybind_class_methods`, which passed.
- Built the native extension with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` and executed `ctest --test-dir cmake-build-release -R for_unit_tests`, which passed.
- Executed the full Python test suite `python3 test.py`, which initially failed due to a missing `Pillow` dependency for xvfb screenshot assertions, installed it with `python3 -m pip install --user Pillow`, re-ran `python3 test.py`, and the suite passed.
- Verified the regression asserts ensure `CPluginLoader.loadDynamicPlugin` is not exported and `event_loop.instance` remains exported after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31cb7e047c8326b59c5c9f62b0d9f4)