### PR TITLE
Reduce coverage exclusions and add audit report

### DIFF
--- a/scripts/coverage_exclusions.json
+++ b/scripts/coverage_exclusions.json
@@ -19,9 +19,7 @@
         "85",
         "133",
         "150",
-        "220-221",
         "307",
-        "333-334",
         "399-400",
         "416",
         "457",
@@ -131,6 +129,7 @@
       "reason": "Reviewed legacy uncovered branch baseline; unreviewed coverage changes remain visible in the 95% scoped line gate.",
       "ranges": [
         "53",
+        "64",
         "90",
         "98",
         "100-101",
@@ -138,24 +137,33 @@
         "146-147",
         "154",
         "236",
+        "262",
         "286",
         "289",
         "385",
+        "411",
         "448",
         "460",
         "511",
         "518",
         "521",
+        "537",
         "547",
         "553",
+        "573",
         "578",
         "583-584",
         "596",
+        "604",
         "620",
+        "647",
         "687",
+        "714",
         "719",
         "723",
-        "730"
+        "730",
+        "750",
+        "757"
       ]
     },
     {
@@ -296,33 +304,18 @@
       "path": "src/core/CSerialization.cpp",
       "reason": "Reviewed legacy uncovered branch baseline; unreviewed coverage changes remain visible in the 95% scoped line gate.",
       "ranges": [
-        "106",
         "149",
-        "164-165",
         "181-182",
         "231",
         "275",
-        "281-282",
-        "284",
         "301",
         "316",
         "338",
         "344",
         "352",
-        "356",
         "364",
         "370",
-        "387",
-        "402-403",
-        "405-406",
-        "409",
-        "411",
-        "415",
-        "417",
-        "421",
-        "423",
-        "427",
-        "429"
+        "387"
       ]
     },
     {
@@ -330,8 +323,7 @@
       "reason": "Reviewed legacy uncovered branch baseline; unreviewed coverage changes remain visible in the 95% scoped line gate.",
       "ranges": [
         "222",
-        "238",
-        "243"
+        "238"
       ]
     },
     {
@@ -370,17 +362,9 @@
       "path": "src/gui/CAnimation.cpp",
       "reason": "Reviewed legacy uncovered branch baseline; unreviewed coverage changes remain visible in the 95% scoped line gate.",
       "ranges": [
-        "40",
-        "44-45",
-        "95",
-        "99",
         "106",
         "109",
-        "123-124",
         "136",
-        "141-142",
-        "148-152",
-        "156-160",
         "181"
       ]
     },
@@ -432,7 +416,6 @@
         "71",
         "77-79",
         "81",
-        "104-105",
         "115",
         "133-134",
         "141-142",
@@ -590,7 +573,6 @@
       "ranges": [
         "36",
         "41-43",
-        "49",
         "64",
         "69-71",
         "76",
@@ -630,11 +612,9 @@
       "path": "src/gui/panel/CGameInventoryPanel.cpp",
       "reason": "Reviewed legacy uncovered branch baseline; unreviewed coverage changes remain visible in the 95% scoped line gate.",
       "ranges": [
-        "38-44",
+        "41-44",
         "53",
-        "82",
-        "108-112",
-        "114"
+        "82"
       ]
     },
     {
@@ -693,7 +673,6 @@
         "173-175",
         "187-190",
         "211-214",
-        "228",
         "265",
         "308"
       ]

--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -25,6 +25,11 @@ def parse_args():
         default=[],
         help="Root-relative source path prefix to include. May be repeated. Defaults to the full repository.",
     )
+    parser.add_argument(
+        "--audit-exclusions",
+        action="store_true",
+        help="Write exclusion audit reports with raw hit counts and source snippets.",
+    )
     return parser.parse_args()
 
 
@@ -345,6 +350,57 @@ def write_html_report(
     )
 
 
+def build_exclusion_audit(root: Path, merged, exclusions):
+    lines = []
+    for source_path in sorted(exclusions):
+        line_counts = merged.get(source_path, {})
+        try:
+            source_lines = source_path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            source_lines = []
+        for line_number, reason in sorted(exclusions[source_path].items()):
+            if line_number <= 0 or line_number not in line_counts:
+                continue
+            count = line_counts[line_number]
+            snippet = source_lines[line_number - 1].strip() if line_number <= len(source_lines) else ""
+            lines.append(
+                {
+                    "path": str(source_path.relative_to(root)),
+                    "line": line_number,
+                    "count": count,
+                    "covered": count > 0,
+                    "reason": reason,
+                    "source": snippet,
+                }
+            )
+
+    covered = sum(1 for line in lines if line["covered"])
+    return {
+        "total": len(lines),
+        "covered": covered,
+        "uncovered": len(lines) - covered,
+        "lines": lines,
+    }
+
+
+def write_exclusion_audit_text(report_path: Path, audit):
+    lines = [
+        f"EXCLUDED LINES {audit['total']} total, {audit['covered']} covered, {audit['uncovered']} uncovered",
+        "",
+    ]
+    for item in audit["lines"]:
+        status = "covered" if item["covered"] else "uncovered"
+        lines.append(
+            f"{item['path']}:{item['line']} count={item['count']} {status} "
+            f"reason={json.dumps(item['reason'])} source={json.dumps(item['source'])}"
+        )
+    report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_exclusion_audit_json(report_path: Path, audit):
+    report_path.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
 def main():
     args = parse_args()
     root = args.root.resolve()
@@ -365,6 +421,11 @@ def main():
     write_html_report(
         report_dir / "coverage.html", summary, covered_lines, total_lines, total_percentage, excluded_lines
     )
+    if args.audit_exclusions:
+        audit = build_exclusion_audit(root, merged, exclusions)
+        write_exclusion_audit_text(report_dir / "exclusion_audit.txt", audit)
+        write_exclusion_audit_json(report_dir / "exclusion_audit.json", audit)
+        print("exclusions: " f"{audit['total']} total ({audit['covered']} covered, {audit['uncovered']} uncovered)")
 
     print(f"lines: {total_percentage:.2f}% ({covered_lines} out of {total_lines}, {excluded_lines} excluded)")
     if total_percentage < args.min_line:

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -6,6 +6,7 @@ BUILD_DIR="${BUILD_DIR:-cmake-build-coverage}"
 MIN_COVERAGE="${MIN_COVERAGE:-95}"
 REPORT_DIR="${ROOT_DIR}/coverage"
 COVERAGE_LINE_EXCLUSIONS="${COVERAGE_LINE_EXCLUSIONS:-${ROOT_DIR}/scripts/coverage_exclusions.json}"
+COVERAGE_AUDIT_EXCLUSIONS="${COVERAGE_AUDIT_EXCLUSIONS:-0}"
 COVERAGE_INCLUDE_PREFIXES="${COVERAGE_INCLUDE_PREFIXES:-src native_plugins}"
 COVERAGE_JOBS="${COVERAGE_JOBS:-$(nproc)}"
 COVERAGE_REPORTER="${COVERAGE_REPORTER:-python}"
@@ -124,6 +125,9 @@ generate_report() {
         )
         if [[ -n "${COVERAGE_LINE_EXCLUSIONS}" ]]; then
             coverage_report_args+=(--line-exclusions "${COVERAGE_LINE_EXCLUSIONS}")
+        fi
+        if [[ "${COVERAGE_AUDIT_EXCLUSIONS}" == "1" ]]; then
+            coverage_report_args+=(--audit-exclusions)
         fi
         if [[ -n "${COVERAGE_INCLUDE_PREFIXES}" ]]; then
             read -r -a coverage_include_prefixes <<<"${COVERAGE_INCLUDE_PREFIXES}"

--- a/test.py
+++ b/test.py
@@ -7473,6 +7473,48 @@ class GameTest(unittest.TestCase):
         return True, json.dumps({"rolf_letters": player.countItems("letterFromRolf")}, sort_keys=True)
 
     @game_test
+    def test_inventory_double_select_uses_selected_item(self):
+        game = load_game_module()
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.loadGui(g)
+        game.CGameLoader.startGameWithPlayer(g, "nouraajd", "Warrior")
+        pump_event_loop(5)
+
+        gui = g.getGui()
+        player = g.getMap().getPlayer()
+        for item in list(player.getItems()):
+            player.removeItem(lambda current, target=item: current == target, True)
+
+        potion = g.createObject("LesserLifePotion")
+        player.addItem(potion)
+        player.setHp(max(1, player.getHpMax() - 10))
+
+        inventory_panel = g.getGuiHandler().openPanel("inventoryPanel")
+        pump_event_loop(5)
+        inventory_list = next(
+            list_view
+            for list_view in collect_gui_children(inventory_panel, "CListView")
+            if list_view.getCollection() == "inventoryCollection"
+        )
+        inventory_list.setTileSize(50)
+        inventory_list.setXPrefferedSize(2)
+        inventory_list.setYPrefferedSize(2)
+        inventory_list.refresh()
+
+        self.assertTrue(inventory_list.mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 1, 1))
+        self.assertGreater(
+            get_panel_selection_box_counts_by_collection(inventory_panel).get("inventoryCollection", 0), 0
+        )
+        self.assertTrue(inventory_list.mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 1, 1))
+
+        self.assertEqual(0, player.countItems("LesserLifePotion"))
+        self.assertEqual(0, get_panel_selection_box_counts_by_collection(inventory_panel).get("inventoryCollection", 0))
+
+        return True, json.dumps(
+            {"hp_ratio": player.getHpRatio(), "potions": player.countItems("LesserLifePotion")}, sort_keys=True
+        )
+
+    @game_test
     def test_fight_panel_callbacks_and_list_views(self):
         game = load_game_module()
         drain_sdl_events()
@@ -7496,6 +7538,12 @@ class GameTest(unittest.TestCase):
         static_object = g.createObject("CItem")
         static_object.animation = "images/item"
         static_animation = g.createObject("CStaticAnimation")
+        static_animation.renderObject(gui, 0, 0, 24, 24, 0)
+        missing_static_object = g.createObject("CGameObject")
+        missing_static_object.animation = "images/does-not-exist"
+        missing_static_animation = g.createObject("CStaticAnimation")
+        missing_static_animation.setObject(missing_static_object)
+        missing_static_animation.renderObject(gui, 0, 0, 24, 24, 0)
         static_animation.setObject(static_object)
         static_animation.renderObject(gui, 0, 0, 24, 24, 0)
         static_animation.setColorMod(200, 100, 50, 180)
@@ -7511,6 +7559,40 @@ class GameTest(unittest.TestCase):
         dynamic_animation.initialize()
         pump_event_loop(5)
         dynamic_animation.renderObject(gui, 0, 0, 24, 24, 100)
+        pritzmage_object = g.createObject("CGameObject")
+        pritzmage_object.animation = "images/monsters/pritzmage"
+        pritzmage_animation = g.createObject("CDynamicAnimation")
+        pritzmage_animation.setObject(pritzmage_object)
+        pritzmage_animation.initialize()
+        pump_event_loop(5)
+        pritzmage_animation.renderObject(gui, 0, 0, 24, 24, 250)
+
+        def write_animation_fixture(name, timings=None, copy_frames=True):
+            fixture_dir = Path("images") / f"unit_{name}_{time.time_ns()}"
+            fixture_dir.mkdir(parents=True, exist_ok=True)
+            if timings is not None:
+                (fixture_dir / "time.json").write_text(json.dumps(timings), encoding="utf-8")
+                if copy_frames:
+                    source_frame = Path("images") / "monsters" / "octobogz" / "0.png"
+                    for key in timings:
+                        shutil.copyfile(source_frame, fixture_dir / f"{key}.png")
+            return fixture_dir.as_posix()
+
+        for animation_path, should_render in (
+            (write_animation_fixture("positive", {"0": 100}), True),
+            (write_animation_fixture("missing_frame", {"0": 100}, copy_frames=False), True),
+            (write_animation_fixture("missing_time", None), False),
+            (write_animation_fixture("invalid_time", {"0": "bad"}), False),
+            (write_animation_fixture("zero_time", {"0": 0}), False),
+        ):
+            fixture_object = g.createObject("CGameObject")
+            fixture_object.animation = animation_path
+            fixture_animation = g.createObject("CDynamicAnimation")
+            fixture_animation.setObject(fixture_object)
+            fixture_animation.initialize()
+            pump_event_loop(5)
+            if should_render:
+                fixture_animation.renderObject(gui, 0, 0, 24, 24, 100)
 
         selection_box = g.createObject("CSelectionBox")
         selection_box.setThickness(3)
@@ -7572,6 +7654,66 @@ class GameTest(unittest.TestCase):
         pump_event_loop(5)
         list_views = collect_gui_children(inventory_panel, "CListView")
         self.assertGreaterEqual(len(list_views), 2)
+        inventory_list = next(
+            list_view for list_view in list_views if list_view.getCollection() == "inventoryCollection"
+        )
+        equipped_list = next(list_view for list_view in list_views if list_view.getCollection() == "equippedCollection")
+        for list_view in (inventory_list, equipped_list):
+            list_view.setTileSize(50)
+            list_view.setXPrefferedSize(2)
+            list_view.setYPrefferedSize(2)
+            list_view.setAllowOversize(True)
+            list_view.refresh()
+
+        def populated_cell(list_view):
+            list_view.refresh()
+            for y in range(2):
+                for x in range(2):
+                    if list_view.getProxiedObjects(gui, x, y):
+                        return x, y
+            return None
+
+        def empty_cell(list_view):
+            list_view.refresh()
+            for y in range(2):
+                for x in range(2):
+                    if not list_view.getProxiedObjects(gui, x, y):
+                        return x, y
+            return 1, 1
+
+        inventory_cell = populated_cell(inventory_list)
+        self.assertIsNotNone(inventory_cell)
+        self.assertTrue(
+            inventory_list.mouseEvent(
+                gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, inventory_cell[0] * 50 + 1, inventory_cell[1] * 50 + 1
+            )
+        )
+        self.assertTrue(equipped_list.mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 1, 1))
+        equipped_cell = populated_cell(equipped_list)
+        self.assertIsNotNone(equipped_cell)
+        self.assertTrue(
+            equipped_list.mouseEvent(
+                gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, equipped_cell[0] * 50 + 1, equipped_cell[1] * 50 + 1
+            )
+        )
+        inventory_empty_cell = empty_cell(inventory_list)
+        self.assertTrue(
+            inventory_list.mouseEvent(
+                gui,
+                SDL_MOUSEBUTTONDOWN,
+                SDL_BUTTON_LEFT,
+                inventory_empty_cell[0] * 50 + 1,
+                inventory_empty_cell[1] * 50 + 1,
+            )
+        )
+        inventory_list.mouseEvent(
+            gui,
+            SDL_MOUSEBUTTONDOWN,
+            SDL_BUTTON_RIGHT,
+            inventory_empty_cell[0] * 50 + 1,
+            inventory_empty_cell[1] * 50 + 1,
+        )
+        self.assertTrue(inventory_panel.mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_RIGHT, 0, 0))
         proxied_counts = {}
         for index, list_view in enumerate(list_views):
             list_view.setTileSize(50)
@@ -7648,6 +7790,26 @@ class GameTest(unittest.TestCase):
 
         root.removeChild(branch)
         self.assertEqual([], list(root.getChildren()))
+
+        return True, ""
+
+    @game_test
+    def test_render_only_widget_ignores_mouse_clicks(self):
+        game = load_game_module()
+        drain_sdl_events()
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.loadGui(g)
+        game.CGameLoader.startGameWithPlayer(g, "nouraajd", "Warrior")
+        panel = g.getGuiHandler().openPanel("questionPanel")
+        panel.setStringProperty("question", "Render-only widget event coverage?")
+        pump_event_loop(5)
+
+        push_sdl_mouse_click(960, 500, SDL_BUTTON_RIGHT)
+        push_sdl_mouse_click(960, 500, SDL_BUTTON_LEFT)
+        pump_event_loop(5)
+
+        self.assertTrue(gui_contains_class(g, "CGameQuestionPanel"))
+        panel.close()
 
         return True, ""
 
@@ -11094,6 +11256,62 @@ class CoverageReportTest(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "glob"):
                 coverage_report.load_include_prefixes(root, ["src/*.cpp"])
+
+    def test_coverage_exclusion_audit_reports_raw_counts_and_snippets(self):
+        coverage_report = self._load_coverage_report_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            source = root / "src" / "sample.cpp"
+            source.parent.mkdir()
+            source.write_text("one\ntwo\nthree\n", encoding="utf-8")
+            manifest_path = self._write_manifest(
+                root,
+                [
+                    {
+                        "path": "src/sample.cpp",
+                        "reason": "synthetic exclusion",
+                        "ranges": ["2-3"],
+                    }
+                ],
+            )
+
+            merged = {source.resolve(): {1: 1, 2: 0, 3: 7}}
+            exclusions = coverage_report.load_line_exclusions(root, manifest_path)
+            coverage_report.validate_line_exclusions(root, merged, exclusions)
+
+            audit = coverage_report.build_exclusion_audit(root, merged, exclusions)
+            self.assertEqual(2, audit["total"])
+            self.assertEqual(1, audit["covered"])
+            self.assertEqual(1, audit["uncovered"])
+            self.assertEqual(
+                [
+                    {
+                        "path": "src/sample.cpp",
+                        "line": 2,
+                        "count": 0,
+                        "covered": False,
+                        "reason": "synthetic exclusion",
+                        "source": "two",
+                    },
+                    {
+                        "path": "src/sample.cpp",
+                        "line": 3,
+                        "count": 7,
+                        "covered": True,
+                        "reason": "synthetic exclusion",
+                        "source": "three",
+                    },
+                ],
+                audit["lines"],
+            )
+
+            text_report = root / "exclusion_audit.txt"
+            json_report = root / "exclusion_audit.json"
+            coverage_report.write_exclusion_audit_text(text_report, audit)
+            coverage_report.write_exclusion_audit_json(json_report, audit)
+            self.assertIn("src/sample.cpp:3 count=7 covered", text_report.read_text(encoding="utf-8"))
+            self.assertEqual(audit, json.loads(json_report.read_text(encoding="utf-8")))
 
 
 class McpServerTest(unittest.TestCase):

--- a/tests/unit/test_controller.cpp
+++ b/tests/unit/test_controller.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CMap.h"
 #include "core/CStats.h"
 #include "object/CCreature.h"
+#include "object/CItem.h"
 #include "object/CPlayer.h"
 #include "object/CTile.h"
 #include "test_harness.h"
@@ -226,6 +227,33 @@ void test_fight_controller_guard_paths_and_fallbacks() {
                 "player fight controller should fall back to base opponent selection without a panel");
 }
 
+void test_monster_fight_controller_uses_mana_item_when_mana_is_low() {
+    auto game = std::make_shared<CGame>();
+    auto map = std::make_shared<CMap>();
+    game->setMap(map);
+    map->setGame(game);
+
+    auto monster = creature_at(0, 0, 0);
+    monster->setGame(game);
+    monster->getBaseStats()->setIntelligence(10);
+    monster->setHp(monster->getHpMax());
+    monster->setMana(0);
+
+    auto opponent = creature_at(1, 0, 0);
+    opponent->setGame(game);
+
+    auto mana_potion = std::make_shared<CPotion>();
+    mana_potion->setGame(game);
+    mana_potion->setPower(5);
+    mana_potion->addTag(CTag::Mana);
+    monster->addItem(mana_potion);
+
+    auto controller = std::make_shared<CMonsterFightController>();
+    expect_true(controller->control(monster, opponent),
+                "monster fight controller should use a mana item when mana is low");
+    expect_true(monster->getItems().empty(), "used disposable mana item should be removed from inventory");
+}
+
 } // namespace
 
 int main() {
@@ -233,6 +261,7 @@ int main() {
     test_npc_random_controller_clears_current_tile_path();
     test_npc_random_controller_clears_stale_blocked_path();
     test_fight_controller_guard_paths_and_fallbacks();
+    test_monster_fight_controller_uses_mana_item_when_mana_is_low();
 
     return finish_tests();
 }

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "core/CJsonUtil.h"
+#include "core/CGame.h"
 #include "core/CPathFinder.h"
 #include "core/CSaveFormat.h"
 #include "core/CSerialization.h"
@@ -24,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CTags.h"
 #include "core/CUtil.h"
 #include "gui/CSdlResources.h"
+#include "object/CGameObject.h"
 #include "test_harness.h"
 #include "vutil.h"
 
@@ -42,6 +44,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 namespace {
+
+template <typename Func> void expect_runtime_error(Func func, const char *message) {
+    bool threw = false;
+    try {
+        func();
+    } catch (const std::runtime_error &) {
+        threw = true;
+    }
+    expect_true(threw, message);
+}
 
 struct TagProbe {
     CTags tags;
@@ -593,6 +605,92 @@ void test_save_format_codec_validation() {
                 "save format should reject envelopes with invalid map names");
 }
 
+void test_serialization_collection_and_error_helpers() {
+    auto game = std::make_shared<CGame>();
+    auto object = std::make_shared<CGameObject>();
+    object->setName("serializedObject");
+    object->setType("CGameObject");
+
+    CSerialization::setProperty(nullptr, "ignored", std::make_shared<json>(true));
+    CSerialization::setProperty(object, "type", std::make_shared<json>(42));
+    expect_true(object->getType() == "42", "numeric JSON should coerce into string-backed properties");
+    CSerialization::setProperty(object, "dynamicJsonFromString",
+                                std::make_shared<json>(std::string(R"({"value": true})")));
+    CSerialization::setProperty(object, "dynamicMapFromString",
+                                std::make_shared<json>(std::string(R"({"entry": {"class": "CGameObject"}})")));
+    CSerialization::setProperty(object, "dynamicJson", std::make_shared<json>(json::parse(R"({"value": true})")));
+
+    std::set<std::shared_ptr<CGameObject>> object_set{object};
+    auto serialized_set =
+        CSerializerFunction<std::shared_ptr<json>, std::set<std::shared_ptr<CGameObject>>>::serialize(object_set);
+    expect_true(serialized_set->is_array() && serialized_set->size() == 1,
+                "set serializer should encode game objects as a JSON array");
+
+    auto empty_array = std::make_shared<json>(json::array());
+    auto deserialized_set =
+        CSerializerFunction<std::shared_ptr<json>, std::set<std::shared_ptr<CGameObject>>>::deserialize(game,
+                                                                                                        empty_array);
+    expect_true(deserialized_set.empty(), "set deserializer should accept empty arrays");
+
+    std::map<std::string, std::shared_ptr<CGameObject>> object_map{{"entry", object}};
+    auto serialized_map =
+        CSerializerFunction<std::shared_ptr<json>, std::map<std::string, std::shared_ptr<CGameObject>>>::serialize(
+            object_map);
+    expect_true(serialized_map->is_object() && serialized_map->contains("entry"),
+                "map serializer should encode game objects by key");
+
+    auto empty_object = std::make_shared<json>(json::object());
+    auto deserialized_map =
+        CSerializerFunction<std::shared_ptr<json>, std::map<std::string, std::shared_ptr<CGameObject>>>::deserialize(
+            game, empty_object);
+    expect_true(deserialized_map.empty(), "map deserializer should accept empty objects");
+
+    expect_true(CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(
+                    nullptr, std::make_shared<json>(json::object())) == nullptr,
+                "non-strict object deserialization should fail closed without a game");
+
+    expect_runtime_error(
+        [&]() {
+            CSerialization::StrictScope strict;
+            CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(
+                nullptr, std::make_shared<json>(json::object()));
+        },
+        "strict object deserialization should reject a missing game");
+
+    auto unresolved_ref = std::make_shared<json>(json::object());
+    (*unresolved_ref)["ref"] = "missingObjectType";
+    expect_runtime_error(
+        [&]() {
+            CSerialization::StrictScope strict;
+            CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game, unresolved_ref);
+        },
+        "strict object deserialization should report unresolved references");
+
+    auto invalid_array = std::make_shared<json>(json::array({1}));
+    auto non_strict_skipped =
+        CSerializerFunction<std::shared_ptr<json>, std::set<std::shared_ptr<CGameObject>>>::deserialize(game,
+                                                                                                        invalid_array);
+    expect_true(non_strict_skipped.empty(), "non-strict array deserialization should skip malformed entries");
+
+    expect_runtime_error(
+        [&]() {
+            CSerialization::StrictScope strict;
+            CSerializerFunction<std::shared_ptr<json>, std::set<std::shared_ptr<CGameObject>>>::deserialize(
+                game, invalid_array);
+        },
+        "strict array deserialization should reject malformed entries");
+
+    auto invalid_map = std::make_shared<json>(json::object());
+    (*invalid_map)["bad"] = 1;
+    expect_runtime_error(
+        [&]() {
+            CSerialization::StrictScope strict;
+            CSerializerFunction<std::shared_ptr<json>,
+                                std::map<std::string, std::shared_ptr<CGameObject>>>::deserialize(game, invalid_map);
+        },
+        "strict map deserialization should reject malformed entries");
+}
+
 } // namespace
 
 int main() {
@@ -621,6 +719,7 @@ int main() {
     test_delayed_future_handlers_run_through_event_loop();
     test_script_rejects_executable_expressions();
     test_save_format_codec_validation();
+    test_serialization_collection_and_error_helpers();
 
     return finish_tests();
 }

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -22,10 +22,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CMap.h"
 #include "core/CProvider.h"
 #include "core/CSceneManager.h"
+#include "core/CSerialization.h"
+#include "core/CStats.h"
+#include "object/CCreature.h"
 #include "object/CGameObject.h"
 #include "object/CMapObject.h"
 #include "object/CPlayer.h"
 #include "object/CTile.h"
+#include "object/CTrigger.h"
 #include "test_harness.h"
 #include "veventloop.h"
 
@@ -34,6 +38,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <algorithm>
 #include <memory>
 #include <set>
+#include <stdexcept>
 
 namespace {
 
@@ -163,6 +168,67 @@ void test_scene_manager_null_and_legacy_missing_target_behavior() {
     expect_true(game->getMap()->getTurn() == 21, "missing-map compatibility path should copy the old turn");
     expect_true(game->getSceneManager()->getTransitionState() == CSceneManager::TransitionState::Idle,
                 "missing-map compatibility path should reset transition state");
+}
+
+class FixedStepController : public CController {
+  public:
+    explicit FixedStepController(Coords target, bool remove_before_return = false)
+        : target(target), removeBeforeReturn(remove_before_return) {}
+
+    std::shared_ptr<vstd::future<Coords, void>> control(std::shared_ptr<CCreature> creature) override {
+        return vstd::later([this, creature]() {
+            if (removeBeforeReturn && creature && creature->getMap()) {
+                creature->getMap()->removeObject(creature);
+            }
+            return target;
+        });
+    }
+
+    void interrupt(std::shared_ptr<CCreature>) override { interruptCount++; }
+
+    void onStepCommitted(std::shared_ptr<CCreature>, const Coords &) override { committedCount++; }
+
+    void onTurnEnded(std::shared_ptr<CCreature>) override { turnEndedCount++; }
+
+    Coords target;
+    bool removeBeforeReturn = false;
+    int interruptCount = 0;
+    int committedCount = 0;
+    int turnEndedCount = 0;
+};
+
+std::shared_ptr<CStats> creature_stats() {
+    auto stats = std::make_shared<CStats>();
+    stats->setMainStat("intelligence");
+    stats->setIntelligence(10);
+    stats->setStrength(10);
+    stats->setAgility(10);
+    stats->setStamina(10);
+    return stats;
+}
+
+std::shared_ptr<CCreature> test_creature(const std::shared_ptr<CGame> &game, const std::string &name, Coords coords,
+                                         const std::shared_ptr<CController> &controller) {
+    auto creature = std::make_shared<CCreature>();
+    creature->setBaseStats(creature_stats());
+    creature->setName(name);
+    creature->setGame(game);
+    creature->setController(controller);
+    creature->setPosX(coords.x);
+    creature->setPosY(coords.y);
+    creature->setPosZ(coords.z);
+    creature->setHp(creature->getHpMax());
+    return creature;
+}
+
+template <typename Func> void expect_runtime_error(Func func, const char *message) {
+    bool threw = false;
+    try {
+        func();
+    } catch (const std::runtime_error &) {
+        threw = true;
+    }
+    expect_true(threw, message);
 }
 
 void test_map_tiles_bounds_wrapping_and_object_cache() {
@@ -298,6 +364,156 @@ void test_map_tiles_bounds_wrapping_and_object_cache() {
     expect_true(map->getObjects().empty(), "removeObjects should erase matching objects from a cloned iteration");
 }
 
+void test_map_defensive_branches_and_strict_validation() {
+    auto map = std::make_shared<CMap>();
+    map->setXBounds({{0, -1}});
+    map->setYBounds({{0, 0}});
+    map->setWrapX({{0, 1}});
+    expect_true(map->normalizeCoords(Coords(5, 0, 0)) == Coords(5, 0, 0),
+                "wrapped normalization should leave invalid bounds unchanged");
+
+    map->setXBounds({{0, 2}});
+    auto bounds = map->getBounds();
+    expect_true(bounds.at(0) == std::make_pair(2, 0), "getBounds should return combined bounds");
+    expect_true(map->getAdjacentCoords(Coords(1, 1, 0)).size() == 4,
+                "non-wrapped adjacency should return four neighbors");
+
+    auto located = std::make_shared<CMapObject>();
+    located->setName("locatedObject");
+    located->setCanStep(false);
+    located->setPosX(1);
+    located->setPosY(0);
+    located->setPosZ(0);
+    map->addObject(located);
+    expect_true(map->getLocationByName("locatedObject") == Coords(1, 0, 0),
+                "getLocationByName should return existing object coordinates");
+    expect_true(map->getLocationByName("missingObject") == ZERO,
+                "getLocationByName should return ZERO for missing objects");
+    expect_true(map->addObjectByName("CMapObject", Coords(1, 0, 0)).empty(),
+                "addObjectByName should return an empty name for blocked coordinates");
+
+    auto named_tile = std::make_shared<CTile>();
+    named_tile->setTileType("namedTile");
+    expect_true(map->addTile(named_tile, 0, 0, 0), "fixture tile should be added");
+    expect_true(map->getTile(Coords(0, 0, 0)) == named_tile, "coordinate getTile overload should return stored tiles");
+    expect_true(map->getTiles().size() == 1, "getTiles should return stored tile snapshots");
+    expect_true(map->getObjects().size() == 1, "getObjects should return stored object snapshots");
+    expect_true(map->getObjectsAtCoords(Coords(99, 99, 0)).empty(),
+                "empty coordinate lookups should return an empty set");
+
+    map->setPlayer(nullptr);
+
+    std::string error;
+    auto empty_map = std::make_shared<CMap>();
+    expect_true(!empty_map->restorePlayerAfterLoad(error) && error == "saved map does not contain a player object",
+                "restorePlayerAfterLoad should reject maps without a player");
+
+    auto invalid_player_map = std::make_shared<CMap>();
+    auto invalid_player = std::make_shared<CPlayer>();
+    invalid_player->setBaseStats(creature_stats());
+    invalid_player->setName("notPlayer");
+    invalid_player_map->addObject(invalid_player);
+    expect_true(!invalid_player_map->restorePlayerAfterLoad(error) &&
+                    error == "saved player object is not named player",
+                "restorePlayerAfterLoad should reject non-canonical player names");
+
+    auto duplicate_player_map = std::make_shared<CMap>();
+    auto first_player = std::make_shared<CPlayer>();
+    first_player->setBaseStats(creature_stats());
+    first_player->setName("firstPlayer");
+    auto second_player = std::make_shared<CPlayer>();
+    second_player->setBaseStats(creature_stats());
+    second_player->setName("secondPlayer");
+    duplicate_player_map->addObject(first_player);
+    duplicate_player_map->addObject(second_player);
+    first_player->setName("player");
+    second_player->setName("player");
+    expect_true(!duplicate_player_map->restorePlayerAfterLoad(error) &&
+                    error == "saved map contains multiple player objects",
+                "restorePlayerAfterLoad should reject multiple player instances");
+
+    auto duplicate_name = std::make_shared<CMapObject>();
+    duplicate_name->setName("locatedObject");
+    map->addObject(nullptr);
+    map->addObject(duplicate_name);
+    expect_true(map->getObjects().size() == 1, "addObject should ignore null and duplicate objects");
+
+    {
+        CSerialization::StrictScope strict;
+        expect_runtime_error([&]() { map->setObjects({nullptr}); }, "strict setObjects should reject null objects");
+
+        auto empty_name = std::make_shared<CMapObject>();
+        empty_name->setName("");
+        expect_runtime_error([&]() { map->setObjects({empty_name}); },
+                             "strict setObjects should reject empty object names");
+    }
+
+    map->dumpPaths("/tmp/no-player-map-paths.txt");
+    map->setTriggers({nullptr});
+    map->objectMoved(nullptr, ZERO, ZERO);
+    expect_true(map->getTriggers().empty(), "null triggers should be ignored");
+
+    auto normal_trigger = std::make_shared<CTrigger>();
+    normal_trigger->setObject("locatedObject");
+    normal_trigger->setEvent("onTurn");
+    auto custom_trigger = std::make_shared<CCustomTrigger>("locatedObject", "onDestroy", [](auto, auto) {});
+    map->setTriggers({normal_trigger, custom_trigger});
+    auto restored_triggers = map->getTriggers();
+    expect_true(restored_triggers.contains(normal_trigger) && !restored_triggers.contains(custom_trigger),
+                "getTriggers should omit custom trigger callbacks from serialized trigger snapshots");
+}
+
+void test_map_move_interrupts_invalid_planned_steps() {
+    auto game = CGameLoader::loadGame();
+    auto map = std::make_shared<CMap>();
+    game->setMap(map);
+    map->setGame(game);
+    map->setXBounds({{0, 2}});
+    map->setYBounds({{0, 2}});
+    for (int y = 0; y <= 2; ++y) {
+        for (int x = 0; x <= 2; ++x) {
+            auto tile = std::make_shared<CTile>();
+            tile->setCanStep(!(x == 2 && y == 1));
+            map->addTile(tile, x, y, 0);
+        }
+    }
+
+    auto removing_controller = std::make_shared<FixedStepController>(Coords(1, 0, 0), true);
+    auto removed_creature = test_creature(game, "removedCreature", Coords(0, 0, 0), removing_controller);
+    map->addObject(removed_creature);
+    map->move();
+    expect_true(removing_controller->interruptCount == 1,
+                "move should interrupt creatures removed before their planned step is committed");
+    expect_true(map->getObjectByName("removedCreature") == nullptr,
+                "fixture creature should have removed itself during planning");
+
+    auto blocked_controller = std::make_shared<FixedStepController>(Coords(2, 1, 0));
+    auto blocked_creature = test_creature(game, "blockedCreature", Coords(1, 1, 0), blocked_controller);
+    map->addObject(blocked_creature);
+    map->move();
+    expect_true(blocked_controller->interruptCount == 1,
+                "move should interrupt creatures whose planned step becomes blocked");
+    expect_true(blocked_controller->committedCount == 0, "blocked planned steps should not be committed");
+    expect_true(blocked_creature->getCoords() == Coords(1, 1, 0), "blocked creatures should stay in place");
+}
+
+void test_map_player_trigger_registration_is_idempotent() {
+    auto game = CGameLoader::loadGame();
+    auto map = std::make_shared<CMap>();
+    game->setMap(map);
+    map->setGame(game);
+    map->setXBounds({{0, 2}});
+    map->setYBounds({{0, 2}});
+
+    auto first_player = std::make_shared<CPlayer>();
+    first_player->setBaseStats(creature_stats());
+    auto second_player = std::make_shared<CPlayer>();
+    second_player->setBaseStats(creature_stats());
+    map->setPlayer(first_player);
+    map->setPlayer(second_player);
+    expect_true(map->getPlayer() == second_player, "setPlayer should still replace the active player");
+}
+
 void test_map_keeps_tiles_and_objects_separate_by_z() {
     auto map = std::make_shared<CMap>();
     map->setXBounds({{0, 4}, {1, 4}});
@@ -396,6 +612,9 @@ int main() {
     test_scene_manager_repeated_transitions_and_controller_usability();
     test_scene_manager_null_and_legacy_missing_target_behavior();
     test_map_tiles_bounds_wrapping_and_object_cache();
+    test_map_defensive_branches_and_strict_validation();
+    test_map_move_interrupts_invalid_planned_steps();
+    test_map_player_trigger_registration_is_idempotent();
     test_map_keeps_tiles_and_objects_separate_by_z();
     test_can_step_checks_default_tile_passability_without_materializing();
     test_animation_provider_uses_dynamic_animation_for_directory_resources();


### PR DESCRIPTION
## What changed
- Added an optional exclusion-audit mode to `scripts/coverage_report.py`, wired through `COVERAGE_AUDIT_EXCLUSIONS=1` in `scripts/run_coverage.sh`.
- Trimmed reviewed line exclusions where new native and Python coverage now exercises the paths.
- Added native regression coverage for controller, serialization, map, and trigger/strict-validation branches.
- Added Python coverage for inventory/list-view behavior, render-only widgets, animation fallback paths, and the audit writer.

## Why
- Coverage exclusions should remain reviewable and narrow, with stale or accidentally covered exclusions visible instead of hidden in the baseline.
- The audit report gives raw hit counts and source snippets for each excluded line so future reduction passes can target the remaining exclusions.

## Validation performed
- `clang-format -i tests/unit/test_controller.cpp tests/unit/test_core.cpp tests/unit/test_map.cpp`
- `black -l 120 test.py scripts/coverage_report.py`
- `cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance`
- `python3 test.py`
- `COVERAGE_AUDIT_EXCLUSIONS=1 ./scripts/run_coverage.sh` -> `lines: 98.84% (7523 out of 7611, 771 excluded)` and audit output `771 total (89 covered, 682 uncovered)`

## Known limitations / follow-up
- The new audit report still identifies covered excluded lines. This PR makes them visible and removes a first batch; follow-up passes can continue reducing the manifest.