### PR TITLE
Fix minimap layout test expectations

### DIFF
--- a/test.py
+++ b/test.py
@@ -355,7 +355,7 @@ SDL_PIXELFORMAT_RGBA32 = 376840196
 GUI_WIDTH = 1920
 GUI_HEIGHT = 1080
 GUI_TILE_SIZE = 50
-MINIMAP_RECT = (1700, 820, 220, 220)
+MINIMAP_RECT = (1700, 860, 220, 220)
 MINIMAP_PLAYER_RGB = (255, 255, 0)
 MINIMAP_VIEWPORT_RGB = (255, 255, 255)
 COMBAT_STALE_LOOP_TIMEOUT_SECONDS = 5.0 if os.environ.get("GAME_COVERAGE_RUN") == "1" else 2.0
@@ -3332,17 +3332,16 @@ class GameTest(unittest.TestCase):
         layout_props = layout.get("properties", {})
         self.assertEqual(1, minimap_props.get("priority"))
         self.assertEqual("CLayout", layout.get("class"))
-        self.assertEqual(
-            {"x": 1700, "y": 820, "w": 220, "h": 220},
-            {key: int(layout_props.get(key)) for key in ("x", "y", "w", "h")},
-        )
+        self.assertEqual("RIGHT", layout_props.get("horizontal"))
+        self.assertEqual("DOWN", layout_props.get("vertical"))
+        self.assertEqual({"w": 220, "h": 220}, {key: int(layout_props.get(key)) for key in ("w", "h")})
         self.assertEqual("CScript", minimap_props.get("visible", {}).get("class"))
 
         return True, json.dumps(
             {
                 "class": minimap.get("class"),
                 "priority": minimap_props.get("priority"),
-                "layout": {key: layout_props.get(key) for key in ("x", "y", "w", "h")},
+                "layout": {key: layout_props.get(key) for key in ("horizontal", "vertical", "w", "h")},
             },
             sort_keys=True,
         )


### PR DESCRIPTION
### Motivation
- The minimap HUD was snapped to a bottom-right anchored layout and the tests still expected absolute `x`/`y` coordinates and the old sampling rectangle, causing screenshot and layout assertions to fail.

### Description
- Update the test expectations in `test.py` by moving `MINIMAP_RECT` to `(1700, 860, 220, 220)` and change the GUI layout assertions to expect `horizontal == "RIGHT"` and `vertical == "DOWN"` while asserting the fixed `220x220` size and returning the `("horizontal","vertical","w","h")` layout keys.

### Testing
- Built unit targets with `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` and verified C++ unit tests via `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` which passed; the coverage build was started but interrupted due to environment time constraints.
- Ran the full Python test suite with `python3 test.py` (including the updated minimap layout test) which completed successfully (`OK`, with the Xvfb screenshot tests skipped where appropriate), and ran the focused GUI checks `python3 test.py GameTest.test_gui_includes_display_only_minimap_layout XvfbGameplayProcessTest.test_screenshot_minimap_has_rendered_pixels` which also passed after installing Pillow (`python3 -m pip install Pillow`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3398322d30832695cb32cb50d2fc2c)