### PR TITLE
[codex] Polish Victor timed rescue quest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,6 +389,8 @@ After finishing a change, always complete the repository delivery workflow:
 
 Keep one logical change per commit where practical. Do not bundle unrelated cleanup with feature or bug-fix work. Do not manually merge a pull request, enable auto-merge without explicit opt-in, bypass failing required checks, or bypass unresolved merge conflicts unless the user explicitly instructs that specific bypass. If pushing, opening, or enabling requested auto-merge is blocked by missing remotes, authentication, permissions, unavailable checks, or platform failures, report the exact blocker and leave the branch and pull request intact.
 
+When working on a GitHub issue, it may be closed after the fixing pull request has been merged. Do not close the issue before the merge unless the user explicitly asks for that.
+
 Before finishing, summarize:
 
 - files changed;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ These instructions apply to the entire repository unless a more specific `AGENTS
 
 The default branch is `main`.
 
-Keep changes narrow. Do not modify unrelated files, generated build output, packaged artifacts, dependency lock state, or submodule SHAs unless the task explicitly requires it. Do not rebase or update from `main` unless asked. Pull request auto-merge is explicit opt-in only; enable it only when the user or task instructions specifically request it. If a task requires touching `random-dungeon-generator` or `vstd`, state that clearly and rerun the full validation workflow.
+Keep changes narrow. Do not modify unrelated files, generated build output, packaged artifacts, dependency lock state, or submodule SHAs unless the task explicitly requires it. Do not rebase or update from `main` unless asked. Pull request auto-merge is the default; enable it after opening a pull request unless the user explicitly asks not to, the repository does not support it, or merge requirements are not satisfied. If a task requires touching `random-dungeon-generator` or `vstd`, state that clearly and rerun the full validation workflow.
 
 When this file conflicts with the current code, tests, or build scripts, trust the code and update this file as part of the fix.
 
@@ -384,10 +384,10 @@ After finishing a change, always complete the repository delivery workflow:
 3. Commit the change with a clear, specific commit message.
 4. Push the branch to the remote.
 5. Open a pull request targeting `main`.
-6. Enable auto-merge only when the user or task instructions explicitly request it.
-7. When auto-merge was explicitly requested and is enabled, do not wait for GitHub checks to finish; leave the pull request in auto-merge state.
+6. Enable auto-merge for the pull request by default, unless the user explicitly asks not to or GitHub reports that auto-merge is unavailable.
+7. When auto-merge is enabled, do not wait for GitHub checks to finish; leave the pull request in auto-merge state.
 
-Keep one logical change per commit where practical. Do not bundle unrelated cleanup with feature or bug-fix work. Do not manually merge a pull request, enable auto-merge without explicit opt-in, bypass failing required checks, or bypass unresolved merge conflicts unless the user explicitly instructs that specific bypass. If pushing, opening, or enabling requested auto-merge is blocked by missing remotes, authentication, permissions, unavailable checks, or platform failures, report the exact blocker and leave the branch and pull request intact.
+Keep one logical change per commit where practical. Do not bundle unrelated cleanup with feature or bug-fix work. Do not bypass failing required checks or unresolved merge conflicts unless the user explicitly instructs that specific bypass. If pushing, opening, merging, or enabling auto-merge is blocked by missing remotes, authentication, permissions, unavailable checks, merge conflicts, or platform failures, report the exact blocker and leave the branch and pull request intact.
 
 When working on a GitHub issue, it may be closed after the fixing pull request has been merged. Do not close the issue before the merge unless the user explicitly asks for that.
 

--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -263,7 +263,7 @@
   "victorQuest": {
     "class": "VictorQuest",
     "properties": {
-      "description": "Find Victor's daughter by following the town hall clue to the courtyard."
+      "description": "Find Victor's daughter by following tavern and town-hall clues to the courtyard."
     }
   },
   "holyRelic": {

--- a/res/maps/nouraajd/dialog.json
+++ b/res/maps/nouraajd/dialog.json
@@ -234,7 +234,7 @@
           "class": "CDialogState",
           "properties": {
             "stateId": "INKEEPER_ABOUT_GIRL",
-            "text": "They prowled after a young lass. I cursed them out and sent them hunting elsewhere. Does this accursed inn look fit for a child to you?",
+            "text": "They prowled after a young lass, then drifted toward the old civic court. I cursed them out and sent them hunting elsewhere. If Victor's girl is their quarry, the town hall ledgers may know the door they seek.",
             "options": [
               {
                 "ref": "askAboutMarumi",

--- a/res/maps/nouraajd/dialog3.json
+++ b/res/maps/nouraajd/dialog3.json
@@ -107,7 +107,7 @@
           "class": "CDialogState",
           "properties": {
             "stateId": "VICTOR_SPEECH",
-            "text": "I'm Victor. It's my daughter... She's been gone three days. My ex-wife lost her in the market crowd, and neither I nor the guards can find a trace. I'm terrified she's gone forever. (sobs)",
+            "text": "I'm Victor. It's my daughter... She's been gone three days. My ex-wife lost her in the market crowd, and neither I nor the guards can find a trace. Every hour makes the town quieter about her. I'm terrified she's gone forever. (sobs)",
             "options": [
               {
                 "class": "CDialogOption",
@@ -133,14 +133,14 @@
           "class": "CDialogState",
           "properties": {
             "stateId": "VICTOR_CLUE",
-            "text": "No... Someone swore they saw a girl like her near the courtyard, but when I rushed there I found nothing. No tracks, no ribbon, nothing.",
+            "text": "A washerwoman swore she saw a girl like her near the old courtyard between the tavern, town hall, and chapel. When I rushed there I found nothing. No tracks, no ribbon, nothing.",
             "options": [
               {
                 "class": "CDialogOption",
                 "properties": {
                   "number": 0,
                   "nextStateId": "COURTYARD_PATH",
-                  "text": "We'll scour the courtyard together."
+                  "text": "I'll search that courtyard before the trail dies."
                 }
               },
               {
@@ -148,7 +148,7 @@
                 "properties": {
                   "number": 1,
                   "nextStateId": "SUGGEST_TOWN_HALL",
-                  "text": "Maybe the town hall keeps a clue."
+                  "text": "Maybe the town hall keeps older records about that courtyard."
                 }
               }
             ]
@@ -158,14 +158,14 @@
           "class": "CDialogState",
           "properties": {
             "stateId": "SUGGEST_TOWN_HALL",
-            "text": "What?! I've heard of them but never knew where their chapel hides. We should check the town hall—someone there must know.",
+            "text": "What?! I've heard of them but never knew where their chapel hides. If they took her, they will not wait for grieving men. The town hall ledgers may name the door they use.",
             "options": [
               {
                 "class": "CDialogOption",
                 "properties": {
                   "number": 0,
                   "nextStateId": "EXIT",
-                  "text": "Then let's head for the town hall."
+                  "text": "Then I'll check the town hall records."
                 }
               },
               {
@@ -173,7 +173,7 @@
                 "properties": {
                   "number": 1,
                   "nextStateId": "COURTYARD_PATH",
-                  "text": "I'll take the courtyard."
+                  "text": "I'll run to the courtyard now."
                 }
               }
             ]
@@ -183,13 +183,13 @@
           "class": "CDialogState",
           "properties": {
             "stateId": "COURTYARD_PATH",
-            "text": "You reach the courtyard and find a wooden door branded with the Cult of Marumi Baso sigil. The place is occupied; press on and you may yet save Victor's child.",
+            "text": "You reach the courtyard between the tavern, town hall, and chapel. Behind a wooden door branded with the Cult of Marumi Baso sigil, voices count down a rite; press on now or Victor's child will vanish into stained glass and knives.",
             "options": [
               {
                 "class": "CDialogOption",
                 "properties": {
                   "number": 0,
-                  "text": "I'll confront them in that courtyard.",
+                  "text": "Break into the courtyard rite.",
                   "action": "spawn_cultists",
                   "nextStateId": "EXIT"
                 }
@@ -208,7 +208,7 @@
           "class": "CDialogState",
           "properties": {
             "stateId": "ENTRY",
-            "text": "You smash through the stained glass and drag Victor's trembling daughter into the light. Overwhelmed, Victor presses 500 gold into your palm and urges you to take whatever potions he still has left.",
+            "text": "You smash through the stained glass and drag Victor's trembling daughter into the light before the last verse is spoken. Overwhelmed, Victor presses 500 gold into your palm and urges you to take whatever potions he still has left.",
             "options": [
               {
                 "ref": "exitOption",

--- a/res/maps/nouraajd/dialog4.json
+++ b/res/maps/nouraajd/dialog4.json
@@ -13,7 +13,7 @@
                 "class": "CDialogOption",
                 "properties": {
                   "number": 0,
-                  "condition": "talked_to_victor",
+                  "condition": "can_discuss_victor_records",
                   "nextStateId": "VICTOR_CLUE",
                   "text": "Do your ledgers mention Victor's missing daughter?"
                 }
@@ -22,6 +22,33 @@
                 "class": "CDialogOption",
                 "properties": {
                   "number": 1,
+                  "condition": "victor_encounter_active",
+                  "nextStateId": "VICTOR_ACTIVE_REMINDER",
+                  "text": "About Victor's daughter..."
+                }
+              },
+              {
+                "class": "CDialogOption",
+                "properties": {
+                  "number": 2,
+                  "condition": "victor_good_end",
+                  "nextStateId": "VICTOR_GOOD_REPORT",
+                  "text": "Victor's daughter is safe."
+                }
+              },
+              {
+                "class": "CDialogOption",
+                "properties": {
+                  "number": 3,
+                  "condition": "victor_bad_end",
+                  "nextStateId": "VICTOR_BAD_REPORT",
+                  "text": "Victor's daughter is gone."
+                }
+              },
+              {
+                "class": "CDialogOption",
+                "properties": {
+                  "number": 4,
                   "condition": "has_letter_quest",
                   "nextStateId": "ASK_HELP_REPEAT",
                   "text": "About the sealed letter..."
@@ -30,7 +57,7 @@
               {
                 "class": "CDialogOption",
                 "properties": {
-                  "number": 2,
+                  "number": 5,
                   "condition": "can_chart_wayfarer_route",
                   "action": "chart_wayfarer_route",
                   "nextStateId": "WAYFARER_ROUTE",
@@ -40,7 +67,7 @@
               {
                 "class": "CDialogOption",
                 "properties": {
-                  "number": 3,
+                  "number": 6,
                   "condition": "can_offer_letter_work",
                   "nextStateId": "ASK_HELP",
                   "text": "I'm looking for work."
@@ -49,7 +76,7 @@
               {
                 "ref": "exitOption",
                 "properties": {
-                  "number": 4
+                  "number": 7
                 }
               }
             ]
@@ -114,12 +141,12 @@
           "class": "CDialogState",
           "properties": {
             "stateId": "VICTOR_CLUE",
-            "text": "Among dusty ledgers you find a note on the Cult of Marumi Baso. A decade ago they concealed their chapel behind a wooden door in the courtyard. The author swears they sacrifice girls who resemble their dead prophet's daughter to preserve a stained glass and stretch the prophet's unnatural life.",
+            "text": "Among dusty ledgers you find a note on the Cult of Marumi Baso. A decade ago they concealed their chapel behind a wooden door in the courtyard between the tavern, town hall, and chapel. The author swears they sacrifice girls who resemble their dead prophet's daughter to preserve a stained glass and stretch the prophet's unnatural life. If Victor's child is there, the rite has already begun.",
             "options": [
               {
                 "class": "CDialogOption",
                 "properties": {
-                  "text": "Search the courtyard",
+                  "text": "Run to the courtyard now.",
                   "number": 0,
                   "action": "spawn_cultists",
                   "nextStateId": "EXIT"
@@ -129,6 +156,51 @@
                 "ref": "exitOption",
                 "properties": {
                   "number": 1
+                }
+              }
+            ]
+          }
+        },
+        {
+          "class": "CDialogState",
+          "properties": {
+            "stateId": "VICTOR_ACTIVE_REMINDER",
+            "text": "Mayor Irvin shuts the ledger with shaking hands. If the courtyard door is open, there is no time left for ink or argument.",
+            "options": [
+              {
+                "ref": "exitOption",
+                "properties": {
+                  "number": 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "class": "CDialogState",
+          "properties": {
+            "stateId": "VICTOR_GOOD_REPORT",
+            "text": "Word reaches the hall that Victor carried his daughter from the cult door alive. Irvin marks the ledger with a rare clean line: rescued.",
+            "options": [
+              {
+                "ref": "exitOption",
+                "properties": {
+                  "number": 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "class": "CDialogState",
+          "properties": {
+            "stateId": "VICTOR_BAD_REPORT",
+            "text": "Irvin has only an ash-stained ribbon and a cleaned courtyard to record. The Cult of Marumi Baso left no debtor, no corpse, and no road to follow.",
+            "options": [
+              {
+                "ref": "exitOption",
+                "properties": {
+                  "number": 0
                 }
               }
             ]

--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -11,6 +11,7 @@ def load(self, context):
     VICTOR_CULTIST_PREFIX = "victorCultist"
     VICTOR_COURTYARD_SPAWNS = [(44, 100, 0), (46, 100, 0), (45, 99, 0), (45, 101, 0)]
     VICTOR_COURTYARD_LEADER_SPAWN = (45, 100, 0)
+    VICTOR_COURTYARD_FALLBACK_RADIUS = 3
 
     def _clear_victor_encounter(game_map):
         def should_remove(obj):
@@ -19,6 +20,31 @@ def load(self, context):
 
         game_map.removeAll(should_remove)
         game_map.setNumericProperty("VICTOR_COURTYARD_TURN", -1)
+        game_map.setNumericProperty("VICTOR_CULTISTS_PLACED", 0)
+
+    def _coords_key(coords):
+        return coords.x, coords.y, coords.z
+
+    def _victor_spawn_candidates(preferred):
+        x, y, z = preferred
+        yield preferred
+        for radius in range(1, VICTOR_COURTYARD_FALLBACK_RADIUS + 1):
+            for dx in range(-radius, radius + 1):
+                for dy in range(-radius, radius + 1):
+                    if abs(dx) + abs(dy) != radius:
+                        continue
+                    yield x + dx, y + dy, z
+
+    def _find_victor_spawn_coords(game_map, preferred, reserved):
+        for candidate in _victor_spawn_candidates(preferred):
+            coords = Coords(*candidate)
+            key = _coords_key(coords)
+            if key in reserved:
+                continue
+            if game_map.canStep(coords):
+                reserved.add(key)
+                return coords
+        return None
 
     def _expire_victor_search(game_map):
         quest_system = _get_quest_system(game_map)
@@ -55,33 +81,55 @@ def load(self, context):
             _expire_victor_search(game_map)
             return False
 
-        spawned = False
-        for index, (x, y, z) in enumerate(dialog.COURTYARD_SPAWNS, start=1):
-            coords = Coords(x, y, z)
-            if game_map.canStep(coords):
-                mon = game.createObject("Cultist")
-                target_ctrl = game.createObject("CTargetController")
-                target_ctrl.setTarget("player")
-                mon.setController(target_ctrl)
-                mon.setStringProperty("name", f"{VICTOR_CULTIST_PREFIX}{index}")
-                game_map.addObject(mon)
-                mon.moveTo(coords.x, coords.y, coords.z)
-                spawned = True
+        _clear_victor_encounter(game_map)
+        reserved = set()
+        leader_coords = _find_victor_spawn_coords(game_map, dialog.COURTYARD_LEADER_SPAWN, reserved)
+        if leader_coords is None:
+            game.getGuiHandler().showMessage(
+                "The courtyard is choked with bodies and barricades; the cult's hidden door cannot be reached yet."
+            )
+            return False
 
-        coords = Coords(*dialog.COURTYARD_LEADER_SPAWN)
-        if game_map.canStep(coords):
-            leader = game.createObject("CultLeader")
-            leader.setStringProperty("name", "cultLeaderQuest")
+        leader = game.createObject("CultLeader")
+        leader.setStringProperty("name", "cultLeaderQuest")
+        target_ctrl = game.createObject("CTargetController")
+        target_ctrl.setTarget("player")
+        leader.setController(target_ctrl)
+        game_map.addObject(leader)
+        if game_map.getObjectByName("cultLeaderQuest") is None:
+            game.getGuiHandler().showMessage(
+                "The cult door shudders open, then slams shut before the leader can be drawn into the courtyard."
+            )
+            return False
+        leader.moveTo(leader_coords.x, leader_coords.y, leader_coords.z)
+
+        placed_cultists = 0
+        for index, preferred in enumerate(dialog.COURTYARD_SPAWNS, start=1):
+            coords = _find_victor_spawn_coords(game_map, preferred, reserved)
+            if coords is None:
+                continue
+            mon = game.createObject("Cultist")
             target_ctrl = game.createObject("CTargetController")
             target_ctrl.setTarget("player")
-            leader.setController(target_ctrl)
-            game_map.addObject(leader)
-            leader.moveTo(coords.x, coords.y, coords.z)
-            spawned = True
+            mon.setController(target_ctrl)
+            mon.setStringProperty("name", f"{VICTOR_CULTIST_PREFIX}{index}")
+            game_map.addObject(mon)
+            mon.moveTo(coords.x, coords.y, coords.z)
+            placed_cultists += 1
 
-        if spawned:
-            quest_system.mark_victor_encounter_active()
-        return spawned
+        if placed_cultists == 0:
+            _clear_victor_encounter(game_map)
+            game.getGuiHandler().showMessage(
+                "The cult leader vanishes back through the branded door; the courtyard is too choked for a fight."
+            )
+            return False
+
+        game_map.setNumericProperty("VICTOR_CULTISTS_PLACED", placed_cultists)
+        quest_system.mark_victor_encounter_active()
+        game.getGuiHandler().showMessage(
+            "The cultists reel toward the stained-glass door. Break their rite before Victor's daughter is taken."
+        )
+        return True
 
     class _TrackedQuest:
         def __init__(self, name):
@@ -553,15 +601,26 @@ def load(self, context):
             state = _quest_system_from(self).get_state("victor")
             if state == "encounter_active":
                 return "Defeat the cultists in the courtyard before Victor's daughter is taken."
+            if state == "good_end":
+                return "Victor's daughter survived the courtyard rite."
+            if state == "bad_end":
+                return "Victor's daughter was taken when the courtyard rite ended."
             if state in ("met_victor", "records_reviewed", "courtyard_known"):
-                return "Follow Victor's clue from the tavern and town hall to the marked courtyard."
+                return "Follow Victor's clue from the tavern to the town hall records, then to the courtyard."
             return "Find Victor's missing daughter."
 
         def getReward(self):
             return "500 gold, healing, and Victor's remaining potions if you reach the courtyard in time."
 
         def getHint(self):
-            return "The tavern rumor and town-hall records point to the courtyard."
+            state = _quest_system_from(self).get_state("victor")
+            if state == "encounter_active":
+                return f"The cultists began their rite; you have {VICTOR_COURTYARD_TIMEOUT_TURNS} turns from first contact."
+            if state == "good_end":
+                return "Victor and his daughter have fled the courtyard alive."
+            if state == "bad_end":
+                return "The courtyard is empty now, scrubbed clean by Marumi Baso's servants."
+            return "Ask Victor at the tavern, search the town hall ledgers, then hurry to the courtyard."
 
         def onComplete(self):
             pass
@@ -770,8 +829,25 @@ def load(self, context):
         def talked_to_victor(self):
             return self.getGame().getMap().getBoolProperty("TALKED_TO_VICTOR")
 
+        def can_discuss_victor_records(self):
+            if not self.talked_to_victor():
+                return False
+            state = _quest_system_from(self).get_state("victor")
+            return state in ("not_started", "met_victor", "records_reviewed", "courtyard_known")
+
+        def victor_encounter_active(self):
+            return _quest_system_from(self).get_state("victor") == "encounter_active"
+
+        def victor_good_end(self):
+            return _quest_system_from(self).get_state("victor") == "good_end"
+
+        def victor_bad_end(self):
+            return _quest_system_from(self).get_state("victor") == "bad_end"
+
         def start_victor_quest(self):
             quest_system = _quest_system_from(self)
+            if quest_system.get_state("victor") == "not_started" and self.talked_to_victor():
+                quest_system.record_met_victor()
             quest_system.record_victor_records()
             self._ensure_quest("victorQuest")
 

--- a/test.py
+++ b/test.py
@@ -423,7 +423,7 @@ NOURAAJD_QUEST_DESCRIPTIONS = {
     "retrieveRelicQuest": "Recover the holy relic from the catacombs",
     "cleanseCaveQuest": "Use the relic to cleanse the OctoBogz cave",
     "octoBogzQuest": "Clear the OctoBogz from the cave east of Nouraajd.",
-    "victorQuest": "Find Victor's daughter by following the town hall clue to the courtyard.",
+    "victorQuest": "Find Victor's daughter by following tavern and town-hall clues to the courtyard.",
     "amuletQuest": "Find the stolen amulet for the old woman.",
 }
 
@@ -870,6 +870,9 @@ def materialized_tile_type(game, game_map, coords):
 MAPS_DIR = REPO_ROOT / "res/maps"
 DEFAULT_PLAYER = "Warrior"
 NOURAAJD_VICTOR_TIMEOUT = 75
+NOURAAJD_VICTOR_FALLBACK_RADIUS = 3
+NOURAAJD_VICTOR_LEADER_SPAWN = (45, 100, 0)
+NOURAAJD_VICTOR_PREFERRED_SPAWNS = ((44, 100, 0), (46, 100, 0), (45, 99, 0), (45, 101, 0), (45, 100, 0))
 TILED_FLIP_FLAG_MASK = 0xF0000000
 SUPPORTED_TILED_LAYER_TYPES = {"tilelayer", "objectgroup"}
 _git_changed_files_cache = None
@@ -1054,6 +1057,43 @@ def advance_map_only(game_map, turns):
 def force_nouraajd_victor_timeout(game_map):
     advance_map_only(game_map, NOURAAJD_VICTOR_TIMEOUT + 1)
     return game_map.getStringProperty("quest_state_victor")
+
+
+def add_nouraajd_victor_spawn_blocker(g, game_map, coords, index):
+    game = load_game_module()
+    blocker = g.createObject("CEvent")
+    blocker.setStringProperty("name", f"victorSpawnBlocker{index}")
+    blocker.setBoolProperty("canStep", False)
+    game_map.addObject(blocker)
+    blocker.moveTo(coords[0], coords[1], coords[2])
+    game_coords = game.Coords(coords[0], coords[1], coords[2])
+    if game_map.canStep(game_coords):
+        raise AssertionError(f"Expected Victor spawn blocker at {coords} to block stepping.")
+    return blocker
+
+
+def nouraajd_victor_spawn_candidates(preferred):
+    x, y, z = preferred
+    yield preferred
+    for radius in range(1, NOURAAJD_VICTOR_FALLBACK_RADIUS + 1):
+        for dx in range(-radius, radius + 1):
+            for dy in range(-radius, radius + 1):
+                if abs(dx) + abs(dy) == radius:
+                    yield x + dx, y + dy, z
+
+
+def add_nouraajd_victor_preferred_spawn_blockers(g, game_map):
+    return [
+        add_nouraajd_victor_spawn_blocker(g, game_map, coords, index)
+        for index, coords in enumerate(NOURAAJD_VICTOR_PREFERRED_SPAWNS, start=1)
+    ]
+
+
+def add_nouraajd_victor_leader_fallback_blockers(g, game_map):
+    return [
+        add_nouraajd_victor_spawn_blocker(g, game_map, coords, index)
+        for index, coords in enumerate(nouraajd_victor_spawn_candidates(NOURAAJD_VICTOR_LEADER_SPAWN), start=1)
+    ]
 
 
 def find_runtime_object(game_map, object_name):
@@ -6540,6 +6580,7 @@ class GameTest(unittest.TestCase):
         self.assertEqual(game_map.getStringProperty("quest_state_victor"), "met_victor")
         self.assertTrue(game_map.getBoolProperty("VICTOR_QUEST_STARTED"))
         self.assertIn("victorQuest", quest_names(player))
+        self.assertTrue(town_hall.can_discuss_victor_records())
 
         town_hall.spawn_cultists()
 
@@ -6553,6 +6594,11 @@ class GameTest(unittest.TestCase):
         self.assertEqual(game_map.getStringProperty("quest_state_victor"), "encounter_active")
         self.assertTrue(game_map.getBoolProperty("VICTOR_COURTYARD_FOUND"))
         self.assertTrue(game_map.getBoolProperty("VICTOR_CULTISTS_SPAWNED"))
+        self.assertFalse(town_hall.can_discuss_victor_records())
+        self.assertTrue(town_hall.victor_encounter_active())
+        victor_quest = find_player_quest(player, "victorQuest")
+        self.assertIn("Defeat the cultists in the courtyard", victor_quest.getObjective())
+        self.assertIn("75 turns", victor_quest.getHint())
         self.assertEqual(leader.getName(), "cultLeaderQuest")
         self.assertTrue(cultists)
 
@@ -6562,6 +6608,7 @@ class GameTest(unittest.TestCase):
                 "victor_started": game_map.getBoolProperty("VICTOR_QUEST_STARTED"),
                 "victor_courtyard_found": game_map.getBoolProperty("VICTOR_COURTYARD_FOUND"),
                 "victor_cultists_spawned": game_map.getBoolProperty("VICTOR_CULTISTS_SPAWNED"),
+                "victor_hint": victor_quest.getHint(),
                 "cultists": cultists,
             },
             sort_keys=True,
@@ -6600,6 +6647,79 @@ class GameTest(unittest.TestCase):
                 "quest_state_victor": game_map.getStringProperty("quest_state_victor"),
                 "leader": leader.getName(),
                 "cultists": cultists,
+            },
+            sort_keys=True,
+        )
+
+    @game_test
+    def test_nouraajd_victor_blocked_preferred_spawns_use_courtyard_fallbacks(self):
+        g, game_map, player = load_game_map_with_player("nouraajd")
+        tavern = g.createObject("tavernDialog2")
+        town_hall = g.createObject("townHallDialog")
+        blocked = set(NOURAAJD_VICTOR_PREFERRED_SPAWNS)
+
+        tavern.talked_to_victor()
+        blockers = add_nouraajd_victor_preferred_spawn_blockers(g, game_map)
+        town_hall.spawn_cultists()
+
+        leader = find_runtime_object(game_map, "cultLeaderQuest")
+        cultists = sorted(
+            (obj for obj in game_map.getObjects() if obj.getName() and obj.getName().startswith("victorCultist")),
+            key=lambda obj: obj.getName(),
+        )
+        encounter_coords = []
+        for obj in [leader] + cultists:
+            coords = obj.getCoords()
+            coord_tuple = (coords.x, coords.y, coords.z)
+            encounter_coords.append(coord_tuple)
+            self.assertNotIn(coord_tuple, blocked)
+
+        self.assertEqual(game_map.getStringProperty("quest_state_victor"), "encounter_active")
+        self.assertEqual(game_map.getNumericProperty("VICTOR_CULTISTS_PLACED"), 4)
+        self.assertEqual(len(cultists), 4)
+        self.assertTrue(game_map.getBoolProperty("VICTOR_CULTISTS_SPAWNED"))
+        self.assertTrue(all(blocker.getName().startswith("victorSpawnBlocker") for blocker in blockers))
+
+        return True, json.dumps(
+            {
+                "quest_state_victor": game_map.getStringProperty("quest_state_victor"),
+                "blocked": sorted(blocked),
+                "encounter_coords": sorted(encounter_coords),
+                "cultists_placed": game_map.getNumericProperty("VICTOR_CULTISTS_PLACED"),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
+    def test_nouraajd_victor_fully_blocked_leader_spawn_does_not_start_timer(self):
+        g, game_map, player = load_game_map_with_player("nouraajd")
+        tavern = g.createObject("tavernDialog2")
+        town_hall = g.createObject("townHallDialog")
+
+        tavern.talked_to_victor()
+        blockers = add_nouraajd_victor_leader_fallback_blockers(g, game_map)
+        town_hall.spawn_cultists()
+
+        self.assertEqual(game_map.getStringProperty("quest_state_victor"), "courtyard_known")
+        self.assertFalse(game_map.getBoolProperty("VICTOR_CULTISTS_SPAWNED"))
+        self.assertEqual(game_map.getNumericProperty("VICTOR_COURTYARD_TURN"), -1)
+        self.assertIsNone(game_map.getObjectByName("cultLeaderQuest"))
+        self.assertFalse(
+            any(obj.getName() and obj.getName().startswith("victorCultist") for obj in game_map.getObjects())
+        )
+
+        advance_map_only(game_map, NOURAAJD_VICTOR_TIMEOUT + 1)
+
+        self.assertEqual(game_map.getStringProperty("quest_state_victor"), "courtyard_known")
+        self.assertFalse(game_map.getBoolProperty("VICTOR_BAD_END"))
+        self.assertTrue(all(blocker.getName().startswith("victorSpawnBlocker") for blocker in blockers))
+
+        return True, json.dumps(
+            {
+                "quest_state_victor": game_map.getStringProperty("quest_state_victor"),
+                "victor_cultists_spawned": game_map.getBoolProperty("VICTOR_CULTISTS_SPAWNED"),
+                "victor_bad_end": game_map.getBoolProperty("VICTOR_BAD_END"),
+                "blocked_count": len(blockers),
             },
             sort_keys=True,
         )
@@ -6649,9 +6769,14 @@ class GameTest(unittest.TestCase):
             self.assertEqual(player.getGold() - start_gold, 500)
             self.assertEqual(heal_amounts, [100])
             self.assertTrue(game_map.getBoolProperty("VICTOR_GOOD_END"))
+            self.assertFalse(game_map.getBoolProperty("VICTOR_BAD_END"))
             self.assertTrue(game_map.getBoolProperty("VICTOR_REWARD_CLAIMED"))
+            self.assertEqual(game_map.getNumericProperty("VICTOR_COURTYARD_TURN"), -1)
             self.assertIn("victorRewardDialog", captured["dialogs"])
             self.assertIn("victorMarket", captured["trades"])
+            self.assertTrue(town_hall.victor_good_end())
+            victor_quest = find_player_quest(player, "victorQuest")
+            self.assertIn("survived", victor_quest.getObjective())
 
             town_hall.spawn_cultists()
             self.assertIsNone(game_map.getObjectByName("cultLeaderQuest"))
@@ -6662,6 +6787,16 @@ class GameTest(unittest.TestCase):
                 )
             )
 
+            duplicate_leader = g.createObject("CultLeader")
+            duplicate_leader.setStringProperty("name", "cultLeaderQuest")
+            game_map.addObject(duplicate_leader)
+            game_map.removeObjectByName("cultLeaderQuest")
+
+            self.assertEqual(player.getGold() - start_gold, 500)
+            self.assertEqual(heal_amounts, [100])
+            self.assertEqual(captured["dialogs"].count("victorRewardDialog"), 1)
+            self.assertEqual(captured["trades"].count("victorMarket"), 1)
+
             return True, json.dumps(
                 {
                     "quest_state_victor": game_map.getStringProperty("quest_state_victor"),
@@ -6669,6 +6804,7 @@ class GameTest(unittest.TestCase):
                     "trades": captured["trades"],
                     "heal_amounts": heal_amounts,
                     "gold_delta": player.getGold() - start_gold,
+                    "victor_objective": victor_quest.getObjective(),
                 },
                 sort_keys=True,
             )
@@ -6684,13 +6820,27 @@ class GameTest(unittest.TestCase):
         town_hall = g.createObject("townHallDialog")
 
         tavern.talked_to_victor()
+        start_gold = player.getGold()
         town_hall.spawn_cultists()
+        spawn_turn = game_map.getNumericProperty("VICTOR_COURTYARD_TURN")
         self.assertIsNotNone(game_map.getObjectByName("cultLeaderQuest"))
 
-        force_nouraajd_victor_timeout(game_map)
+        advance_map_only(game_map, NOURAAJD_VICTOR_TIMEOUT)
+        self.assertEqual(game_map.getStringProperty("quest_state_victor"), "encounter_active")
+        self.assertEqual(game_map.getNumericProperty("VICTOR_COURTYARD_TURN"), spawn_turn)
+
+        advance_map_only(game_map, 1)
 
         self.assertEqual(game_map.getStringProperty("quest_state_victor"), "bad_end")
         self.assertTrue(game_map.getBoolProperty("VICTOR_BAD_END"))
+        self.assertFalse(game_map.getBoolProperty("VICTOR_GOOD_END"))
+        self.assertFalse(game_map.getBoolProperty("VICTOR_REWARD_CLAIMED"))
+        self.assertEqual(game_map.getNumericProperty("VICTOR_COURTYARD_TURN"), -1)
+        self.assertEqual(player.getGold(), start_gold)
+        self.assertTrue(town_hall.victor_bad_end())
+        victor_quest = find_player_quest(player, "victorQuest")
+        self.assertIn("was taken", victor_quest.getObjective())
+        self.assertIn("scrubbed clean", victor_quest.getHint())
         self.assertIsNone(game_map.getObjectByName("cultLeaderQuest"))
         self.assertFalse(
             any(obj.getName() and obj.getName().startswith("victorCultist") for obj in game_map.getObjects())
@@ -6703,6 +6853,48 @@ class GameTest(unittest.TestCase):
             {
                 "quest_state_victor": game_map.getStringProperty("quest_state_victor"),
                 "victor_bad_end": game_map.getBoolProperty("VICTOR_BAD_END"),
+                "victor_objective": victor_quest.getObjective(),
+                "spawn_turn": spawn_turn,
+                "turn": game_map.getTurn(),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
+    def test_nouraajd_victor_optional_does_not_block_main_progression(self):
+        g, game_map, player = load_game_map_with_player("nouraajd")
+        town_hall = g.createObject("townHallDialog")
+        beren = g.createObject("berenDialog")
+
+        self.assertEqual(game_map.getStringProperty("quest_state_victor"), "not_started")
+        self.assertFalse(game_map.getBoolProperty("VICTOR_QUEST_STARTED"))
+        self.assertNotIn("victorQuest", quest_names(player))
+
+        game_map.removeObjectByName("cave1")
+        gooby = find_runtime_object(game_map, "gooby1")
+        game_map.removeObjectByName(gooby.getName())
+        town_hall.give_letter()
+        beren.deliver_letter()
+        game_map.removeObjectByName("catacombs")
+        beren.return_relic()
+        game_map.removeObjectByName("cave2")
+        beren.finish_cleanse()
+        pump_event_loop()
+
+        self.assertEqual(game_map.getStringProperty("quest_state_victor"), "not_started")
+        self.assertFalse(game_map.getBoolProperty("VICTOR_QUEST_STARTED"))
+        self.assertFalse(game_map.getBoolProperty("VICTOR_COURTYARD_FOUND"))
+        self.assertFalse(game_map.getBoolProperty("VICTOR_GOOD_END"))
+        self.assertFalse(game_map.getBoolProperty("VICTOR_BAD_END"))
+        self.assertNotIn("victorQuest", quest_names(player))
+        self.assertEqual(g.getMap().mapName, "ritual")
+
+        return True, json.dumps(
+            {
+                "quest_state_victor": game_map.getStringProperty("quest_state_victor"),
+                "victor_started": game_map.getBoolProperty("VICTOR_QUEST_STARTED"),
+                "map": g.getMap().mapName,
+                "quests": quest_names(player),
             },
             sort_keys=True,
         )
@@ -8369,7 +8561,7 @@ class XvfbGameplayProcessTest(unittest.TestCase):
         self.assertEqual("met_victor", quest_state("victor"))
         self.assertTrue(game_map.getBoolProperty("TALKED_TO_VICTOR"))
         assert_active("victorQuest")
-        show_dialog_with_keyboard(self, game, g, g.createObject("townHallDialog"), [1, 1])
+        show_dialog_with_keyboard(self, game, g, g.createObject("townHallDialog"), [1, 1, "space"])
         leader = find_runtime_object(game_map, "cultLeaderQuest")
         cultists = [obj for obj in game_map.getObjects() if obj.getName() and obj.getName().startswith("victorCultist")]
         self.assertEqual("encounter_active", quest_state("victor"))

--- a/test.py
+++ b/test.py
@@ -3373,8 +3373,13 @@ class GameTest(unittest.TestCase):
         self.assertEqual(1, minimap_props.get("priority"))
         self.assertEqual("CLayout", layout.get("class"))
         self.assertEqual(
-            {"x": 1700, "y": 820, "w": 220, "h": 220},
-            {key: int(layout_props.get(key)) for key in ("x", "y", "w", "h")},
+            {"horizontal": "RIGHT", "vertical": "DOWN", "w": 220, "h": 220},
+            {
+                "horizontal": layout_props.get("horizontal"),
+                "vertical": layout_props.get("vertical"),
+                "w": int(layout_props.get("w")),
+                "h": int(layout_props.get("h")),
+            },
         )
         self.assertEqual("CScript", minimap_props.get("visible", {}).get("class"))
 
@@ -3382,7 +3387,7 @@ class GameTest(unittest.TestCase):
             {
                 "class": minimap.get("class"),
                 "priority": minimap_props.get("priority"),
-                "layout": {key: layout_props.get(key) for key in ("x", "y", "w", "h")},
+                "layout": {key: layout_props.get(key) for key in ("horizontal", "vertical", "w", "h")},
             },
             sort_keys=True,
         )


### PR DESCRIPTION
## Current Victor flow summary

Victor remains an optional Nouraajd side quest. The flow is still tavern clue -> town-hall records -> courtyard encounter -> good or bad ending, with `victorQuest` granted only after engaging Victor/town-hall Victor content. Main Nouraajd/Beren progression can still complete without starting Victor.

## State-machine changes

- Kept existing state names intact: `not_started`, `met_victor`, `records_reviewed`, `courtyard_known`, `encounter_active`, `good_end`, `bad_end`.
- Added clearer Victor quest objective/hint text for active, good, and bad states, including timed pressure once the courtyard rite starts.
- Added town-hall condition helpers so Victor records, active reminder, success report, and failure report are distinct.
- Kept reward ownership in `CultLeaderQuestTrigger`; 500 gold, heal, reward dialog, and market remain guarded by `encounter_active`, `VICTOR_REWARD_CLAIMED`, and `VICTOR_GOOD_END`.

## Dialog/map changes

- Clarified the clue chain from tavern rumor to Victor, town hall ledgers, and the courtyard between town hall, tavern, and chapel.
- Added more urgent encounter text and distinct town-hall post-good/post-bad report states.
- Hardened courtyard spawning with deterministic fallback cells around the authored spawn points.
- The leader is required before the timer starts, zero-cultist starts are rejected, stale encounter objects are cleared before retry, and blocked hard-failure leaves the quest at `courtyard_known` without timing out.

## Workflow doc changes

- Added AGENTS.md guidance that GitHub issues may be closed after the fixing pull request has merged, not before, unless explicitly requested.
- Updated AGENTS.md so pull request auto-merge is the default when GitHub supports it and merge requirements are satisfied.

## Test matrix

- Good ending and reward idempotency: `test_nouraajd_victor_reward_unlock_regression`.
- Bad ending deterministic timeout boundary and cleanup: `test_nouraajd_victor_timeout_cleanup_regression`.
- Spawn fallback when preferred courtyard tiles are blocked: `test_nouraajd_victor_blocked_preferred_spawns_use_courtyard_fallbacks`.
- Fully blocked leader fallback does not start timer or bad-end the quest: `test_nouraajd_victor_fully_blocked_leader_spawn_does_not_start_timer`.
- Optional quest does not block main Nouraajd progression: `test_nouraajd_victor_optional_does_not_block_main_progression`.
- Existing Victor town-hall/direct branch/state-machine/dialog integrity coverage updated.
- Minimap layout baseline updated for the existing anchored `horizontal: RIGHT`, `vertical: DOWN` config from #344, after CI exposed the stale absolute-coordinate assertion.

## Validation output

Passed before rebasing and repeated key checks after rebasing onto `origin/main`:

- `git diff --check` - passed, including after follow-up commits.
- JSON parse for `res/maps/nouraajd/dialog.json`, `dialog3.json`, `dialog4.json`, and `config.json` - passed.
- Focused Victor/dialog tests - `Ran 10 tests`, `OK`.
- Focused post-follow-up tests: `python3 -m unittest test.GameTest.test_gui_includes_display_only_minimap_layout` plus all focused Victor tests - `Ran 8 tests`, `OK`.
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` - passed.
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` - passed.
- `python3 test.py` - passed before rebase, including Xvfb long wrapper.
- `./scripts/run_coverage.sh` - passed before rebase, `lines: 90.08% (9349 out of 10379)`.

Resolves #330.