### PR TITLE
Document RAM-aware queue worker scaling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,12 @@ implementation branches must never modify it. Serialize queue state changes thro
 claim or terminal status PR should mark exactly one issue unless the controller workflow explicitly permits batching and
 all selected issues are proven independent.
 
-Keep at most four implementation workers active at once. Before filling each free worker slot, fetch the latest
-`origin/main`, recalculate the full eligible set from the merged workbook, and exclude:
+Keep at most four implementation workers active at once, but treat four as a hard maximum rather than a target. Before
+filling any slot, inspect current available RAM and running heavy jobs, then set a RAM-safe worker budget for this
+controller iteration. Dispatch only up to the smaller of four and that current budget; if memory is tight, swap is
+active, or another build/test/coverage/Xvfb/MCP job is running, reduce the budget and leave slots empty until the
+blocker clears. Before filling each RAM-approved worker slot, fetch the latest `origin/main`, recalculate the full
+eligible set from the merged workbook, and exclude:
 
 - rows whose status is not `NOT_STARTED`;
 - rows with dependencies that are not `DONE`;
@@ -46,10 +50,11 @@ status table. Include worker owner, issue key, phase, progress estimate, last ac
 command, branch, PR state, blockers, and next controller action. Use subagent status polling or structured worker
 updates for live status; the workbook is durable queue state, not the live worker-status channel.
 
-For local RAM safety, queue-controller workers must not use high-parallelism builds. Adapt repository build commands such
-as `-j$(nproc)` to `-j1` unless the user explicitly allows a higher count. Do not run multiple heavy build, test,
+For local RAM safety, queue-controller workers must not use high-parallelism builds. Adapt repository build commands
+such as `-j$(nproc)` to `-j1` unless the user explicitly allows a higher count. Do not run multiple heavy build, test,
 coverage, Xvfb, or MCP validation jobs concurrently across workers. Serialize memory-heavy validation and report the
-exact adjusted commands used.
+exact adjusted commands used. Recalculate the RAM-safe worker budget again before starting heavy validation; pausing
+validation or dispatch is preferred to overcommitting memory.
 
 ## Project overview
 

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -109,8 +109,13 @@ Alternatively use `claim --format prompt`.
 
 ## Live worker status
 
-Keep at most four implementation workers active at once. Poll every active worker through the available subagent/task
-interface. If direct polling is unavailable, require structured status updates from the worker.
+Keep at most four implementation workers active at once, but make the active worker count RAM-aware. Before dispatching
+or refilling workers, inspect current available RAM, swap pressure, and running heavy build/test/coverage/Xvfb/MCP jobs.
+Set the live worker budget to the smaller of four and the number of workers the machine can support without memory
+pressure. Leave slots empty when RAM is tight, and raise the count again only after the RAM gate clears.
+
+Poll every active worker through the available subagent/task interface. If direct polling is unavailable, require
+structured status updates from the worker.
 
 After every controller loop iteration, claim or pull-request status check, and before dispatching new work, print a live
 status table containing at least:
@@ -237,4 +242,6 @@ python3 scripts/issue_queue.py show --issue "$ISSUE_NAME"
 - Serialize workbook claim, heartbeat, and terminal-status pull requests; do not keep multiple binary workbook PRs open for merge.
 - To spare RAM, queue-controller workers must use serial local builds such as `-j1` unless the user explicitly allows more parallelism.
 - Do not run multiple heavy build, test, coverage, Xvfb, or MCP validation jobs concurrently across workers.
+- Recalculate the RAM-safe worker budget before each dispatch/refill and before starting heavy validation; fewer than
+  four active workers can still be the correct budget.
 - If RAM-safety limits or missing worker status prevent safe dispatch, stop filling worker slots until the blocker clears.

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -16,11 +16,15 @@ Explicitly spawn worker subagents for implementation tasks. Do not merely descri
 6. Never bypass failing checks, unresolved conflicts, missing approvals, or repository protections.
 7. Never use `git reset --hard`, `git clean`, force-push, or destructive checkout operations against a worktree containing unreviewed user changes.
 8. Use a separate Git worktree and branch for every claim publication, implementation task, and terminal queue update.
-9. Keep at most four implementation workers active at once.
+9. Keep at most four implementation workers active at once, and dynamically lower that cap based on current available
+   RAM and running heavy jobs.
 10. Serialize all workbook pull requests. The XLSX file is binary and must never be modified concurrently on multiple branches intended to merge.
 11. Claim and terminal-status pull requests normally update exactly one issue. Do not batch workbook edits unless this workflow explicitly permits it and all selected issues are proven independent.
 12. Preserve public identifiers and backward compatibility unless source evidence proves they are broken.
-13. For local RAM safety, use serial or very low-parallelism validation. Replace repository-local `-j$(nproc)` build commands with `-j1` unless the user explicitly authorizes more parallelism.
+13. For local RAM safety, use serial or very low-parallelism validation. Replace repository-local `-j$(nproc)` build
+   commands with `-j1` unless the user explicitly authorizes more parallelism.
+14. Recalculate a RAM-safe worker budget before every dispatch/refill decision and before starting heavy validation.
+   Four workers is a hard ceiling, not a fill target.
 
 ## Startup
 
@@ -121,7 +125,11 @@ structured worker updates are the live-status source.
 
 ## Eligibility and random selection
 
-Before filling each free worker slot, fetch the latest merged queue state from `origin/main` and calculate the complete
+Before filling each free worker slot, first recalculate the current RAM-safe worker budget from available memory,
+swap pressure, active worker status, and running heavy build/test/coverage/Xvfb/MCP jobs. Four workers is the maximum
+allowed budget, not the default. If current RAM conditions only support fewer workers, leave the extra slots empty.
+
+For each RAM-approved free slot, fetch the latest merged queue state from `origin/main` and calculate the complete
 eligible set yourself. The `claim` command is deterministic by workbook order, so use it only after selecting the exact
 issue.
 
@@ -145,7 +153,7 @@ Never default to spreadsheet order, and never randomize an ineligible issue into
 
 ## Dispatch loop
 
-For each free subagent slot:
+For each RAM-approved free subagent slot:
 
 1. Inspect current `IN_PROGRESS`, `BLOCKED`, and dependency states.
 2. Recalculate the eligible set from the latest merged workbook and select one issue using the required priority/story/substory randomization.
@@ -160,7 +168,8 @@ For each free subagent slot:
 Do not bypass dependencies to keep workers occupied.
 
 Do not start additional workers when live worker status is missing, when the next candidate conflicts with active work,
-or when RAM-safety limits require waiting for heavy validation to finish.
+or when RAM-safety limits require waiting for heavy validation to finish. If available RAM drops after workers are
+already active, stop refilling slots and pause new heavy validation until the budget recovers.
 
 ## Phase 1: publish an `IN_PROGRESS` claim
 
@@ -331,8 +340,13 @@ If a worker disappears, do not overwrite the active claim. Inspect its worktree 
 
 ## RAM-safe validation
 
-Repository instructions may show parallel build examples such as `-j$(nproc)`. In queue-controller operation, adapt those
-local commands to `-j1` unless the user explicitly permits a higher job count. Record the adjusted command in worker
+The controller owns a dynamic RAM gate. Before dispatching workers, refilling slots, or starting any heavy validation,
+inspect current available RAM and running processes, for example with `free -h` or `free -m` plus a process listing.
+Set the active worker budget to the smaller of four and the number of workers that can run without risking swap pressure
+or out-of-memory failures. Record the RAM-gate decision in the live status table when it affects dispatch or validation.
+
+Repository instructions may show parallel build examples such as `-j$(nproc)`. In queue-controller operation, adapt
+those local commands to `-j1` unless the user explicitly permits a higher job count. Record the adjusted command in worker
 reports and PR bodies.
 
 The controller must serialize memory-heavy validation across workers:
@@ -346,6 +360,8 @@ The controller must serialize memory-heavy validation across workers:
 
 Workers may perform lightweight source inspection and prepare summaries while waiting for the RAM gate. Do not dispatch
 additional implementation work when doing so would leave active workers unpollable or start competing heavy validation.
+Do not treat an empty worker slot as fillable merely because fewer than four workers are active; it is fillable only
+when the current RAM budget allows it.
 
 ## Phase 3: review and publish implementation
 


### PR DESCRIPTION
## What changed
- Updated the queue-controller workflow docs so the active worker count is dynamically capped by current RAM conditions.
- Clarified that four workers is a hard maximum, not a target to fill.
- Added RAM-gate checks before dispatch/refill decisions and before heavy validation.

## Why
The controller should avoid overcommitting memory when builds, tests, coverage, Xvfb, MCP sessions, or other agents are already consuming RAM.

## Validation
- `git diff --check`
- `python3 scripts/issue_queue.py validate`
- `python3 -m unittest tests.test_issue_queue`

## Known limitations
- Documentation-only change.
