### PR TITLE
Restore Windows vcpkg installed cache fallbacks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,6 +177,9 @@ jobs:
         with:
           path: ${{ env.VCPKG_INSTALLED_DIR }}
           key: ${{ runner.os }}-${{ env.VCPKG_TARGET_TRIPLET }}-vcpkg-installed-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake', 'configure.bat', 'CMakeLists.txt', 'cmake/**/*.cmake') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.VCPKG_TARGET_TRIPLET }}-vcpkg-installed-
+            ${{ runner.os }}-vcpkg-installed-
       - name: Cache sccache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:


### PR DESCRIPTION
## What changed

- Added restore-key fallbacks to the Windows `Cache vcpkg installed tree` step.
- Kept the exact primary cache key and the existing `Validate vcpkg installed cache` safety gate before skipping dependency install.

## Why

The Windows CI job appeared hung because a CMake/workflow hash change missed the exact vcpkg installed-tree cache key, forcing a cold source build of the native dependency tree. A prior run completed `Install native deps` after roughly 27 minutes, then was cancelled during the later build step by a force-push/merge.

The restore keys allow GitHub Actions to reuse an older installed-tree cache when the exact key changes, while the validation step still rejects unusable restored caches and falls back to `vcpkg install`.

## Validation

- `git diff --check`
- Reviewed the workflow diff and confirmed the restore keys are scoped to the `Cache vcpkg installed tree` step.

## Known limitations

- Windows cache behavior must be proven by GitHub Actions. This local Linux environment cannot validate a Windows Actions cache restore or Visual Studio/vcpkg install path.