### PR TITLE
Redesign crafting station recipe flow

### DIFF
--- a/res/config/crafting.json
+++ b/res/config/crafting.json
@@ -45,7 +45,8 @@
         ],
         "output": { "item": "GreaterLifePotion", "count": 1 },
         "gold": 45,
-        "successChance": 90
+        "successChance": 90,
+        "unlockFlag": "CAN_BREW_GREATER_POTIONS"
     },
     "blend_greater_mana_potion": {
         "station": "alchemyTable",
@@ -54,7 +55,8 @@
         ],
         "output": { "item": "GreaterManaPotion", "count": 1 },
         "gold": 45,
-        "successChance": 90
+        "successChance": 90,
+        "unlockFlag": "CAN_BREW_GREATER_POTIONS"
     },
     "brew_full_life_potion": {
         "station": "alchemyTable",

--- a/res/plugins/crafting.py
+++ b/res/plugins/crafting.py
@@ -18,6 +18,13 @@ import json
 import game
 from game import randint
 
+LEAVE_OPTION = "Leave"
+
+UNLOCK_HINTS = {
+    "CAN_CRAFT_SCROLLS": "Deliver Mayor Irvin's sealed letter to Father Beren.",
+    "CAN_BREW_GREATER_POTIONS": "Return the holy relic to Father Beren.",
+}
+
 
 def _status(ok, reason=""):
     return {"ok": ok, "reason": reason}
@@ -206,17 +213,29 @@ class CraftingRuntime:
     def get_item_label(self, item_id):
         return self._item_labels.get(item_id, item_id)
 
-    def describe_recipe(self, recipe):
+    def describe_entries(self, entries):
         parts = [
-            f"{req['count']}x {self.get_item_label(req['item_id'])}" for req in recipe["inputs"] if req["count"] > 0
+            f"{entry['count']}x {self.get_item_label(entry['item_id'])}" for entry in entries if entry["count"] > 0
         ]
+        return ", ".join(parts) if parts else "None"
+
+    def describe_requirements(self, recipe):
+        parts = [self.describe_entries(recipe["inputs"])]
         if recipe["gold"] > 0:
             parts.append(f"{recipe['gold']}g")
-        parts_text = ", ".join(parts) if parts else "No cost"
+        return ", ".join(part for part in parts if part and part != "None") or "No cost"
+
+    def describe_outputs(self, recipe):
+        return self.describe_entries(recipe["outputs"])
+
+    def describe_recipe(self, recipe):
+        parts_text = self.describe_requirements(recipe)
         output = recipe["outputs"][0]
-        output_label = self.get_item_label(output["item_id"])
         chance = recipe["success_chance"]
-        return f"{recipe['display_name']} [{recipe['id']}]: {parts_text} -> {output['count']}x {output_label} ({chance}% success)"
+        return (
+            f"{recipe['display_name']} [{recipe['id']}] | "
+            f"Output: {self.describe_outputs(recipe)} | Requires: {parts_text} | {chance}% success"
+        )
 
     def missing_requirements(self, player, recipe):
         missing = []
@@ -235,12 +254,28 @@ class CraftingRuntime:
                 missing.append(f"{gold_cost - held_gold}g")
         return missing
 
+    def recipe_unlock_hint(self, recipe):
+        unlock_state = recipe.get("unlock", {"type": "none", "value": None})
+        if unlock_state["type"] != "flag":
+            return ""
+        flag_name = unlock_state["value"]
+        return UNLOCK_HINTS.get(flag_name, f"Requires {flag_name}.")
+
+    def recipe_state(self, player, recipe):
+        if not self.is_unlocked(player, recipe):
+            return "locked"
+        if self.missing_requirements(player, recipe):
+            return "missing"
+        return "ready"
+
     def describe_recipe_for_player(self, player, recipe):
         description = self.describe_recipe(recipe)
+        if not self.is_unlocked(player, recipe):
+            return f"LOCKED - {description} | Unlock: {self.recipe_unlock_hint(recipe)}"
         missing = self.missing_requirements(player, recipe)
         if not missing:
-            return f"{description} [ready]"
-        return f"{description} [missing: {', '.join(missing)}]"
+            return f"READY - {description}"
+        return f"MISSING - {description} | Missing: {', '.join(missing)}"
 
     def is_unlocked(self, player, recipe):
         unlock_state = recipe.get("unlock", {"type": "none", "value": None})
@@ -259,6 +294,11 @@ class CraftingRuntime:
     def available_recipes(self, player, station_id):
         return [recipe for recipe in self.station_recipes(station_id) if self.is_unlocked(player, recipe)]
 
+    def station_options(self, player, station_id):
+        recipes = self.station_recipes(station_id)
+        option_map = {self.describe_recipe_for_player(player, recipe): recipe for recipe in recipes}
+        return recipes, option_map
+
     def execute_recipe(self, game_instance, player, recipe):
         if not self.is_unlocked(player, recipe):
             return _status(False, "locked")
@@ -275,7 +315,7 @@ def get_runtime():
     return _RUNTIME
 
 
-def _format_result_message(runtime, recipe, result):
+def _format_result_message(runtime, recipe, result, player=None):
     if result["ok"]:
         output = recipe["outputs"][0]
         label = runtime.get_item_label(output["item_id"])
@@ -284,11 +324,16 @@ def _format_result_message(runtime, recipe, result):
             return f"You crafted {quantity}x {label}."
         return f"You crafted {label}."
     reason = result.get("reason", "")
+    if reason == "locked":
+        return f"That recipe is locked. {runtime.recipe_unlock_hint(recipe)}"
     if reason == "failed":
         return "The reagents fizzled and nothing was created."
     if reason == "missing:gold":
         return "You need more gold to craft this."
     if reason.startswith("missing:"):
+        missing = runtime.missing_requirements(player, recipe) if player else []
+        if missing:
+            return f"You are missing {', '.join(missing)}."
         missing_item = reason.split("missing:", 1)[1]
         return f"You need more {runtime.get_item_label(missing_item)}."
     return reason or "Crafting failed."
@@ -311,24 +356,22 @@ def open_crafting_station(station, player):
     game_instance = station.getGame()
     handler = game_instance.getGuiHandler()
     station_label = station.getStringProperty("label") or station_id
-    leave_option = "Leave"
     while True:
-        available = runtime.available_recipes(player, station_id)
-        if not available:
+        recipes, option_map = runtime.station_options(player, station_id)
+        if not recipes:
             handler.showInfo(f"No known recipes for {station_label}.", True)
             return
-        option_map = {}
-        options = []
-        for recipe in available:
-            description = runtime.describe_recipe_for_player(player, recipe)
-            option_map[description] = recipe
-            options.append(description)
-        options.append(leave_option)
+        options = list(option_map.keys())
+        options.append(LEAVE_OPTION)
         selection = handler.showSelection(game.list_string(game_instance, options))
-        if selection == leave_option or selection not in option_map:
+        if selection == LEAVE_OPTION or selection not in option_map:
             break
-        result = runtime.execute_recipe(game_instance, player, option_map[selection])
-        handler.showInfo(_format_result_message(runtime, option_map[selection], result), True)
+        recipe = option_map[selection]
+        if not runtime.is_unlocked(player, recipe):
+            handler.showInfo(_format_result_message(runtime, recipe, _status(False, "locked"), player), True)
+            continue
+        result = runtime.execute_recipe(game_instance, player, recipe)
+        handler.showInfo(_format_result_message(runtime, recipe, result, player), True)
 
 
 def craft_recipe(game_instance, player, recipe_id):

--- a/test.py
+++ b/test.py
@@ -2652,7 +2652,7 @@ class GameTest(unittest.TestCase):
 
         assert result["ok"], f"Crafting failed: {result}"
         assert before == 2 and after == 0, f"Unexpected reagent counts: before={before}, after={after}"
-        assert crafted_count >= 1, "Player did not receive the crafted item."
+        assert crafted_count == 1, "Player should receive exactly one crafted item."
         assert remaining_gold == 80, f"Expected 80 gold after crafting, got {remaining_gold}"
 
         return True, {
@@ -2709,6 +2709,7 @@ class GameTest(unittest.TestCase):
 
         # RNG failure leaves inventory and gold untouched
         reset()
+        player.setBoolProperty("CAN_BREW_GREATER_POTIONS", True)
         player.addItem("LifePotion")
         player.addItem("LifePotion")
         player.setNumericProperty("gold", 200)
@@ -2737,6 +2738,10 @@ class GameTest(unittest.TestCase):
         g, game_map, player = load_game_map_with_player("nouraajd")
         runtime = crafting.get_runtime()
 
+        initial_alchemy_recipes = {recipe["id"] for recipe in runtime.available_recipes(player, "alchemyTable")}
+        self.assertIn("brew_life_potion", initial_alchemy_recipes)
+        self.assertNotIn("blend_greater_life_potion", initial_alchemy_recipes)
+        self.assertNotIn("brew_full_life_potion", initial_alchemy_recipes)
         self.assertNotIn(
             "craft_town_portal_scroll",
             {recipe["id"] for recipe in runtime.available_recipes(player, "scribeDesk")},
@@ -2752,6 +2757,8 @@ class GameTest(unittest.TestCase):
         game_map.removeObjectByName("catacombs")
         beren.return_relic()
         alchemy_recipes = {recipe["id"] for recipe in runtime.available_recipes(player, "alchemyTable")}
+        self.assertIn("blend_greater_life_potion", alchemy_recipes)
+        self.assertIn("blend_greater_mana_potion", alchemy_recipes)
         self.assertIn("brew_full_life_potion", alchemy_recipes)
         self.assertIn("brew_full_mana_potion", alchemy_recipes)
 
@@ -2764,6 +2771,195 @@ class GameTest(unittest.TestCase):
             },
             sort_keys=True,
         )
+
+    @game_test
+    def test_crafting_locked_recipe_attempt_is_atomic(self):
+        import crafting
+
+        g, _game_map, player = load_game_map_with_player("nouraajd")
+        player.setNumericProperty("gold", 500)
+        player.addItem("Scroll")
+        player.addItem("ManaPotion")
+        player.addItem("GreaterLifePotion")
+        player.addItem("GreaterLifePotion")
+
+        before = {
+            "gold": player.getNumericProperty("gold"),
+            "scroll": player.countItems("Scroll"),
+            "mana": player.countItems("ManaPotion"),
+            "greater_life": player.countItems("GreaterLifePotion"),
+            "town_portal": player.countItems("TownPortalScroll"),
+            "full_life": player.countItems("FullLifePotion"),
+        }
+
+        scroll_result = crafting.craft_recipe(g, player, "craft_town_portal_scroll")
+        potion_result = crafting.craft_recipe(g, player, "brew_full_life_potion")
+
+        self.assertEqual({"ok": False, "reason": "locked"}, scroll_result)
+        self.assertEqual({"ok": False, "reason": "locked"}, potion_result)
+        self.assertEqual(before["gold"], player.getNumericProperty("gold"))
+        self.assertEqual(before["scroll"], player.countItems("Scroll"))
+        self.assertEqual(before["mana"], player.countItems("ManaPotion"))
+        self.assertEqual(before["greater_life"], player.countItems("GreaterLifePotion"))
+        self.assertEqual(before["town_portal"], player.countItems("TownPortalScroll"))
+        self.assertEqual(before["full_life"], player.countItems("FullLifePotion"))
+
+        return True, json.dumps({"scroll_result": scroll_result, "potion_result": potion_result}, sort_keys=True)
+
+    @game_test
+    def test_crafting_invalid_recipe_id_is_atomic(self):
+        import crafting
+
+        g, _game_map, player = load_game_map_with_player("nouraajd")
+        player.setNumericProperty("gold", 123)
+        player.addItem("LesserLifePotion")
+        before_items = player.countItems("LesserLifePotion")
+
+        result = crafting.craft_recipe(g, player, "not_a_real_recipe")
+
+        self.assertEqual({"ok": False, "reason": "missing:recipe"}, result)
+        self.assertEqual(123, player.getNumericProperty("gold"))
+        self.assertEqual(before_items, player.countItems("LesserLifePotion"))
+
+        return True, json.dumps(result, sort_keys=True)
+
+    @game_test
+    def test_crafting_station_options_show_recipe_states(self):
+        import crafting
+
+        game = load_game_module()
+        g, game_map, player = load_game_map_with_player("nouraajd")
+        player.setNumericProperty("gold", 100)
+        player.addItem("LesserLifePotion")
+        player.addItem("LesserLifePotion")
+
+        class FakeEvent:
+            def __init__(self, cause):
+                self.cause = cause
+
+            def getCause(self):
+                return self.cause
+
+        captured_options = []
+        captured_infos = []
+        original_show_selection = game.CGuiHandler.showSelection
+        original_show_info = game.CGuiHandler.showInfo
+
+        def capture_selection(self, list_string):
+            options = sorted(list_string.getValues())
+            captured_options.append(options)
+            return crafting.LEAVE_OPTION
+
+        def capture_info(self, message, centered=True):
+            captured_infos.append((message, centered))
+
+        try:
+            game.CGuiHandler.showSelection = capture_selection
+            game.CGuiHandler.showInfo = capture_info
+            find_runtime_object(game_map, "alchemyTable1").onEnter(FakeEvent(player))
+            find_runtime_object(game_map, "scribeDesk1").onEnter(FakeEvent(player))
+        finally:
+            game.CGuiHandler.showSelection = original_show_selection
+            game.CGuiHandler.showInfo = original_show_info
+
+        self.assertEqual(2, len(captured_options))
+        alchemy_options, scribe_options = captured_options
+        self.assertTrue(
+            any(option.startswith("READY -") and "[brew_life_potion]" in option for option in alchemy_options)
+        )
+        self.assertTrue(
+            any(option.startswith("MISSING -") and "[brew_mana_potion]" in option for option in alchemy_options)
+        )
+        self.assertTrue(
+            any(option.startswith("LOCKED -") and "[blend_greater_life_potion]" in option for option in alchemy_options)
+        )
+        self.assertTrue(
+            any(option.startswith("LOCKED -") and "[brew_full_life_potion]" in option for option in alchemy_options)
+        )
+        self.assertTrue(any("Output:" in option and "Requires:" in option for option in alchemy_options))
+        self.assertTrue(
+            any(option.startswith("LOCKED -") and "[craft_town_portal_scroll]" in option for option in scribe_options)
+        )
+        self.assertEqual([], captured_infos)
+
+        return True, json.dumps({"alchemy": alchemy_options, "scribe": scribe_options}, sort_keys=True)
+
+    @game_test
+    def test_crafting_station_locked_missing_and_success_paths(self):
+        import crafting
+
+        game = load_game_module()
+        g, game_map, player = load_game_map_with_player("nouraajd")
+        player.setNumericProperty("gold", 200)
+
+        def clear_item(item_id):
+            while player.countItems(item_id) > 0:
+                player.removeItem(lambda it, tid=item_id: it.getTypeId() == tid, True)
+
+        for item_id in ("Scroll", "ManaPotion", "TownPortalScroll", "LesserLifePotion", "LifePotion"):
+            clear_item(item_id)
+
+        class FakeEvent:
+            def __init__(self, cause):
+                self.cause = cause
+
+            def getCause(self):
+                return self.cause
+
+        selections = []
+        captured_infos = []
+        original_show_selection = game.CGuiHandler.showSelection
+        original_show_info = game.CGuiHandler.showInfo
+
+        def select_recipe(recipe_id):
+            def select(options):
+                return next(option for option in options if f"[{recipe_id}]" in option)
+
+            return select
+
+        def queued_selection(self, list_string):
+            options = sorted(list_string.getValues())
+            choice = selections.pop(0) if selections else crafting.LEAVE_OPTION
+            return choice(options) if callable(choice) else choice
+
+        def capture_info(self, message, centered=True):
+            captured_infos.append(message)
+
+        try:
+            game.CGuiHandler.showSelection = queued_selection
+            game.CGuiHandler.showInfo = capture_info
+
+            player.addItem("Scroll")
+            player.addItem("ManaPotion")
+            selections[:] = [select_recipe("craft_town_portal_scroll"), crafting.LEAVE_OPTION]
+            find_runtime_object(game_map, "scribeDesk1").onEnter(FakeEvent(player))
+            self.assertEqual(1, player.countItems("Scroll"))
+            self.assertEqual(1, player.countItems("ManaPotion"))
+            self.assertEqual(0, player.countItems("TownPortalScroll"))
+
+            player.setBoolProperty("CAN_CRAFT_SCROLLS", True)
+            clear_item("Scroll")
+            selections[:] = [select_recipe("craft_town_portal_scroll"), crafting.LEAVE_OPTION]
+            find_runtime_object(game_map, "scribeDesk1").onEnter(FakeEvent(player))
+            self.assertEqual(1, player.countItems("ManaPotion"))
+            self.assertEqual(0, player.countItems("TownPortalScroll"))
+
+            player.addItem("LesserLifePotion")
+            player.addItem("LesserLifePotion")
+            selections[:] = [select_recipe("brew_life_potion"), crafting.LEAVE_OPTION]
+            find_runtime_object(game_map, "alchemyTable1").onEnter(FakeEvent(player))
+        finally:
+            game.CGuiHandler.showSelection = original_show_selection
+            game.CGuiHandler.showInfo = original_show_info
+
+        self.assertTrue(any("locked" in message.lower() for message in captured_infos))
+        self.assertTrue(any("missing" in message.lower() and "Scroll" in message for message in captured_infos))
+        self.assertTrue(any("You crafted Life Potion." == message for message in captured_infos))
+        self.assertEqual(0, player.countItems("LesserLifePotion"))
+        self.assertEqual(1, player.countItems("LifePotion"))
+        self.assertEqual(180, player.getNumericProperty("gold"))
+
+        return True, json.dumps({"messages": captured_infos}, sort_keys=True)
 
     @game_test
     def test_potions_are_not_consumed_at_full_resources(self):

--- a/tests/regression/test_crafting_gui_refresh.py
+++ b/tests/regression/test_crafting_gui_refresh.py
@@ -40,7 +40,9 @@ def load_crafting_with_fake_game():
     old_game = sys.modules.get("game")
     sys.modules["game"] = fake_game
     try:
-        spec = importlib.util.spec_from_file_location("crafting_under_test", REPO_ROOT / "res" / "plugins" / "crafting.py")
+        spec = importlib.util.spec_from_file_location(
+            "crafting_under_test", REPO_ROOT / "res" / "plugins" / "crafting.py"
+        )
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module
@@ -111,7 +113,7 @@ class FakePlayer:
 
 class FakeRuntime:
     def __init__(self):
-        self.available_calls = 0
+        self.station_option_calls = 0
         self.recipe = {
             "id": "brew_life_potion",
             "inputs": [{"item_id": "LesserLifePotion", "count": 2}],
@@ -120,16 +122,20 @@ class FakeRuntime:
             "success_chance": 100,
         }
 
-    def available_recipes(self, player, station_id):
-        self.available_calls += 1
-        return [self.recipe]
+    def station_options(self, player, station_id):
+        self.station_option_calls += 1
+        description = self.describe_recipe_for_player(player, self.recipe)
+        return [self.recipe], {description: self.recipe}
+
+    def is_unlocked(self, player, recipe):
+        return True
 
     def describe_recipe(self, recipe):
         return "Life Potion [brew_life_potion]: 2x Lesser Life Potion, 20g -> 1x Life Potion (100% success)"
 
     def describe_recipe_for_player(self, player, recipe):
-        state = "ready" if player.item_count >= 2 and player.gold >= 20 else "missing"
-        return f"{self.describe_recipe(recipe)} [{state}]"
+        state = "READY" if player.item_count >= 2 and player.gold >= 20 else "MISSING"
+        return f"{state} - {self.describe_recipe(recipe)}"
 
     def execute_recipe(self, game_instance, player, recipe):
         player.item_count = 0
@@ -150,10 +156,10 @@ class CraftingGuiRefreshTest(unittest.TestCase):
 
         crafting.open_crafting_station(FakeStation(handler), player)
 
-        self.assertEqual(2, runtime.available_calls)
+        self.assertEqual(2, runtime.station_option_calls)
         self.assertEqual(2, len(handler.menus))
-        self.assertIn("[ready]", handler.menus[0][0])
-        self.assertIn("[missing]", handler.menus[1][0])
+        self.assertIn("READY -", handler.menus[0][0])
+        self.assertIn("MISSING -", handler.menus[1][0])
         self.assertEqual(("You crafted Life Potion.", True), handler.messages[-1])
 
 


### PR DESCRIPTION
Resolves #327

## Current bug / root cause
- Crafting stations listed only `available_recipes()`, so quest-locked recipes disappeared instead of showing a locked state, requirements, and an unlock clue.
- Locked recipe failures returned `locked` from the runtime but had no player-facing station message.
- Greater potion blend recipes were available before the relic return even though stronger potion brewing is meant to be gated by `CAN_BREW_GREATER_POTIONS`.

## GUI changes and unlock behavior
- Crafting station menus now list every recipe for the station with `READY`, `MISSING`, or `LOCKED` state text.
- Recipe rows include output preview, requirements, success chance, missing requirements, and dark-fantasy unlock hints for Beren's letter and relic milestones.
- Locked selections show a clear message and do not mutate inventory or gold.
- Missing-ingredient selections show the full missing requirement list and do not mutate inventory or gold.
- Successful crafts still use the existing transaction path and refresh the station menu after crafting.
- Scroll crafting remains gated by `CAN_CRAFT_SCROLLS`; greater and full potion brewing are gated by `CAN_BREW_GREATER_POTIONS`.

## Recipe / test matrix
- Direct successful craft: consumes exact inputs and creates exactly one output.
- Direct locked craft: scroll and full potion attempts before unlock are atomic.
- Invalid recipe id: atomic failure with no gold or item mutation.
- Story unlocks: Beren letter unlocks scribe recipes; relic return unlocks greater/full potion recipes.
- Station menu visibility: `alchemyTable1` and `scribeDesk1` show ready, missing, and locked states.
- Station behavior: locked, missing, and success paths show distinct messages and preserve expected inventory/gold behavior.
- Regression helper: station menus refresh from ready to missing after a successful craft.

## Validation
- `python3 -m py_compile res/plugins/crafting.py test.py tests/regression/test_crafting_gui_refresh.py`
- `python3 -m json.tool res/config/crafting.json`
- `git diff --check`
- Focused crafting tests:
  `python3 -m unittest test.GameTest.test_crafting_runtime_applies_recipe test.GameTest.test_crafting_transactions_are_atomic test.GameTest.test_crafting_unlocks_follow_story_progression test.GameTest.test_crafting_locked_recipe_attempt_is_atomic test.GameTest.test_crafting_invalid_recipe_id_is_atomic test.GameTest.test_crafting_station_options_show_recipe_states test.GameTest.test_crafting_station_locked_missing_and_success_paths test.GameTest.test_crafting_config_is_valid`
- `python3 tests/regression/test_crafting_gui_refresh.py`
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `python3 test.py`
- `./scripts/run_coverage.sh` -> lines: 90.14% (9356 out of 10379)

## Known limitations
- This keeps the current station modal flow and improves its recipe state presentation rather than introducing a new C++ panel class; broader GUI lifecycle redesign should be handled separately if needed.
