### PR TITLE
Document queue controller workflow updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,47 @@ Keep changes narrow. Do not modify unrelated files, generated build output, pack
 
 When this file conflicts with the current code, tests, or build scripts, trust the code and update this file as part of the fix.
 
+## Queue controller workflow
+
+When acting as the Codex queue controller for `planning/fall_of_nouraajd_issue_proposals.xlsx`, also follow
+`prompts/codex-queue-controller.md` and `docs/codex-agent-queue.md`.
+
+The workbook on `main` is the single queue source of truth. The controller is the only writer of the workbook; worker
+implementation branches must never modify it. Serialize queue state changes through workbook-only pull requests. Each
+claim or terminal status PR should mark exactly one issue unless the controller workflow explicitly permits batching and
+all selected issues are proven independent.
+
+Keep at most four implementation workers active at once. Before filling each free worker slot, fetch the latest
+`origin/main`, recalculate the full eligible set from the merged workbook, and exclude:
+
+- rows whose status is not `NOT_STARTED`;
+- rows with dependencies that are not `DONE`;
+- direct target-file overlaps with active work;
+- active-scope conflicts, including indirect conflicts through shared headers, bindings, tests, CMake, map scripts,
+  dialog/config files, serialization, generated resources, or shared runtime systems.
+
+After exclusions, keep only the highest currently available priority tier. Group candidates by `(Epic #, Story #)`,
+randomly select one story with equal probability, then randomly select one eligible substory in that story. Do not fall
+back to spreadsheet order and do not include ineligible rows in the random choice.
+
+For each selected issue, merge a workbook-only `IN_PROGRESS` claim PR before implementation starts. After the claim PR
+actually merges, create a fresh implementation worktree from updated `origin/main`, assign exactly one worker subagent,
+and pass it the generated issue prompt plus any controller overrides. Workers must inspect source, verify root cause,
+make the smallest backward-compatible change, add regression coverage, run focused and required validation where
+feasible, and report exact commands and outcomes. The controller reviews the diff, commits, pushes, opens the
+implementation PR, and enables squash auto-merge; do not mark the issue `DONE` until that implementation PR actually
+merges.
+
+After every controller loop iteration, claim/PR status check, and before dispatching new work, print a concise live
+status table. Include worker owner, issue key, phase, progress estimate, last action, changed files, running validation
+command, branch, PR state, blockers, and next controller action. Use subagent status polling or structured worker
+updates for live status; the workbook is durable queue state, not the live worker-status channel.
+
+For local RAM safety, queue-controller workers must not use high-parallelism builds. Adapt repository build commands such
+as `-j$(nproc)` to `-j1` unless the user explicitly allows a higher count. Do not run multiple heavy build, test,
+coverage, Xvfb, or MCP validation jobs concurrently across workers. Serialize memory-heavy validation and report the
+exact adjusted commands used.
+
 ## Project overview
 
 `fall-of-nouraajd` is a C++ dark-fantasy 2D game with Python scripts/plugins, JSON resource configuration, SDL assets, CMake builds, and a pybind11 `_game` extension module.

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -1,6 +1,9 @@
 # Local Codex agent queue
 
-This workflow lets one controller Codex process coordinate several local subagents while the committed XLSX workbook remains the canonical task queue. It deliberately does not automate branches, commits, pushes, merges, or pull requests.
+This workflow lets one controller Codex process coordinate local worker subagents while the committed XLSX workbook
+remains the canonical task queue. The controller owns Git worktrees, queue-state pull requests, implementation pull
+requests, and terminal workbook updates. Worker subagents implement code in isolated branches and must never edit the
+workbook.
 
 ## Files
 
@@ -20,7 +23,10 @@ The queue uses two different mechanisms:
 
 Each active row has both an `Owner` and a random `Claim ID`. Heartbeat, completion, block, failure, cancellation, and release operations require both values. A subagent cannot update a task merely by knowing its issue title.
 
-The queue lock prevents duplicate task claims. It does **not** prevent two subagents from editing the same source file. By default `claim` skips tasks whose exact `Target Files / Modules` overlap an existing `IN_PROGRESS` row. The controller must still inspect scopes and serialize work when shared headers, generated files, or indirectly coupled modules are involved.
+The queue lock prevents duplicate task claims. It does **not** prevent two subagents from editing the same source file.
+By default `claim` skips tasks whose exact `Target Files / Modules` overlap an existing `IN_PROGRESS` row. The
+controller must still inspect scopes and serialize work when shared headers, bindings, tests, CMake, map scripts,
+dialog/config files, serialization, generated resources, or shared runtime systems are coupled.
 
 ## Setup
 
@@ -47,15 +53,35 @@ Validate first:
 python3 scripts/issue_queue.py validate
 ```
 
-Claim one task for each subagent:
+The queue CLI `claim` command is deterministic: it picks the first eligible row by priority and workbook order. The
+controller workflow requires explicit random selection instead. Before each claim, fetch latest `origin/main`, read the
+merged workbook, and calculate the complete eligible set by excluding:
+
+- rows whose status is not `NOT_STARTED`;
+- rows with unfinished dependencies;
+- direct target-file overlaps with active work;
+- active-scope conflicts;
+- indirect conflicts through shared headers, bindings, tests, CMake, map scripts, dialog/config files, serialization,
+  generated resources, or shared runtime systems.
+
+Keep only the highest currently available priority tier. Group remaining candidates by `(Epic #, Story #)`, randomly
+select one story with equal probability, then randomly select one eligible substory inside it. Never default to workbook
+order and never randomize ineligible rows.
+
+After selecting an exact issue, claim that row:
 
 ```bash
 python3 scripts/issue_queue.py claim \
   --owner controller/subagent-1 \
-  --lease-minutes 120
+  --lease-minutes 1440 \
+  --issue "$ISSUE_NAME"
 ```
 
-`claim` selects the first eligible row by priority (`P0`, `P1`, `P2`) and epic/story/substory order. A row is eligible only when:
+The claim branch and pull request must be workbook-only and must merge before implementation starts. After the claim PR
+actually merges into `main`, create the implementation worktree from the updated `origin/main`, generate the worker
+prompt, and assign exactly one worker to that implementation branch.
+
+The CLI considers a row mechanically eligible only when:
 
 - status is `NOT_STARTED`;
 - every issue in `Dependencies` is `DONE`;
@@ -81,9 +107,36 @@ python3 scripts/issue_queue.py prompt \
 
 Alternatively use `claim --format prompt`.
 
+## Live worker status
+
+Keep at most four implementation workers active at once. Poll every active worker through the available subagent/task
+interface. If direct polling is unavailable, require structured status updates from the worker.
+
+After every controller loop iteration, claim or pull-request status check, and before dispatching new work, print a live
+status table containing at least:
+
+- worker owner;
+- issue key;
+- current phase;
+- progress estimate;
+- last reported action;
+- changed files if known;
+- current validation command if running;
+- branch name;
+- pull request number or pending PR state;
+- blockers;
+- next controller action.
+
+Do not rely on workbook fields for live status. The workbook records durable queue state; live worker state comes from
+subagent polling or structured worker reports.
+
 ## Subagent progress protocol
 
-A worker should update the same workbook after meaningful milestones:
+A worker should report meaningful milestones to the controller after source inspection, root-cause analysis,
+implementation, focused validation, and full validation. Workers must not update the workbook directly during queue
+controller runs.
+
+When the controller needs to persist a heartbeat, it does so from a fresh workbook-only branch:
 
 ```bash
 python3 scripts/issue_queue.py heartbeat \
@@ -96,7 +149,7 @@ python3 scripts/issue_queue.py heartbeat \
 
 Every heartbeat extends the lease. Recommended checkpoints are 5%, 20%, 70%, and 90%.
 
-Complete only after validation is finished:
+Complete only after the implementation pull request has actually merged and validation results have been reviewed:
 
 ```bash
 cat >/tmp/task-summary.txt <<'EOF'
@@ -104,8 +157,9 @@ Implemented the detailed fight result contract while preserving the bool compati
 EOF
 
 cat >/tmp/task-validation.txt <<'EOF'
-cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc): PASS
+cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j1: PASS
 ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests: PASS
+ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance: PASS
 python3 test.py: PASS
 EOF
 
@@ -117,7 +171,8 @@ python3 scripts/issue_queue.py complete \
   --validation-file /tmp/task-validation.txt
 ```
 
-`DONE` requires a result summary, validation results, `Progress %=100`, and a completion timestamp.
+`DONE` requires a result summary, validation results, `Progress %=100`, and a completion timestamp. Do not mark `DONE`
+while implementation auto-merge is merely queued.
 
 ## Block, fail, cancel, and release
 
@@ -178,3 +233,8 @@ python3 scripts/issue_queue.py show --issue "$ISSUE_NAME"
 - A worker must inspect relevant project files and verify repository-specific details against raw GitHub source before editing.
 - A worker must make the smallest safe change and preserve public identifiers unless they are verified broken.
 - Queue completion records validation; it does not prove the code has been integrated into another subagent's uncommitted work.
+- Worker implementation branches must not modify `planning/fall_of_nouraajd_issue_proposals.xlsx`.
+- Serialize workbook claim, heartbeat, and terminal-status pull requests; do not keep multiple binary workbook PRs open for merge.
+- To spare RAM, queue-controller workers must use serial local builds such as `-j1` unless the user explicitly allows more parallelism.
+- Do not run multiple heavy build, test, coverage, Xvfb, or MCP validation jobs concurrently across workers.
+- If RAM-safety limits or missing worker status prevent safe dispatch, stop filling worker slots until the blocker clears.

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -16,8 +16,11 @@ Explicitly spawn worker subagents for implementation tasks. Do not merely descri
 6. Never bypass failing checks, unresolved conflicts, missing approvals, or repository protections.
 7. Never use `git reset --hard`, `git clean`, force-push, or destructive checkout operations against a worktree containing unreviewed user changes.
 8. Use a separate Git worktree and branch for every claim publication, implementation task, and terminal queue update.
-9. Serialize all workbook pull requests. The XLSX file is binary and must never be modified concurrently on multiple branches intended to merge.
-10. Preserve public identifiers and backward compatibility unless source evidence proves they are broken.
+9. Keep at most four implementation workers active at once.
+10. Serialize all workbook pull requests. The XLSX file is binary and must never be modified concurrently on multiple branches intended to merge.
+11. Claim and terminal-status pull requests normally update exactly one issue. Do not batch workbook edits unless this workflow explicitly permits it and all selected issues are proven independent.
+12. Preserve public identifiers and backward compatibility unless source evidence proves they are broken.
+13. For local RAM safety, use serial or very low-parallelism validation. Replace repository-local `-j$(nproc)` build commands with `-j1` unless the user explicitly authorizes more parallelism.
 
 ## Startup
 
@@ -93,12 +96,59 @@ codex/status-epic-01-story-02-substory-03-failed
 
 Use lowercase ASCII, hyphens, and repository-approved naming. Do not reuse a branch name from another active or merged task.
 
+## Live status reporting
+
+Regularly poll every active worker using the available subagent or task interface. If direct polling is unavailable,
+require structured worker updates and summarize the latest update.
+
+After every controller loop iteration, after every claim or pull-request status check, and before dispatching new work,
+print a concise live status table. Include at minimum:
+
+- worker owner;
+- issue key;
+- current phase;
+- progress estimate;
+- last reported action;
+- changed files if known;
+- current validation command if one is running;
+- branch name;
+- pull request number or pending PR state;
+- blockers;
+- next controller action.
+
+Do not rely on the workbook alone for live worker status. The workbook records durable queue state; worker polling or
+structured worker updates are the live-status source.
+
+## Eligibility and random selection
+
+Before filling each free worker slot, fetch the latest merged queue state from `origin/main` and calculate the complete
+eligible set yourself. The `claim` command is deterministic by workbook order, so use it only after selecting the exact
+issue.
+
+Exclude every row that has:
+
+- a status other than `NOT_STARTED`;
+- any dependency that is not `DONE`;
+- a target-file overlap with active work;
+- an active-scope conflict;
+- an indirect conflict through shared headers, bindings, tests, CMake, map scripts, dialog/config files, serialization,
+  generated resources, or shared runtime systems.
+
+After exclusions:
+
+1. Keep only the highest currently available priority tier.
+2. Group the remaining candidates by `(Epic #, Story #)`.
+3. Randomly select one story with equal probability.
+4. Randomly select one eligible substory within the chosen story.
+
+Never default to spreadsheet order, and never randomize an ineligible issue into consideration.
+
 ## Dispatch loop
 
 For each free subagent slot:
 
 1. Inspect current `IN_PROGRESS`, `BLOCKED`, and dependency states.
-2. Select only an eligible `NOT_STARTED` issue whose dependencies are `DONE` and whose code scope does not conflict with active work.
+2. Recalculate the eligible set from the latest merged workbook and select one issue using the required priority/story/substory randomization.
 3. Publish the claim to `main` before starting implementation.
 4. Create the implementation worktree from the post-claim `origin/main`.
 5. Generate the exact worker prompt and explicitly spawn a worker subagent in that worktree.
@@ -108,6 +158,9 @@ For each free subagent slot:
 9. Remove completed worktrees and dispatch the next eligible task.
 
 Do not bypass dependencies to keep workers occupied.
+
+Do not start additional workers when live worker status is missing, when the next candidate conflicts with active work,
+or when RAM-safety limits require waiting for heavy validation to finish.
 
 ## Phase 1: publish an `IN_PROGRESS` claim
 
@@ -219,6 +272,7 @@ If the claim PR conflicts, fails validation, or cannot merge, do not start imple
    - the implementation branch name;
    - a strict instruction not to edit the workbook;
    - a requirement to report progress to the controller rather than directly mutating queue state.
+   - a RAM-safety instruction to avoid parallel builds and use `-j1` for local CMake builds unless the user explicitly allows more.
 
 6. Do not dispatch tasks concurrently when their scopes overlap directly or indirectly through shared headers, tests, bindings, registration units, CMake, shared JSON, map scripts, dialogs, serialization, or generated resources.
 
@@ -236,8 +290,10 @@ Every worker must:
 8. Add regression coverage for bug fixes.
 9. Run focused validation during implementation and all required repository validation before completion.
 10. Never edit `planning/fall_of_nouraajd_issue_proposals.xlsx` on the implementation branch.
-11. Never commit unrelated local changes, generated build output, packaged artifacts, dependency lock changes, or submodule SHA changes unless the issue explicitly requires them.
-12. Produce a final report containing:
+11. Avoid parallel local builds. Use `-j1` for CMake builds and wait when the controller has paused heavy validation for RAM safety.
+12. Never start heavy build, test, coverage, Xvfb, or MCP validation while the controller reports another heavy validation job is running.
+13. Never commit unrelated local changes, generated build output, packaged artifacts, dependency lock changes, or submodule SHA changes unless the issue explicitly requires them.
+14. Produce a final report containing:
     - what was checked;
     - what was broken;
     - what changed;
@@ -272,6 +328,24 @@ python3 scripts/issue_queue.py heartbeat \
 Commit and merge that workbook-only change using the same status-PR process as claim publication.
 
 If a worker disappears, do not overwrite the active claim. Inspect its worktree and branch, wait for lease expiry, and use `reclaim-stale` only when the claim is genuinely stale and no recoverable work remains.
+
+## RAM-safe validation
+
+Repository instructions may show parallel build examples such as `-j$(nproc)`. In queue-controller operation, adapt those
+local commands to `-j1` unless the user explicitly permits a higher job count. Record the adjusted command in worker
+reports and PR bodies.
+
+The controller must serialize memory-heavy validation across workers:
+
+- CMake builds;
+- `ctest` suites;
+- `python3 test.py` full or GUI suites;
+- `./scripts/run_coverage.sh`;
+- Xvfb tests;
+- MCP gameplay sessions.
+
+Workers may perform lightweight source inspection and prepare summaries while waiting for the RAM gate. Do not dispatch
+additional implementation work when doing so would leave active workers unpollable or start competing heavy validation.
 
 ## Phase 3: review and publish implementation
 
@@ -394,6 +468,8 @@ Stop dispatching new tasks when:
 - all remaining work is blocked by dependencies;
 - every safe task conflicts with active work;
 - available subagent capacity is exhausted;
+- live worker status cannot be polled or recovered safely;
+- RAM-safety limits require waiting before more work can start;
 - the repository is in an unresolved state.
 
 Before stopping, report:


### PR DESCRIPTION
### What changed
- Added the current queue-controller rules to `AGENTS.md`.
- Updated `prompts/codex-queue-controller.md` for up to four active workers, explicit randomized eligibility selection, live status polling, serialized workbook PRs, and RAM-safe validation.
- Updated `docs/codex-agent-queue.md` so it matches the Git/PR-backed controller flow and controller-owned workbook model.

### Why
- The repository docs needed to reflect the current workflow: worker subagents are implementation-only, the controller is the only workbook writer, live status must be polled, and local heavy validation must be serialized with `-j1` builds unless explicitly overridden.

### Validation performed
- `git diff --check`: PASS
- `python3 scripts/issue_queue.py validate`: PASS
- `python3 -m unittest tests.test_issue_queue`: PASS

### Known limitations or follow-up
- Docs-only change. No build, full Python suite, or coverage run was performed because no code or workbook behavior changed.