### PR TITLE
Document four-issue queue controller target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,12 +20,15 @@ implementation branches must never modify it. Serialize queue state changes thro
 claim or terminal status PR should mark exactly one issue unless the controller workflow explicitly permits batching and
 all selected issues are proven independent.
 
-Keep at most four implementation workers active at once, but treat four as a hard maximum rather than a target. Before
-filling any slot, inspect current available RAM and running heavy jobs, then set a RAM-safe worker budget for this
-controller iteration. Dispatch only up to the smaller of four and that current budget; if memory is tight, swap is
-active, or another build/test/coverage/Xvfb/MCP job is running, reduce the budget and leave slots empty until the
-blocker clears. Before filling each RAM-approved worker slot, fetch the latest `origin/main`, recalculate the full
-eligible set from the merged workbook, and exclude:
+Keep at least four live subagents attached to the controller whenever the subagent interface is available. Keep four
+implementation issues active whenever four safe, eligible, non-conflicting issues exist. With the default cap of four
+implementation workers, four active issues are both the operating target and the cap unless the user explicitly changes
+the cap. Before filling any implementation slot, inspect current available RAM and running heavy jobs, then set a
+RAM-safe worker budget for this controller iteration. Dispatch implementation work up to four whenever RAM, issue
+eligibility, live worker status, and repository safety allow it. Use standby subagents only when fewer than four
+implementation issues can safely run; they may do lightweight status, eligibility, or review-prep tasks, but must not
+claim issues, edit files, or run heavy validation. Before filling each RAM-approved worker slot, fetch the latest
+`origin/main`, recalculate the full eligible set from the merged workbook, and exclude:
 
 - rows whose status is not `NOT_STARTED`;
 - rows with dependencies that are not `DONE`;
@@ -51,10 +54,11 @@ command, branch, PR state, blockers, and next controller action. Use subagent st
 updates for live status; the workbook is durable queue state, not the live worker-status channel.
 
 For local RAM safety, queue-controller workers must not use high-parallelism builds. Adapt repository build commands
-such as `-j$(nproc)` to `-j1` unless the user explicitly allows a higher count. Do not run multiple heavy build, test,
-coverage, Xvfb, or MCP validation jobs concurrently across workers. Serialize memory-heavy validation and report the
-exact adjusted commands used. Recalculate the RAM-safe worker budget again before starting heavy validation; pausing
-validation or dispatch is preferred to overcommitting memory.
+such as `-j$(nproc)` to `-j1` unless the user explicitly allows a higher count. Recalculate the RAM-safe heavy-job budget
+before starting validation. When every heavy job is explicitly serial, such as `-j1` or an equivalent one-worker test
+setting, and RAM has headroom with no swap pressure, up to four heavy jobs may run concurrently. Lower that count when
+jobs are not serial, RAM is tight, swap is active, or the jobs are known to be memory-hungry. Report the exact adjusted
+commands used.
 
 ## Project overview
 

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -109,10 +109,16 @@ Alternatively use `claim --format prompt`.
 
 ## Live worker status
 
-Keep at most four implementation workers active at once, but make the active worker count RAM-aware. Before dispatching
-or refilling workers, inspect current available RAM, swap pressure, and running heavy build/test/coverage/Xvfb/MCP jobs.
-Set the live worker budget to the smaller of four and the number of workers the machine can support without memory
-pressure. Leave slots empty when RAM is tight, and raise the count again only after the RAM gate clears.
+Keep at least four live subagents attached to the controller whenever the subagent interface is available. Keep four
+implementation issues active whenever four safe, eligible, non-conflicting issues exist, and make that active
+implementation count RAM-aware. Before dispatching or refilling implementation workers, inspect current available RAM,
+swap pressure, and running heavy build/test/coverage/Xvfb/MCP jobs. Set the live implementation worker budget to the
+smaller of four and the number of workers the machine can support without memory pressure. If the controller cannot keep
+four issue workers active, report the concrete eligibility, conflict, status, RAM, or repository-safety blocker.
+
+Standby subagents may help with lightweight status polling, eligibility summaries, or review preparation only when fewer
+than four implementation issues can safely run. They must not claim issues, edit files, touch the workbook, start builds,
+run tests, or launch coverage/Xvfb/MCP validation.
 
 Poll every active worker through the available subagent/task interface. If direct polling is unavailable, require
 structured status updates from the worker.
@@ -241,7 +247,11 @@ python3 scripts/issue_queue.py show --issue "$ISSUE_NAME"
 - Worker implementation branches must not modify `planning/fall_of_nouraajd_issue_proposals.xlsx`.
 - Serialize workbook claim, heartbeat, and terminal-status pull requests; do not keep multiple binary workbook PRs open for merge.
 - To spare RAM, queue-controller workers must use serial local builds such as `-j1` unless the user explicitly allows more parallelism.
-- Do not run multiple heavy build, test, coverage, Xvfb, or MCP validation jobs concurrently across workers.
-- Recalculate the RAM-safe worker budget before each dispatch/refill and before starting heavy validation; fewer than
-  four active workers can still be the correct budget.
+- Multiple heavy build, test, coverage, Xvfb, or MCP validation jobs may run concurrently only inside the current
+  RAM-safe heavy-job budget. If all heavy jobs are explicitly serial, such as `-j1` or equivalent, and RAM has headroom
+  with no swap pressure, that budget can be at least four concurrent heavy jobs.
+- Keep at least four live subagents and four active implementation issues whenever four issues are safe and eligible,
+  using standby roles only when fewer than four implementation workers are safe.
+- Recalculate the RAM-safe implementation worker and heavy-job budgets before each dispatch/refill and before starting
+  heavy validation; fewer than four active implementation workers or heavy jobs can still be the correct budget.
 - If RAM-safety limits or missing worker status prevent safe dispatch, stop filling worker slots until the blocker clears.

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -16,15 +16,18 @@ Explicitly spawn worker subagents for implementation tasks. Do not merely descri
 6. Never bypass failing checks, unresolved conflicts, missing approvals, or repository protections.
 7. Never use `git reset --hard`, `git clean`, force-push, or destructive checkout operations against a worktree containing unreviewed user changes.
 8. Use a separate Git worktree and branch for every claim publication, implementation task, and terminal queue update.
-9. Keep at most four implementation workers active at once, and dynamically lower that cap based on current available
-   RAM and running heavy jobs.
-10. Serialize all workbook pull requests. The XLSX file is binary and must never be modified concurrently on multiple branches intended to merge.
-11. Claim and terminal-status pull requests normally update exactly one issue. Do not batch workbook edits unless this workflow explicitly permits it and all selected issues are proven independent.
-12. Preserve public identifiers and backward compatibility unless source evidence proves they are broken.
-13. For local RAM safety, use serial or very low-parallelism validation. Replace repository-local `-j$(nproc)` build
+9. Keep at least four live subagents attached to the controller whenever the subagent interface is available.
+10. Keep four implementation issues active whenever four safe, eligible, non-conflicting issues exist. With the default
+   cap of four implementation workers, four active issues are both the operating target and the cap unless the user
+   explicitly changes the cap.
+11. Serialize all workbook pull requests. The XLSX file is binary and must never be modified concurrently on multiple branches intended to merge.
+12. Claim and terminal-status pull requests normally update exactly one issue. Do not batch workbook edits unless this workflow explicitly permits it and all selected issues are proven independent.
+13. Preserve public identifiers and backward compatibility unless source evidence proves they are broken.
+14. For local RAM safety, use serial or very low-parallelism validation. Replace repository-local `-j$(nproc)` build
    commands with `-j1` unless the user explicitly authorizes more parallelism.
-14. Recalculate a RAM-safe worker budget before every dispatch/refill decision and before starting heavy validation.
-   Four workers is a hard ceiling, not a fill target.
+15. Recalculate a RAM-safe worker budget before every dispatch/refill decision and before starting heavy validation.
+   If fewer than four issue workers are active, document the concrete eligibility, conflict, status, RAM, or repository
+   safety blocker that prevents filling the slot.
 
 ## Startup
 
@@ -102,6 +105,11 @@ Use lowercase ASCII, hyphens, and repository-approved naming. Do not reuse a bra
 
 ## Live status reporting
 
+Maintain at least four live subagents and aim to keep four implementation issues active. If fewer than four
+implementation issues can safely run, assign the excess subagents only lightweight standby roles such as status polling,
+eligibility summaries, or review preparation, and print the exact blocker preventing four active issues. Standby
+subagents must not claim issues, edit files, start builds, run tests, or touch the workbook.
+
 Regularly poll every active worker using the available subagent or task interface. If direct polling is unavailable,
 require structured worker updates and summarize the latest update.
 
@@ -125,9 +133,11 @@ structured worker updates are the live-status source.
 
 ## Eligibility and random selection
 
-Before filling each free worker slot, first recalculate the current RAM-safe worker budget from available memory,
-swap pressure, active worker status, and running heavy build/test/coverage/Xvfb/MCP jobs. Four workers is the maximum
-allowed budget, not the default. If current RAM conditions only support fewer workers, leave the extra slots empty.
+Before filling each free worker slot, first ensure at least four live subagents are attached to the controller, then
+recalculate the current RAM-safe implementation worker budget from available memory, swap pressure, active worker status,
+and running heavy build/test/coverage/Xvfb/MCP jobs. Four active implementation workers is the default operating target
+and current cap. If current conditions only support fewer implementation workers, keep the extra subagents in standby and
+record the blocker rather than assigning unsafe implementation issues.
 
 For each RAM-approved free slot, fetch the latest merged queue state from `origin/main` and calculate the complete
 eligible set yourself. The `claim` command is deterministic by workbook order, so use it only after selecting the exact
@@ -169,7 +179,8 @@ Do not bypass dependencies to keep workers occupied.
 
 Do not start additional workers when live worker status is missing, when the next candidate conflicts with active work,
 or when RAM-safety limits require waiting for heavy validation to finish. If available RAM drops after workers are
-already active, stop refilling slots and pause new heavy validation until the budget recovers.
+already active, stop refilling implementation slots and pause new heavy validation until the budget recovers. Keep at
+least four subagents alive by assigning standby-only work when fewer than four implementation slots are safe.
 
 ## Phase 1: publish an `IN_PROGRESS` claim
 
@@ -299,8 +310,11 @@ Every worker must:
 8. Add regression coverage for bug fixes.
 9. Run focused validation during implementation and all required repository validation before completion.
 10. Never edit `planning/fall_of_nouraajd_issue_proposals.xlsx` on the implementation branch.
-11. Avoid parallel local builds. Use `-j1` for CMake builds and wait when the controller has paused heavy validation for RAM safety.
-12. Never start heavy build, test, coverage, Xvfb, or MCP validation while the controller reports another heavy validation job is running.
+11. Avoid parallel local builds. Use `-j1` for CMake builds and wait when the controller has paused heavy validation for
+    RAM safety.
+12. Start heavy build, test, coverage, Xvfb, or MCP validation only when the controller reports that the current
+    RAM-safe heavy-job budget has capacity. Serial heavy jobs may run alongside other serial heavy jobs up to that
+    budget.
 13. Never commit unrelated local changes, generated build output, packaged artifacts, dependency lock changes, or submodule SHA changes unless the issue explicitly requires them.
 14. Produce a final report containing:
     - what was checked;
@@ -340,16 +354,23 @@ If a worker disappears, do not overwrite the active claim. Inspect its worktree 
 
 ## RAM-safe validation
 
-The controller owns a dynamic RAM gate. Before dispatching workers, refilling slots, or starting any heavy validation,
-inspect current available RAM and running processes, for example with `free -h` or `free -m` plus a process listing.
-Set the active worker budget to the smaller of four and the number of workers that can run without risking swap pressure
-or out-of-memory failures. Record the RAM-gate decision in the live status table when it affects dispatch or validation.
+The controller owns a dynamic RAM gate. Before dispatching implementation workers, refilling implementation slots, or
+starting any heavy validation, inspect current available RAM and running processes, for example with `free -h` or
+`free -m` plus a process listing. Set the active implementation worker budget to the smaller of four and the number of
+workers that can run without risking swap pressure or out-of-memory failures. Treat four active issue workers as the
+target; record the RAM-gate decision in the live status table whenever it prevents four active issues or affects
+validation.
 
 Repository instructions may show parallel build examples such as `-j$(nproc)`. In queue-controller operation, adapt
 those local commands to `-j1` unless the user explicitly permits a higher job count. Record the adjusted command in worker
 reports and PR bodies.
 
-The controller must serialize memory-heavy validation across workers:
+The controller must calculate a RAM-safe heavy-job budget across workers. If every heavy command is explicitly serial
+(`-j1` or equivalent), RAM has headroom, and swap is idle, the budget may be at least four concurrent heavy jobs. Lower
+the budget, potentially to one, for non-serial commands, memory-hungry jobs, low available RAM, swap activity, or missing
+worker status.
+
+This budget applies to:
 
 - CMake builds;
 - `ctest` suites;
@@ -358,10 +379,11 @@ The controller must serialize memory-heavy validation across workers:
 - Xvfb tests;
 - MCP gameplay sessions.
 
-Workers may perform lightweight source inspection and prepare summaries while waiting for the RAM gate. Do not dispatch
-additional implementation work when doing so would leave active workers unpollable or start competing heavy validation.
-Do not treat an empty worker slot as fillable merely because fewer than four workers are active; it is fillable only
-when the current RAM budget allows it.
+Workers and standby subagents may perform lightweight source inspection and prepare summaries while waiting for the RAM
+gate. Do not dispatch additional implementation work when doing so would leave active workers unpollable or exceed the
+current heavy-job budget. Empty implementation slots should be filled until four issues are active unless the current RAM
+budget, eligibility set, conflicts, missing status, or repository safety prevents it. The subagent floor is satisfied by
+standby subagents only when four active implementation issues are not safe.
 
 ## Phase 3: review and publish implementation
 

--- a/prompts/codex-queue-goal.md
+++ b/prompts/codex-queue-goal.md
@@ -6,19 +6,26 @@ Act as the Fall of Nouraajd queue controller. Read and follow `prompts/codex-que
 Use `planning/fall_of_nouraajd_issue_proposals.xlsx` as the single durable task source of truth. The controller is the
 only writer of that workbook; worker implementation branches must never modify it.
 
-## Worker budget
+## Subagent and worker budget
 
-Keep up to four implementation issues active, but treat four as a hard maximum rather than a target. Before every
-dispatch, refill, or heavy validation decision, inspect current available RAM, swap pressure, active worker status, and
-running build/test/coverage/Xvfb/MCP jobs. Dynamically set the active worker budget to the smaller of four and the
-number of workers the machine can currently support without memory pressure.
+Keep at least four live subagents attached to the controller whenever the subagent interface is available. Keep four
+implementation issues active whenever four safe, eligible, non-conflicting issues exist. With the default cap of four
+implementation workers, four active issues are both the operating target and the cap unless the user explicitly changes
+the cap. Before every dispatch, refill, or heavy validation decision, inspect current available RAM, swap pressure, active
+worker status, and running build/test/coverage/Xvfb/MCP jobs. Dynamically set the active implementation worker budget to
+the smaller of four and the number of workers the machine can currently support without memory pressure.
 
-Leave worker slots empty when RAM is tight, swap is active, worker status is missing, or another heavy validation job is
-running. Raise the worker count again only after the RAM gate clears.
+When RAM is tight, swap is active, worker status is missing, conflicts block selection, or no safe eligible issue exists,
+keep excess subagents in standby instead of assigning unsafe implementation work. Raise the active implementation count
+back to four as soon as the blocker clears. Standby subagents may do lightweight status polling, eligibility summaries,
+or review prep, but must not claim issues, edit files, touch the workbook, start builds, run tests, or launch
+coverage/Xvfb/MCP validation.
 
 Workers must not use parallel local builds. Adapt repository-local commands such as `-j$(nproc)` to `-j1` unless the
-user explicitly allows a higher job count. Do not run multiple heavy build, test, coverage, Xvfb, or MCP validation jobs
-concurrently across workers. Serialize memory-heavy validation and report every adjusted command exactly.
+user explicitly allows a higher job count. Recalculate the RAM-safe heavy-job budget before validation. If every heavy
+job is explicitly serial, such as `-j1` or an equivalent one-worker test setting, and RAM has headroom with no swap
+pressure, allow at least four concurrent heavy jobs. Lower that budget when jobs are not serial, RAM is tight, swap is
+active, worker status is missing, or a job is known to be memory-hungry. Report every adjusted command exactly.
 
 ## Eligibility and selection
 
@@ -81,7 +88,7 @@ Do not rely on the workbook alone for live worker status. Use workbook updates o
 
 ## Stop conditions
 
-Continuously refill RAM-approved free worker slots up to the current dynamic worker budget. Stop only when no safe
-eligible issue remains, all remaining work is blocked or conflicting, GitHub/authentication/worktree state is unsafe,
-active workers cannot be polled or recovered safely, RAM-safety limits prevent further progress, or the user stops the
-run.
+Continuously refill RAM-approved free implementation slots up to four active issues while maintaining at least four live
+subagents through standby roles when needed. Stop only when no safe eligible issue remains, all remaining work is blocked
+or conflicting, GitHub/authentication/worktree state is unsafe, active workers cannot be polled or recovered safely,
+RAM-safety limits prevent further progress, or the user stops the run.


### PR DESCRIPTION
## What changed
- Updated queue-controller workflow docs to keep four implementation issues active whenever four safe, eligible, non-conflicting issues exist.
- Clarified that the controller should maintain at least four live subagents, using standby roles only when fewer than four implementation issues can safely run.
- Documented that explicitly serial heavy jobs, such as `-j1` builds or equivalent one-worker tests, may run concurrently up to the RAM-safe budget of at least four when memory is healthy.

## Why
The queue controller should keep enough active issue work moving while still respecting dependencies, conflicts, live worker status, repository safety, and RAM constraints.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `python3 scripts/issue_queue.py validate`
- `python3 -m unittest tests.test_issue_queue`

## Known limitations
- Documentation-only change.
