### PR TITLE
[codex] Guard item interaction setter

### DIFF
--- a/src/object/CItem.cpp
+++ b/src/object/CItem.cpp
@@ -61,7 +61,9 @@ std::shared_ptr<CInteraction> CItem::getInteraction() { return interaction; }
 
 void CItem::setInteraction(std::shared_ptr<CInteraction> interaction) {
     this->interaction = interaction;
-    interaction->setManaCost(0);
+    if (interaction) {
+        interaction->setManaCost(0);
+    }
 }
 
 CBelt::CBelt() {}


### PR DESCRIPTION
## Summary
- allows `CItem::setInteraction(nullptr)` without dereferencing the missing interaction
- keeps the existing zero-mana-cost normalization for non-null item interactions

## Why
Equipment/config loading can clear object properties. The setter should accept a null interaction safely instead of crashing while resetting mana cost.

## Validation
- Not run in this environment; changes were prepared through the GitHub connector without a local checkout or `gh` CLI.