### PR TITLE
[codex] add content JSON validator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
         run: python3 -m pip install --upgrade -r requirements-dev.txt
       - name: Smoke test Python deps
         run: python3 -c "from PIL import Image; import black; print('python deps ok')"
+      - name: Validate content JSON
+        run: |
+          python3 scripts/validate_content.py --repo-root .
+          python3 -m unittest tests.test_content_validator
       - name: detect coverage need
         id: coverage-needed
         shell: bash
@@ -138,6 +142,10 @@ jobs:
         run: python -m pip install --upgrade -r requirements-dev.txt
       - name: Smoke test Python deps
         run: python -c "from PIL import Image; import black; print('python deps ok')"
+      - name: Validate content JSON
+        run: |
+          python scripts/validate_content.py --repo-root .
+          python -m unittest tests.test_content_validator
       - name: submodules
         run: git submodule update --init --recursive
       - name: Set up MSVC command prompt

--- a/README.md
+++ b/README.md
@@ -72,18 +72,23 @@ git submodule update --init --recursive
 
 From the repository root, run:
 <pre>
+python3 scripts/validate_content.py --repo-root .
+python3 -m unittest tests.test_content_validator
 cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)
 ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
 python3 test.py
 </pre>
 For Windows Visual Studio builds, use `--config Release`, pass `-C Release` to `ctest`,
-and set `GAME_BUILD_CONFIG=Release` before running `python test.py`.
+and set `GAME_BUILD_CONFIG=Release` before running `python test.py`. Use
+`python scripts/validate_content.py --repo-root .` and
+`python -m unittest tests.test_content_validator` for the Windows content-validation
+steps.
 Also run `./scripts/run_coverage.sh` when a change touches tests (for example
 `test.py` or `tests/unit/**`), `src/core/**`, `src/handler/**`, `src/object/**`,
 or the coverage tooling. The total line coverage threshold for that run is 90%;
 see `docs/testing.md` for details, including recommended branch-protection checks.
-Data validation tests run without needing the compiled `_game` module, but
-other tests require it to be built.
+Content JSON validation and its focused fixture tests run without needing the
+compiled `_game` module, but other tests require it to be built.
 `requirements-dev.txt` is the pinned source for pip-managed Python test tools
 used by CI, Windows, and virtual environments. Linux native build dependencies,
 including pybind11, still come from the OS packages installed by `./configure.sh`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,15 +21,24 @@ python -m pip install --upgrade -r requirements-dev.txt
 Run from the repository root:
 
 ```bash
+python3 scripts/validate_content.py --repo-root .
+python3 -m unittest tests.test_content_validator
 cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j$(nproc)
 ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
 ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance
 python3 test.py
 ```
 
+The content JSON validator and its focused fixture tests use only the Python
+standard library and do not require the compiled `_game` module. They are run
+early in CI before the native build so broken map/config/dialog refs fail before
+expensive gameplay tests.
+
 For Windows Visual Studio Release builds, use the same target and CTest label with the active configuration:
 
 ```bat
+python scripts/validate_content.py --repo-root .
+python -m unittest tests.test_content_validator
 cmake --build cmake-build-release --config Release --target _game for_unit_tests performance_guard_tests
 ctest --test-dir cmake-build-release -C Release --output-on-failure -R for_unit_tests
 ctest --test-dir cmake-build-release -C Release --output-on-failure --verbose -L performance

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -1,0 +1,915 @@
+#!/usr/bin/env python3
+"""Fast JSON and script consistency checks for game content.
+
+The validator intentionally avoids importing ``game`` or ``_game`` so it can run
+before the native extension is built.  It checks the content shapes that the
+runtime loader currently accepts late or silently: missing refs, bad classes,
+dialog links/actions, duplicate map object names, and literal script refs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+OBJECT_SCHEMA_KEYS = {"class", "ref", "properties"}
+SCRIPT_REF_CALLS = {"createObject", "addObjectByName"}
+SCRIPT_ITEM_CALLS = {"addItem"}
+SCRIPT_QUEST_CALLS = {"addQuest", "ensure_quest", "_grant_quest", "grant_quest"}
+SCRIPT_MAP_CALLS = {"changeMap"}
+SCRIPT_OBJECT_NAME_CALLS = {"getObjectByName", "removeObjectByName"}
+KNOWN_EVENT_NAMES = {
+    "onCreate",
+    "onDestroy",
+    "onEnter",
+    "onEquip",
+    "onLeave",
+    "onTurn",
+    "onUnequip",
+    "onUse",
+}
+BUILTIN_CLASSES = {
+    "CArmor",
+    "CBelt",
+    "CBoots",
+    "CBuilding",
+    "CController",
+    "CCreature",
+    "CDialog",
+    "CDialogOption",
+    "CDialogState",
+    "CEffect",
+    "CEvent",
+    "CFightController",
+    "CGameObject",
+    "CGloves",
+    "CGroundController",
+    "CHelmet",
+    "CInteraction",
+    "CItem",
+    "CMapObject",
+    "CMarket",
+    "CMonsterFightController",
+    "CNpcRandomController",
+    "CPlayer",
+    "CPlayerController",
+    "CPlayerFightController",
+    "CPotion",
+    "CQuest",
+    "CRandomController",
+    "CRangeController",
+    "CScroll",
+    "CScript",
+    "CSmallWeapon",
+    "CStats",
+    "CTargetController",
+    "CTile",
+    "CTrigger",
+    "CWeapon",
+}
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    path: str
+    location: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.path}: {self.location}: {self.message}"
+
+
+@dataclass(frozen=True)
+class ConfigEntry:
+    key: str
+    data: Any
+    path: Path
+
+
+@dataclass
+class ScriptCall:
+    name: str
+    value: str
+    lineno: int
+    context: str
+
+    @property
+    def location(self) -> str:
+        call = f'{self.name}("{self.value}")'
+        return f"{self.context}:{self.lineno} {call}" if self.context else f"line {self.lineno} {call}"
+
+
+@dataclass
+class ScriptInfo:
+    path: Path
+    classes: set[str] = field(default_factory=set)
+    methods_by_class: dict[str, set[str]] = field(default_factory=dict)
+    calls: list[ScriptCall] = field(default_factory=list)
+    trigger_targets: list[ScriptCall] = field(default_factory=list)
+    named_objects: set[str] = field(default_factory=set)
+
+
+@dataclass
+class MapContext:
+    name: str
+    directory: Path
+    map_path: Path
+    map_data: Any
+    config_entries: dict[str, ConfigEntry]
+    config_files: dict[Path, Any]
+    script_info: ScriptInfo | None
+    placed_names: set[str] = field(default_factory=set)
+
+
+class ScriptAnalyzer(ast.NodeVisitor):
+    def __init__(self, path: Path) -> None:
+        self.info = ScriptInfo(path=path)
+        self._class_stack: list[str] = []
+        self._function_stack: list[str] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> Any:
+        self.info.classes.add(node.name)
+        self.info.methods_by_class.setdefault(node.name, set())
+        self._class_stack.append(node.name)
+        for child in node.body:
+            self.visit(child)
+        self._class_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> Any:
+        if self._class_stack:
+            self.info.methods_by_class.setdefault(self._class_stack[-1], set()).add(node.name)
+        self._function_stack.append(node.name)
+        for child in node.body:
+            self.visit(child)
+        self._function_stack.pop()
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> Any:
+        self.visit_FunctionDef(node)
+
+    def visit_Call(self, node: ast.Call) -> Any:
+        name = call_name(node.func)
+        if name:
+            self._record_script_call(name, node)
+            self._record_named_object(name, node)
+        self.generic_visit(node)
+
+    def _record_script_call(self, name: str, node: ast.Call) -> None:
+        literal = first_string_arg(node)
+        if literal is None:
+            return
+        context = ".".join([*self._class_stack, *self._function_stack])
+        if (
+            name
+            in SCRIPT_REF_CALLS | SCRIPT_ITEM_CALLS | SCRIPT_QUEST_CALLS | SCRIPT_MAP_CALLS | SCRIPT_OBJECT_NAME_CALLS
+        ):
+            self.info.calls.append(ScriptCall(name=name, value=literal, lineno=node.lineno, context=context))
+
+    def _record_named_object(self, name: str, node: ast.Call) -> None:
+        if name == "setStringProperty" and len(node.args) >= 2:
+            key = string_literal(node.args[0])
+            value = string_literal(node.args[1])
+            if key == "name" and value:
+                self.info.named_objects.add(value)
+
+
+def call_name(func: ast.AST) -> str | None:
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def string_literal(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def first_string_arg(node: ast.Call) -> str | None:
+    for arg in node.args:
+        literal = string_literal(arg)
+        if literal is not None:
+            return literal
+    return None
+
+
+class TriggerAnalyzer(ast.NodeVisitor):
+    def __init__(self, info: ScriptInfo) -> None:
+        self.info = info
+        self._class_stack: list[str] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> Any:
+        self._class_stack.append(node.name)
+        for decorator in node.decorator_list:
+            self._record_trigger(decorator, node)
+        for child in node.body:
+            self.visit(child)
+        self._class_stack.pop()
+
+    def _record_trigger(self, decorator: ast.AST, node: ast.ClassDef) -> None:
+        if not isinstance(decorator, ast.Call) or call_name(decorator.func) != "trigger":
+            return
+        event_name = string_literal(decorator.args[1]) if len(decorator.args) >= 2 else None
+        target_name = string_literal(decorator.args[2]) if len(decorator.args) >= 3 else None
+        context = node.name
+        if event_name:
+            self.info.trigger_targets.append(
+                ScriptCall(name="trigger event", value=event_name, lineno=node.lineno, context=context)
+            )
+        if target_name:
+            self.info.trigger_targets.append(
+                ScriptCall(name="trigger target", value=target_name, lineno=node.lineno, context=context)
+            )
+
+
+class ContentValidator:
+    def __init__(self, repo_root: Path) -> None:
+        self.repo_root = repo_root.resolve()
+        self.issues: list[ValidationIssue] = []
+        self.global_entries: dict[str, ConfigEntry] = {}
+        self.global_files: dict[Path, Any] = {}
+        self.map_contexts: list[MapContext] = []
+        self.plugin_info: list[ScriptInfo] = []
+        self.engine_classes: set[str] = set(BUILTIN_CLASSES)
+        self.plugin_classes: set[str] = set()
+
+    def validate(self) -> list[ValidationIssue]:
+        self._collect_engine_classes()
+        self._collect_plugin_classes()
+        self._load_global_configs()
+        self._load_maps()
+        self._validate_global_configs()
+        for context in self.map_contexts:
+            self._validate_map_context(context)
+        return sorted(self.issues, key=lambda issue: (issue.path, issue.location, issue.message))
+
+    def _collect_engine_classes(self) -> None:
+        source_roots = [self.repo_root / "src"]
+        for source_root in source_roots:
+            if not source_root.exists():
+                continue
+            for path in source_root.rglob("*"):
+                if path.suffix not in {".cpp", ".h", ".hpp"}:
+                    continue
+                try:
+                    text = path.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    text = path.read_text(encoding="utf-8", errors="ignore")
+                for match in re.finditer(r"register_type(?:_metadata)?<\s*([^,>]+)", text):
+                    self.engine_classes.add(normalize_cpp_type(match.group(1)))
+                for match in re.finditer(r"V_META\(\s*([A-Za-z_]\w*)", text):
+                    self.engine_classes.add(match.group(1))
+
+    def _collect_plugin_classes(self) -> None:
+        plugin_dir = self.repo_root / "res" / "plugins"
+        for path in sorted(plugin_dir.glob("*.py")):
+            info = self._parse_script(path)
+            if info:
+                self.plugin_info.append(info)
+                self.plugin_classes.update(info.classes)
+
+    def _load_global_configs(self) -> None:
+        config_dir = self.repo_root / "res" / "config"
+        for path in sorted(config_dir.glob("*.json")):
+            data = self._load_json(path)
+            if data is None:
+                continue
+            self.global_files[path] = data
+            if isinstance(data, dict):
+                for key, value in data.items():
+                    self.global_entries[key] = ConfigEntry(key=key, data=value, path=path)
+            else:
+                self._issue(path, "$", "expected top-level JSON object")
+
+    def _load_maps(self) -> None:
+        maps_dir = self.repo_root / "res" / "maps"
+        for directory in sorted(path for path in maps_dir.glob("*") if path.is_dir()):
+            map_path = directory / "map.json"
+            map_data = self._load_json(map_path)
+            if map_data is None:
+                continue
+            config_entries: dict[str, ConfigEntry] = {}
+            config_files: dict[Path, Any] = {}
+            for path in sorted(directory.glob("*.json")):
+                if path.name == "map.json":
+                    continue
+                data = self._load_json(path)
+                if data is None:
+                    continue
+                config_files[path] = data
+                if isinstance(data, dict):
+                    for key, value in data.items():
+                        config_entries[key] = ConfigEntry(key=key, data=value, path=path)
+                else:
+                    self._issue(path, "$", "expected top-level JSON object")
+            script_info = self._parse_script(directory / "script.py")
+            self.map_contexts.append(
+                MapContext(
+                    name=directory.name,
+                    directory=directory,
+                    map_path=map_path,
+                    map_data=map_data,
+                    config_entries=config_entries,
+                    config_files=config_files,
+                    script_info=script_info,
+                )
+            )
+
+    def _load_json(self, path: Path) -> Any:
+        if not path.exists():
+            self._issue(path, "$", "missing required JSON file")
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            self._issue(path, f"line {exc.lineno} column {exc.colno}", exc.msg)
+            return None
+
+    def _parse_script(self, path: Path) -> ScriptInfo | None:
+        if not path.exists():
+            return None
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError as exc:
+            self._issue(path, f"line {exc.lineno or 0}", exc.msg)
+            return None
+        analyzer = ScriptAnalyzer(path)
+        analyzer.visit(tree)
+        TriggerAnalyzer(analyzer.info).visit(tree)
+        return analyzer.info
+
+    def _validate_global_configs(self) -> None:
+        visible = dict(self.global_entries)
+        known_classes = self.engine_classes | self.plugin_classes
+        for entry in self.global_entries.values():
+            self._validate_config_entry(entry, visible, known_classes)
+        self._validate_crafting_refs()
+
+    def _validate_map_context(self, context: MapContext) -> None:
+        visible = self._visible_entries(context)
+        known_classes = self._known_classes(context)
+        for entry in context.config_entries.values():
+            self._validate_config_entry(entry, visible, known_classes)
+        self._validate_top_level_ref_cycles(context, visible)
+        self._validate_map_json(context, visible, known_classes)
+        self._validate_dialogs(context, visible)
+        self._validate_script_refs(context, visible, known_classes)
+
+    def _visible_entries(self, context: MapContext) -> dict[str, ConfigEntry]:
+        visible = dict(self.global_entries)
+        visible.update(context.config_entries)
+        return visible
+
+    def _known_classes(self, context: MapContext) -> set[str]:
+        classes = set(self.engine_classes | self.plugin_classes)
+        if context.script_info:
+            classes.update(context.script_info.classes)
+        return classes
+
+    def _validate_config_entry(
+        self, entry: ConfigEntry, visible: dict[str, ConfigEntry], known_classes: set[str]
+    ) -> None:
+        self._validate_object_shape(entry.path, entry.key, entry.data)
+        self._validate_refs(entry.path, entry.key, entry.data, visible)
+        self._validate_object_classes(entry.path, entry.key, entry.data, known_classes)
+
+    def _validate_object_shape(self, path: Path, location: str, value: Any) -> None:
+        if isinstance(value, dict):
+            has_ref = "ref" in value
+            has_class = "class" in value
+            is_object_node = has_ref or (has_class and ("properties" in value or set(value) <= OBJECT_SCHEMA_KEYS))
+            if is_object_node and has_ref and has_class:
+                self._issue(path, location, 'object node must not define both "ref" and "class"')
+            if is_object_node:
+                unexpected = sorted(set(value) - OBJECT_SCHEMA_KEYS)
+                if unexpected:
+                    self._issue(path, location, f"object node has unsupported keys: {', '.join(unexpected)}")
+                properties = value.get("properties")
+                if "properties" in value and not isinstance(properties, dict):
+                    self._issue(path, f"{location}.properties", "expected object")
+            for key, child in value.items():
+                self._validate_object_shape(path, append_field(location, key), child)
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                self._validate_object_shape(path, append_index(location, index), child)
+
+    def _validate_object_classes(
+        self, path: Path, location: str, value: Any, known_classes: set[str], in_object_node: bool = True
+    ) -> None:
+        if isinstance(value, dict):
+            is_object_node = self._is_object_node(value)
+            class_name = value.get("class")
+            if is_object_node or in_object_node:
+                if isinstance(class_name, str) and class_name not in known_classes:
+                    self._issue(path, f"{location}.class", f'unknown class "{class_name}"')
+                elif class_name is not None and not isinstance(class_name, str):
+                    self._issue(path, f"{location}.class", "expected string class name")
+            for key, child in value.items():
+                self._validate_object_classes(path, append_field(location, key), child, known_classes, is_object_node)
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                self._validate_object_classes(path, append_index(location, index), child, known_classes, False)
+
+    def _validate_refs(self, path: Path, location: str, value: Any, visible: dict[str, ConfigEntry]) -> None:
+        if isinstance(value, dict):
+            ref = value.get("ref")
+            if ref is not None:
+                ref_location = append_field(location, "ref")
+                if not isinstance(ref, str):
+                    self._issue(path, ref_location, "expected string ref")
+                elif ref not in visible:
+                    self._issue(path, ref_location, f'unknown ref "{ref}"')
+            for key, child in value.items():
+                self._validate_refs(path, append_field(location, key), child, visible)
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                self._validate_refs(path, append_index(location, index), child, visible)
+
+    def _validate_top_level_ref_cycles(self, context: MapContext, visible: dict[str, ConfigEntry]) -> None:
+        for entry in list(context.config_entries.values()) + list(self.global_entries.values()):
+            seen: list[str] = []
+            current = entry
+            while isinstance(current.data, dict) and isinstance(current.data.get("ref"), str):
+                ref = current.data["ref"]
+                if current.key in seen:
+                    cycle = " -> ".join([*seen, current.key])
+                    self._issue(entry.path, f"{entry.key}.ref", f"cyclic ref chain: {cycle}")
+                    break
+                seen.append(current.key)
+                next_entry = visible.get(ref)
+                if next_entry is None:
+                    break
+                current = next_entry
+
+    def _validate_map_json(self, context: MapContext, visible: dict[str, ConfigEntry], known_classes: set[str]) -> None:
+        data = context.map_data
+        if not isinstance(data, dict):
+            self._issue(context.map_path, "$", "expected top-level JSON object")
+            return
+        layers = data.get("layers")
+        if not isinstance(layers, list):
+            self._issue(context.map_path, "layers", "expected array")
+            return
+        width = data.get("width")
+        height = data.get("height")
+        tile_types = tile_types_by_id(data)
+        for layer_index, layer in enumerate(layers):
+            layer_location = f"layers[{layer_index}]"
+            if not isinstance(layer, dict):
+                self._issue(context.map_path, layer_location, "expected object")
+                continue
+            layer_type = layer.get("type")
+            if layer_type == "tilelayer":
+                self._validate_tile_layer(
+                    context, layer, layer_location, width, height, tile_types, visible, known_classes
+                )
+            elif layer_type == "objectgroup":
+                self._validate_object_layer(context, layer, layer_location, visible, known_classes)
+
+    def _validate_tile_layer(
+        self,
+        context: MapContext,
+        layer: dict[str, Any],
+        location: str,
+        map_width: Any,
+        map_height: Any,
+        tile_types: dict[int, str],
+        visible: dict[str, ConfigEntry],
+        known_classes: set[str],
+    ) -> None:
+        data = layer.get("data")
+        if not isinstance(data, list):
+            self._issue(context.map_path, f"{location}.data", "expected tile data array")
+            return
+        layer_width = layer.get("width", map_width)
+        layer_height = layer.get("height", map_height)
+        if isinstance(layer_width, int) and isinstance(layer_height, int):
+            expected = layer_width * layer_height
+            if len(data) != expected:
+                self._issue(context.map_path, f"{location}.data", f"expected {expected} tile ids, got {len(data)}")
+        for index, tile_id in enumerate(data):
+            if not isinstance(tile_id, int):
+                self._issue(context.map_path, f"{location}.data[{index}]", "expected integer tile id")
+                continue
+            if tile_id == 0:
+                continue
+            tile_type = tile_types.get(tile_id - 1)
+            if not tile_type:
+                self._issue(
+                    context.map_path,
+                    f"{location}.data[{index}]",
+                    f"tile id {tile_id} has no tilesets[0].tileproperties[{tile_id - 1}].type",
+                )
+            elif tile_type not in visible and tile_type not in known_classes:
+                self._issue(context.map_path, f"{location}.data[{index}]", f'unknown tile type "{tile_type}"')
+
+    def _validate_object_layer(
+        self,
+        context: MapContext,
+        layer: dict[str, Any],
+        location: str,
+        visible: dict[str, ConfigEntry],
+        known_classes: set[str],
+    ) -> None:
+        objects = layer.get("objects")
+        if not isinstance(objects, list):
+            self._issue(context.map_path, f"{location}.objects", "expected object array")
+            return
+        seen_names: dict[str, str] = {}
+        for object_index, obj in enumerate(objects):
+            object_location = f"{location}.objects[{object_index}]"
+            if not isinstance(obj, dict):
+                self._issue(context.map_path, object_location, "expected object")
+                continue
+            name = obj.get("name")
+            if isinstance(name, str) and name:
+                if name in context.placed_names:
+                    previous = seen_names.get(name, "another layer")
+                    self._issue(
+                        context.map_path,
+                        f"{object_location}.name",
+                        f'duplicate object name "{name}", previously defined at {previous}',
+                    )
+                else:
+                    context.placed_names.add(name)
+                    seen_names[name] = object_location
+            object_type = obj.get("type")
+            if not isinstance(object_type, str) or not object_type:
+                self._issue(context.map_path, f"{object_location}.type", "expected non-empty object type")
+            elif object_type not in visible and object_type not in known_classes:
+                self._issue(context.map_path, f"{object_location}.type", f'unknown object type "{object_type}"')
+            for numeric_key in ("width", "height"):
+                numeric_value = obj.get(numeric_key)
+                if numeric_value is not None and not isinstance(numeric_value, (int, float)):
+                    self._issue(context.map_path, f"{object_location}.{numeric_key}", "expected number")
+
+    def _validate_dialogs(self, context: MapContext, visible: dict[str, ConfigEntry]) -> None:
+        if not context.script_info:
+            return
+        methods_by_class = context.script_info.methods_by_class
+        for entry in context.config_entries.values():
+            if not isinstance(entry.data, dict):
+                continue
+            properties = entry.data.get("properties")
+            if not isinstance(properties, dict) or not isinstance(properties.get("states"), list):
+                continue
+            self._validate_dialog(entry, visible, methods_by_class, context.script_info.path)
+
+    def _validate_dialog(
+        self,
+        entry: ConfigEntry,
+        visible: dict[str, ConfigEntry],
+        methods_by_class: dict[str, set[str]],
+        script_path: Path,
+    ) -> None:
+        dialog_class = entry.data.get("class")
+        states = entry.data.get("properties", {}).get("states", [])
+        state_ids: dict[str, int] = {}
+        edges: dict[str, set[str]] = {}
+        option_numbers: dict[str, set[int]] = {}
+        for state_index, state in enumerate(states):
+            state_location = f"{entry.key}.properties.states[{state_index}]"
+            if not isinstance(state, dict):
+                self._issue(entry.path, state_location, "expected dialog state object")
+                continue
+            props = state.get("properties")
+            if not isinstance(props, dict):
+                self._issue(entry.path, f"{state_location}.properties", "expected object")
+                continue
+            state_id = props.get("stateId")
+            if not isinstance(state_id, str) or not state_id:
+                self._issue(entry.path, f"{state_location}.properties.stateId", "expected non-empty state id")
+                continue
+            if state_id in state_ids:
+                previous = f"{entry.key}.properties.states[{state_ids[state_id]}]"
+                self._issue(
+                    entry.path,
+                    f"{state_location}.properties.stateId",
+                    f'duplicate dialog state "{state_id}", previously defined at {previous}',
+                )
+            state_ids[state_id] = state_index
+            edges.setdefault(state_id, set())
+            options = props.get("options", [])
+            if options is None:
+                options = []
+            if not isinstance(options, list):
+                self._issue(entry.path, f"{state_location}.properties.options", "expected array")
+                continue
+            for option_index, option in enumerate(options):
+                option_location = f"{state_location}.properties.options[{option_index}]"
+                option_props = self._merged_option_properties(option, visible)
+                if option_props is None:
+                    continue
+                number = option_props.get("number")
+                if isinstance(number, int):
+                    used_numbers = option_numbers.setdefault(state_id, set())
+                    if number in used_numbers:
+                        self._issue(
+                            entry.path, f"{option_location}.properties.number", f"duplicate option number {number}"
+                        )
+                    used_numbers.add(number)
+                next_state = option_props.get("nextStateId")
+                if isinstance(next_state, str) and next_state != "EXIT":
+                    if next_state not in state_ids and not any(
+                        get_state_id(candidate) == next_state for candidate in states[state_index + 1 :]
+                    ):
+                        self._issue(
+                            entry.path, f"{option_location}.properties.nextStateId", f'unknown state "{next_state}"'
+                        )
+                    edges.setdefault(state_id, set()).add(next_state)
+                elif next_state is not None and not isinstance(next_state, str):
+                    self._issue(entry.path, f"{option_location}.properties.nextStateId", "expected string state id")
+                self._validate_dialog_method(
+                    entry.path,
+                    f"{option_location}.properties.action",
+                    option_props.get("action"),
+                    dialog_class,
+                    methods_by_class,
+                    script_path,
+                    "action",
+                )
+                self._validate_dialog_method(
+                    entry.path,
+                    f"{option_location}.properties.condition",
+                    option_props.get("condition"),
+                    dialog_class,
+                    methods_by_class,
+                    script_path,
+                    "condition",
+                )
+        if "ENTRY" not in state_ids:
+            self._issue(entry.path, f"{entry.key}.properties.states", "dialog is missing ENTRY state")
+            return
+        reachable = reachable_states(edges, "ENTRY")
+        for state_id, state_index in state_ids.items():
+            if state_id not in reachable and state_id != "EXIT":
+                state = states[state_index]
+                props = state.get("properties") if isinstance(state, dict) else {}
+                if isinstance(props, dict) and props.get("condition"):
+                    continue
+                self._issue(
+                    entry.path,
+                    f"{entry.key}.properties.states[{state_index}].properties.stateId",
+                    f'dialog state "{state_id}" is unreachable from ENTRY',
+                )
+
+    def _merged_option_properties(self, option: Any, visible: dict[str, ConfigEntry]) -> dict[str, Any] | None:
+        if not isinstance(option, dict):
+            return None
+        merged: dict[str, Any] = {}
+        ref = option.get("ref")
+        if isinstance(ref, str):
+            ref_entry = visible.get(ref)
+            if ref_entry and isinstance(ref_entry.data, dict):
+                ref_props = ref_entry.data.get("properties")
+                if isinstance(ref_props, dict):
+                    merged.update(ref_props)
+        props = option.get("properties")
+        if isinstance(props, dict):
+            merged.update(props)
+        return merged
+
+    def _validate_dialog_method(
+        self,
+        path: Path,
+        location: str,
+        method: Any,
+        dialog_class: Any,
+        methods_by_class: dict[str, set[str]],
+        script_path: Path,
+        method_kind: str,
+    ) -> None:
+        if method is None:
+            return
+        if not isinstance(method, str):
+            self._issue(path, location, f"expected string dialog {method_kind}")
+            return
+        if not isinstance(dialog_class, str):
+            self._issue(path, location, f'dialog {method_kind} "{method}" has no dialog class')
+            return
+        available_methods = methods_by_class.get(dialog_class, set())
+        if method not in available_methods:
+            self._issue(
+                path,
+                location,
+                f'dialog {method_kind} "{method}" is not defined on {dialog_class} in {self._rel(script_path)}',
+            )
+
+    def _validate_script_refs(
+        self, context: MapContext, visible: dict[str, ConfigEntry], known_classes: set[str]
+    ) -> None:
+        if not context.script_info:
+            return
+        map_names = {map_context.name for map_context in self.map_contexts}
+        object_names = context.placed_names | context.script_info.named_objects | {"player"}
+        for call in context.script_info.calls:
+            if call.name in SCRIPT_REF_CALLS:
+                if call.value not in visible and call.value not in known_classes:
+                    self._issue(
+                        context.script_info.path,
+                        call.location,
+                        f'unknown object ref or class "{call.value}"',
+                    )
+            elif call.name in SCRIPT_ITEM_CALLS:
+                if call.value not in visible:
+                    self._issue(context.script_info.path, call.location, f'unknown item ref "{call.value}"')
+            elif call.name in SCRIPT_QUEST_CALLS:
+                if call.value not in visible:
+                    self._issue(context.script_info.path, call.location, f'unknown quest id "{call.value}"')
+                elif not self._entry_is_quest(visible[call.value], visible):
+                    self._issue(context.script_info.path, call.location, f'"{call.value}" does not resolve to a quest')
+            elif call.name in SCRIPT_MAP_CALLS:
+                if call.value not in map_names:
+                    expected = f"res/maps/{call.value}/map.json"
+                    self._issue(context.script_info.path, call.location, f"map transition target is missing {expected}")
+            elif call.name in SCRIPT_OBJECT_NAME_CALLS and call.value not in object_names:
+                self._issue(context.script_info.path, call.location, f'unknown map object name "{call.value}"')
+        for trigger in context.script_info.trigger_targets:
+            if trigger.name == "trigger event":
+                if trigger.value not in KNOWN_EVENT_NAMES:
+                    self._issue(context.script_info.path, trigger.location, f'unknown trigger event "{trigger.value}"')
+            elif trigger.name == "trigger target" and trigger.value not in object_names:
+                self._issue(context.script_info.path, trigger.location, f'unknown trigger target "{trigger.value}"')
+
+    def _entry_is_quest(self, entry: ConfigEntry, visible: dict[str, ConfigEntry]) -> bool:
+        resolved = self._resolve_entry(entry, visible)
+        if not isinstance(resolved.data, dict):
+            return False
+        class_name = resolved.data.get("class")
+        return isinstance(class_name, str) and (class_name == "CQuest" or class_name.endswith("Quest"))
+
+    def _resolve_entry(self, entry: ConfigEntry, visible: dict[str, ConfigEntry]) -> ConfigEntry:
+        current = entry
+        seen: set[str] = set()
+        while isinstance(current.data, dict) and isinstance(current.data.get("ref"), str):
+            if current.key in seen:
+                return current
+            seen.add(current.key)
+            next_entry = visible.get(current.data["ref"])
+            if next_entry is None:
+                return current
+            current = next_entry
+        return current
+
+    def _validate_crafting_refs(self) -> None:
+        crafting_path = self.repo_root / "res" / "config" / "crafting.json"
+        data = self.global_files.get(crafting_path)
+        if not isinstance(data, dict):
+            return
+        for recipe_name, recipe in data.items():
+            if not isinstance(recipe, dict):
+                self._issue(crafting_path, recipe_name, "expected recipe object")
+                continue
+            station = recipe.get("station")
+            if isinstance(station, str) and station not in self._crafting_station_ids():
+                self._issue(crafting_path, f"{recipe_name}.station", f'unknown crafting station "{station}"')
+            inputs = recipe.get("inputs", [])
+            if isinstance(inputs, list):
+                for index, item in enumerate(inputs):
+                    self._validate_recipe_item(crafting_path, f"{recipe_name}.inputs[{index}]", item)
+            output = recipe.get("output")
+            self._validate_recipe_item(crafting_path, f"{recipe_name}.output", output)
+
+    def _validate_recipe_item(self, path: Path, location: str, item: Any) -> None:
+        if not isinstance(item, dict):
+            self._issue(path, location, "expected recipe item object")
+            return
+        item_name = item.get("item")
+        if isinstance(item_name, str) and item_name not in self.global_entries:
+            self._issue(path, f"{location}.item", f'unknown recipe item "{item_name}"')
+        elif item_name is not None and not isinstance(item_name, str):
+            self._issue(path, f"{location}.item", "expected string item id")
+
+    def _crafting_station_ids(self) -> set[str]:
+        station_ids: set[str] = set()
+        for entry in self.global_entries.values():
+            if not isinstance(entry.data, dict):
+                continue
+            properties = entry.data.get("properties")
+            if not isinstance(properties, dict):
+                continue
+            station_id = properties.get("craftingStationId")
+            if isinstance(station_id, str):
+                station_ids.add(station_id)
+        return station_ids
+
+    def _issue(self, path: Path, location: str, message: str) -> None:
+        self.issues.append(ValidationIssue(path=self._rel(path), location=location, message=message))
+
+    def _rel(self, path: Path) -> str:
+        try:
+            return path.resolve().relative_to(self.repo_root).as_posix()
+        except ValueError:
+            return path.as_posix()
+
+    def _is_object_node(self, value: dict[str, Any]) -> bool:
+        has_ref = "ref" in value
+        has_class = "class" in value
+        return has_ref or (has_class and ("properties" in value or set(value) <= OBJECT_SCHEMA_KEYS))
+
+
+def iter_map_objects(map_data: Any) -> list[dict[str, Any]]:
+    objects: list[dict[str, Any]] = []
+    if not isinstance(map_data, dict):
+        return objects
+    layers = map_data.get("layers")
+    if not isinstance(layers, list):
+        return objects
+    for layer in layers:
+        if not isinstance(layer, dict) or layer.get("type") != "objectgroup":
+            continue
+        layer_objects = layer.get("objects")
+        if isinstance(layer_objects, list):
+            objects.extend(obj for obj in layer_objects if isinstance(obj, dict))
+    return objects
+
+
+def tile_types_by_id(map_data: Any) -> dict[int, str]:
+    if not isinstance(map_data, dict):
+        return {}
+    tilesets = map_data.get("tilesets")
+    if not isinstance(tilesets, list) or not tilesets or not isinstance(tilesets[0], dict):
+        return {}
+    tileproperties = tilesets[0].get("tileproperties")
+    if not isinstance(tileproperties, dict):
+        return {}
+    tile_types: dict[int, str] = {}
+    for raw_tile_id, tile_config in tileproperties.items():
+        try:
+            tile_id = int(raw_tile_id)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(tile_config, dict) and isinstance(tile_config.get("type"), str):
+            tile_types[tile_id] = tile_config["type"]
+    return tile_types
+
+
+def normalize_cpp_type(raw: str) -> str:
+    name = raw.strip()
+    wrapper_match = re.match(r"CWrapper<\s*([A-Za-z_]\w*)\s*>", name)
+    if wrapper_match:
+        return wrapper_match.group(1)
+    return re.sub(r"\s+", "", name)
+
+
+def append_field(location: str, key: Any) -> str:
+    if isinstance(key, str) and re.match(r"^[A-Za-z_]\w*$", key):
+        return f"{location}.{key}"
+    return f"{location}[{json.dumps(key)}]"
+
+
+def append_index(location: str, index: int) -> str:
+    return f"{location}[{index}]"
+
+
+def get_state_id(state: Any) -> str | None:
+    if not isinstance(state, dict):
+        return None
+    props = state.get("properties")
+    if not isinstance(props, dict):
+        return None
+    state_id = props.get("stateId")
+    return state_id if isinstance(state_id, str) else None
+
+
+def reachable_states(edges: dict[str, set[str]], start: str) -> set[str]:
+    seen: set[str] = set()
+    pending = [start]
+    while pending:
+        state = pending.pop()
+        if state in seen:
+            continue
+        seen.add(state)
+        pending.extend(edges.get(state, set()) - seen)
+    return seen
+
+
+def validate_repo(repo_root: Path | str) -> list[ValidationIssue]:
+    return ContentValidator(Path(repo_root)).validate()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate game JSON resources and literal script refs.")
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args(argv)
+
+    issues = validate_repo(args.repo_root)
+    if issues:
+        for issue in issues:
+            print(issue)
+        print(f"Content validation failed: {len(issues)} issue(s)", file=sys.stderr)
+        return 1
+
+    print("Content validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -1,0 +1,345 @@
+# fall-of-nouraajd c++ dark fantasy game
+# Copyright (C) 2026  Andrzej Lis
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import json
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.validate_content import validate_repo
+
+
+class ContentValidatorTest(unittest.TestCase):
+    def test_current_content_passes_validation(self):
+        issues = validate_repo(REPO_ROOT)
+        self.assertEqual([], [str(issue) for issue in issues])
+
+    def test_missing_refs_report_path_entry_and_field(self):
+        root = self.make_fixture()
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["brokenCave"] = {"class": "CBuilding", "properties": {"monster": {"ref": "MissingMonster"}}}
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "brokenCave.properties.monster.ref",
+            'unknown ref "MissingMonster"',
+        )
+
+    def test_duplicate_map_object_names_report_both_locations(self):
+        root = self.make_fixture()
+        map_path = root / "res/maps/broken/map.json"
+        map_data = read_json(map_path)
+        map_data["layers"][1]["objects"].append(
+            {"id": 2, "name": "start", "type": "StartEvent", "x": 1, "y": 1, "width": 1, "height": 1}
+        )
+        write_json(map_path, map_data)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/map.json",
+            "layers[1].objects[1].name",
+            'duplicate object name "start"',
+            "previously defined at layers[1].objects[0]",
+        )
+
+    def test_unreachable_dialog_state_reports_dialog_and_state(self):
+        root = self.make_fixture()
+        dialog_path = root / "res/maps/broken/dialog.json"
+        dialog = read_json(dialog_path)
+        dialog["brokenDialog"]["properties"]["states"].append(
+            {
+                "class": "CDialogState",
+                "properties": {
+                    "stateId": "ORPHAN_STATE",
+                    "text": "Nobody can reach this.",
+                    "options": [{"ref": "exitOption", "properties": {"number": 0}}],
+                },
+            }
+        )
+        write_json(dialog_path, dialog)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/dialog.json",
+            "brokenDialog.properties.states[2].properties.stateId",
+            "ORPHAN_STATE",
+            "unreachable from ENTRY",
+        )
+
+    def test_invalid_dialog_action_and_condition_report_script_class_context(self):
+        root = self.make_fixture()
+        dialog_path = root / "res/maps/broken/dialog.json"
+        dialog = read_json(dialog_path)
+        option = dialog["brokenDialog"]["properties"]["states"][0]["properties"]["options"][0]["properties"]
+        option["action"] = "missing_action"
+        option["condition"] = "missing_condition"
+        write_json(dialog_path, dialog)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/dialog.json",
+            "properties.action",
+            'dialog action "missing_action" is not defined on BrokenDialog',
+            "res/maps/broken/script.py",
+        )
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/dialog.json",
+            "properties.condition",
+            'dialog condition "missing_condition" is not defined on BrokenDialog',
+            "res/maps/broken/script.py",
+        )
+
+    def test_invalid_market_refs_report_market_field(self):
+        root = self.make_fixture()
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["validMarket"]["properties"]["items"][0]["ref"] = "MissingPotion"
+        config["brokenStand"] = {"class": "CBuilding", "properties": {"market": {"ref": "MissingMarket"}}}
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "validMarket.properties.items[0].ref",
+            'unknown ref "MissingPotion"',
+        )
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "brokenStand.properties.market.ref",
+            'unknown ref "MissingMarket"',
+        )
+
+    def test_invalid_script_quest_ids_report_call_location(self):
+        root = self.make_fixture(script_quest="missingQuest")
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'ensure_quest("missingQuest")',
+            'unknown quest id "missingQuest"',
+        )
+
+    def test_invalid_transition_targets_report_map_name(self):
+        root = self.make_fixture(script_map="missingMap")
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'changeMap("missingMap")',
+            "map transition target is missing res/maps/missingMap/map.json",
+        )
+
+    def test_invalid_class_names_report_object_and_field(self):
+        root = self.make_fixture()
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["brokenEvent"] = {"class": "MissingEventClass"}
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "brokenEvent.class",
+            'unknown class "MissingEventClass"',
+        )
+
+    def assertIssueContains(self, issues, *substrings):
+        issue_text = "\n".join(str(issue) for issue in issues)
+        for substring in substrings:
+            with self.subTest(substring=substring):
+                self.assertIn(substring, issue_text)
+
+    def make_fixture(self, script_quest="goodQuest", script_map="broken"):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        root = Path(temp_dir.name)
+        (root / "res/config").mkdir(parents=True)
+        (root / "res/plugins").mkdir(parents=True)
+        (root / "res/maps/broken").mkdir(parents=True)
+
+        write_json(
+            root / "res/config/items.json",
+            {
+                "LifePotion": {"class": "CPotion"},
+                "HitEffect": {"class": "CEffect"},
+                "Attack": {"class": "CInteraction", "properties": {"effect": {"ref": "HitEffect"}}},
+            },
+        )
+        write_json(
+            root / "res/config/misc.json",
+            {
+                "exitOption": {
+                    "class": "CDialogOption",
+                    "properties": {"text": "Leave.", "nextStateId": "EXIT"},
+                }
+            },
+        )
+        write_json(
+            root / "res/maps/broken/map.json",
+            {
+                "type": "map",
+                "width": 2,
+                "height": 2,
+                "layers": [
+                    {"type": "tilelayer", "width": 2, "height": 2, "data": [0, 0, 0, 0]},
+                    {
+                        "type": "objectgroup",
+                        "objects": [
+                            {
+                                "id": 1,
+                                "name": "start",
+                                "type": "StartEvent",
+                                "x": 0,
+                                "y": 0,
+                                "width": 1,
+                                "height": 1,
+                            }
+                        ],
+                    },
+                ],
+                "tilesets": [{"firstgid": 1, "tileproperties": {}}],
+                "nextobjectid": 2,
+            },
+        )
+        write_json(
+            root / "res/maps/broken/config.json",
+            {
+                "goodQuest": {"class": "GoodQuest"},
+                "validMarket": {"class": "CMarket", "properties": {"items": [{"ref": "LifePotion"}]}},
+            },
+        )
+        write_json(root / "res/maps/broken/dialog.json", valid_dialog_config())
+        write_script(root / "res/maps/broken/script.py", script_quest=script_quest, script_map=script_map)
+        return root
+
+
+def valid_dialog_config():
+    return {
+        "brokenDialog": {
+            "class": "BrokenDialog",
+            "properties": {
+                "states": [
+                    {
+                        "class": "CDialogState",
+                        "properties": {
+                            "stateId": "ENTRY",
+                            "text": "Start.",
+                            "options": [
+                                {
+                                    "class": "CDialogOption",
+                                    "properties": {
+                                        "number": 0,
+                                        "text": "Continue.",
+                                        "nextStateId": "DONE",
+                                        "action": "valid_action",
+                                        "condition": "valid_condition",
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                    {
+                        "class": "CDialogState",
+                        "properties": {
+                            "stateId": "DONE",
+                            "text": "Done.",
+                            "options": [{"ref": "exitOption", "properties": {"number": 0}}],
+                        },
+                    },
+                ]
+            },
+        }
+    }
+
+
+def write_script(path, script_quest, script_map):
+    path.write_text(
+        textwrap.dedent(f"""
+            def load(self, context):
+                from game import CDialog
+                from game import CEvent
+                from game import CQuest
+                from game import register
+                from game import trigger
+
+                def ensure_quest(player, quest_name):
+                    player.addQuest(quest_name)
+
+                @register(context)
+                class StartEvent(CEvent):
+                    def onEnter(self, event):
+                        self.getGame().createObject("validMarket")
+                        self.getGame().changeMap("{script_map}")
+                        ensure_quest(event.getCause(), "{script_quest}")
+                        event.getCause().addItem("LifePotion")
+                        self.getMap().getObjectByName("start")
+
+                @register(context)
+                class GoodQuest(CQuest):
+                    pass
+
+                @register(context)
+                class BrokenDialog(CDialog):
+                    def valid_action(self):
+                        pass
+
+                    def valid_condition(self):
+                        return True
+
+                @trigger(context, "onEnter", "start")
+                class StartTrigger(CEvent):
+                    pass
+            """).lstrip(),
+        encoding="utf-8",
+    )
+
+
+def read_json(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path, data):
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #333.

## What changed
- Added `scripts/validate_content.py`, a pure-stdlib content validator for global config JSON, map-local config/dialog JSON, Tiled map JSON, and literal references in map/plugin scripts.
- Added focused regression tests in `tests/test_content_validator.py` using temporary invalid fixtures.
- Added early Linux and Windows CI steps so content validation runs before native setup/build and gameplay walkthroughs.
- Documented the validator in `README.md` and `docs/testing.md`.

## Validation categories implemented
- Global and map-local object specs: `class`/`ref` shape, recursive missing refs, and class-name resolution from native registrations plus Python scripts/plugins.
- Map JSON: object layer type refs, duplicate non-empty object names, tile layer data shape, used tile ids, and tile type refs.
- Dialog JSON: required `ENTRY`, duplicate states/options, invalid `nextStateId`, unreachable states, and missing dialog `action`/`condition` methods.
- Script literals: `createObject`/`addObjectByName`, `addItem`, quest helpers, `changeMap`, object-name lookups/removals, and trigger targets/events.
- Resource configs: crafting station ids, recipe item refs, market item refs, and nested object refs.

## Examples of errors caught
- `brokenCave.properties.monster.ref` pointing at an unknown object id.
- Duplicate map object names inside a single `objectgroup`.
- Dialog states that cannot be reached from `ENTRY`.
- Dialog options naming missing `action` or `condition` methods.
- `changeMap("missingMap")`, missing quest ids, invalid market refs, and unknown class names.

## Deferred checks
- Dynamic or non-literal script references are skipped so the validator can stay import-free and avoid false positives.
- Broad GUI callback, image asset, and gameplay topology checks remain covered by the existing runtime tests.
- The validator intentionally does not import `_game`, start SDL, or require compiled binaries.

## Validation
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/validate_content.py --repo-root .` -> `Content validation passed`
- `python3 -m unittest tests.test_content_validator` -> `Ran 9 tests`, `OK`
- `cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` -> `9/9 Test #... Passed`
- `ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance` -> `100% tests passed`
- `python3 test.py` -> `Ran 194 tests`, `OK (skipped=22)`
- `GAME_TEST_JOBS=1 GAME_XVFB_JOBS=1 ./scripts/run_coverage.sh` -> `lines: 100.00% (7188 out of 7188, 774 excluded)`

Notes:
- A default parallel `./scripts/run_coverage.sh` attempt stalled after the Python worker shards in this environment, so the successful coverage run used single Python/Xvfb jobs.
- A sandboxed single-job coverage attempt reached the HTTP MCP socket test and failed with `PermissionError: [Errno 1] Operation not permitted`; the same command passed when rerun with the required socket permissions.
