### PR TITLE
Add build/test/coverage time optimization guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,24 @@ When validation cannot be run, do not imply that it passed. Report the exact com
 
 Every bug fix must include at least one corresponding automated test (unit, integration, or regression) that fails before the fix and passes after it. Treat this as required bugfix test coverage; do not mark a bug fix complete without a regression test covering the fixed behavior.
 
+## Build, test, and coverage time optimization
+
+Treat build, test, and coverage runtime as a first-class maintenance concern. Optimize aggressively for fast
+feedback while preserving the required validation guarantees.
+
+- During iteration, prefer the narrowest reliable build or test command that exercises the changed behavior, then run the
+  required full validation workflow before finishing.
+- Use available parallelism for local builds and automation, such as `-j$(nproc)` for CMake builds on Linux, without
+  hiding failures or racing shared test state.
+- Avoid unnecessary clean builds, dependency reinstalls, broad resource recopies, full-suite reruns, or repo-wide
+  formatting when a targeted command is sufficient.
+- Keep new and updated tests deterministic, focused, and reasonably scoped; split slow end-to-end coverage from fast
+  regression checks when correctness allows.
+- When adding scripts, CI steps, fixtures, MCP walkthroughs, or coverage checks, account for their runtime cost and avoid
+  repeated expensive setup inside loops or per-test fixtures.
+- If a required validation command is slow, do not skip it silently; run it when possible and report exact blockers when
+  the environment prevents it.
+
 ## MCP game-session validation
 
 When a change affects maps, quests, dialogs, triggers, map scripts, gameplay-facing C++ bindings, or MCP tooling


### PR DESCRIPTION
### Motivation

- Reduce developer and CI turnaround by making build, test, and coverage runtime a first-class maintenance concern.
- Encourage targeted, deterministic validation and avoid expensive or redundant work during iteration.

### Description

- Add a new "Build, test, and coverage time optimization" section to `AGENTS.md` with guidelines to prefer narrow builds and fast feedback loops.
- Recommend using available parallelism such as `-j$(nproc)` and avoiding unnecessary clean builds, reinstalls, broad resource recopies, and full-suite reruns when not required.
- Advise keeping tests deterministic and scoped, splitting slow end-to-end coverage from fast regression checks, and accounting for runtime cost when adding scripts or CI steps.
- Require reporting of slow validation blockers rather than silently skipping required commands.

### Testing

- This change is documentation-only and did not modify production code or tests, so no automated tests were run or required for this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33a8c9336083269a1bd9511a26c322)