### PR TITLE
Extract reusable quest state helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,7 @@ configure_file(test.py test.py)
 configure_file(play.py play.py)
 configure_file(mcp.py mcp.py)
 configure_file(game_simulation.py game_simulation.py)
+configure_file(quest_state.py quest_state.py)
 
 install(TARGETS game_core _game DESTINATION fall-of-nouraajd)
 install(TARGETS ${NATIVE_PLUGIN_TARGETS}
@@ -479,7 +480,7 @@ install(DIRECTORY res/images DESTINATION fall-of-nouraajd)
 install(DIRECTORY res/maps DESTINATION fall-of-nouraajd)
 install(DIRECTORY res/plugins DESTINATION fall-of-nouraajd)
 
-install(FILES res/game.py play.py mcp.py test.py game_simulation.py DESTINATION fall-of-nouraajd)
+install(FILES res/game.py play.py mcp.py test.py game_simulation.py quest_state.py DESTINATION fall-of-nouraajd)
 
 if (WIN32)
     install(FILES play.bat DESTINATION fall-of-nouraajd)

--- a/quest_state.py
+++ b/quest_state.py
@@ -1,0 +1,154 @@
+# fall-of-nouraajd c++ dark fantasy game
+# Copyright (C) 2026  Andrzej Lis
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LegacyBoolFlag:
+    name: str
+    quest: str
+    states: tuple[str, ...] = ()
+    excluded_states: tuple[str, ...] = ()
+    predicate: object = None
+
+    def evaluate(self, state):
+        if self.predicate is not None:
+            return bool(self.predicate(state))
+        if self.excluded_states:
+            return state not in self.excluded_states
+        return state in self.states
+
+
+class QuestStateStore:
+    QUEST_KEYS = {}
+    QUEST_DEFAULTS = {}
+    QUEST_NUMERIC_DEFAULTS = {}
+    LEGACY_BOOL_FLAGS = ()
+
+    def __init__(self, game_map):
+        self.map = game_map
+
+    def is_stale(self, game_map):
+        return self.map != game_map
+
+    def key(self, quest):
+        return self.QUEST_KEYS[quest]
+
+    def get_state(self, quest):
+        state = self.map.getStringProperty(self.key(quest))
+        if not state:
+            state = self.QUEST_DEFAULTS[quest]
+            self.map.setStringProperty(self.key(quest), state)
+        return state
+
+    def set_state(self, quest, state, sync=True):
+        self.map.setStringProperty(self.key(quest), state)
+        if sync:
+            self.sync_legacy_flags()
+
+    def _set_state(self, quest, state, sync=True):
+        self.set_state(quest, state, sync=sync)
+
+    def reset_all(self):
+        for quest, state in self.QUEST_DEFAULTS.items():
+            self.map.setStringProperty(self.key(quest), state)
+        self.reset_numeric_defaults()
+        self.sync_legacy_flags()
+
+    def initialize_defaults(self):
+        changed = False
+        for quest, state in self.QUEST_DEFAULTS.items():
+            if not self.map.getStringProperty(self.key(quest)):
+                self.map.setStringProperty(self.key(quest), state)
+                changed = True
+        if changed:
+            self.reset_numeric_defaults()
+            self.sync_legacy_flags()
+        return changed
+
+    def reset_numeric_defaults(self):
+        for name, value in self.QUEST_NUMERIC_DEFAULTS.items():
+            self.map.setNumericProperty(name, value)
+
+    def sync_legacy_flags(self):
+        for flag in self.LEGACY_BOOL_FLAGS:
+            self.map.setBoolProperty(flag.name, flag.evaluate(self.get_state(flag.quest)))
+
+    def _sync_legacy_flags(self):
+        self.sync_legacy_flags()
+
+    def state_in(self, quest, states):
+        return self.get_state(quest) in states
+
+
+class TrackedQuest:
+    def __init__(self, name):
+        self._name = name
+
+    def getName(self):
+        return self._name
+
+    def getTypeId(self):
+        return self._name
+
+
+class PlayerQuestRegistry:
+    def __init__(self):
+        self._quests = {}
+
+    def reset(self, _player=None):
+        self._quests.clear()
+
+    def install_on(self, player_cls):
+        if hasattr(player_cls, "getQuests"):
+            return
+        registry = self
+
+        def get_quests(_player):
+            return list(registry._quests.values())
+
+        player_cls.getQuests = get_quests
+
+    def remember(self, quest_name):
+        self._quests[quest_name] = TrackedQuest(quest_name)
+
+
+def quest_id(quest):
+    if hasattr(quest, "getTypeId"):
+        quest_type = quest.getTypeId()
+        if quest_type:
+            return quest_type
+    return quest.getName()
+
+
+def player_has_quest(player, quest_name, registry=None):
+    if hasattr(player, "getQuests"):
+        return any(quest_id(quest) == quest_name for quest in player.getQuests())
+    if registry is not None:
+        return quest_name in registry._quests
+    return False
+
+
+def ensure_quest(player, quest_name, registry=None):
+    if player_has_quest(player, quest_name, registry=registry):
+        return False
+    player.addQuest(quest_name)
+    if registry is not None:
+        registry.remember(quest_name)
+    return True

--- a/res/game.py
+++ b/res/game.py
@@ -1,6 +1,13 @@
 from _game import *
 import json
 
+from quest_state import LegacyBoolFlag
+from quest_state import PlayerQuestRegistry
+from quest_state import QuestStateStore
+from quest_state import ensure_quest
+from quest_state import player_has_quest
+from quest_state import quest_id
+
 set_logger_sink("disabled", None)
 
 _native_configure_playtest_trace = configure_playtest_trace

--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -5,6 +5,10 @@ def load(self, context):
     from game import CPlayer
     from game import CDialog
     from game import Coords
+    from game import LegacyBoolFlag
+    from game import PlayerQuestRegistry
+    from game import QuestStateStore
+    from game import ensure_quest
     from game import register, trigger
 
     VICTOR_COURTYARD_TIMEOUT_TURNS = 75
@@ -131,48 +135,14 @@ def load(self, context):
         )
         return True
 
-    class _TrackedQuest:
-        def __init__(self, name):
-            self._name = name
-
-        def getName(self):
-            return self._name
-
-    _player_quests = {}
+    _player_quest_registry = PlayerQuestRegistry()
+    _player_quest_registry.install_on(CPlayer)
 
     def _reset_player_quests(player):
-        _player_quests.clear()
-
-    def _ensure_player_quest_api(player):
-        if not isinstance(_player_quests, dict):
-            _player_quests.clear()
-
-    def _quest_id(quest):
-        if hasattr(quest, "getTypeId"):
-            quest_id = quest.getTypeId()
-            if quest_id:
-                return quest_id
-        return quest.getName()
-
-    def _player_has_quest(player, quest_name):
-        if hasattr(player, "getQuests"):
-            return any(_quest_id(quest) == quest_name for quest in player.getQuests())
-        _ensure_player_quest_api(player)
-        return quest_name in _player_quests
+        _player_quest_registry.reset(player)
 
     def _grant_quest(player, quest_name):
-        if _player_has_quest(player, quest_name):
-            return
-        player.addQuest(quest_name)
-        if not hasattr(player, "getQuests"):
-            _player_quests[quest_name] = _TrackedQuest(quest_name)
-
-    def _python_get_quests(self):
-        _ensure_player_quest_api(self)
-        return list(_player_quests.values())
-
-    if not hasattr(CPlayer, "getQuests"):
-        CPlayer.getQuests = _python_get_quests
+        ensure_quest(player, quest_name, registry=_player_quest_registry)
 
     def _get_quest_system(game_map):
         return QuestSystem(game_map)
@@ -180,7 +150,7 @@ def load(self, context):
     def _quest_system_from(obj):
         return _get_quest_system(obj.getGame().getMap())
 
-    class QuestSystem:
+    class QuestSystem(QuestStateStore):
         QUEST_KEYS = {
             "rolf": "quest_state_rolf",
             "main": "quest_state_main",
@@ -199,116 +169,49 @@ def load(self, context):
             "victor": "not_started",
         }
 
-        def __init__(self, game_map):
-            self.map = game_map
+        QUEST_NUMERIC_DEFAULTS = {
+            "VICTOR_COURTYARD_TURN": -1,
+        }
 
-        def is_stale(self, game_map):
-            return self.map != game_map
-
-        def _key(self, quest):
-            return self.QUEST_KEYS[quest]
-
-        def get_state(self, quest):
-            state = self.map.getStringProperty(self._key(quest))
-            if not state:
-                state = self.QUEST_DEFAULTS[quest]
-                self.map.setStringProperty(self._key(quest), state)
-            return state
-
-        def _set_state(self, quest, state, sync=True):
-            self.map.setStringProperty(self._key(quest), state)
-            if sync:
-                self._sync_legacy_flags()
-
-        def reset_all(self):
-            for quest, state in self.QUEST_DEFAULTS.items():
-                self.map.setStringProperty(self._key(quest), state)
-            self.map.setNumericProperty("VICTOR_COURTYARD_TURN", -1)
-            self._sync_legacy_flags()
-
-        def initialize_defaults(self):
-            changed = False
-            for quest, state in self.QUEST_DEFAULTS.items():
-                if not self.map.getStringProperty(self._key(quest)):
-                    self.map.setStringProperty(self._key(quest), state)
-                    changed = True
-            if changed:
-                self.map.setNumericProperty("VICTOR_COURTYARD_TURN", -1)
-                self._sync_legacy_flags()
-
-        # --- Compatibility helpers ---
-        def _beren_flags(self):
-            state = self.get_state("beren_chain")
-            delivered = state not in ("letter_pending", "letter_in_hand", "octobogz_slain_pending_letter")
-            relic_returned = state in (
-                "relic_returned_waiting_kill",
-                "ready_to_report",
-                "purged",
-            )
-            octobogz_slain = state in (
-                "octobogz_slain_pending_letter",
-                "octobogz_slain_no_relic",
-                "ready_to_report",
-                "purged",
-            )
-            octobogz_cleared = state in ("ready_to_report", "purged")
-            cave_purged = state == "purged"
-            return delivered, relic_returned, octobogz_slain, octobogz_cleared, cave_purged
-
-        def _victor_flags(self):
-            state = self.get_state("victor")
-            started = state in (
-                "met_victor",
-                "records_reviewed",
-                "courtyard_known",
-                "encounter_active",
-                "good_end",
-                "bad_end",
-            )
-            courtyard_found = state in ("courtyard_known", "encounter_active", "good_end", "bad_end")
-            encounter_active = state == "encounter_active"
-            good_end = state == "good_end"
-            bad_end = state == "bad_end"
-            return started, courtyard_found, encounter_active, good_end, bad_end
-
-        def _sync_legacy_flags(self):
-            self.map.setBoolProperty("completed_rolf", self.get_state("rolf") == "skull_recovered")
-            self.map.setBoolProperty("completed_gooby", self.get_state("main") == "gooby_slain")
-
-            (
-                delivered,
-                relic_returned,
-                octobogz_slain,
-                octobogz_cleared,
-                cave_purged,
-            ) = self._beren_flags()
-            self.map.setBoolProperty("DELIVERED_LETTER", delivered)
-            self.map.setBoolProperty("RELIC_RETURNED", relic_returned)
-            self.map.setBoolProperty("OCTOBOGZ_SLAIN", octobogz_slain)
-            self.map.setBoolProperty("OCTOBOGZ_CLEARED", octobogz_cleared)
-            self.map.setBoolProperty("CAVE_PURGED", cave_purged)
-
-            contract_state = self.get_state("octobogz_contract")
-            self.map.setBoolProperty("completed_octobogz", contract_state == "completed")
-
-            amulet_state = self.get_state("amulet")
-            self.map.setBoolProperty("AMULET_QUEST_STARTED", amulet_state == "active")
-            self.map.setBoolProperty("AMULET_RETURNED", amulet_state == "returned")
-
-            (
-                victor_started,
-                courtyard_found,
-                encounter_active,
-                victor_good,
-                victor_bad,
-            ) = self._victor_flags()
-            self.map.setBoolProperty("VICTOR_QUEST_STARTED", victor_started)
-            self.map.setBoolProperty("VICTOR_COURTYARD_FOUND", courtyard_found)
-            self.map.setBoolProperty("VICTOR_CULTISTS_SPAWNED", encounter_active)
-            self.map.setBoolProperty("VICTOR_GOOD_END", victor_good)
-            self.map.setBoolProperty("VICTOR_BAD_END", victor_bad)
-            self.map.setBoolProperty("VICTOR_HELP", victor_good)
-            self.map.setBoolProperty("VICTOR_REWARD_CLAIMED", victor_good)
+        LEGACY_BOOL_FLAGS = (
+            LegacyBoolFlag("completed_rolf", "rolf", states=("skull_recovered",)),
+            LegacyBoolFlag("completed_gooby", "main", states=("gooby_slain",)),
+            LegacyBoolFlag(
+                "DELIVERED_LETTER",
+                "beren_chain",
+                excluded_states=("letter_pending", "letter_in_hand", "octobogz_slain_pending_letter"),
+            ),
+            LegacyBoolFlag(
+                "RELIC_RETURNED",
+                "beren_chain",
+                states=("relic_returned_waiting_kill", "ready_to_report", "purged"),
+            ),
+            LegacyBoolFlag(
+                "OCTOBOGZ_SLAIN",
+                "beren_chain",
+                states=("octobogz_slain_pending_letter", "octobogz_slain_no_relic", "ready_to_report", "purged"),
+            ),
+            LegacyBoolFlag("OCTOBOGZ_CLEARED", "beren_chain", states=("ready_to_report", "purged")),
+            LegacyBoolFlag("CAVE_PURGED", "beren_chain", states=("purged",)),
+            LegacyBoolFlag("completed_octobogz", "octobogz_contract", states=("completed",)),
+            LegacyBoolFlag("AMULET_QUEST_STARTED", "amulet", states=("active",)),
+            LegacyBoolFlag("AMULET_RETURNED", "amulet", states=("returned",)),
+            LegacyBoolFlag(
+                "VICTOR_QUEST_STARTED",
+                "victor",
+                states=("met_victor", "records_reviewed", "courtyard_known", "encounter_active", "good_end", "bad_end"),
+            ),
+            LegacyBoolFlag(
+                "VICTOR_COURTYARD_FOUND",
+                "victor",
+                states=("courtyard_known", "encounter_active", "good_end", "bad_end"),
+            ),
+            LegacyBoolFlag("VICTOR_CULTISTS_SPAWNED", "victor", states=("encounter_active",)),
+            LegacyBoolFlag("VICTOR_GOOD_END", "victor", states=("good_end",)),
+            LegacyBoolFlag("VICTOR_BAD_END", "victor", states=("bad_end",)),
+            LegacyBoolFlag("VICTOR_HELP", "victor", states=("good_end",)),
+            LegacyBoolFlag("VICTOR_REWARD_CLAIMED", "victor", states=("good_end",)),
+        )
 
         # --- Rolf / Gooby ---
         def ensure_main_quest(self, player):
@@ -436,13 +339,15 @@ def load(self, context):
 
         # --- Query helpers ---
         def is_letter_delivered(self):
-            return self._beren_flags()[0]
+            return not self.state_in(
+                "beren_chain", ("letter_pending", "letter_in_hand", "octobogz_slain_pending_letter")
+            )
 
         def is_relic_returned(self):
-            return self._beren_flags()[1]
+            return self.state_in("beren_chain", ("relic_returned_waiting_kill", "ready_to_report", "purged"))
 
         def is_cave_purged(self):
-            return self._beren_flags()[4]
+            return self.state_in("beren_chain", ("purged",))
 
         def is_octobogz_contract_completed(self):
             return self.get_state("octobogz_contract") == "completed"

--- a/test.py
+++ b/test.py
@@ -40,6 +40,7 @@ import unittest
 
 import game_simulation
 import mcp
+import quest_state
 
 REPO_ROOT = Path(__file__).resolve().parent
 
@@ -124,6 +125,7 @@ VALID_TEST_SUITES = ("fast", "gameplay", "ui", "coverage-safe", "full")
 FAST_TEST_PREFIXES = (
     "CoverageReportTest.",
     "PlayBootstrapTest.",
+    "QuestStateHelperTest.",
     "TestRunnerSuiteTest.",
 )
 FAST_TEST_NAMES = {
@@ -13495,6 +13497,137 @@ class CoverageReportTest(unittest.TestCase):
             coverage_report.write_exclusion_audit_json(json_report, audit)
             self.assertIn("src/sample.cpp:3 count=7 covered", text_report.read_text(encoding="utf-8"))
             self.assertEqual(audit, json.loads(json_report.read_text(encoding="utf-8")))
+
+
+class QuestStateHelperTest(unittest.TestCase):
+    class FakeMap:
+        def __init__(self):
+            self.strings = {}
+            self.bools = {}
+            self.numerics = {}
+
+        def getStringProperty(self, name):
+            return self.strings.get(name, "")
+
+        def setStringProperty(self, name, value):
+            self.strings[name] = value
+
+        def getBoolProperty(self, name):
+            return self.bools.get(name, False)
+
+        def setBoolProperty(self, name, value):
+            self.bools[name] = bool(value)
+
+        def getNumericProperty(self, name):
+            return self.numerics.get(name, 0)
+
+        def setNumericProperty(self, name, value):
+            self.numerics[name] = value
+
+    class DemoQuestStore(quest_state.QuestStateStore):
+        QUEST_KEYS = {
+            "alpha": "quest_state_alpha",
+            "beta": "quest_state_beta",
+        }
+        QUEST_DEFAULTS = {
+            "alpha": "pending",
+            "beta": "locked",
+        }
+        QUEST_NUMERIC_DEFAULTS = {
+            "demo_turn": -1,
+        }
+        LEGACY_BOOL_FLAGS = (
+            quest_state.LegacyBoolFlag("alpha_done", "alpha", states=("done",)),
+            quest_state.LegacyBoolFlag("beta_unlocked", "beta", excluded_states=("locked",)),
+        )
+
+    class FakeQuest:
+        def __init__(self, name="", type_id=""):
+            self._name = name
+            self._type_id = type_id
+
+        def getName(self):
+            return self._name
+
+        def getTypeId(self):
+            return self._type_id
+
+    class FakePlayer:
+        def __init__(self):
+            self.added_quests = []
+
+        def addQuest(self, quest_name):
+            self.added_quests.append(quest_name)
+
+    class NativeQuestPlayer(FakePlayer):
+        def __init__(self, quests):
+            super().__init__()
+            self._quests = quests
+
+        def getQuests(self):
+            return self._quests
+
+    def test_quest_state_store_initializes_resets_and_syncs_legacy_flags(self):
+        fake_map = self.FakeMap()
+        fake_map.setStringProperty("quest_state_alpha", "done")
+        fake_map.setNumericProperty("demo_turn", 42)
+        store = self.DemoQuestStore(fake_map)
+
+        self.assertTrue(store.initialize_defaults())
+        self.assertEqual("done", fake_map.getStringProperty("quest_state_alpha"))
+        self.assertEqual("locked", fake_map.getStringProperty("quest_state_beta"))
+        self.assertEqual(-1, fake_map.getNumericProperty("demo_turn"))
+        self.assertTrue(fake_map.getBoolProperty("alpha_done"))
+        self.assertFalse(fake_map.getBoolProperty("beta_unlocked"))
+
+        store.set_state("beta", "active")
+        self.assertEqual("active", fake_map.getStringProperty("quest_state_beta"))
+        self.assertTrue(fake_map.getBoolProperty("beta_unlocked"))
+
+        store.reset_all()
+        self.assertEqual("pending", fake_map.getStringProperty("quest_state_alpha"))
+        self.assertEqual("locked", fake_map.getStringProperty("quest_state_beta"))
+        self.assertEqual(-1, fake_map.getNumericProperty("demo_turn"))
+        self.assertFalse(fake_map.getBoolProperty("alpha_done"))
+        self.assertFalse(fake_map.getBoolProperty("beta_unlocked"))
+
+    def test_ensure_quest_uses_type_ids_and_python_fallback_registry(self):
+        native_player = self.NativeQuestPlayer([self.FakeQuest(name="displayName", type_id="existingQuest")])
+        self.assertFalse(quest_state.ensure_quest(native_player, "existingQuest"))
+        self.assertTrue(quest_state.ensure_quest(native_player, "newQuest"))
+        self.assertEqual(["newQuest"], native_player.added_quests)
+
+        fallback_player = self.FakePlayer()
+        registry = quest_state.PlayerQuestRegistry()
+        self.assertTrue(quest_state.ensure_quest(fallback_player, "fallbackQuest", registry=registry))
+        self.assertFalse(quest_state.ensure_quest(fallback_player, "fallbackQuest", registry=registry))
+        self.assertEqual(["fallbackQuest"], fallback_player.added_quests)
+        self.assertEqual(["fallbackQuest"], [quest.getTypeId() for quest in registry._quests.values()])
+
+        class PythonOnlyPlayer(self.FakePlayer):
+            pass
+
+        installed_registry = quest_state.PlayerQuestRegistry()
+        installed_registry.install_on(PythonOnlyPlayer)
+        installed_player = PythonOnlyPlayer()
+        self.assertTrue(quest_state.ensure_quest(installed_player, "installedQuest", registry=installed_registry))
+        self.assertFalse(quest_state.ensure_quest(installed_player, "installedQuest", registry=installed_registry))
+        self.assertEqual(["installedQuest"], installed_player.added_quests)
+        self.assertEqual(["installedQuest"], [quest.getTypeId() for quest in installed_player.getQuests()])
+
+    def test_nouraajd_quest_state_uses_shared_helpers_and_stable_keys(self):
+        script = (REPO_ROOT / "res/maps/nouraajd/script.py").read_text(encoding="utf-8")
+        game_module = (REPO_ROOT / "res/game.py").read_text(encoding="utf-8")
+        cmake = (REPO_ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+
+        self.assertIn("from quest_state import QuestStateStore", game_module)
+        self.assertIn("configure_file(quest_state.py quest_state.py)", cmake)
+        self.assertIn("from game import QuestStateStore", script)
+        self.assertIn("class QuestSystem(QuestStateStore)", script)
+        self.assertNotIn("class _TrackedQuest", script)
+        self.assertNotIn("_player_quests = {}", script)
+        for quest_name in NOURAAJD_QUEST_STATE_NAMES:
+            self.assertIn(f'"{quest_name}": "quest_state_{quest_name}"', script)
 
 
 class TestRunnerSuiteTest(unittest.TestCase):


### PR DESCRIPTION
## What changed

- Added reusable `quest_state.py` helpers for string-backed quest state, legacy bool flag synchronization, and safe quest-grant checks.
- Re-exported the helpers through `res/game.py` so resource scripts can use them through the existing plugin import path.
- Refactored the Nouraajd quest system to inherit from the shared store while keeping map-specific quest transitions, dialog actions, rewards, Victor encounter logic, and trigger behavior in `res/maps/nouraajd/script.py`.
- Preserved the existing Nouraajd quest state keys/defaults and legacy bool flag names for save compatibility.
- Added helper-level tests plus Nouraajd migration assertions, including the Python fallback quest registry path.
- Added `quest_state.py` to CMake copy/install rules.

## Why

Issue #332 asks for reusable quest-state machinery instead of keeping that infrastructure embedded in the Nouraajd map script. This keeps the reusable state/flag/quest-log pieces in one module while leaving authored Nouraajd behavior map-local.

## Validation

- `timeout 180s black -l 120 quest_state.py res/game.py res/maps/nouraajd/script.py test.py`
- `python3 -m py_compile quest_state.py res/game.py res/maps/nouraajd/script.py test.py`
- `git diff --check`
- `python3 test.py QuestStateHelperTest GameTest.test_nouraajd_quest_state_machine GameTest.test_nouraajd_save_load_quest_milestones GameTest.test_nouraajd_save_load_optional_quest_object_state GameTest.test_game_simulation_nouraajd_quest_walkthrough GameTest.test_nouraajd_quest_integrity_regression GameTest.test_nouraajd_restored_map_text_contract McpServerTest.test_stdio_map_walkthrough_nouraajd`
- `cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance`
- `python3 test.py`
- `./scripts/run_coverage.sh` after rebasing onto `origin/main`; final line coverage: `95.85% (8221 out of 8577, 715 excluded)`

The coverage command was run outside the sandbox locally because the sandbox denied loopback socket creation for an MCP HTTP test.

## Known limitations

- Ritual and siege still have small local quest-grant helpers; this PR introduces the reusable API and migrates Nouraajd first, matching #332's scope.

Fixes #332
