### PR TITLE
[codex] encapsulate SDL render copy calls

### DIFF
--- a/src/core/CUtil.cpp
+++ b/src/core/CUtil.cpp
@@ -87,4 +87,14 @@ int CUtil::setRenderDrawColor(SDL_Renderer *renderer, SDL_Color color) {
     return SDL_SAFE(SDL_SetRenderDrawColor(renderer, color.r, color.g, color.b, color.a));
 }
 
+int CUtil::renderCopy(SDL_Renderer *renderer, SDL_Texture *texture, const SDL_Rect *source,
+                      const SDL_Rect *destination) {
+    return SDL_SAFE(SDL_RenderCopy(renderer, texture, source, destination));
+}
+
+int CUtil::renderCopyEx(SDL_Renderer *renderer, SDL_Texture *texture, const SDL_Rect *source,
+                        const SDL_Rect *destination, double angle, const SDL_Point *center, SDL_RendererFlip flip) {
+    return SDL_SAFE(SDL_RenderCopyEx(renderer, texture, source, destination, angle, center, flip));
+}
+
 // TODO: implement drag_drop

--- a/src/core/CUtil.h
+++ b/src/core/CUtil.h
@@ -96,6 +96,13 @@ class CUtil {
 
     static int setRenderDrawColor(SDL_Renderer *renderer, SDL_Color color);
 
+    static int renderCopy(SDL_Renderer *renderer, SDL_Texture *texture, const SDL_Rect *source,
+                          const SDL_Rect *destination);
+
+    static int renderCopyEx(SDL_Renderer *renderer, SDL_Texture *texture, const SDL_Rect *source,
+                            const SDL_Rect *destination, double angle, const SDL_Point *center,
+                            SDL_RendererFlip flip);
+
     template <fn::FilePredicate Predicate> static std::set<std::string> findFiles(std::string dir, Predicate pred) {
         std::set<std::string> retValue;
         for (const auto &entry : std::filesystem::directory_iterator(dir)) {

--- a/src/gui/CAnimation.cpp
+++ b/src/gui/CAnimation.cpp
@@ -40,9 +40,9 @@ void CStaticAnimation::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<S
         SDL_SetTextureAlphaMod(texture, colorA);
     }
     if (rotation == 0) {
-        SDL_SAFE(SDL_RenderCopy(gui->getRenderer(), texture, nullptr, rect.get()));
+        CUtil::renderCopy(gui->getRenderer(), texture, nullptr, rect.get());
     } else {
-        SDL_SAFE(SDL_RenderCopyEx(gui->getRenderer(), texture, nullptr, rect.get(), rotation, nullptr, SDL_FLIP_NONE));
+        CUtil::renderCopyEx(gui->getRenderer(), texture, nullptr, rect.get(), rotation, nullptr, SDL_FLIP_NONE);
     }
     if (useColorMod) {
         SDL_SetTextureColorMod(texture, 255, 255, 255);
@@ -111,7 +111,7 @@ void CDynamicAnimation::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<
             vstd::logger::error("CDynamicAnimation: missing frame", paths[currFrame]);
             return;
         }
-        SDL_SAFE(SDL_RenderCopy(gui->getRenderer(), texture, nullptr, rect.get()));
+        CUtil::renderCopy(gui->getRenderer(), texture, nullptr, rect.get());
     }
 }
 

--- a/src/gui/CTextManager.cpp
+++ b/src/gui/CTextManager.cpp
@@ -73,7 +73,7 @@ void CTextManager::drawText(const std::string &text, int x, int y, int w) {
         actual.y = y;
         SDL_Texture *pTexture = getTexture(text, w);
         SDL_SAFE(SDL_QueryTexture(pTexture, nullptr, nullptr, &actual.w, &actual.h));
-        SDL_SAFE(SDL_RenderCopy(_gui.lock()->getRenderer(), pTexture, nullptr, &actual));
+        CUtil::renderCopy(_gui.lock()->getRenderer(), pTexture, nullptr, &actual);
     }
 }
 
@@ -83,7 +83,7 @@ void CTextManager::drawTextCentered(const std::string &text, int x, int y, int w
         SDL_Texture *pTexture = getTexture(text, w);
         SDL_SAFE(SDL_QueryTexture(pTexture, nullptr, nullptr, &actual.w, &actual.h));
         auto centered = CUtil::boxInBox(CUtil::rect(x, y, w, h), CUtil::rect(0, 0, actual.w, actual.h));
-        SDL_SAFE(SDL_RenderCopy(_gui.lock()->getRenderer(), pTexture, nullptr, centered.get()));
+        CUtil::renderCopy(_gui.lock()->getRenderer(), pTexture, nullptr, centered.get());
     }
 }
 

--- a/src/gui/object/CGameGraphicsObject.cpp
+++ b/src/gui/object/CGameGraphicsObject.cpp
@@ -196,7 +196,7 @@ void CGameGraphicsObject::renderBackground(std::shared_ptr<CGui> gui, std::share
             vstd::logger::error("CGameGraphicsObject: missing background", background);
             return;
         }
-        SDL_SAFE(SDL_RenderCopy(gui->getRenderer(), texture, nullptr, rect.get()));
+        CUtil::renderCopy(gui->getRenderer(), texture, nullptr, rect.get());
     }
 }
 

--- a/src/gui/object/CMinimapGraphicsObject.cpp
+++ b/src/gui/object/CMinimapGraphicsObject.cpp
@@ -357,7 +357,7 @@ void CMinimapGraphicsObject::renderObject(std::shared_ptr<CGui> gui, std::shared
         terrainSignature = signature;
     }
     if (terrainTexture) {
-        SDL_SAFE(SDL_RenderCopy(renderer, terrainTexture.get(), nullptr, rect.get()));
+        CUtil::renderCopy(renderer, terrainTexture.get(), nullptr, rect.get());
     } else {
         fill_rect(renderer, rect, MINIMAP_BACKGROUND);
         draw_terrain(renderer, map, playerCoords.z, scale);

--- a/todo.txt
+++ b/todo.txt
@@ -5,7 +5,6 @@
 //TODO: migrate remaining global/static providers and UI/session services into CGameContext where safe
 //TODO: initiative
 //TODO: when lost fight in cave, panel pops out after return to position
-//TODO: encapsulate SDL_RenderCopy
 //TODO: what if we return to oldMap after switch?
 //TODO: make function to compare objects
 //TODO: load assets from map


### PR DESCRIPTION
## Summary

- add `CUtil::renderCopy` and `CUtil::renderCopyEx` wrappers around SDL render-copy calls
- replace direct `SDL_RenderCopy`/`SDL_RenderCopyEx` usage in animation, text, minimap, and background rendering paths
- remove the resolved `encapsulate SDL_RenderCopy` item from `todo.txt`

## Why

`todo.txt` tracked encapsulating direct `SDL_RenderCopy` calls. Centralizing those calls behind `CUtil` keeps SDL error handling consistent with the existing `SDL_SAFE` helper and gives render-copy behavior one place to evolve.

## Validation

Not run in this environment; changes were applied through the GitHub connector without a local checkout/build workspace.