### PR TITLE
[codex] Fix crafting station menu refresh

### DIFF
--- a/res/plugins/crafting.py
+++ b/res/plugins/crafting.py
@@ -218,6 +218,30 @@ class CraftingRuntime:
         chance = recipe["success_chance"]
         return f"{recipe['display_name']} [{recipe['id']}]: {parts_text} -> {output['count']}x {output_label} ({chance}% success)"
 
+    def missing_requirements(self, player, recipe):
+        missing = []
+        for requirement in recipe["inputs"]:
+            required_count = requirement["count"]
+            if required_count <= 0:
+                continue
+            item_id = requirement["item_id"]
+            held_count = count_inventory_matches(player, item_id)
+            if held_count < required_count:
+                missing.append(f"{required_count - held_count}x {self.get_item_label(item_id)}")
+        gold_cost = recipe["gold"]
+        if gold_cost > 0:
+            held_gold = player.getNumericProperty("gold")
+            if held_gold < gold_cost:
+                missing.append(f"{gold_cost - held_gold}g")
+        return missing
+
+    def describe_recipe_for_player(self, player, recipe):
+        description = self.describe_recipe(recipe)
+        missing = self.missing_requirements(player, recipe)
+        if not missing:
+            return f"{description} [ready]"
+        return f"{description} [missing: {', '.join(missing)}]"
+
     def is_unlocked(self, player, recipe):
         unlock_state = recipe.get("unlock", {"type": "none", "value": None})
         if unlock_state["type"] == "flag":
@@ -287,16 +311,16 @@ def open_crafting_station(station, player):
     game_instance = station.getGame()
     handler = game_instance.getGuiHandler()
     station_label = station.getStringProperty("label") or station_id
-    available = runtime.available_recipes(player, station_id)
-    if not available:
-        handler.showInfo(f"No known recipes for {station_label}.", True)
-        return
     leave_option = "Leave"
     while True:
+        available = runtime.available_recipes(player, station_id)
+        if not available:
+            handler.showInfo(f"No known recipes for {station_label}.", True)
+            return
         option_map = {}
         options = []
         for recipe in available:
-            description = runtime.describe_recipe(recipe)
+            description = runtime.describe_recipe_for_player(player, recipe)
             option_map[description] = recipe
             options.append(description)
         options.append(leave_option)

--- a/tests/regression/test_crafting_gui_refresh.py
+++ b/tests/regression/test_crafting_gui_refresh.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# fall-of-nouraajd c++ dark fantasy game
+# Copyright (C) 2026  Andrzej Lis
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_crafting_with_fake_game():
+    fake_game = types.ModuleType("game")
+    fake_game.randint = lambda lower, upper: lower
+    fake_game.list_string = lambda game_instance, options: list(options)
+
+    class FakeResourcesProvider:
+        @classmethod
+        def getInstance(cls):
+            return cls()
+
+        def load(self, filename):
+            return "{}"
+
+    fake_game.CResourcesProvider = FakeResourcesProvider
+    old_game = sys.modules.get("game")
+    sys.modules["game"] = fake_game
+    try:
+        spec = importlib.util.spec_from_file_location("crafting_under_test", REPO_ROOT / "res" / "plugins" / "crafting.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if old_game is None:
+            sys.modules.pop("game", None)
+        else:
+            sys.modules["game"] = old_game
+
+
+class FakeHandler:
+    def __init__(self):
+        self.menus = []
+        self.messages = []
+
+    def showSelection(self, options):
+        self.menus.append(list(options))
+        if len(self.menus) == 1:
+            return self.menus[-1][0]
+        return "Leave"
+
+    def showInfo(self, message, centered=True):
+        self.messages.append((message, centered))
+
+
+class FakeGame:
+    def __init__(self, handler):
+        self.handler = handler
+
+    def getGuiHandler(self):
+        return self.handler
+
+
+class FakeStation:
+    def __init__(self, handler):
+        self.game = FakeGame(handler)
+
+    def getStringProperty(self, key):
+        return {"craftingStationId": "alchemyTable", "label": "Alchemy Table"}.get(key, "")
+
+    def getTypeId(self):
+        return "AlchemyTable"
+
+    def getGame(self):
+        return self.game
+
+
+class FakePlayer:
+    def __init__(self):
+        self.item_count = 2
+        self.gold = 20
+
+    def isPlayer(self):
+        return True
+
+    def countItems(self, item_id):
+        return self.item_count
+
+    def getNumericProperty(self, key):
+        return self.gold if key == "gold" else 0
+
+    def getBoolProperty(self, key):
+        return False
+
+    def getMap(self):
+        return None
+
+
+class FakeRuntime:
+    def __init__(self):
+        self.available_calls = 0
+        self.recipe = {
+            "id": "brew_life_potion",
+            "inputs": [{"item_id": "LesserLifePotion", "count": 2}],
+            "outputs": [{"item_id": "LifePotion", "count": 1}],
+            "gold": 20,
+            "success_chance": 100,
+        }
+
+    def available_recipes(self, player, station_id):
+        self.available_calls += 1
+        return [self.recipe]
+
+    def describe_recipe(self, recipe):
+        return "Life Potion [brew_life_potion]: 2x Lesser Life Potion, 20g -> 1x Life Potion (100% success)"
+
+    def describe_recipe_for_player(self, player, recipe):
+        state = "ready" if player.item_count >= 2 and player.gold >= 20 else "missing"
+        return f"{self.describe_recipe(recipe)} [{state}]"
+
+    def execute_recipe(self, game_instance, player, recipe):
+        player.item_count = 0
+        player.gold = 0
+        return {"ok": True, "reason": ""}
+
+    def get_item_label(self, item_id):
+        return {"LifePotion": "Life Potion", "LesserLifePotion": "Lesser Life Potion"}.get(item_id, item_id)
+
+
+class CraftingGuiRefreshTest(unittest.TestCase):
+    def test_crafting_station_refreshes_recipe_menu_after_attempt(self):
+        crafting = load_crafting_with_fake_game()
+        runtime = FakeRuntime()
+        crafting.get_runtime = lambda: runtime
+        handler = FakeHandler()
+        player = FakePlayer()
+
+        crafting.open_crafting_station(FakeStation(handler), player)
+
+        self.assertEqual(2, runtime.available_calls)
+        self.assertEqual(2, len(handler.menus))
+        self.assertIn("[ready]", handler.menus[0][0])
+        self.assertIn("[missing]", handler.menus[1][0])
+        self.assertEqual(("You crafted Life Potion.", True), handler.messages[-1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Refresh crafting station recipes every time the modal menu is rebuilt instead of reusing the initial recipe list.
- Add per-player recipe labels that show whether a recipe is ready or which item/gold requirements are missing.
- Add a fake-game regression covering a craft attempt followed by a refreshed crafting menu.

## Root cause
`open_crafting_station()` calculated `available_recipes(...)` once before entering the selection loop. After a craft changed inventory or gold, the next menu still represented the pre-craft state.

## Validation
- `python3 -m py_compile /mnt/data/fall-of-nouraajd/res/plugins/crafting.py` against the prepared scratch copy
- `cd /mnt/data/fall-of-nouraajd && python3 -m unittest tests.regression.test_crafting_gui_refresh` against the prepared scratch copy

Not run in a real checkout: `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`, `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`, or `python3 test.py`, because this environment does not have a local repository checkout and cloning from GitHub failed due DNS/network resolution. The branch was written through the GitHub connector.