### PR TITLE
Align worker queue prompt protocol

### DIFF
--- a/scripts/issue_queue.py
+++ b/scripts/issue_queue.py
@@ -1143,14 +1143,14 @@ Preserve backward compatibility unless something is clearly broken.
 {values.get('Validation / Tests')}
 
 9. Queue protocol
-- Before editing, run a heartbeat at 5% with a note describing the files inspected.
-- After root-cause analysis, heartbeat at 20% with the verified root cause.
-- After implementation, heartbeat at 70% with the changed files.
-- After focused validation, heartbeat at 90% with exact commands and results.
-- Use this exact Claim ID and Owner for every queue update.
-- Do not edit the workflow columns in the XLSX manually.
-- On success, call complete with a result summary and exact validation results.
-- On a verified blocker, call block with a precise reason. Do not invent missing source details.
+- Report queue milestones to the controller after source inspection, root-cause analysis, implementation, focused
+    validation, and full validation.
+- Include this exact Claim ID and Owner in milestone reports so the controller can publish workbook updates from a
+    workbook-only branch.
+- The controller owns workbook updates; worker implementation branches must not edit the workbook or workflow columns.
+- Do not run issue_queue.py heartbeat, complete, block, fail, cancel, or release from this implementation worktree.
+- On success, provide a result summary and exact validation results for controller completion.
+- On a verified blocker, report a precise reason to the controller. Do not invent missing source details.
 
 10. Required final report
 Report:

--- a/tests/test_issue_queue.py
+++ b/tests/test_issue_queue.py
@@ -295,6 +295,12 @@ class IssueQueueTest(unittest.TestCase):
         self.assertIn(claim["claimId"], prompt)
         self.assertIn("Inspect the relevant project files first.", prompt)
         self.assertIn("Do not commit, push, merge, or open a PR", prompt)
+        self.assertIn("Report queue milestones to the controller", prompt)
+        self.assertIn("The controller owns workbook updates", prompt)
+        self.assertIn("Do not run issue_queue.py heartbeat, complete, block, fail, cancel, or release", prompt)
+        self.assertNotIn("run a heartbeat", prompt)
+        self.assertNotIn("call complete", prompt)
+        self.assertNotIn("call block", prompt)
 
     def test_unrelated_xlsx_parts_are_preserved_byte_for_byte(self) -> None:
         marker_name = "custom/marker.bin"


### PR DESCRIPTION
## What changed

- Updated generated worker prompts so workers report queue milestones to the controller instead of running queue-mutating commands directly.
- Added a regression assertion that generated prompts preserve controller-owned workbook updates.

## Why

The queue-controller docs require the controller to be the only workbook writer. The generated worker prompt still instructed implementation workers to run `heartbeat`, `complete`, and `block`, which could cause workbook conflicts or premature queue state changes from implementation worktrees.

## Validation

- `python3 scripts/issue_queue.py validate`: PASS
- `python3 -m unittest tests.test_issue_queue`: PASS
- `python3 test.py GameTest.test_indentation`: PASS
- `python3 test.py GameTest.test_python_black_formatting`: PASS
- `cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j1`: PASS
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`: PASS
- `ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance`: PASS
- `python3 test.py`: PASS after fixing the generated prompt indentation; first run failed only `GameTest.test_indentation`.
- `git diff --check`: PASS

## Known limitations / follow-up

- Coverage was not run because this change does not touch the repo paths that require coverage under `AGENTS.md`.
- Follow-up optimizer checkpoint: add disk-space-aware controller auditing and periodic safe worktree cleanup reporting.
