### PR TITLE
Fix Windows native test linkage after CI split

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,9 @@ configure_cpp_target(game_core)
 set_target_properties(game_core PROPERTIES
     OUTPUT_NAME "game_core"
 )
+if (WIN32)
+    target_compile_definitions(game_core PRIVATE GAME_CORE_BUILD)
+endif ()
 if (GAME_ENABLE_PCH AND WIN32)
     target_precompile_headers(game_core PRIVATE "${CMAKE_SOURCE_DIR}/src/core/CGlobal.h")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,12 @@ set(GAME_CORE_LINK_LIBS
     ${CMAKE_DL_LIBS}
 )
 
-add_library(game_core_objects OBJECT ${GAME_CORE_SRC})
+set(GAME_CORE_OBJECT_SRC ${GAME_CORE_SRC})
+if (WIN32)
+    list(FILTER GAME_CORE_OBJECT_SRC EXCLUDE REGEX ".*/src/core/CModule\\.cpp$")
+endif ()
+
+add_library(game_core_objects OBJECT ${GAME_CORE_OBJECT_SRC})
 configure_cpp_target(game_core_objects)
 set_target_properties(game_core_objects PROPERTIES
     POSITION_INDEPENDENT_CODE ON
@@ -173,10 +178,19 @@ target_compile_definitions(game_core_objects PRIVATE
 )
 target_link_libraries(game_core_objects PRIVATE ${GAME_CORE_LINK_LIBS})
 
-add_library(game_core SHARED $<TARGET_OBJECTS:game_core_objects>)
+set(GAME_CORE_SHARED_SRC $<TARGET_OBJECTS:game_core_objects>)
+if (WIN32)
+    list(APPEND GAME_CORE_SHARED_SRC ${CMAKE_SOURCE_DIR}/src/core/CModule.cpp)
+endif ()
+
+add_library(game_core SHARED ${GAME_CORE_SHARED_SRC})
+configure_cpp_target(game_core)
 set_target_properties(game_core PROPERTIES
     OUTPUT_NAME "game_core"
 )
+if (GAME_ENABLE_PCH AND WIN32)
+    target_precompile_headers(game_core PRIVATE "${CMAKE_SOURCE_DIR}/src/core/CGlobal.h")
+endif ()
 target_link_libraries(game_core PRIVATE
     ${GAME_CORE_LINK_LIBS}
 )
@@ -574,7 +588,11 @@ endfunction()
 add_game_unit_test(core_unit_tests tests/unit/test_core.cpp)
 add_game_unit_test(controller_unit_tests tests/unit/test_controller.cpp)
 add_game_unit_test(gui_unit_tests tests/unit/test_gui.cpp)
-add_game_unit_test(handler_unit_tests tests/unit/test_handler.cpp src/handler/CScriptHandler.cpp)
+set(GAME_HANDLER_UNIT_TEST_SRC tests/unit/test_handler.cpp)
+if (NOT WIN32)
+    list(APPEND GAME_HANDLER_UNIT_TEST_SRC src/handler/CScriptHandler.cpp)
+endif ()
+add_game_unit_test(handler_unit_tests ${GAME_HANDLER_UNIT_TEST_SRC})
 add_game_unit_test(object_unit_tests tests/unit/test_object.cpp)
 
 add_executable(performance_guard_tests
@@ -582,8 +600,8 @@ add_executable(performance_guard_tests
     tests/unit/test_pathfinder_performance.cpp
     tests/unit/test_engine_hotspot_performance.cpp
 )
-if (GAME_UNIT_TEST_SUPPORT_SRC)
-    target_sources(performance_guard_tests PRIVATE ${GAME_UNIT_TEST_SUPPORT_SRC})
+if (WIN32)
+    target_sources(performance_guard_tests PRIVATE $<TARGET_OBJECTS:game_core_objects>)
 endif ()
 configure_cpp_target(performance_guard_tests)
 target_link_libraries(performance_guard_tests PRIVATE
@@ -593,7 +611,7 @@ target_link_libraries(performance_guard_tests PRIVATE
     ${SDL2_IMAGE_LIBS}
     ${SDL2_TTF_LIBS}
 )
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (NOT WIN32)
     target_link_libraries(performance_guard_tests PRIVATE game_core)
 endif ()
 add_test(NAME "performance.performance_guard_tests" COMMAND performance_guard_tests)

--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -51,6 +51,7 @@ def normalize_path(path_str: str, cwd: Path) -> Path:
 
 
 def validate_include_prefix(root: Path, prefix_str: str) -> Path:
+    root = root.resolve()
     if not isinstance(prefix_str, str) or not prefix_str:
         raise ValueError("coverage include prefixes must be non-empty strings")
     prefix = Path(prefix_str)
@@ -76,16 +77,17 @@ def load_include_prefixes(root: Path, include_prefixes):
 
 
 def is_included(root: Path, source_path: Path, include_prefixes=()) -> bool:
+    root = root.resolve()
     try:
         resolved = source_path.resolve()
-        resolved.relative_to(root.resolve())
+        resolved.relative_to(root)
     except ValueError:
         return False
     if not include_prefixes:
         return True
     for include_prefix in include_prefixes:
         try:
-            resolved.relative_to(include_prefix)
+            resolved.relative_to(include_prefix.resolve())
             return True
         except ValueError:
             pass
@@ -93,6 +95,7 @@ def is_included(root: Path, source_path: Path, include_prefixes=()) -> bool:
 
 
 def validate_exclusion_path(root: Path, rel_path_str: str) -> Path:
+    root = root.resolve()
     if not isinstance(rel_path_str, str) or not rel_path_str:
         raise ValueError("coverage exclusion paths must be non-empty strings")
     rel_path = Path(rel_path_str)
@@ -171,7 +174,9 @@ def load_line_exclusions(root: Path, manifest_path: Path | None):
 
 
 def validate_line_exclusions(root: Path, merged, exclusions):
+    root = root.resolve()
     for source_path, line_reasons in exclusions.items():
+        source_path = source_path.resolve()
         rel_path = source_path.relative_to(root)
         if source_path not in merged:
             raise ValueError(f"coverage exclusion path is stale or was not instrumented: {rel_path}")
@@ -249,6 +254,7 @@ def merge_line_counts(root: Path, reports, include_prefixes=()):
 
 
 def summarize(root: Path, merged, exclusions=None):
+    root = root.resolve()
     exclusions = exclusions or {}
     summary = []
     total_lines = 0
@@ -269,7 +275,7 @@ def summarize(root: Path, merged, exclusions=None):
         missing = [
             line for line, count in sorted(line_counts.items()) if line > 0 and line not in excluded_set and count == 0
         ]
-        rel_path = source_path.relative_to(root)
+        rel_path = source_path.resolve().relative_to(root)
         summary.append(
             {
                 "path": rel_path,

--- a/test.py
+++ b/test.py
@@ -11221,6 +11221,56 @@ class CoverageReportTest(unittest.TestCase):
             self.assertEqual((covered, total, percentage, excluded), (1, 2, 50.0, 0))
             self.assertEqual(summary[0]["path"], Path("src/sample.cpp"))
 
+    def test_coverage_paths_accept_noncanonical_root(self):
+        coverage_report = self._load_coverage_report_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            real_root = Path(tmpdir) / "real"
+            alias_root = Path(tmpdir) / "alias"
+            real_root.mkdir()
+            try:
+                os.symlink(real_root, alias_root, target_is_directory=True)
+            except (OSError, NotImplementedError) as exc:
+                self.skipTest(f"symlink root setup is unavailable: {exc}")
+
+            source = alias_root / "src" / "sample.cpp"
+            source.parent.mkdir()
+            source.write_text("one\ntwo\n", encoding="utf-8")
+            manifest_path = self._write_manifest(
+                alias_root,
+                [
+                    {
+                        "path": "src/sample.cpp",
+                        "reason": "synthetic unreachable branch",
+                        "ranges": ["2"],
+                    }
+                ],
+            )
+            reports = [
+                {
+                    "current_working_directory": str(alias_root),
+                    "files": [
+                        {
+                            "file": str(source),
+                            "lines": [
+                                {"line_number": 1, "count": 1},
+                                {"line_number": 2, "count": 0},
+                            ],
+                        }
+                    ],
+                }
+            ]
+
+            include_prefixes = coverage_report.load_include_prefixes(alias_root, ["src"])
+            merged = coverage_report.merge_line_counts(alias_root, reports, include_prefixes)
+            exclusions = coverage_report.load_line_exclusions(alias_root, manifest_path)
+            coverage_report.validate_line_exclusions(alias_root, merged, exclusions)
+            summary, covered, total, percentage, excluded = coverage_report.summarize(alias_root, merged, exclusions)
+
+            self.assertEqual(set(merged), {source.resolve()})
+            self.assertEqual((covered, total, percentage, excluded), (1, 1, 100.0, 1))
+            self.assertEqual(summary[0]["path"], Path("src/sample.cpp"))
+
     def test_coverage_line_exclusions_fail_closed(self):
         coverage_report = self._load_coverage_report_module()
 

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -26,6 +26,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CPlayer.h"
 #include "test_harness.h"
 
+#include <pybind11/embed.h>
+
 namespace {
 
 void test_widget_ignores_unarmed_non_left_clicks() {
@@ -81,6 +83,8 @@ void test_inventory_double_select_uses_selected_item_and_clears_selection() {
 } // namespace
 
 int main() {
+    pybind11::scoped_interpreter guard{};
+
     test_widget_ignores_unarmed_non_left_clicks();
     test_inventory_double_select_uses_selected_item_and_clears_selection();
 


### PR DESCRIPTION
## What changed
- Kept `CModule.cpp` out of Windows test object linkage and compiled it into `game_core` with `GAME_CORE_BUILD` so `init_game_module` is exported correctly.
- Kept Windows performance guard tests on the same engine objects as native unit tests, while preserving the Linux handler-test source path.
- Initialized Python in `gui_unit_tests` and normalized coverage reporter path checks against resolved roots.
- Added a non-canonical-root regression test for include-prefix and line-exclusion coverage paths.

## Why
- Windows CI exposed native linkage issues after the CI split, then failed `CoverageReportTest` when temp paths mixed short and canonical Windows path spellings.

## Validation performed
- `black -l 120 test.py scripts/coverage_report.py`
- `python3 test.py CoverageReportTest`
- `cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance`
- `python3 test.py`
- `./scripts/run_coverage.sh` on the rebased branch: `98.83% (7522 out of 7611, 771 excluded)`

## Known limitations
- Windows-specific behavior is validated by GitHub Actions; local validation was run on Linux.