### PR TITLE
Fix fast suite CI path handling

### DIFF
--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -50,6 +50,33 @@ def normalize_path(path_str: str, cwd: Path) -> Path:
     return path.resolve()
 
 
+def filesystem_relative_path(root: Path, path: Path) -> Path:
+    root = root.resolve()
+    path = path.resolve()
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        matching_relative_path = relative_path_from_matching_ancestor(root, path)
+        if matching_relative_path is not None:
+            return matching_relative_path
+        raise
+
+
+def relative_path_from_matching_ancestor(root: Path, path: Path) -> Path | None:
+    suffix = []
+    current = path
+    while True:
+        try:
+            if current.samefile(root):
+                return Path(*reversed(suffix)) if suffix else Path(".")
+        except OSError:
+            return None
+        if current.parent == current:
+            return None
+        suffix.append(current.name)
+        current = current.parent
+
+
 def validate_include_prefix(root: Path, prefix_str: str) -> Path:
     root = root.resolve()
     if not isinstance(prefix_str, str) or not prefix_str:
@@ -64,7 +91,7 @@ def validate_include_prefix(root: Path, prefix_str: str) -> Path:
 
     include_path = (root / prefix).resolve()
     try:
-        include_path.relative_to(root)
+        filesystem_relative_path(root, include_path)
     except ValueError as exc:
         raise ValueError(f"coverage include prefix escapes repository root: {prefix_str}") from exc
     if not include_path.exists():
@@ -80,14 +107,14 @@ def is_included(root: Path, source_path: Path, include_prefixes=()) -> bool:
     root = root.resolve()
     try:
         resolved = source_path.resolve()
-        resolved.relative_to(root)
+        filesystem_relative_path(root, resolved)
     except ValueError:
         return False
     if not include_prefixes:
         return True
     for include_prefix in include_prefixes:
         try:
-            resolved.relative_to(include_prefix.resolve())
+            filesystem_relative_path(include_prefix, resolved)
             return True
         except ValueError:
             pass
@@ -108,7 +135,7 @@ def validate_exclusion_path(root: Path, rel_path_str: str) -> Path:
 
     source_path = (root / rel_path).resolve()
     try:
-        source_path.relative_to(root)
+        filesystem_relative_path(root, source_path)
     except ValueError as exc:
         raise ValueError(f"coverage exclusion path escapes repository root: {rel_path_str}") from exc
     if not source_path.exists():
@@ -177,7 +204,7 @@ def validate_line_exclusions(root: Path, merged, exclusions):
     root = root.resolve()
     for source_path, line_reasons in exclusions.items():
         source_path = source_path.resolve()
-        rel_path = source_path.relative_to(root)
+        rel_path = filesystem_relative_path(root, source_path)
         if source_path not in merged:
             raise ValueError(f"coverage exclusion path is stale or was not instrumented: {rel_path}")
 
@@ -285,7 +312,7 @@ def summarize(root: Path, merged, exclusions=None):
         missing = [
             line for line, count in sorted(line_counts.items()) if line > 0 and line not in excluded_set and count == 0
         ]
-        rel_path = source_path.resolve().relative_to(root)
+        rel_path = filesystem_relative_path(root, source_path)
         summary.append(
             {
                 "path": rel_path,
@@ -383,7 +410,7 @@ def build_exclusion_audit(root: Path, merged, exclusions):
             snippet = source_lines[line_number - 1].strip() if line_number <= len(source_lines) else ""
             lines.append(
                 {
-                    "path": source_path.relative_to(root).as_posix(),
+                    "path": filesystem_relative_path(root, source_path).as_posix(),
                     "line": line_number,
                     "count": count,
                     "covered": count > 0,

--- a/test.py
+++ b/test.py
@@ -123,7 +123,6 @@ XVFB_GAMEPLAY_PARENT_TEST = "XvfbGameplayTest.test_keyboard_gameplay_under_xvfb"
 VALID_TEST_SUITES = ("fast", "gameplay", "ui", "coverage-safe", "full")
 FAST_TEST_PREFIXES = (
     "CoverageReportTest.",
-    "PanelLayoutManifestTest.",
     "PlayBootstrapTest.",
     "TestRunnerSuiteTest.",
 )
@@ -136,6 +135,7 @@ FAST_TEST_NAMES = {
     "McpServerTest.test_map_design_brief_rejects_path_traversal",
     "McpServerTest.test_serialize_result_lists_python_methods_for_handles",
     "McpServerTest.test_stdio_batch_handles_initialize_and_tool_listing",
+    "PanelLayoutManifestTest.test_panel_layout_manifest_matches_panels_json",
 }
 GAMEPLAY_TEST_PREFIXES = (
     "ConsoleEventIsolationTest.",
@@ -13397,10 +13397,12 @@ class CoverageReportTest(unittest.TestCase):
             exclusions = coverage_report.load_line_exclusions(alias_root, manifest_path)
             coverage_report.validate_line_exclusions(alias_root, merged, exclusions)
             summary, covered, total, percentage, excluded = coverage_report.summarize(alias_root, merged, exclusions)
+            audit = coverage_report.build_exclusion_audit(alias_root, merged, exclusions)
 
             self.assertEqual(set(merged), {source.resolve()})
             self.assertEqual((covered, total, percentage, excluded), (1, 1, 100.0, 1))
             self.assertEqual(summary[0]["path"], Path("src/sample.cpp"))
+            self.assertEqual(["src/sample.cpp"], [line["path"] for line in audit["lines"]])
 
     def test_coverage_line_exclusions_fail_closed(self):
         coverage_report = self._load_coverage_report_module()
@@ -13531,7 +13533,10 @@ class TestRunnerSuiteTest(unittest.TestCase):
             filter_test_names_by_suite(sample_names, "gameplay"),
         )
         self.assertEqual(
-            ["PanelLayoutManifestTest.test_panel_layout_manifest_matches_panels_json", XVFB_GAMEPLAY_PARENT_TEST],
+            [
+                "PanelLayoutManifestTest.test_panel_layout_manifest_matches_panels_json",
+                XVFB_GAMEPLAY_PARENT_TEST,
+            ],
             filter_test_names_by_suite(sample_names, "ui"),
         )
         self.assertEqual(sample_names, filter_test_names_by_suite(sample_names, "coverage-safe"))


### PR DESCRIPTION
## What changed

- Split the panel layout manifest test so the build-free fast suite keeps only JSON manifest validation.
- Kept the `_game` binding smoke in the UI/full runtime suite where the native module is available.
- Made bootstrap path assertions compare filesystem identity instead of exact string spelling.
- Made coverage report root-relative path handling tolerate existing path aliases such as Windows short/long user-profile paths.

## Why

The merged queue overlay PR #402 exposed existing CI failures in the pre-build fast suite:

- `PanelLayoutManifestTest.test_panel_layout_manifest_matches_panels_json` imported `_game` before CI built the native extension.
- Windows fast tests compared equivalent temp paths with different spellings.
- Coverage exclusion audit path rendering used lexical `Path.relative_to(...)`, which failed across equivalent path aliases.

## Validation

- `python3 -m py_compile test.py scripts/coverage_report.py`
- `timeout 180s black -l 120 test.py scripts/coverage_report.py`
- `GAME_BUILD_DIR=/tmp/no-such-game-build python3 test.py --suite fast`
- `python3 test.py PanelLayoutManifestTest.test_panel_layout_runtime_binding_smoke`
- `cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance`
- `python3 test.py`
- `./scripts/run_coverage.sh` (`lines: 95.85%`)
- `python3 test.py CoverageReportTest.test_coverage_paths_accept_noncanonical_root CoverageReportTest.test_coverage_exclusion_audit_reports_raw_counts_and_snippets TestRunnerSuiteTest.test_suite_filters_keep_runtime_groups_distinct`

## Known limitations

- This is a focused CI follow-up for #402. It does not change the queue overlay content.
