### PR TITLE
[codex] Stabilize coverage timeouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   linux:
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -100,11 +101,14 @@ jobs:
       - name: performance guard (native)
         run: ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance
       - name: test (python gameplay)
+        timeout-minutes: 45
         run: python3 test.py --suite gameplay --jobs "$(nproc)"
       - name: test (python ui)
+        timeout-minutes: 45
         run: GAME_XVFB_JOBS=4 python3 test.py --suite ui --jobs "$(nproc)"
       - name: coverage
         if: steps.coverage-needed.outputs.run == 'true'
+        timeout-minutes: 60
         run: ./scripts/run_coverage.sh
       - name: ccache stats after coverage
         if: always()
@@ -125,6 +129,7 @@ jobs:
 
   windows-deps:
     runs-on: windows-2022
+    timeout-minutes: 120
     outputs:
       vcpkg-installed-cache-key: ${{ steps.select-vcpkg-installed-cache.outputs.key }}
     env: &windows-env
@@ -349,6 +354,7 @@ jobs:
   windows:
     needs: windows-deps
     runs-on: windows-2022
+    timeout-minutes: 120
     env: *windows-env
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -463,6 +469,7 @@ jobs:
           ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance
           if errorlevel 1 exit /b 1
       - name: test (python gameplay)
+        timeout-minutes: 45
         shell: cmd
         run: |
           set GAME_BUILD_DIR=cmake-build-release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -559,6 +559,7 @@ function(add_game_unit_test target_name)
     add_test(NAME "${test_name}" COMMAND ${target_name})
     set_tests_properties("${test_name}" PROPERTIES
         LABELS "for_unit_tests;unit;${target_name}"
+        TIMEOUT 60
     )
     if (WIN32)
         if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ steps.
 Also run `./scripts/run_coverage.sh` when a change touches tests (for example
 `test.py` or `tests/unit/**`), `src/core/**`, `src/handler/**`, `src/object/**`,
 `native_plugins/**`, or the coverage tooling. The default coverage run uses the Python reporter with
-`scripts/coverage_exclusions.json` and enforces a 95% eligible-line gate; see
-`docs/testing.md` for details, including recommended branch-protection checks.
+`scripts/coverage_exclusions.json`, runs the bounded `coverage-safe` Python suite, and enforces a 95% eligible-line
+gate; see `docs/testing.md` for details, including recommended branch-protection checks.
 Content JSON validation and its focused fixture tests run without needing the
 compiled `_game` module, but other tests require it to be built.
 `requirements-dev.txt` is the pinned source for pip-managed Python test tools

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -65,8 +65,9 @@ python3 test.py --suite full
 - `gameplay` runs deterministic engine, map, save/load, quest, combat, and MCP gameplay checks after `_game` is built.
 - `ui` runs the Xvfb parent test and GUI layout manifest checks; it is intended for Linux/Unix environments with
   `xvfb-run` and `xauth`.
-- `coverage-safe` is the Python suite used by `./scripts/run_coverage.sh`; it preserves the coverage-oriented full
-  behavior while making the coverage entrypoint explicit.
+- `coverage-safe` is the Python suite used by `./scripts/run_coverage.sh`; it keeps deterministic coverage drivers and
+  GUI coverage, but omits duplicate subprocess walkthrough checks that are already covered by the normal gameplay CI
+  suite.
 - `full` is the default full-suite behavior and is equivalent to omitting `--suite`.
 
 Use `--jobs <n>` with any suite to enable the existing sharded runner, for example
@@ -147,7 +148,7 @@ The script:
 - reuses the existing coverage configure by default; set `COVERAGE_FRESH_CONFIGURE=1` to force a fresh configure
 - builds `_game`, `for_unit_tests`, and `performance_guard_tests` with GCC/Clang coverage flags
 - runs native CTest, including the deterministic `performance` label guard
-- runs `python3 test.py` against the coverage build
+- runs `python3 test.py --suite coverage-safe` against the coverage build with a finite outer timeout
 - generates reports in `coverage/coverage.txt` and `coverage/coverage.html`
 - uses the repo-local Python reporter by default; set `COVERAGE_REPORTER=gcovr` only for diagnostic comparison
 - applies line exclusions from `scripts/coverage_exclusions.json` unless `COVERAGE_LINE_EXCLUSIONS` is overridden
@@ -158,6 +159,8 @@ Optional coverage speed controls:
 - `COVERAGE_CXX_COMPILER_LAUNCHER=` disables the compiler launcher
 - when `COVERAGE_CXX_COMPILER_LAUNCHER` is unset, the script uses `ccache` automatically if it is available
 - `COVERAGE_JOBS=<n>` controls parallel coverage build and report collection jobs
+- `COVERAGE_PYTHON_TIMEOUT_SECONDS=<seconds>` bounds the coverage Python phase; the default is 1800 seconds
+- `COVERAGE_GCOV_TIMEOUT_SECONDS=<seconds>` bounds each `gcov` JSON extraction; the default is 120 seconds
 
 ## Coverage scope
 The canonical coverage report is scoped to production/native plugin code by default:

--- a/scripts/coverage_report.py
+++ b/scripts/coverage_report.py
@@ -18,6 +18,12 @@ def parse_args():
     parser.add_argument("--report-dir", required=True, type=Path)
     parser.add_argument("--min-line", required=True, type=float)
     parser.add_argument("--jobs", default=max(1, os.cpu_count() or 1), type=positive_int)
+    parser.add_argument(
+        "--gcov-timeout",
+        default=positive_float(os.environ.get("COVERAGE_GCOV_TIMEOUT_SECONDS", "120")),
+        type=positive_float,
+        help="Seconds allowed for each gcov JSON extraction command.",
+    )
     parser.add_argument("--line-exclusions", type=Path, help="Reviewed root-relative line exclusion manifest.")
     parser.add_argument(
         "--include-prefix",
@@ -40,6 +46,16 @@ def positive_int(value: str) -> int:
         raise argparse.ArgumentTypeError(f"{value!r} is not an integer") from exc
     if parsed < 1:
         raise argparse.ArgumentTypeError("--jobs must be at least 1")
+    return parsed
+
+
+def positive_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a number") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("--gcov-timeout must be greater than 0")
     return parsed
 
 
@@ -230,15 +246,19 @@ def scope_line_exclusions(root: Path, exclusions, include_prefixes=()):
     }
 
 
-def collect_reports_for_gcda(gcda: Path, output_dir: Path):
+def collect_reports_for_gcda(gcda: Path, output_dir: Path, timeout_seconds: float):
     output_dir.mkdir()
-    subprocess.run(
-        ["gcov", "-j", "-p", str(gcda)],
-        cwd=output_dir,
-        check=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    try:
+        subprocess.run(
+            ["gcov", "-j", "-p", str(gcda)],
+            cwd=output_dir,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"gcov timed out after {timeout_seconds:g}s for {gcda}") from exc
 
     reports = []
     for report_path in sorted(output_dir.glob("*.gcov.json.gz")):
@@ -247,7 +267,7 @@ def collect_reports_for_gcda(gcda: Path, output_dir: Path):
     return reports
 
 
-def collect_gcov_reports(build_dir: Path, jobs: int):
+def collect_gcov_reports(build_dir: Path, jobs: int, timeout_seconds: float):
     gcda_files = sorted(build_dir.rglob("*.gcda"))
     if not gcda_files:
         raise RuntimeError(f"No .gcda files found under {build_dir}")
@@ -260,12 +280,12 @@ def collect_gcov_reports(build_dir: Path, jobs: int):
 
         if jobs == 1:
             for index, gcda in enumerate(gcda_files):
-                reports.extend(collect_reports_for_gcda(gcda, tmp_path / f"gcov-{index}"))
+                reports.extend(collect_reports_for_gcda(gcda, tmp_path / f"gcov-{index}", timeout_seconds))
             return reports
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as executor:
             futures = [
-                executor.submit(collect_reports_for_gcda, gcda, tmp_path / f"gcov-{index}")
+                executor.submit(collect_reports_for_gcda, gcda, tmp_path / f"gcov-{index}", timeout_seconds)
                 for index, gcda in enumerate(gcda_files)
             ]
             for future in concurrent.futures.as_completed(futures):
@@ -455,7 +475,7 @@ def main():
 
     include_prefixes = load_include_prefixes(root, args.include_prefix)
     exclusions = load_line_exclusions(root, args.line_exclusions)
-    reports = collect_gcov_reports(build_dir, args.jobs)
+    reports = collect_gcov_reports(build_dir, args.jobs, args.gcov_timeout)
     merged = merge_line_counts(root, reports, include_prefixes)
     exclusions = scope_line_exclusions(root, exclusions, include_prefixes)
     validate_line_exclusions(root, merged, exclusions)

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -10,6 +10,8 @@ COVERAGE_AUDIT_EXCLUSIONS="${COVERAGE_AUDIT_EXCLUSIONS:-0}"
 COVERAGE_INCLUDE_PREFIXES="${COVERAGE_INCLUDE_PREFIXES:-src native_plugins}"
 COVERAGE_JOBS="${COVERAGE_JOBS:-$(nproc)}"
 COVERAGE_REPORTER="${COVERAGE_REPORTER:-python}"
+COVERAGE_PYTHON_TIMEOUT_SECONDS="${COVERAGE_PYTHON_TIMEOUT_SECONDS:-1800}"
+COVERAGE_GCOV_TIMEOUT_SECONDS="${COVERAGE_GCOV_TIMEOUT_SECONDS:-120}"
 GAME_TEST_JOBS="${GAME_TEST_JOBS:-${COVERAGE_JOBS}}"
 GAME_XVFB_JOBS="${GAME_XVFB_JOBS:-4}"
 GAME_TEST_OUTPUT_DIR="${GAME_TEST_OUTPUT_DIR:-${REPORT_DIR}/test-output}"
@@ -27,6 +29,14 @@ if [[ ! "${GAME_TEST_JOBS}" =~ ^[1-9][0-9]*$ ]]; then
 fi
 if [[ ! "${GAME_XVFB_JOBS}" =~ ^[1-9][0-9]*$ ]]; then
     echo "GAME_XVFB_JOBS must be a positive integer, got: ${GAME_XVFB_JOBS}" >&2
+    exit 2
+fi
+if [[ ! "${COVERAGE_PYTHON_TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "COVERAGE_PYTHON_TIMEOUT_SECONDS must be a positive integer, got: ${COVERAGE_PYTHON_TIMEOUT_SECONDS}" >&2
+    exit 2
+fi
+if [[ ! "${COVERAGE_GCOV_TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "COVERAGE_GCOV_TIMEOUT_SECONDS must be a positive integer, got: ${COVERAGE_GCOV_TIMEOUT_SECONDS}" >&2
     exit 2
 fi
 
@@ -58,6 +68,32 @@ run_phase() {
         log_phase "FAIL ${name} ($(format_duration "${elapsed}"), exit ${status})"
     fi
     return "${status}"
+}
+
+run_with_timeout() {
+    local timeout_seconds="$1"
+    shift
+
+    if ! command -v timeout >/dev/null 2>&1; then
+        echo "warning: timeout command not found; running without outer timeout" >&2
+        "$@"
+        return
+    fi
+
+    timeout --kill-after=30s "${timeout_seconds}s" "$@"
+}
+
+list_recent_test_artifacts() {
+    if [[ ! -d "${GAME_TEST_OUTPUT_DIR}" ]]; then
+        echo "No test output directory was created at ${GAME_TEST_OUTPUT_DIR}" >&2
+        return
+    fi
+
+    echo "Recent test output files under ${GAME_TEST_OUTPUT_DIR}:" >&2
+    find "${GAME_TEST_OUTPUT_DIR}" -maxdepth 4 -type f -printf '%T@ %p\n' 2>/dev/null \
+        | sort -n \
+        | tail -n 40 \
+        | cut -d' ' -f2- >&2 || true
 }
 
 cmake_launcher_args=()
@@ -122,6 +158,7 @@ generate_report() {
             --report-dir "${REPORT_DIR}"
             --min-line "${MIN_COVERAGE}"
             --jobs "${COVERAGE_JOBS}"
+            --gcov-timeout "${COVERAGE_GCOV_TIMEOUT_SECONDS}"
         )
         if [[ -n "${COVERAGE_LINE_EXCLUSIONS}" ]]; then
             coverage_report_args+=(--line-exclusions "${COVERAGE_LINE_EXCLUSIONS}")
@@ -143,18 +180,30 @@ generate_report() {
     fi
 }
 
+run_python_coverage_tests() {
+    mkdir -p "${GAME_TEST_OUTPUT_DIR}"
+    run_with_timeout "${COVERAGE_PYTHON_TIMEOUT_SECONDS}" env \
+        GAME_BUILD_DIR="${BUILD_DIR}" \
+        GAME_COVERAGE_RUN=1 \
+        GAME_TEST_JOBS="${GAME_TEST_JOBS}" \
+        GAME_XVFB_JOBS="${GAME_XVFB_JOBS}" \
+        GAME_TEST_OUTPUT_DIR="${GAME_TEST_OUTPUT_DIR}" \
+        python3 test.py --suite coverage-safe --jobs "${GAME_TEST_JOBS}"
+    local status=$?
+    if [[ "${status}" -eq 124 || "${status}" -eq 137 ]]; then
+        echo "Coverage Python test phase timed out or was killed after ${COVERAGE_PYTHON_TIMEOUT_SECONDS}s." >&2
+        echo "The bounded command was: python3 test.py --suite coverage-safe --jobs ${GAME_TEST_JOBS}" >&2
+        list_recent_test_artifacts
+    fi
+    return "${status}"
+}
+
 run_phase "configure" cmake "${cmake_args[@]}"
 run_phase "build _game, for_unit_tests, and performance_guard_tests" \
     cmake --build "${BUILD_DIR}" --target _game for_unit_tests performance_guard_tests -j"${COVERAGE_JOBS}"
 run_phase "coverage data cleanup" find "${BUILD_DIR}" -name '*.gcda' -delete
 run_phase "ctest" ctest --test-dir "${BUILD_DIR}" --output-on-failure
-run_phase "python test suite" env \
-    GAME_BUILD_DIR="${BUILD_DIR}" \
-    GAME_COVERAGE_RUN=1 \
-    GAME_TEST_JOBS="${GAME_TEST_JOBS}" \
-    GAME_XVFB_JOBS="${GAME_XVFB_JOBS}" \
-    GAME_TEST_OUTPUT_DIR="${GAME_TEST_OUTPUT_DIR}" \
-    python3 test.py --suite coverage-safe --jobs "${GAME_TEST_JOBS}"
+run_phase "python test suite" run_python_coverage_tests
 run_phase "report generation" generate_report
 
 total_elapsed=$((SECONDS - SCRIPT_START))

--- a/test.py
+++ b/test.py
@@ -148,6 +148,16 @@ GAMEPLAY_TEST_PREFIXES = (
 GAMEPLAY_EXCLUDED_TEST_NAMES = {
     "McpServerTest.test_http_notification_response_declares_empty_body",
 }
+COVERAGE_SAFE_EXCLUDED_TEST_NAMES = {
+    "ConsoleEventIsolationTest.test_console_key_history_in_fresh_process",
+    "GameTest.test_map_walkthroughs",
+    "McpServerTest.test_stdio_map_walkthrough_multilevel",
+    "McpServerTest.test_stdio_map_walkthrough_nouraajd",
+    "McpServerTest.test_stdio_map_walkthrough_ritual",
+    "McpServerTest.test_stdio_map_walkthrough_siege",
+    "McpServerTest.test_stdio_map_walkthrough_test",
+    "McpServerTest.test_stdio_scene_manager_map_transition_walkthrough",
+}
 SERIAL_TEST_NAMES = {
     "GameTest.test_load_saved_map_slot_name_does_not_override_object_type_configs",
     "GameTest.test_missing_save_resource_directory_lists_empty",
@@ -13802,6 +13812,27 @@ class CoverageReportTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "glob"):
                 coverage_report.load_include_prefixes(root, ["src/*.cpp"])
 
+    def test_coverage_report_gcov_timeout_reports_data_file(self):
+        coverage_report = self._load_coverage_report_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            gcda = root / "sample.gcda"
+            gcda.write_bytes(b"")
+
+            original_run = coverage_report.subprocess.run
+
+            def fake_run(*args, **kwargs):
+                self.assertEqual(7.5, kwargs.get("timeout"))
+                raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+            coverage_report.subprocess.run = fake_run
+            try:
+                with self.assertRaisesRegex(RuntimeError, r"gcov timed out after 7.5s for .*sample\.gcda"):
+                    coverage_report.collect_reports_for_gcda(gcda, root / "gcov-output", 7.5)
+            finally:
+                coverage_report.subprocess.run = original_run
+
     def test_coverage_exclusion_audit_reports_raw_counts_and_snippets(self):
         coverage_report = self._load_coverage_report_module()
 
@@ -14032,7 +14063,16 @@ class TestRunnerSuiteTest(unittest.TestCase):
             ],
             filter_test_names_by_suite(sample_names, "ui"),
         )
-        self.assertEqual(sample_names, filter_test_names_by_suite(sample_names, "coverage-safe"))
+        self.assertEqual(
+            [
+                "CoverageReportTest.test_coverage_paths_accept_noncanonical_root",
+                "GameTest.test_map_walkthrough_nouraajd",
+                "PanelLayoutManifestTest.test_panel_layout_manifest_matches_panels_json",
+                XVFB_GAMEPLAY_PARENT_TEST,
+                "XvfbGameplayProcessTest.test_screenshot_inventory_panel_has_rendered_pixels",
+            ],
+            filter_test_names_by_suite(sample_names, "coverage-safe"),
+        )
 
     def test_suite_commands_are_documented_and_used_by_automation(self):
         build_workflow = (REPO_ROOT / ".github" / "workflows" / "build.yml").read_text(encoding="utf-8")
@@ -14047,6 +14087,8 @@ class TestRunnerSuiteTest(unittest.TestCase):
         self.assertIn("python test.py --suite gameplay", build_workflow)
         self.assertIn("python3 test.py --suite full", release_workflow)
         self.assertIn("python3 test.py --suite coverage-safe", coverage_script)
+        self.assertIn("COVERAGE_PYTHON_TIMEOUT_SECONDS", coverage_script)
+        self.assertIn("--gcov-timeout", coverage_script)
 
         for suite_name in VALID_TEST_SUITES:
             self.assertIn(f"--suite {suite_name}", testing_docs)
@@ -15222,7 +15264,9 @@ def selected_unittest_args(unittest_argv):
 
 
 def test_name_matches_suite(test_name, suite_name):
-    if suite_name in {"coverage-safe", "full"}:
+    if suite_name == "coverage-safe":
+        return test_name not in COVERAGE_SAFE_EXCLUDED_TEST_NAMES
+    if suite_name == "full":
         return True
     if suite_name == "fast":
         return test_name in FAST_TEST_NAMES or test_name.startswith(FAST_TEST_PREFIXES)


### PR DESCRIPTION
## What changed

- Added a bounded coverage Python phase in `scripts/run_coverage.sh` with `COVERAGE_PYTHON_TIMEOUT_SECONDS` and recent-artifact diagnostics on timeout.
- Added a per-`.gcda` `gcov` extraction timeout in `scripts/coverage_report.py` via `--gcov-timeout` / `COVERAGE_GCOV_TIMEOUT_SECONDS`, plus regression coverage for timeout reporting.
- Made `coverage-safe` skip duplicate subprocess walkthrough coverage while keeping the Xvfb GUI coverage driver needed for the current 95% line gate.
- Added native unit CTest timeouts and GitHub Actions job/step timeout caps for long-running coverage/gameplay lanes.
- Documented the bounded coverage workflow and timeout controls.

## Why

Issue #321 identified several ways the coverage path could run too long or hang: the coverage Python phase had no outer timeout, `gcov` extraction had no per-file timeout, duplicate subprocess walkthroughs made coverage slower than necessary, and CI lacked timeout caps around the affected jobs/steps.

## Validation

- `cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` - 9/9 passed
- `ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance` - passed
- `timeout 1800s python3 test.py` - passed outside the sandbox; the sandbox blocks the local socket creation used by the MCP HTTP test
- `./scripts/run_coverage.sh` - passed on the final rebased commit; Python phase 00:03:04, report generation 00:00:06, total 00:03:17, lines 95.14% (8177 / 8595, 715 excluded)
- `git diff --check`
- `bash -n scripts/run_coverage.sh`
- `python3 -m py_compile test.py scripts/coverage_report.py`
- `python3 -m unittest test.CoverageReportTest.test_coverage_report_gcov_timeout_reports_data_file test.TestRunnerSuiteTest.test_suite_filters_keep_runtime_groups_distinct test.TestRunnerSuiteTest.test_suite_commands_are_documented_and_used_by_automation`
- `python3 test.py --suite fast`

## Known limitations

`coverage-safe` still runs the Xvfb GUI coverage driver because the current 95% eligible-line gate depends on that coverage. This change removes duplicate subprocess walkthrough coverage rather than removing all process or GUI coverage work.

Fixes #321