### PR TITLE
Add deterministic game simulation API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,7 @@ configure_file(res/game.py game.py)
 configure_file(test.py test.py)
 configure_file(play.py play.py)
 configure_file(mcp.py mcp.py)
+configure_file(game_simulation.py game_simulation.py)
 
 install(TARGETS game_core _game DESTINATION fall-of-nouraajd)
 install(TARGETS ${NATIVE_PLUGIN_TARGETS}
@@ -478,7 +479,7 @@ install(DIRECTORY res/images DESTINATION fall-of-nouraajd)
 install(DIRECTORY res/maps DESTINATION fall-of-nouraajd)
 install(DIRECTORY res/plugins DESTINATION fall-of-nouraajd)
 
-install(FILES res/game.py play.py mcp.py test.py DESTINATION fall-of-nouraajd)
+install(FILES res/game.py play.py mcp.py test.py game_simulation.py DESTINATION fall-of-nouraajd)
 
 if (WIN32)
     install(FILES play.bat DESTINATION fall-of-nouraajd)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -72,6 +72,16 @@ python3 test.py --suite full
 Use `--jobs <n>` with any suite to enable the existing sharded runner, for example
 `python3 test.py --suite gameplay --jobs "$(nproc)"`.
 
+## Deterministic simulation helpers
+Use `game_simulation.py` for new Python gameplay walkthroughs that need stable setup, bounded movement, object
+interaction, map/inventory/quest inspection, GUI tree assertions, or screenshot capture callbacks. The helper raises
+`SimulationError` with the failed step and a compact current-state snapshot when a step cannot complete.
+
+Codex and MCP workflows can use the `simulation_run` MCP tool for the same high-level step model without raw handle
+or method calls. `capture_gui_screenshot` returns PNG metadata and inline base64 data for MCP callers instead of
+writing arbitrary server-side paths. Prefer this layer for new walkthrough coverage, then drop to `engine_call` or
+`engine_handle_call` only when the helper does not expose the needed engine operation.
+
 ## Native performance guards
 The deterministic native performance guard suite is built with the `performance_guard_tests` target and run through
 CTest label `performance`:

--- a/game_simulation.py
+++ b/game_simulation.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+
+# fall-of-nouraajd c++ dark fantasy game
+# Copyright (C) 2026  Andrzej Lis
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+import base64
+import binascii
+import json
+import struct
+import zlib
+from pathlib import Path
+
+
+class SimulationError(RuntimeError):
+    def __init__(self, step, message, state=None):
+        self.step = step
+        self.message = message
+        self.state = state or {}
+        rendered_state = json.dumps(self.state, sort_keys=True, default=str)
+        super().__init__(f"{step}: {message}; current_state={rendered_state}")
+
+    def asDict(self):
+        return {
+            "step": self.step,
+            "error": self.message,
+            "state": self.state,
+        }
+
+
+def runSimulation(game_module, map_name, player_class="Warrior", load_gui=False, steps=None):
+    simulation = GameSimulation.startGame(
+        game_module,
+        map_name,
+        player_class=player_class,
+        load_gui=load_gui,
+    )
+    return simulation.runSteps(steps or [])
+
+
+class GameSimulation:
+    def __init__(self, game_module, game_instance, map_name, player_class):
+        self.gameModule = game_module
+        self.gameInstance = game_instance
+        self.mapName = map_name
+        self.playerClass = player_class
+        self.gameMap = None
+        self.player = None
+        self.refreshHandles()
+
+    @classmethod
+    def startGame(cls, game_module, map_name, player_class="Warrior", load_gui=False):
+        game_instance = game_module.CGameLoader.loadGame()
+        if load_gui:
+            game_module.CGameLoader.loadGui(game_instance)
+        game_module.CGameLoader.startGameWithPlayer(game_instance, map_name, player_class)
+        simulation = cls(game_module, game_instance, map_name, player_class)
+        simulation.pumpEvents(5 if load_gui else 1)
+        return simulation
+
+    def refreshHandles(self):
+        self.gameMap = self.gameInstance.getMap()
+        self.player = self.gameMap.getPlayer()
+        return self
+
+    def fail(self, step, message):
+        raise SimulationError(step, message, self.safeState())
+
+    def safeState(self):
+        try:
+            return self.readMapState(include_objects=True, max_objects=20)
+        except Exception as exc:
+            return {"state_error": str(exc), "map": self.mapName, "playerClass": self.playerClass}
+
+    def pumpEvents(self, times=1, drain=False, max_iterations=100):
+        loop = self.gameModule.event_loop.instance()
+        minimum_iterations = max(int(times), 0)
+        max_iterations = max(int(max_iterations), minimum_iterations)
+        iterations = 0
+        for _ in range(minimum_iterations):
+            loop.run()
+            iterations += 1
+        while drain and iterations < max_iterations and loop.run():
+            iterations += 1
+        self.refreshHandles()
+        return {"pumped": iterations, "drain": bool(drain), "turn": self.gameMap.getTurn()}
+
+    def advanceTurns(self, turns):
+        turns = max(int(turns), 0)
+        for _ in range(turns):
+            self.gameMap.move()
+            self.pumpEvents(1)
+        return {"turns": turns, "turn": self.gameMap.getTurn(), "player": self.playerSummary()}
+
+    def objectByName(self, object_name):
+        obj = self.gameMap.getObjectByName(object_name)
+        if obj is None:
+            self.fail("objectByName", f"Could not find object `{object_name}`.")
+        return obj
+
+    def objectsByType(self, type_name):
+        return [
+            obj
+            for obj in self.gameMap.getObjects()
+            if self._safeCall(obj, "getTypeId") == type_name or self._safeCall(obj, "getType") == type_name
+        ]
+
+    def moveToCoords(self, x, y, z=0, max_turns=24, mode="path"):
+        coords = self.gameModule.Coords(int(x), int(y), int(z))
+        start = self.coordsDict(self.player.getCoords())
+        if mode == "direct":
+            self.player.setCoords(coords)
+            self.pumpEvents(1)
+            return {
+                "mode": mode,
+                "from": start,
+                "to": self.coordsDict(self.player.getCoords()),
+                "turn": self.gameMap.getTurn(),
+            }
+        if mode != "path":
+            self.fail("moveToCoords", f"Unknown movement mode `{mode}`.")
+
+        controller = self.player.getController()
+        if not hasattr(controller, "setTarget"):
+            self.fail("moveToCoords", f"Player controller cannot set a deterministic target: {type(controller)!r}.")
+        controller.setTarget(self.player, coords)
+
+        target = self.coordsDict(coords)
+        for turn_index in range(max(int(max_turns), 0) + 1):
+            if self.coordsDict(self.player.getCoords()) == target:
+                return {
+                    "mode": mode,
+                    "from": start,
+                    "to": target,
+                    "turns": turn_index,
+                    "turn": self.gameMap.getTurn(),
+                }
+            if turn_index == max(int(max_turns), 0):
+                break
+            self.gameMap.move()
+            self.pumpEvents(1)
+
+        self.fail(
+            "moveToCoords",
+            f"Player did not reach {target} from {start} within {max_turns} bounded turns.",
+        )
+
+    def moveToObject(self, object_name, max_turns=24, mode="path"):
+        obj = self.objectByName(object_name)
+        coords = obj.getCoords()
+        result = self.moveToCoords(coords.x, coords.y, coords.z, max_turns=max_turns, mode=mode)
+        result["object"] = self.objectSummary(obj)
+        return result
+
+    def interactWithObject(self, object_name, mode="remove", approach=True, move_mode="direct", max_turns=24):
+        obj = self.objectByName(object_name)
+        before = self.objectSummary(obj)
+        approach_result = None
+        if mode in {"remove", "destroy"}:
+            if approach:
+                coords = obj.getCoords()
+                approach_coords = self._interactionCoords(coords)
+                if move_mode == "direct":
+                    start = self.coordsDict(self.player.getCoords())
+                    self.player.setCoords(approach_coords)
+                    approach_result = {
+                        "mode": move_mode,
+                        "from": start,
+                        "to": self.coordsDict(self.player.getCoords()),
+                        "target": self.coordsDict(coords),
+                        "distance": self._distance(self.player.getCoords(), coords),
+                    }
+                else:
+                    approach_result = self.moveToCoords(
+                        approach_coords.x,
+                        approach_coords.y,
+                        approach_coords.z,
+                        max_turns=max_turns,
+                        mode=move_mode,
+                    )
+                    approach_result["target"] = self.coordsDict(coords)
+                    approach_result["distance"] = self._distance(self.player.getCoords(), coords)
+            runtime_name = self._safeCall(obj, "getName") or object_name
+            self.gameMap.removeObjectByName(runtime_name)
+        elif mode == "enter":
+            coords = obj.getCoords()
+            approach_result = self.moveToCoords(coords.x, coords.y, coords.z, max_turns=max_turns, mode=move_mode)
+        else:
+            self.fail("interactWithObject", f"Unknown interaction mode `{mode}`.")
+        self.pumpEvents(3)
+        return {
+            "mode": mode,
+            "approach": approach_result,
+            "object": before,
+            "state": self.readMapState(include_objects=False),
+        }
+
+    def openPanel(self, panel_name):
+        panel = self.gameInstance.getGuiHandler().openPanel(panel_name)
+        self.pumpEvents(3)
+        return {
+            "panel": self.objectSummary(panel),
+            "guiClasses": sorted(self.guiClasses()),
+        }
+
+    def readQuestLog(self):
+        return {
+            "active": [self.questSummary(quest) for quest in self._safeCollection(self.player.getQuests)],
+            "completed": [self.questSummary(quest) for quest in self._safeCollection(self.player.getCompletedQuests)],
+        }
+
+    def readInventory(self):
+        items = [self.itemSummary(item) for item in self._safeCollection(self.player.getItems)]
+        items.sort(key=lambda item: (item.get("typeId") or "", item.get("name") or ""))
+        return items
+
+    def hasInventoryItem(self, item_name):
+        for item in self.readInventory():
+            if item.get("name") == item_name or item.get("typeId") == item_name:
+                return True
+        return False
+
+    def readMapState(
+        self,
+        include_objects=True,
+        max_objects=80,
+        bool_flags=None,
+        string_properties=None,
+        numeric_properties=None,
+    ):
+        self.refreshHandles()
+        state = {
+            "map": self._mapName(),
+            "playerClass": self.playerClass,
+            "turn": self.gameMap.getTurn(),
+            "player": self.playerSummary(),
+        }
+        if include_objects:
+            objects = [self.objectSummary(obj) for obj in self.gameMap.getObjects()]
+            objects.sort(key=lambda item: (item.get("name") or "", item.get("typeId") or "", str(item.get("coords"))))
+            state["objects"] = objects[: max(int(max_objects), 0)]
+            state["objectCount"] = len(objects)
+        if bool_flags:
+            state["boolFlags"] = {name: self.gameMap.getBoolProperty(name) for name in bool_flags}
+        if string_properties:
+            state["stringProperties"] = {name: self.gameMap.getStringProperty(name) for name in string_properties}
+        if numeric_properties:
+            state["numericProperties"] = {name: self.gameMap.getNumericProperty(name) for name in numeric_properties}
+        return state
+
+    def readGuiTree(self):
+        gui = self.gameInstance.getGui()
+        if gui is None:
+            self.fail("readGuiTree", "Game has no GUI. Start with load_gui=True before reading GUI state.")
+        return json.loads(self.gameModule.jsonify(gui))
+
+    def guiClasses(self):
+        tree = self.readGuiTree()
+        classes = set()
+
+        def visit(node):
+            if not isinstance(node, dict):
+                return
+            class_name = node.get("class")
+            if class_name:
+                classes.add(class_name)
+            for child in node.get("properties", {}).get("children") or []:
+                visit(child)
+
+        visit(tree)
+        return classes
+
+    def guiContainsClass(self, class_name):
+        return class_name in self.guiClasses()
+
+    def captureGuiScreenshot(self, path=None, capture_func=None, include_base64=False):
+        gui = self.gameInstance.getGui()
+        if gui is None:
+            self.fail("captureGuiScreenshot", "Game has no GUI. Start with load_gui=True before capturing screenshots.")
+
+        path = Path(path) if path else None
+        png_data = None
+        width = None
+        height = None
+        if capture_func is None:
+            read_pixels = getattr(gui, "read_pixels", None) or getattr(gui, "readPixels", None)
+            if read_pixels is None:
+                self.fail("captureGuiScreenshot", "GUI does not expose pixel readback and no callback was provided.")
+            pixels, width, height = read_pixels()
+            png_data = self._encodePng(bytes(pixels), int(width), int(height))
+            if path is not None:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(png_data)
+        else:
+            if path is None:
+                self.fail("captureGuiScreenshot", "A screenshot path is required when using a capture callback.")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            result = capture_func(path, gui)
+            if isinstance(result, (list, tuple)) and len(result) >= 3 and isinstance(result[1], int):
+                width = int(result[1])
+                height = int(result[2])
+
+        if path is not None:
+            if not path.exists() or path.stat().st_size <= 0:
+                self.fail("captureGuiScreenshot", f"Screenshot capture did not write a non-empty file: {path}.")
+            info = {
+                "path": str(path),
+                "suffix": path.suffix,
+                "bytes": path.stat().st_size,
+            }
+            if path.suffix.lower() == ".png":
+                width, height = self._pngDimensions(path.read_bytes())
+        else:
+            info = {"suffix": ".png", "bytes": len(png_data)}
+
+        if width is not None and height is not None:
+            info["width"] = width
+            info["height"] = height
+        if include_base64 or path is None:
+            if png_data is None:
+                png_data = path.read_bytes()
+            info["pngBase64"] = base64.b64encode(png_data).decode("ascii")
+        return info
+
+    def runSteps(self, steps):
+        records = []
+        for index, step in enumerate(steps, start=1):
+            records.append(self.runStep(step, index))
+        return {
+            "map": self._mapName(),
+            "playerClass": self.playerClass,
+            "steps": records,
+            "state": self.readMapState(include_objects=True, max_objects=40),
+            "questLog": self.readQuestLog(),
+            "inventory": self.readInventory(),
+        }
+
+    def runStep(self, step, index):
+        if not isinstance(step, dict):
+            raise SimulationError(f"{index}:invalid", "Simulation steps must be objects.", self.safeState())
+        action = step.get("action")
+        label = step.get("name") or f"{index}:{action}"
+        try:
+            result = self._runStepAction(step, action)
+            return {"step": label, "action": action, "result": result}
+        except SimulationError as exc:
+            raise SimulationError(label, exc.message, exc.state) from exc
+        except Exception as exc:
+            raise SimulationError(label, str(exc), self.safeState()) from exc
+
+    def _runStepAction(self, step, action):
+        if action == "move_to_coords":
+            coords = step.get("coords")
+            if isinstance(coords, dict):
+                x, y, z = coords.get("x"), coords.get("y"), coords.get("z", 0)
+            elif isinstance(coords, (list, tuple)) and len(coords) in {2, 3}:
+                x, y = coords[0], coords[1]
+                z = coords[2] if len(coords) == 3 else 0
+            else:
+                x, y, z = step.get("x"), step.get("y"), step.get("z", 0)
+            return self.moveToCoords(
+                x,
+                y,
+                z,
+                max_turns=step.get("max_turns", 24),
+                mode=step.get("mode", "path"),
+            )
+        if action == "move_to_object":
+            return self.moveToObject(
+                step.get("object"),
+                max_turns=step.get("max_turns", 24),
+                mode=step.get("mode", "path"),
+            )
+        if action == "interact_object":
+            return self.interactWithObject(
+                step.get("object"),
+                mode=step.get("mode", "remove"),
+                approach=step.get("approach", True),
+                move_mode=step.get("move_mode", "direct"),
+                max_turns=step.get("max_turns", 24),
+            )
+        if action == "advance_turns":
+            return self.advanceTurns(step.get("turns", 1))
+        if action == "pump_events":
+            return self.pumpEvents(
+                step.get("times", 1),
+                drain=step.get("drain", False),
+                max_iterations=step.get("max_iterations", 100),
+            )
+        if action == "open_panel":
+            return self.openPanel(step.get("panel"))
+        if action == "read_quest_log":
+            return self.readQuestLog()
+        if action == "read_inventory":
+            return self.readInventory()
+        if action == "read_map_state":
+            return self.readMapState(
+                include_objects=step.get("include_objects", True),
+                max_objects=step.get("max_objects", 80),
+                bool_flags=step.get("bool_flags"),
+                string_properties=step.get("string_properties"),
+                numeric_properties=step.get("numeric_properties"),
+            )
+        if action == "read_gui_tree":
+            return self.readGuiTree()
+        if action == "capture_gui_screenshot":
+            return self.captureGuiScreenshot(
+                step.get("path"),
+                include_base64=step.get("include_base64", False),
+            )
+        if action == "assert_map_bool":
+            name = step.get("property") or step.get("name")
+            expected = step.get("value", True)
+            actual = self.gameMap.getBoolProperty(name)
+            if actual != expected:
+                self.fail("assert_map_bool", f"Expected map bool `{name}` to be {expected}, got {actual}.")
+            return {"property": name, "value": actual}
+        if action == "assert_inventory_contains":
+            item = step.get("item")
+            if not self.hasInventoryItem(item):
+                self.fail("assert_inventory_contains", f"Inventory does not contain `{item}`.")
+            return {"item": item, "present": True}
+        if action == "assert_gui_contains_class":
+            class_name = step.get("class")
+            if not self.guiContainsClass(class_name):
+                self.fail("assert_gui_contains_class", f"GUI tree does not contain `{class_name}`.")
+            return {"class": class_name, "present": True}
+        self.fail("runStep", f"Unknown simulation action `{action}`.")
+
+    def playerSummary(self):
+        summary = self.objectSummary(self.player)
+        summary["gold"] = self._safeCall(self.player, "getGold")
+        summary["level"] = self._safeCall(self.player, "getLevel")
+        summary["hpRatio"] = self._safeCall(self.player, "getHpRatio")
+        return summary
+
+    def objectSummary(self, obj):
+        if obj is None:
+            return None
+        coords = self._safeCall(obj, "getCoords")
+        return {
+            "class": obj.__class__.__name__,
+            "name": self._safeCall(obj, "getName"),
+            "type": self._safeCall(obj, "getType"),
+            "typeId": self._safeCall(obj, "getTypeId"),
+            "label": self._safeCall(obj, "getLabel"),
+            "coords": self.coordsDict(coords) if coords is not None else None,
+        }
+
+    def itemSummary(self, item):
+        return {
+            "name": self._safeCall(item, "getName"),
+            "typeId": self._safeCall(item, "getTypeId"),
+            "label": self._safeCall(item, "getLabel"),
+            "description": self._safeCall(item, "getDescription"),
+        }
+
+    def questSummary(self, quest):
+        return {
+            "name": self._safeCall(quest, "getName"),
+            "typeId": self._safeCall(quest, "getTypeId"),
+            "objective": self._safeCall(quest, "getObjective"),
+            "reward": self._safeCall(quest, "getReward"),
+            "hint": self._safeCall(quest, "getHint"),
+        }
+
+    @staticmethod
+    def coordsDict(coords):
+        return {"x": coords.x, "y": coords.y, "z": coords.z}
+
+    def _interactionCoords(self, coords):
+        candidates = (
+            (0, 1, 0),
+            (1, 0, 0),
+            (-1, 0, 0),
+            (0, -1, 0),
+            (0, 0, 0),
+        )
+        for dx, dy, dz in candidates:
+            candidate = self.gameModule.Coords(coords.x + dx, coords.y + dy, coords.z + dz)
+            if self._safeCall(self.gameMap, "canStep", candidate):
+                return candidate
+        return coords
+
+    @staticmethod
+    def _distance(left, right):
+        return abs(left.x - right.x) + abs(left.y - right.y) + abs(left.z - right.z)
+
+    @staticmethod
+    def _encodePng(rgba_data, width, height):
+        if width <= 0 or height <= 0:
+            raise ValueError(f"Invalid screenshot dimensions: {width}x{height}.")
+        pitch = width * 4
+        if len(rgba_data) != pitch * height:
+            raise ValueError(
+                f"Screenshot pixel buffer has {len(rgba_data)} bytes, expected {pitch * height} for {width}x{height}."
+            )
+
+        def chunk(name, data):
+            name = name.encode("ascii")
+            crc = binascii.crc32(name + data) & 0xFFFFFFFF
+            return struct.pack(">I", len(data)) + name + data + struct.pack(">I", crc)
+
+        rows = b"".join(b"\x00" + rgba_data[row * pitch : (row + 1) * pitch] for row in range(height))
+        header = struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)
+        return b"\x89PNG\r\n\x1a\n" + chunk("IHDR", header) + chunk("IDAT", zlib.compress(rows)) + chunk("IEND", b"")
+
+    @staticmethod
+    def _pngDimensions(data):
+        if not data.startswith(b"\x89PNG\r\n\x1a\n"):
+            raise ValueError("Screenshot file is not a PNG.")
+        if len(data) < 33 or data[12:16] != b"IHDR":
+            raise ValueError("Screenshot PNG is missing an IHDR chunk.")
+        if struct.unpack(">I", data[8:12])[0] != 13:
+            raise ValueError("Screenshot PNG has an invalid IHDR chunk.")
+        width, height = struct.unpack(">II", data[16:24])
+        if width <= 0 or height <= 0:
+            raise ValueError(f"Screenshot PNG has invalid dimensions: {width}x{height}.")
+        return width, height
+
+    def _mapName(self):
+        name = getattr(self.gameMap, "mapName", None)
+        return name or self._safeCall(self.gameMap, "getName") or self.mapName
+
+    @staticmethod
+    def _safeCollection(fn):
+        try:
+            return list(fn())
+        except Exception:
+            return []
+
+    @staticmethod
+    def _safeCall(obj, method_name, *args):
+        if obj is None:
+            return None
+        method = getattr(obj, method_name, None)
+        if method is None:
+            return None
+        try:
+            return method(*args)
+        except Exception:
+            return None

--- a/mcp.py
+++ b/mcp.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
+import game_simulation
+
 JSONRPC_VERSION = "2.0"
 SERVER_NAME = "fall-of-nouraajd-engine-mcp"
 SERVER_TITLE = "Fall of Nouraajd Engine MCP"
@@ -963,6 +965,57 @@ class EngineMcpServer:
                 },
             },
             {
+                "name": "simulation_run",
+                "title": "Run deterministic game simulation",
+                "description": (
+                    "Start a game and execute bounded high-level simulation steps for Codex/MCP walkthroughs."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "map": {"type": "string"},
+                        "player_class": {"type": "string", "default": "Warrior"},
+                        "load_gui": {"type": "boolean", "default": False},
+                        "steps": {
+                            "type": "array",
+                            "default": [],
+                            "items": {"type": "object"},
+                            "maxItems": 100,
+                        },
+                    },
+                    "required": ["map"],
+                    "additionalProperties": False,
+                },
+                "outputSchema": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "map": {"type": "string"},
+                                "playerClass": {"type": "string"},
+                                "steps": {"type": "array"},
+                                "state": {"type": "object"},
+                                "questLog": {"type": "object"},
+                                "inventory": {"type": "array"},
+                            },
+                            "required": ["map", "playerClass", "steps", "state", "questLog", "inventory"],
+                            "additionalProperties": False,
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "step": {"type": "string"},
+                                "error": {"type": "string"},
+                                "state": {"type": "object"},
+                                "traceback": {"type": "string"},
+                            },
+                            "required": ["step", "error"],
+                            "additionalProperties": False,
+                        },
+                    ],
+                },
+            },
+            {
                 "name": "map_design_brief",
                 "title": "Build map design brief",
                 "description": (
@@ -1087,6 +1140,17 @@ class EngineMcpServer:
                 level="info",
                 logger_name="tools",
                 data={"message": "tool call completed", "tool": tool_name},
+            )
+            return result
+
+        if tool_name == "simulation_run":
+            result = self._simulation_run(arguments)
+            self._emit_log(
+                transport=transport,
+                session_id=session_id,
+                level="info",
+                logger_name="tools",
+                data={"message": "tool call completed", "tool": tool_name, "isError": result.get("isError", False)},
             )
             return result
 
@@ -1240,6 +1304,63 @@ class EngineMcpServer:
                         "text": json.dumps(error_payload, ensure_ascii=False),
                     }
                 ],
+                "structuredContent": error_payload,
+                "isError": True,
+            }
+
+    def _simulation_run(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        map_name = arguments.get("map")
+        player_class = arguments.get("player_class", "Warrior")
+        load_gui = arguments.get("load_gui", False)
+        steps = arguments.get("steps", [])
+
+        if self.game_module is None:
+            raise ProtocolError(-32603, "simulation_run requires imported game modules")
+        if not isinstance(map_name, str) or not map_name:
+            raise ProtocolError(-32602, "simulation_run requires non-empty string `map`")
+        if not isinstance(player_class, str) or not player_class:
+            raise ProtocolError(-32602, "simulation_run `player_class` must be a non-empty string")
+        if not isinstance(load_gui, bool):
+            raise ProtocolError(-32602, "simulation_run `load_gui` must be a boolean")
+        if not isinstance(steps, list):
+            raise ProtocolError(-32602, "simulation_run `steps` must be an array")
+        if len(steps) > 100:
+            raise ProtocolError(-32602, "simulation_run accepts at most 100 steps")
+        for step in steps:
+            if isinstance(step, dict) and step.get("action") == "capture_gui_screenshot" and step.get("path"):
+                raise ProtocolError(
+                    -32602,
+                    "simulation_run capture_gui_screenshot returns screenshot data inline; file paths are not allowed",
+                )
+
+        try:
+            structured = game_simulation.runSimulation(
+                self.game_module,
+                map_name,
+                player_class=player_class,
+                load_gui=load_gui,
+                steps=steps,
+            )
+            return {
+                "content": [{"type": "text", "text": json.dumps(structured, ensure_ascii=False)}],
+                "structuredContent": structured,
+                "isError": False,
+            }
+        except game_simulation.SimulationError as exc:
+            error_payload = exc.asDict()
+            return {
+                "content": [{"type": "text", "text": json.dumps(error_payload, ensure_ascii=False)}],
+                "structuredContent": error_payload,
+                "isError": True,
+            }
+        except Exception as exc:
+            error_payload = {
+                "step": "simulation_run",
+                "error": str(exc),
+                "traceback": traceback.format_exc(limit=10),
+            }
+            return {
+                "content": [{"type": "text", "text": json.dumps(error_payload, ensure_ascii=False)}],
                 "structuredContent": error_payload,
                 "isError": True,
             }

--- a/test.py
+++ b/test.py
@@ -38,6 +38,7 @@ from http import HTTPStatus
 from pathlib import Path
 import unittest
 
+import game_simulation
 import mcp
 
 REPO_ROOT = Path(__file__).resolve().parent
@@ -10354,6 +10355,126 @@ class GameTest(unittest.TestCase):
         return missing_tests == [], json.dumps(summary)
 
     @game_test
+    def test_game_simulation_nouraajd_quest_walkthrough(self):
+        simulation = game_simulation.GameSimulation.startGame(load_game_module(), "nouraajd", DEFAULT_PLAYER)
+        result = simulation.runSteps(
+            [
+                {"action": "interact_object", "object": "cave1", "name": "recover Rolf skull"},
+                {"action": "move_to_object", "object": "nouraajdSign", "mode": "direct", "name": "stand at gate sign"},
+                {"action": "interact_object", "object": "gooby1", "name": "defeat Gooby"},
+                {"action": "interact_object", "object": "catacombs", "name": "recover relic"},
+                {"action": "interact_object", "object": "cave2", "name": "clear OctoBogz"},
+                {"action": "assert_map_bool", "property": "completed_rolf"},
+                {"action": "assert_map_bool", "property": "completed_gooby"},
+                {"action": "assert_map_bool", "property": "OCTOBOGZ_SLAIN"},
+                {"action": "assert_inventory_contains", "item": "skullOfRolf"},
+                {"action": "assert_inventory_contains", "item": "holyRelic"},
+            ]
+        )
+
+        flag_state = simulation.readMapState(
+            include_objects=False,
+            bool_flags=["completed_rolf", "completed_gooby", "OCTOBOGZ_SLAIN"],
+            string_properties=["quest_state_rolf", "quest_state_main", "quest_state_beren_chain"],
+        )
+        summary = {
+            "steps": [step["step"] for step in result["steps"]],
+            "approaches": [
+                step["result"].get("approach") for step in result["steps"] if step["action"] == "interact_object"
+            ],
+            "flags": flag_state["boolFlags"],
+            "quest_states": flag_state["stringProperties"],
+            "inventory": [item["name"] for item in simulation.readInventory()],
+            "quest_log": simulation.readQuestLog(),
+        }
+        ok = (
+            flag_state["boolFlags"]["completed_rolf"]
+            and flag_state["boolFlags"]["completed_gooby"]
+            and flag_state["boolFlags"]["OCTOBOGZ_SLAIN"]
+            and "skullOfRolf" in summary["inventory"]
+            and "holyRelic" in summary["inventory"]
+            and flag_state["stringProperties"]["quest_state_rolf"] == "skull_recovered"
+            and flag_state["stringProperties"]["quest_state_main"] == "gooby_slain"
+            and all(
+                step["result"].get("approach")
+                and step["result"]["approach"]["target"] == step["result"]["object"]["coords"]
+                and step["result"]["approach"]["distance"] <= 1
+                for step in result["steps"]
+                if step["action"] == "interact_object"
+            )
+        )
+        return ok, json.dumps(summary, sort_keys=True)
+
+    @game_test
+    def test_game_simulation_gui_tree_and_screenshot_helpers(self):
+        simulation = game_simulation.GameSimulation.startGame(
+            load_game_module(),
+            "test",
+            DEFAULT_PLAYER,
+            load_gui=True,
+        )
+        panel_result = simulation.openPanel("inventoryPanel")
+        screenshot_path = TEST_OUTPUT_DIR / "simulation_inventory_panel.png"
+
+        def write_test_screenshot(path, _gui):
+            from PIL import Image
+
+            Image.new("RGBA", (320, 200), (31, 47, 63, 255)).save(path)
+            return None, 320, 200
+
+        screenshot = simulation.captureGuiScreenshot(screenshot_path, write_test_screenshot)
+        from PIL import Image
+
+        with Image.open(screenshot_path) as image:
+            image.load()
+            loaded_size = image.size
+        inline_screenshot = simulation.runSteps(
+            [{"action": "capture_gui_screenshot", "name": "capture inline screenshot"}]
+        )["steps"][0]["result"]
+        ok = (
+            "CGameInventoryPanel" in panel_result["guiClasses"]
+            and simulation.guiContainsClass("CGameInventoryPanel")
+            and screenshot["suffix"] == ".png"
+            and screenshot["bytes"] > 0
+            and screenshot["width"] == 320
+            and screenshot["height"] == 200
+            and loaded_size == (320, 200)
+            and inline_screenshot["suffix"] == ".png"
+            and inline_screenshot["bytes"] > 0
+            and inline_screenshot["width"] > 0
+            and inline_screenshot["height"] > 0
+            and len(inline_screenshot["pngBase64"]) > 0
+        )
+        return ok, json.dumps(
+            {
+                "panel": panel_result,
+                "screenshot": screenshot,
+                "inline_screenshot": {
+                    key: (len(value) if key == "pngBase64" else value) for key, value in inline_screenshot.items()
+                },
+            },
+            sort_keys=True,
+        )
+
+    @game_test
+    def test_game_simulation_errors_include_step_and_state(self):
+        simulation = game_simulation.GameSimulation.startGame(load_game_module(), "test", DEFAULT_PLAYER)
+        try:
+            simulation.runSteps(
+                [{"action": "move_to_object", "object": "missingSimulationTarget", "name": "missing target"}]
+            )
+        except game_simulation.SimulationError as exc:
+            payload = exc.asDict()
+            ok = (
+                payload["step"] == "missing target"
+                and "missingSimulationTarget" in payload["error"]
+                and payload["state"].get("map") == "test"
+                and "player" in payload["state"]
+            )
+            return ok, json.dumps(payload, sort_keys=True)
+        return False, "SimulationError was not raised"
+
+    @game_test
     def test_json_validity(self):
         errors = []
         for path in (REPO_ROOT / "res").rglob("*.json"):
@@ -13514,6 +13635,53 @@ class McpServerTest(unittest.TestCase):
         }
         self.assertTrue({"getTransitionStateName", "requestMapChange"}.issubset(method_names))
 
+    def test_simulation_run_tool_executes_nouraajd_steps(self):
+        server = mcp.EngineMcpServer(repo_root=REPO_ROOT, build_dir=build_dir)
+        server.import_modules()
+
+        result = server._call_tool(
+            {
+                "name": "simulation_run",
+                "arguments": {
+                    "map": "nouraajd",
+                    "player_class": DEFAULT_PLAYER,
+                    "steps": [
+                        {"action": "interact_object", "object": "cave1", "name": "recover Rolf skull"},
+                        {"action": "interact_object", "object": "gooby1", "name": "defeat Gooby"},
+                        {"action": "interact_object", "object": "catacombs", "name": "recover relic"},
+                        {"action": "interact_object", "object": "cave2", "name": "clear OctoBogz"},
+                        {
+                            "action": "read_map_state",
+                            "include_objects": False,
+                            "bool_flags": ["completed_rolf", "completed_gooby", "OCTOBOGZ_SLAIN"],
+                        },
+                        {"action": "assert_inventory_contains", "item": "skullOfRolf"},
+                        {"action": "assert_inventory_contains", "item": "holyRelic"},
+                    ],
+                },
+            },
+            transport="stdio",
+            session_id=None,
+        )
+
+        self.assertFalse(result["isError"], result["structuredContent"])
+        structured = result["structuredContent"]
+        self.assertEqual("nouraajd", structured["map"])
+        inventory_names = {item["name"] for item in structured["inventory"]}
+        self.assertTrue({"skullOfRolf", "holyRelic"}.issubset(inventory_names))
+        self.assertTrue(
+            all(
+                step["result"].get("approach")
+                and step["result"]["approach"]["target"] == step["result"]["object"]["coords"]
+                and step["result"]["approach"]["distance"] <= 1
+                for step in structured["steps"][:4]
+            )
+        )
+        flag_step = structured["steps"][4]["result"]["boolFlags"]
+        self.assertTrue(flag_step["completed_rolf"])
+        self.assertTrue(flag_step["completed_gooby"])
+        self.assertTrue(flag_step["OCTOBOGZ_SLAIN"])
+
     def test_engine_call_resolves_handle_arguments_for_python_methods(self):
         server = self.make_stub_server()
 
@@ -13667,7 +13835,7 @@ class McpServerTest(unittest.TestCase):
         self.assertEqual(batch_response[0].get("id"), 2)
         tools = batch_response[0].get("result", {}).get("tools", [])
         tool_names = {tool.get("name") for tool in tools}
-        self.assertTrue({"engine_list", "engine_call", "engine_handle_call"}.issubset(tool_names))
+        self.assertTrue({"engine_list", "engine_call", "engine_handle_call", "simulation_run"}.issubset(tool_names))
 
     def test_map_design_brief_summarizes_selected_map_hooks(self):
         server = self.make_stub_server()
@@ -13850,7 +14018,7 @@ class McpServerTest(unittest.TestCase):
             self.assertEqual(tools_response.get("id"), 2)
             tools = tools_response.get("result", {}).get("tools", [])
             tool_names = {tool.get("name") for tool in tools}
-            self.assertTrue({"engine_list", "engine_call", "engine_handle_call"}.issubset(tool_names))
+            self.assertTrue({"engine_list", "engine_call", "engine_handle_call", "simulation_run"}.issubset(tool_names))
 
             game_handle = self._call_tool(proc, 3, "engine_call", {"name": "CGameLoader.loadGame"})["result"]
             self._call_tool(proc, 4, "engine_call", {"name": "CGameLoader.loadGui", "args": [game_handle]})


### PR DESCRIPTION
## What changed

- Added `game_simulation.py`, a deterministic Python helper layer for starting games, selecting player classes, bounded movement, proximity-aware object interactions, quest/inventory/map reads, GUI tree inspection, and PNG screenshot capture.
- Added the MCP `simulation_run` tool so Codex/MCP workflows can execute the same simulation steps and receive structured state or step-scoped errors.
- Added regression coverage for a Nouraajd quest walkthrough, GUI tree and screenshot helpers, simulation error output, and MCP `simulation_run`.
- Packaged the helper through CMake and documented the Python and MCP entry points.

## Why

Issue #337 asks for a deterministic higher-level API for Codex and MCP tests so workflows can avoid ad hoc movement, random probing, and low-context failures.

## Validation

- `timeout 180s black -l 120 game_simulation.py mcp.py test.py`
- `python3 -m py_compile game_simulation.py mcp.py test.py`
- `git diff --check`
- `python3 test.py GameTest.test_game_simulation_nouraajd_quest_walkthrough GameTest.test_game_simulation_gui_tree_and_screenshot_helpers GameTest.test_game_simulation_errors_include_step_and_state McpServerTest.test_simulation_run_tool_executes_nouraajd_steps McpServerTest.test_stdio_batch_handles_initialize_and_tool_listing`
- `cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance`
- `python3 test.py`
- `./scripts/run_coverage.sh` - passed with `lines: 95.85% (8221 out of 8577, 715 excluded)`

## Known limitations

- Existing tests are not broadly migrated; this adds the helper layer and representative coverage so migration can happen gradually.

Fixes #337
