### PR TITLE
Stabilize Windows CI dependency caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,9 +119,11 @@ jobs:
           name: fall-of-nouraajd-linux
           path: cmake-build-release/fall-of-nouraajd-*.tar.gz
 
-  windows:
+  windows-deps:
     runs-on: windows-2022
-    env:
+    outputs:
+      vcpkg-installed-cache-key: ${{ steps.select-vcpkg-installed-cache.outputs.key }}
+    env: &windows-env
       CONFIGURE_BUILD_DIRS: cmake-build-release
       GAME_TEST_TIMINGS_FILE: test/test-timings-windows.json
       GAME_WINDOWS_FAST_BUILD: "1"
@@ -146,13 +148,13 @@ jobs:
         run: |
           python scripts/validate_content.py --repo-root .
           python -m unittest tests.test_content_validator
-      - name: submodules
-        run: git submodule update --init --recursive
-      - name: Set up MSVC command prompt
+      - &setup-msvc
+        name: Set up MSVC command prompt
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
         with:
           arch: x64
-      - name: Set up vcpkg
+      - &setup-vcpkg
+        name: Set up vcpkg
         shell: pwsh
         run: |
           $candidateRoots = @()
@@ -173,43 +175,23 @@ jobs:
 
           "Using vcpkg at $vcpkgRoot"
           "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
-      - name: Enable vcpkg x-gha binary cache
+      - &enable-vcpkg-x-gha
+        name: Enable vcpkg x-gha binary cache
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-      - name: Cache vcpkg installed tree
-        id: cache-vcpkg-installed
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+      - name: Restore vcpkg installed tree
+        id: restore-vcpkg-installed
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ${{ env.VCPKG_INSTALLED_DIR }}
-          key: ${{ runner.os }}-${{ env.VCPKG_TARGET_TRIPLET }}-vcpkg-installed-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake', 'configure.bat', 'CMakeLists.txt', 'cmake/**/*.cmake') }}
+          key: ${{ runner.os }}-${{ env.VCPKG_TARGET_TRIPLET }}-vcpkg-installed-v2-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake', 'configure.bat', 'CMakeLists.txt', 'cmake/**/*.cmake') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.VCPKG_TARGET_TRIPLET }}-vcpkg-installed-
-            ${{ runner.os }}-vcpkg-installed-
-      - name: Cache sccache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
-        with:
-          path: ${{ env.SCCACHE_DIR }}
-          key: ${{ runner.os }}-sccache-${{ hashFiles('**/CMakeLists.txt', 'configure.bat') }}
-          restore-keys: ${{ runner.os }}-sccache-
-      - name: Cache Python test timings
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
-        with:
-          path: ${{ env.GAME_TEST_TIMINGS_FILE }}
-          key: ${{ runner.os }}-test-timings-${{ github.run_id }}
-          restore-keys: ${{ runner.os }}-test-timings-
-      - name: Configure Windows parallelism
-        shell: pwsh
-        run: |
-          $buildJobs = [Math]::Max(1, [Environment]::ProcessorCount)
-          $testJobs = [Math]::Min(4, [Math]::Max(1, [Environment]::ProcessorCount))
-          "CMAKE_BUILD_PARALLEL_LEVEL=$buildJobs" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "GAME_TEST_JOBS=$testJobs" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "Windows build jobs: $buildJobs"
-          "Windows Python test jobs: $testJobs"
-      - name: Validate vcpkg installed cache
+            ${{ runner.os }}-${{ env.VCPKG_TARGET_TRIPLET }}-vcpkg-installed-v2-${{ hashFiles('vcpkg.json', 'cmake/triplets/*.cmake', 'configure.bat', 'CMakeLists.txt', 'cmake/**/*.cmake') }}-
+      - &validate-vcpkg-installed
+        name: Validate vcpkg installed cache
         id: validate-vcpkg-installed
         shell: pwsh
         run: |
@@ -249,6 +231,81 @@ jobs:
             --triplet "$env:VCPKG_TARGET_TRIPLET" `
             --overlay-triplets "$env:VCPKG_OVERLAY_TRIPLETS" `
             "--x-install-root=$env:VCPKG_INSTALLED_DIR"
+      - name: Save vcpkg installed tree
+        if: steps.validate-vcpkg-installed.outputs.valid != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ env.VCPKG_INSTALLED_DIR }}
+          key: ${{ steps.restore-vcpkg-installed.outputs.cache-primary-key }}-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Select vcpkg installed cache key
+        id: select-vcpkg-installed-cache
+        shell: pwsh
+        run: |
+          $key = "${{ steps.restore-vcpkg-installed.outputs.cache-matched-key }}"
+          if ("${{ steps.validate-vcpkg-installed.outputs.valid }}" -ne "true") {
+            $key = "${{ steps.restore-vcpkg-installed.outputs.cache-primary-key }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          }
+          if (-not $key) {
+            throw "No vcpkg installed cache key was produced."
+          }
+          "key=$key" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+  windows:
+    needs: windows-deps
+    runs-on: windows-2022
+    env: *windows-env
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+      - name: Install Python deps
+        run: python -m pip install --upgrade -r requirements-dev.txt
+      - name: Smoke test Python deps
+        run: python -c "from PIL import Image; import black; print('python deps ok')"
+      - name: Validate content JSON
+        run: |
+          python scripts/validate_content.py --repo-root .
+          python -m unittest tests.test_content_validator
+      - name: submodules
+        run: git submodule update --init --recursive
+      - *setup-msvc
+      - *setup-vcpkg
+      - *enable-vcpkg-x-gha
+      - name: Restore vcpkg installed tree
+        id: restore-vcpkg-installed
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ env.VCPKG_INSTALLED_DIR }}
+          key: ${{ needs.windows-deps.outputs.vcpkg-installed-cache-key }}
+      - *validate-vcpkg-installed
+      - name: Require vcpkg installed cache
+        if: steps.validate-vcpkg-installed.outputs.valid != 'true'
+        shell: pwsh
+        run: |
+          throw "windows-deps did not seed a valid vcpkg installed cache for key '${{ needs.windows-deps.outputs.vcpkg-installed-cache-key }}'."
+      - name: Cache sccache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ env.SCCACHE_DIR }}
+          key: ${{ runner.os }}-sccache-${{ hashFiles('**/CMakeLists.txt', 'configure.bat') }}
+          restore-keys: ${{ runner.os }}-sccache-
+      - name: Cache Python test timings
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ env.GAME_TEST_TIMINGS_FILE }}
+          key: ${{ runner.os }}-test-timings-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-test-timings-
+      - name: Configure Windows parallelism
+        shell: pwsh
+        run: |
+          $buildJobs = [Math]::Max(1, [Environment]::ProcessorCount)
+          $testJobs = [Math]::Min(4, [Math]::Max(1, [Environment]::ProcessorCount))
+          "CMAKE_BUILD_PARALLEL_LEVEL=$buildJobs" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "GAME_TEST_JOBS=$testJobs" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "Windows build jobs: $buildJobs"
+          "Windows Python test jobs: $testJobs"
       - name: Configure
         shell: cmd
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,30 +143,40 @@ else ()
     set(GAME_MODULE_SRC ${CMAKE_SOURCE_DIR}/src/core/CModule.cpp)
 endif ()
 
-add_library(game_core SHARED ${GAME_CORE_SRC})
-configure_cpp_target(game_core)
-set_target_properties(game_core PROPERTIES
-    OUTPUT_NAME "game_core"
-)
-if (GAME_ENABLE_UNITY_BUILD)
-    set_target_properties(game_core PROPERTIES
-        UNITY_BUILD ON
-        UNITY_BUILD_BATCH_SIZE ${GAME_UNITY_BATCH_SIZE}
-    )
-endif ()
-if (GAME_ENABLE_PCH)
-    target_precompile_headers(game_core PRIVATE "${CMAKE_SOURCE_DIR}/src/core/CGlobal.h")
-endif ()
-target_compile_definitions(game_core PRIVATE
-    GAME_CORE_BUILD
-)
-target_link_libraries(game_core PRIVATE
+set(GAME_CORE_LINK_LIBS
     Python3::Python
     pybind11::headers
     ${SDL2_LIBS}
     ${SDL2_IMAGE_LIBS}
     ${SDL2_TTF_LIBS}
     ${CMAKE_DL_LIBS}
+)
+
+add_library(game_core_objects OBJECT ${GAME_CORE_SRC})
+configure_cpp_target(game_core_objects)
+set_target_properties(game_core_objects PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+)
+if (GAME_ENABLE_UNITY_BUILD)
+    set_target_properties(game_core_objects PROPERTIES
+        UNITY_BUILD ON
+        UNITY_BUILD_BATCH_SIZE ${GAME_UNITY_BATCH_SIZE}
+    )
+endif ()
+if (GAME_ENABLE_PCH)
+    target_precompile_headers(game_core_objects PRIVATE "${CMAKE_SOURCE_DIR}/src/core/CGlobal.h")
+endif ()
+target_compile_definitions(game_core_objects PRIVATE
+    GAME_CORE_BUILD
+)
+target_link_libraries(game_core_objects PRIVATE ${GAME_CORE_LINK_LIBS})
+
+add_library(game_core SHARED $<TARGET_OBJECTS:game_core_objects>)
+set_target_properties(game_core PROPERTIES
+    OUTPUT_NAME "game_core"
+)
+target_link_libraries(game_core PRIVATE
+    ${GAME_CORE_LINK_LIBS}
 )
 
 pybind11_add_module(_game NO_EXTRAS ${GAME_MODULE_SRC})
@@ -500,15 +510,6 @@ endif ()
 enable_testing()
 
 set(GAME_UNIT_TEST_TARGETS)
-set(GAME_UNIT_TEST_SUPPORT_SRC)
-if (NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    list(APPEND GAME_UNIT_TEST_SUPPORT_SRC
-        src/core/CTags.cpp
-        src/core/CUtil.cpp
-        src/core/CPathFinder.cpp
-        src/core/CFuture.cpp
-    )
-endif ()
 
 if (WIN32)
     get_filename_component(TEST_PYTHONHOME "${Python3_EXECUTABLE}" DIRECTORY)
@@ -519,8 +520,8 @@ endif ()
 
 function(add_game_unit_test target_name)
     add_executable(${target_name} ${ARGN})
-    if (GAME_UNIT_TEST_SUPPORT_SRC)
-        target_sources(${target_name} PRIVATE ${GAME_UNIT_TEST_SUPPORT_SRC})
+    if (WIN32)
+        target_sources(${target_name} PRIVATE $<TARGET_OBJECTS:game_core_objects>)
     endif ()
 
     configure_cpp_target(${target_name})
@@ -531,7 +532,7 @@ function(add_game_unit_test target_name)
         ${SDL2_IMAGE_LIBS}
         ${SDL2_TTF_LIBS}
     )
-    if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if (NOT WIN32)
         target_link_libraries(${target_name} PRIVATE game_core)
     endif ()
 


### PR DESCRIPTION
## Summary
- add a `windows-deps` job that restores/validates/seeds the vcpkg installed-tree cache before the Windows build job
- make the Windows build job consume the exact seeded cache key and fail early instead of running the long vcpkg install path
- build core sources through a shared object target so Windows unit tests use the full core implementation without partial support sources or massive DLL auto-exports

## Testing
- `configure.bat` with `GAME_WINDOWS_FAST_BUILD=1`, local Visual Studio generator fallback: passed
- `cmake --build cmake-build-release --config Release --target _game for_unit_tests --parallel <cores>`: passed
- `ctest --test-dir cmake-build-release -C Release --output-on-failure -R for_unit_tests`: passed
- `_game`/`game` import smoke test: passed
- `python test.py`: attempted locally, but this host used the Visual Studio multi-config layout; the resource provider rooted at `cmake-build-release/Release` while configured resources are copied to `cmake-build-release`. GitHub Windows fast CI uses Ninja single-config, which is the target path for this change.