### PR TITLE
[codex] Install Linux Python test dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
+      - name: Install Python deps
+        run: python -m pip install --upgrade pillow==11.2.1
       - name: detect coverage need
         id: coverage-needed
         shell: bash


### PR DESCRIPTION
## Summary
- adds a Linux CI step after `actions/setup-python` to install the Python dependency used by screenshot tests
- keeps the existing apt-based native dependency setup in `configure.sh`
- leaves the Windows dependency step unchanged

## Why
The Linux workflow runs tests with the `actions/setup-python` Python 3.12 interpreter. `configure.sh` installs `python3-pil` for the system Python, but that package is not visible to the setup-python interpreter, causing `ModuleNotFoundError: No module named 'PIL'` in the UI walkthrough test.

## Validation
- Branch compare shows one workflow file changed and branch is ahead of `main` by one commit.
- GitHub Actions will run on this PR.