### PR TITLE
[codex] Snap minimap to bottom-right corner

### DIFF
--- a/res/config/graphics.json
+++ b/res/config/graphics.json
@@ -71,9 +71,9 @@
         "class": "CLayout",
         "properties": {
           "h": 220,
-          "w": 220,
-          "x": 1700,
-          "y": 820
+          "horizontal": "RIGHT",
+          "vertical": "DOWN",
+          "w": 220
         }
       },
       "visible": {


### PR DESCRIPTION
## Summary

- Replaced the minimap's fixed `x`/`y` coordinates with layout anchors.
- Set the minimap layout to `horizontal: "RIGHT"` and `vertical: "DOWN"` so it snaps to the bottom-right corner of the parent GUI area.

## Impact

The minimap keeps its existing 220x220 size, but now follows the parent layout instead of relying on the hard-coded 1920x1080 coordinate placement.

## Validation

- Parsed the modified `res/config/graphics.json` locally with Python's JSON parser.
- Verified the branch diff contains only `res/config/graphics.json`.