### PR TITLE
[codex] Guard texture loading without GUI

### DIFF
--- a/src/gui/CTextureCache.cpp
+++ b/src/gui/CTextureCache.cpp
@@ -98,7 +98,12 @@ fn::sdl::TexturePtr CTextureCache::loadTexture(std::string path) {
         vstd::logger::error("CTextureCache::loadTexture: cannot load", path);
         return nullptr;
     }
-    return CTextureUtil::calculateAlpha(_gui.lock()->getRenderer(), std::move(surface));
+    auto gui = _gui.lock();
+    if (!gui || !gui->getRenderer()) {
+        vstd::logger::error("CTextureCache::loadTexture: cannot load without an active renderer", path);
+        return nullptr;
+    }
+    return CTextureUtil::calculateAlpha(gui->getRenderer(), std::move(surface));
 }
 
 CTextureCache::CTextureCache(std::shared_ptr<CGui> _gui) : _gui(_gui) {}


### PR DESCRIPTION
## Summary
- checks for an active GUI and renderer before converting loaded surfaces to textures
- logs and returns `nullptr` when texture loading is attempted without a renderer

## Why
`CTextureCache` stores the GUI weakly and also has a default constructor. Loading a texture after the GUI is gone or before a renderer exists could dereference a null GUI.

## Validation
- Not run in this environment; changes were prepared through the GitHub connector without a local checkout or `gh` CLI.