### PR TITLE
Fix Chest random loot handler call

### DIFF
--- a/res/plugins/object.py
+++ b/res/plugins/object.py
@@ -1,5 +1,5 @@
 # fall-of-nouraajd c++ dark fantasy game
-# Copyright (C) 2025  Andrzej Lis
+# Copyright (C) 2025-2026  Andrzej Lis
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -86,9 +86,7 @@ def load(self, context):
     @register(context)
     class Chest(CBuilding):
         def onEnter(self, event):
-            self.getMap().getGame().getLootHandler().addRandomLoot(
-                self.getMap().getPlayer(), self.getNumericProperty("value")
-            )
+            self.getGame().getRngHandler().addRandomLoot(self.getMap().getPlayer(), self.getNumericProperty("value"))
 
     @register(context)
     class Cave(CBuilding):

--- a/test.py
+++ b/test.py
@@ -3436,6 +3436,21 @@ class GameTest(unittest.TestCase):
         return True, json.dumps(report, sort_keys=True)
 
     @game_test
+    def test_chest_on_enter_grants_random_loot_to_real_player(self):
+        _g, game_map, player = load_game_map_with_player("test", "Warrior")
+        chest = game_map.getGame().createObject("chest")
+        self.assertIsNotNone(chest)
+        chest.setNumericProperty("value", 20)
+        game_map.addObject(chest)
+
+        before_items = len(player.getItems())
+        chest.onEnter(None)
+        after_items = len(player.getItems())
+
+        self.assertGreater(after_items, before_items)
+        return True, json.dumps({"before": before_items, "after": after_items}, sort_keys=True)
+
+    @game_test
     def test_array_deserialize_skips_bad_entries_and_consumers_are_safe(self):
         game = load_game_module()
 


### PR DESCRIPTION
## Issue
`[EPIC_03][STORY_02][SUBSTORY_01]Fix Chest loot handler API call`

Owner: `controller/subagent-6`
Claim ID: `37f87e81-f6b5-4aeb-8ee8-625e373fea4b`

## Root cause
`Chest.onEnter()` called `self.getMap().getGame().getLootHandler().addRandomLoot(...)`, but the current game API exposes random loot through `CGame.getRngHandler()` and `CRngHandler.addRandomLoot(...)`.

## What changed
- Updated `Chest.onEnter()` to call `self.getGame().getRngHandler().addRandomLoot(...)`.
- Added a regression that creates a real chest and player, invokes `onEnter`, and verifies the player receives loot.
- Updated the touched Python plugin copyright range to include 2026.

## Files changed
- `res/plugins/object.py`
- `test.py`

## Validation
- `cmake --build cmake-build-release --target _game -j1`: PASS
- `python3 test.py GameTest.test_chest_on_enter_grants_random_loot_to_real_player`: PASS
- `python3 -m py_compile res/plugins/object.py test.py`: PASS
- `python3 scripts/issue_queue.py validate`: PASS
- `git diff --check`: PASS
- `git diff --cached --check`: PASS

## Skipped or blocked checks
- `black -l 120 res/plugins/object.py test.py`: attempted twice but hung without output under concurrent system load; both attempts were terminated. The final diff is small and line lengths remain within the repo limit.
- Full required validation and coverage have not been run yet from this branch; they should be run or covered by CI before terminal queue completion.

## Manual review
- Confirm the focused test’s random-loot value remains suitable if the item power table changes in future content edits.
