### PR TITLE
Balance Nouraajd economy and market pricing

### DIFF
--- a/docs/nouraajd-economy.md
+++ b/docs/nouraajd-economy.md
@@ -1,0 +1,27 @@
+# Nouraajd Economy Assumptions
+
+Nouraajd is the first sustained campaign hub, so its economy should support recovery and optional rewards without letting early combat collapse into unlimited potion use.
+
+## Early access
+
+- Starting gold: 0.
+- The general market offers three Lesser Life Potions, one Lesser Mana Potion, one Scroll, and the aspirational Dagger of Vile Heart.
+- The tavern beer market offers two Dark Beers and one Spiced Beer.
+- Stronger Life and Mana Potions are reserved for Victor's reward market after the courtyard rescue.
+- Greater potion crafting is unlocked through Beren's relic path, not through early markets.
+
+## Prices
+
+- Lesser potions and beers cost 400 gold.
+- A basic scroll costs 200 gold.
+- Life Potion costs 800 gold and Mana Potion costs 1600 gold when Victor's market opens.
+- Customer purchase prices are capped at 100000 gold so high-power items cannot overflow.
+- Merchant buyback prices are capped at 5000 gold and never exceed the customer purchase price. Unique quest rewards remain meaningful equipment, not a way to mint unlimited gold.
+
+## Rewards
+
+- The amulet quest pays 50 gold once.
+- Victor's good ending pays 500 gold, heals the player, and opens his remaining potion market once.
+- The OctoBogz contract pays 1000 gold and one Shadow Blade once.
+
+These values keep early potion purchases limited: before optional rewards, the player cannot buy market potions; after the first major rewards, potion access improves but remains finite and tied to authored stock.

--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -536,9 +536,13 @@ def load(self, context):
 
         def onComplete(self):
             game = self.getGame()
-            player = game.getMap().getPlayer()
+            game_map = game.getMap()
+            if game_map.getBoolProperty("OCTOBOGZ_REWARD_CLAIMED"):
+                return
+            player = game_map.getPlayer()
             player.addGold(1000)
             player.addItem("ShadowBlade")
+            game_map.setBoolProperty("OCTOBOGZ_REWARD_CLAIMED", True)
             game.getGuiHandler().showMessage("The refugees press 1000 gold and the Shadow Blade into your hands.")
 
     @register(context)
@@ -922,10 +926,13 @@ def load(self, context):
             game = self.getGame()
             game_map = game.getMap()
             player = game_map.getPlayer()
+            quest_system = _quest_system_from(self)
+            if quest_system.get_state("amulet") != "active":
+                return
             if player.hasItem(lambda it: it.getName() == "preciousAmulet"):
                 player.removeItem(lambda it: it.getName() == "preciousAmulet", True)
                 player.addGold(50)
-                _quest_system_from(self).finish_amulet()
+                quest_system.finish_amulet()
                 amulet_goblin = game_map.getObjectByName("amuletGoblin")
                 if amulet_goblin:
                     game_map.removeObject(amulet_goblin)

--- a/src/object/CMarket.cpp
+++ b/src/object/CMarket.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -18,6 +18,42 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CMarket.h"
 #include "core/CMap.h"
 #include "object/CCreature.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+
+constexpr int MAX_MARKET_SELL_PRICE = 100000;
+constexpr int MAX_MARKET_BUYBACK_PRICE = 5000;
+
+int boundedMarketCost(std::shared_ptr<CItem> item, int percent, int max_price) {
+    if (!item || percent <= 0 || max_price <= 0) {
+        return 0;
+    }
+
+    const double base_price = std::pow(2.0, static_cast<double>(item->getPower())) * 200.0;
+    if (!std::isfinite(base_price)) {
+        return max_price;
+    }
+    if (base_price <= 0.0) {
+        return 0;
+    }
+
+    const double scaled_price = base_price * static_cast<double>(percent) / 100.0;
+    if (!std::isfinite(scaled_price)) {
+        return max_price;
+    }
+    if (scaled_price >= static_cast<double>(max_price)) {
+        return max_price;
+    }
+    if (scaled_price < 1.0) {
+        return 1;
+    }
+    return std::clamp(static_cast<int>(scaled_price), 1, max_price);
+}
+
+} // namespace
 
 CMarket::CMarket() {}
 
@@ -62,7 +98,7 @@ bool CMarket::sellItem(std::shared_ptr<CCreature> cre, std::shared_ptr<CItem> it
         return false;
     }
     int price = getSellCost(item);
-    if (cre->getGold() < price) {
+    if (price <= 0 || cre->getGold() < price) {
         return false;
     }
     cre->addGold(-price);
@@ -75,7 +111,7 @@ int CMarket::getSellCost(std::shared_ptr<CItem> item) {
     if (!item) {
         return 0;
     }
-    return (int)(pow(2, item->getPower()) * 200.0 * ((double)getSell()) / 100.0);
+    return boundedMarketCost(item, getSell(), MAX_MARKET_SELL_PRICE);
 }
 
 void CMarket::buyItem(std::shared_ptr<CCreature> cre, std::shared_ptr<CItem> item) {
@@ -83,6 +119,9 @@ void CMarket::buyItem(std::shared_ptr<CCreature> cre, std::shared_ptr<CItem> ite
         return;
     }
     int price = getBuyCost(item);
+    if (price <= 0) {
+        return;
+    }
     std::set<std::shared_ptr<CItem>> items = cre->getInInventory();
     if (!vstd::ctn(items, item)) {
         return;
@@ -96,5 +135,5 @@ int CMarket::getBuyCost(std::shared_ptr<CItem> item) {
     if (!item) {
         return 0;
     }
-    return (int)(pow(2, item->getPower()) * 200.0 * ((double)getBuy()) / 100.0);
+    return std::min(boundedMarketCost(item, getBuy(), MAX_MARKET_BUYBACK_PRICE), getSellCost(item));
 }

--- a/test.py
+++ b/test.py
@@ -9514,6 +9514,66 @@ class GameTest(unittest.TestCase):
             game.CGuiHandler.showTrade = original_show_trade
 
     @game_test
+    def test_nouraajd_market_economy_assumptions(self):
+        game = load_game_module()
+        config = json.loads((REPO_ROOT / "res/maps/nouraajd/config.json").read_text())
+        economy_doc = (REPO_ROOT / "docs/nouraajd-economy.md").read_text(encoding="utf-8")
+        g, game_map, player = load_game_map_with_player("nouraajd")
+
+        def market_refs(market_id):
+            return [item["ref"] for item in config[market_id]["properties"]["items"]]
+
+        general_refs = market_refs("exampleMarket")
+        victor_refs = market_refs("victorMarket")
+        tavern_refs = market_refs("tavernBeerMarket")
+
+        self.assertEqual(player.getGold(), 0)
+        self.assertEqual(player.countItems("LesserLifePotion"), 0)
+        self.assertEqual(player.countItems("LesserManaPotion"), 0)
+        self.assertEqual(general_refs.count("LesserLifePotion"), 3)
+        self.assertEqual(general_refs.count("LesserManaPotion"), 1)
+        self.assertEqual(general_refs.count("Scroll"), 1)
+        self.assertEqual(general_refs.count("DaggerOfVileHeart"), 1)
+        self.assertNotIn("LifePotion", general_refs)
+        self.assertNotIn("ManaPotion", general_refs)
+        self.assertEqual(victor_refs, ["LesserLifePotion", "LifePotion", "LesserManaPotion", "ManaPotion"])
+        self.assertEqual(tavern_refs, ["DarkBeer", "DarkBeer", "SpicedBeer"])
+
+        market = g.createObject("exampleMarket")
+        expected_sell_costs = {
+            "Scroll": 200,
+            "LesserLifePotion": 400,
+            "LesserManaPotion": 400,
+            "DarkBeer": 400,
+            "SpicedBeer": 400,
+            "LifePotion": 800,
+            "ManaPotion": 1600,
+            "DaggerOfVileHeart": 100000,
+            "ShadowBlade": 100000,
+        }
+        sell_costs = {item_id: market.getSellCost(g.createObject(item_id)) for item_id in expected_sell_costs}
+        buyback_costs = {
+            item_id: market.getBuyCost(g.createObject(item_id)) for item_id in ("DaggerOfVileHeart", "ShadowBlade")
+        }
+
+        self.assertEqual(expected_sell_costs, sell_costs)
+        self.assertEqual({"DaggerOfVileHeart": 5000, "ShadowBlade": 5000}, buyback_costs)
+        self.assertLess(player.getGold() + 1000 + 500, sell_costs["DaggerOfVileHeart"])
+        self.assertIn("Starting gold: 0", economy_doc)
+        self.assertIn("Merchant buyback prices are capped at 5000 gold", economy_doc)
+
+        return True, json.dumps(
+            {
+                "general_refs": general_refs,
+                "victor_refs": victor_refs,
+                "tavern_refs": tavern_refs,
+                "sell_costs": sell_costs,
+                "buyback_costs": buyback_costs,
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_nouraajd_victor_town_hall_clue_regression(self):
         g, game_map, player = load_game_map_with_player("nouraajd")
         tavern_intro = g.createObject("tavernDialog1")
@@ -9880,12 +9940,43 @@ class GameTest(unittest.TestCase):
         self.assertEqual(game_map.getStringProperty("quest_state_amulet"), "returned")
         self.assertIsNone(game_map.getObjectByName("amuletGoblin"))
 
+        player.addItem("preciousAmulet")
+        quest_return_dialog.complete_amulet_quest()
+        self.assertEqual(player.getGold() - start_gold, 50)
+        self.assertEqual(game_map.getStringProperty("quest_state_amulet"), "returned")
+        self.assertTrue(player.hasItem(lambda it: it.getName() == "preciousAmulet"))
+
         return True, json.dumps(
             {
                 "quest_state_amulet": game_map.getStringProperty("quest_state_amulet"),
                 "gold_delta": player.getGold() - start_gold,
+                "duplicate_amulet_present": player.hasItem(lambda it: it.getName() == "preciousAmulet"),
                 "old_woman_present": game_map.getObjectByName("oldWoman") is not None,
                 "amulet_goblin_present": game_map.getObjectByName("amuletGoblin") is not None,
+            },
+            sort_keys=True,
+        )
+
+    @game_test
+    def test_nouraajd_octobogz_unique_reward_is_not_duplicated(self):
+        g, game_map, player = load_game_map_with_player("nouraajd")
+        quest = g.createObject("octoBogzQuest")
+        start_gold = player.getGold()
+
+        quest.onComplete()
+        self.assertEqual(player.getGold() - start_gold, 1000)
+        self.assertEqual(player.countItems("ShadowBlade"), 1)
+        self.assertTrue(game_map.getBoolProperty("OCTOBOGZ_REWARD_CLAIMED"))
+
+        quest.onComplete()
+        self.assertEqual(player.getGold() - start_gold, 1000)
+        self.assertEqual(player.countItems("ShadowBlade"), 1)
+
+        return True, json.dumps(
+            {
+                "gold_delta": player.getGold() - start_gold,
+                "shadow_blades": player.countItems("ShadowBlade"),
+                "reward_claimed": game_map.getBoolProperty("OCTOBOGZ_REWARD_CLAIMED"),
             },
             sort_keys=True,
         )

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CQuest.h"
 #include "test_harness.h"
 
+#include <limits>
 #include <memory>
 #include <set>
 
@@ -72,6 +73,80 @@ void test_market_guard_paths_and_item_transfers() {
     expect_true(creature->getGold() == 460, "market purchase should pay the creature");
     expect_true(!creature->hasInInventory(item), "market purchase should remove the item from inventory");
     expect_true(market->getItems().contains(item), "market purchase should move the item into stock");
+}
+
+void test_market_prices_are_bounded_and_non_exploitable() {
+    auto market = std::make_shared<CMarket>();
+    auto buyer = std::make_shared<CCreature>();
+    auto seller = std::make_shared<CCreature>();
+    auto powerful_item = std::make_shared<CItem>();
+
+    powerful_item->setPower(25);
+    market->add(powerful_item);
+
+    expect_true(market->getSellCost(powerful_item) == 100000, "high-power market sale price should be capped");
+    expect_true(market->getBuyCost(powerful_item) == 5000, "high-power market buyback should be capped");
+    expect_true(market->getBuyCost(powerful_item) <= market->getSellCost(powerful_item),
+                "market buyback should never exceed sale price");
+
+    buyer->setGold(99999);
+    expect_true(!market->sellItem(buyer, powerful_item), "buyer should not buy a capped item without enough gold");
+    expect_true(buyer->getGold() == 99999, "failed capped sale should not change buyer gold");
+    expect_true(market->getItems().contains(powerful_item), "failed capped sale should keep item in market");
+
+    buyer->setGold(100000);
+    expect_true(market->sellItem(buyer, powerful_item), "buyer should buy capped item at exact price");
+    expect_true(buyer->getGold() == 0, "capped sale should subtract exact capped price");
+    expect_true(buyer->hasInInventory(powerful_item), "capped sale should transfer item to buyer");
+
+    market->buyItem(buyer, powerful_item);
+    expect_true(buyer->getGold() == 5000, "capped buyback should pay the capped buyback price");
+    expect_true(!buyer->hasInInventory(powerful_item), "buyback should remove item from seller inventory");
+    expect_true(market->getItems().contains(powerful_item), "buyback should return item to market stock");
+
+    market->setSell(-100);
+    auto negative_price_item = std::make_shared<CItem>();
+    negative_price_item->setPower(1);
+    market->add(negative_price_item);
+    seller->setGold(1000);
+    expect_true(market->getSellCost(negative_price_item) == 0, "negative sale percentages should price at zero");
+    expect_true(!market->sellItem(seller, negative_price_item), "zero-priced market sales should fail closed");
+    expect_true(seller->getGold() == 1000, "failed zero-priced sale should not change gold");
+    expect_true(market->getItems().contains(negative_price_item), "failed zero-priced sale should keep stock");
+
+    market->setBuy(-100);
+    seller->addItem(negative_price_item);
+    expect_true(market->getBuyCost(negative_price_item) == 0, "negative buyback percentages should price at zero");
+    market->buyItem(seller, negative_price_item);
+    expect_true(seller->getGold() == 1000, "zero-priced buyback should not pay the seller");
+    expect_true(seller->hasInInventory(negative_price_item), "zero-priced buyback should leave item in inventory");
+
+    market->setSell(100);
+    auto underflow_item = std::make_shared<CItem>();
+    underflow_item->setPower(-2000);
+    market->add(underflow_item);
+    expect_true(market->getSellCost(underflow_item) == 0, "underflowed sale prices should fail closed");
+    expect_true(!market->sellItem(seller, underflow_item), "underflowed zero-price market sales should fail closed");
+    expect_true(seller->getGold() == 1000, "underflowed sale should not change gold");
+    expect_true(market->getItems().contains(underflow_item), "underflowed sale should keep stock");
+
+    auto low_power_item = std::make_shared<CItem>();
+    low_power_item->setPower(-10);
+    expect_true(market->getSellCost(low_power_item) == 1, "positive sub-unit sale prices should round up to one");
+
+    auto overflowing_base_item = std::make_shared<CItem>();
+    overflowing_base_item->setPower(2048);
+    expect_true(market->getSellCost(overflowing_base_item) == 100000, "overflowing base prices should cap safely");
+
+    auto overflowing_scale_item = std::make_shared<CItem>();
+    overflowing_scale_item->setPower(1000);
+    market->setSell(std::numeric_limits<int>::max());
+    expect_true(market->getSellCost(overflowing_scale_item) == 100000, "overflowing scaled prices should cap safely");
+
+    auto replacement_item = std::make_shared<CItem>();
+    market->setItems({replacement_item});
+    expect_true(market->getItems().size() == 1 && market->getItems().contains(replacement_item),
+                "market setItems should remove old stock before adding replacements");
 }
 
 void test_player_quest_setters_filter_nulls_and_skip_duplicates() {
@@ -148,6 +223,7 @@ void test_creature_inventory_equipment_and_ratio_helpers() {
 
 int main() {
     test_market_guard_paths_and_item_transfers();
+    test_market_prices_are_bounded_and_non_exploitable();
     test_player_quest_setters_filter_nulls_and_skip_duplicates();
     test_creature_inventory_equipment_and_ratio_helpers();
 


### PR DESCRIPTION
## What changed

- Added bounded market pricing so customer prices cap at 100000 gold and merchant buybacks cap at 5000 gold.
- Made zero, negative, underflowed, and overflowed market prices fail closed without moving items or gold.
- Made the OctoBogz Shadow Blade reward and amulet turn-in reward one-time grants.
- Documented the intended early Nouraajd economy assumptions in `docs/nouraajd-economy.md`.
- Added native and Python regression coverage for trade edge cases, early stock/prices, and duplicate unique rewards.

## Why

Nouraajd is the first campaign hub, so early markets and rewards need to support recovery without creating unlimited potion access, duplicated quest payouts, or buy/sell gold exploits.

Fixes #340.

## Validation

- `python3 -m py_compile test.py res/maps/nouraajd/script.py`
- `git diff --check`
- `cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R object_unit_tests`
- `python3 test.py GameTest.test_nouraajd_market_economy_assumptions GameTest.test_nouraajd_amulet_cleanup_and_repeat_regression GameTest.test_nouraajd_octobogz_unique_reward_is_not_duplicated GameTest.test_nouraajd_victor_reward_unlock_regression GameTest.test_nouraajd_tavern_beer_vendor`
- `python3 test.py McpServerTest.test_stdio_map_walkthrough_nouraajd`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance`
- `python3 test.py`
- `./scripts/run_coverage.sh`

Final coverage report: `TOTAL 8239/8595 eligible lines covered (95.86%), 715 excluded`; `src/object/CMarket.cpp` is `70/70 (100.00%)`.

## Known limitations

- Broader quest reward copy and consistency work is left to #341.
- Telemetry work is intentionally untouched.
