### PR TITLE
Validate restored Windows vcpkg caches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,6 @@ jobs:
           "Windows Python test jobs: $testJobs"
       - name: Validate vcpkg installed cache
         id: validate-vcpkg-installed
-        if: steps.cache-vcpkg-installed.outputs.cache-hit == 'true'
         shell: pwsh
         run: |
           $tripletRoot = Join-Path $env:VCPKG_INSTALLED_DIR $env:VCPKG_TARGET_TRIPLET


### PR DESCRIPTION
## What changed

- Removed the exact-hit-only condition from `Validate vcpkg installed cache`.
- The Windows workflow now validates the vcpkg installed tree after the cache action whether the cache was an exact hit, a restore-key hit, or a miss.

## Why

PR #372 added restore-key fallbacks for the Windows vcpkg installed-tree cache. Upstream `actions/cache` documents `cache-hit` as an exact-match signal; restore-key hits are not reported as `true`. Keeping validation gated on `cache-hit == 'true'` would skip validation for restored caches and fall through to `vcpkg install`, reducing the benefit of restore keys.

Running the validation step unconditionally is safe: on a cache miss, the expected files are absent, `valid=false` is emitted, and the existing `Install native deps` condition runs the install.

## Validation

- `git diff --check`
- Reviewed the Windows vcpkg cache block and confirmed the install condition remains `steps.validate-vcpkg-installed.outputs.valid != 'true'`.
- Verified upstream `actions/cache` metadata documents `cache-hit` as an exact-match output.

## Known limitations

- Windows cache restore behavior still needs to be proven by GitHub Actions on the PR run; this local Linux environment cannot validate Actions cache restoration.