### PR TITLE
[codex] Verify Pillow before Linux screenshot tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install Python deps
-        run: python -m pip install --upgrade pillow==11.2.1
+        run: python3 -m pip install --upgrade pillow==11.2.1
+      - name: Smoke test Python deps
+        run: python3 -c "from PIL import Image; print(Image.__name__)"
       - name: detect coverage need
         id: coverage-needed
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
+      - name: Install Python deps
+        run: python3 -m pip install --upgrade pillow==11.2.1
+      - name: Smoke test Python deps
+        run: python3 -c "from PIL import Image; print(Image.__name__)"
       - name: submodules
         run: git submodule update --init --recursive
       - name: configure

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ tab - open/close python console
 ## running
 ### ubuntu
 <pre>
-sudo apt-get install python3.11 python3.11-dev pybind11-dev nlohmann-json3-dev
+sudo apt-get install python3.11 python3.11-dev python3-pil pybind11-dev nlohmann-json3-dev
 ./configure.sh
 cmake --build cmake-build-release --target _game -j$(nproc)
 python3 play.py


### PR DESCRIPTION
## What changed
- Linux PR CI now installs Pillow with `python3 -m pip` so the dependency is installed for the same interpreter that runs `python3 test.py`.
- Added a `PIL.Image` smoke check before Linux tests in the `build` workflow.
- Added the same pinned Pillow install and smoke check to the tag-only `Release` workflow, which also runs `python3 test.py` on Linux.
- Updated Ubuntu setup docs to mention `python3-pil`, matching the dependency already installed by `./configure.sh`.

## Why
Screenshot helpers in `test.py` import `PIL.Image`. Issue #319 reported Linux CI failures with `ModuleNotFoundError: No module named 'PIL'`, so CI should prove that Pillow is available before screenshot/UI tests run.

Fixes #319

## Validation
- `git diff --check`
- `python3 -c "from PIL import Image; print(Image.__name__)"` -> `PIL.Image`
- `python3 -m unittest tests.security.test_configure_supply_chain` -> `Ran 5 tests`, `OK`

## Known limitations
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`, `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`, and `python3 test.py` were not run in the isolated worktree because it has no configured `cmake-build-release` directory.
- Broader dependency consolidation remains scoped to issue #322.