### PR TITLE
Add controller resource audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,12 +23,13 @@ all selected issues are proven independent.
 Keep at least four live subagents attached to the controller whenever the subagent interface is available. Keep four
 implementation issues active whenever four safe, eligible, non-conflicting issues exist. With the default cap of four
 implementation workers, four active issues are both the operating target and the cap unless the user explicitly changes
-the cap. Before filling any implementation slot, inspect current available RAM and running heavy jobs, then set a
-RAM-safe worker budget for this controller iteration. Dispatch implementation work up to four whenever RAM, issue
-eligibility, live worker status, and repository safety allow it. Use standby subagents only when fewer than four
+the cap. Before filling any implementation slot, inspect current available RAM, free disk space, existing run/worktree
+usage, and running heavy jobs, then set a RAM- and disk-safe worker budget for this controller iteration. Dispatch work
+up to four whenever RAM, disk, issue eligibility, live worker status, and repository safety allow it. Use standby
+subagents only when fewer than four
 implementation issues can safely run; they may do lightweight status, eligibility, or review-prep tasks, but must not
-claim issues, edit files, or run heavy validation. Before filling each RAM-approved worker slot, fetch the latest
-`origin/main`, recalculate the full eligible set from the merged workbook, and exclude:
+claim issues, edit files, or run heavy validation. Before filling each RAM- and disk-approved worker slot, fetch the
+latest `origin/main`, recalculate the full eligible set from the merged workbook, and exclude:
 
 - rows whose status is not `NOT_STARTED`;
 - rows with dependencies that are not `DONE`;
@@ -48,10 +49,11 @@ feasible, and report exact commands and outcomes. The controller reviews the dif
 implementation PR, and enables squash auto-merge; do not mark the issue `DONE` until that implementation PR actually
 merges.
 
-After every controller loop iteration, claim/PR status check, and before dispatching new work, print a concise live
-status table. Include worker owner, issue key, phase, progress estimate, last action, changed files, running validation
-command, branch, PR state, blockers, and next controller action. Use subagent status polling or structured worker
-updates for live status; the workbook is durable queue state, not the live worker-status channel.
+After every controller loop iteration, claim/PR status check, cleanup audit, and before dispatching new work, print a
+concise live status table. Include worker owner, issue key, phase, progress estimate, last action, changed files,
+running validation command, branch, PR state, disk/RAM state, cleanup state, blockers, and next controller action. Use
+subagent status polling or structured worker updates for live status; the workbook is durable queue state, not the
+live worker-status channel.
 
 For local RAM safety, queue-controller workers must not use high-parallelism builds. Adapt repository build commands
 such as `-j$(nproc)` to `-j1` unless the user explicitly allows a higher count. Recalculate the RAM-safe heavy-job budget
@@ -59,6 +61,12 @@ before starting validation. When every heavy job is explicitly serial, such as `
 setting, and RAM has headroom with no swap pressure, up to four heavy jobs may run concurrently. Lower that count when
 jobs are not serial, RAM is tight, swap is active, or the jobs are known to be memory-hungry. Report the exact adjusted
 commands used.
+
+For local disk safety, run `python3 scripts/controller_resource_audit.py --json` before dispatch/refill decisions,
+before starting heavy validation, after every controller loop iteration, and after any merged checkpoint cleanup. Treat
+low free disk, high filesystem usage, large accumulated run/worktrees, or prunable worktree metadata as blockers to new
+work until reported or cleaned safely. Remove only completed clean worktrees, use `git worktree prune` only for prunable
+metadata after review, and do not delete branches unless explicitly asked.
 
 ## Project overview
 

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -111,10 +111,11 @@ Alternatively use `claim --format prompt`.
 
 Keep at least four live subagents attached to the controller whenever the subagent interface is available. Keep four
 implementation issues active whenever four safe, eligible, non-conflicting issues exist, and make that active
-implementation count RAM-aware. Before dispatching or refilling implementation workers, inspect current available RAM,
-swap pressure, and running heavy build/test/coverage/Xvfb/MCP jobs. Set the live implementation worker budget to the
-smaller of four and the number of workers the machine can support without memory pressure. If the controller cannot keep
-four issue workers active, report the concrete eligibility, conflict, status, RAM, or repository-safety blocker.
+implementation count RAM- and disk-aware. Before dispatching or refilling implementation workers, inspect current
+available RAM, swap pressure, free disk, accumulated run/worktrees, prunable worktree metadata, and running heavy
+build/test/coverage/Xvfb/MCP jobs. Set the live implementation worker budget to the smaller of four and the number of
+workers the machine can support without memory or disk pressure. If the controller cannot keep four issue workers
+active, report the concrete eligibility, conflict, status, RAM, disk, cleanup, or repository-safety blocker.
 
 Standby subagents may help with lightweight status polling, eligibility summaries, or review preparation only when fewer
 than four implementation issues can safely run. They must not claim issues, edit files, touch the workbook, start builds,
@@ -123,8 +124,8 @@ run tests, or launch coverage/Xvfb/MCP validation.
 Poll every active worker through the available subagent/task interface. If direct polling is unavailable, require
 structured status updates from the worker.
 
-After every controller loop iteration, claim or pull-request status check, and before dispatching new work, print a live
-status table containing at least:
+After every controller loop iteration, cleanup audit, claim or pull-request status check, and before dispatching new
+work, print a live status table containing at least:
 
 - worker owner;
 - issue key;
@@ -135,11 +136,25 @@ status table containing at least:
 - current validation command if running;
 - branch name;
 - pull request number or pending PR state;
+- current RAM and disk state;
+- cleanup state, including prunable worktree metadata and accumulated run/worktree size when known;
 - blockers;
 - next controller action.
 
 Do not rely on workbook fields for live status. The workbook records durable queue state; live worker state comes from
 subagent polling or structured worker reports.
+
+Run the read-only resource audit before every dispatch/refill decision, before heavy validation, after each controller
+loop, and after merged-checkpoint cleanup:
+
+```bash
+python3 scripts/controller_resource_audit.py --json
+```
+
+The audit reports disk usage, active and prunable worktree registrations, and matching controller run/worktrees such as
+`/tmp/nouraajd-*` and `/tmp/fall-of-nouraajd-codex`. It is report-only by default. Treat audit errors as blockers to new
+heavy work, and treat warnings about prunable worktree metadata or large accumulated run/worktrees as cleanup prompts
+before refilling worker slots.
 
 ## Subagent progress protocol
 
@@ -255,3 +270,7 @@ python3 scripts/issue_queue.py show --issue "$ISSUE_NAME"
 - Recalculate the RAM-safe implementation worker and heavy-job budgets before each dispatch/refill and before starting
   heavy validation; fewer than four active implementation workers or heavy jobs can still be the correct budget.
 - If RAM-safety limits or missing worker status prevent safe dispatch, stop filling worker slots until the blocker clears.
+- If disk-safety limits, prunable worktree metadata, or accumulated run/worktree usage prevent safe dispatch, stop
+  filling worker slots until the blocker is reported or safely cleaned.
+- Remove only completed clean worktrees. Use `git worktree prune` only for prunable metadata after reviewing that the
+  corresponding worktree directories no longer exist. Do not delete branches unless explicitly asked.

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -23,11 +23,14 @@ Explicitly spawn worker subagents for implementation tasks. Do not merely descri
 11. Serialize all workbook pull requests. The XLSX file is binary and must never be modified concurrently on multiple branches intended to merge.
 12. Claim and terminal-status pull requests normally update exactly one issue. Do not batch workbook edits unless this workflow explicitly permits it and all selected issues are proven independent.
 13. Preserve public identifiers and backward compatibility unless source evidence proves they are broken.
-14. For local RAM safety, use serial or very low-parallelism validation. Replace repository-local `-j$(nproc)` build
-   commands with `-j1` unless the user explicitly authorizes more parallelism.
+14. For local RAM and disk safety, use serial or very low-parallelism validation. Replace repository-local
+   `-j$(nproc)` build commands with `-j1` unless the user explicitly authorizes more parallelism.
 15. Recalculate a RAM-safe worker budget before every dispatch/refill decision and before starting heavy validation.
    If fewer than four issue workers are active, document the concrete eligibility, conflict, status, RAM, or repository
    safety blocker that prevents filling the slot.
+16. Run the controller resource audit before dispatch/refill decisions, before heavy validation, after each controller
+   loop, and after merged-checkpoint cleanup. Treat low free disk or stale run/worktree pressure as blockers to new work
+   until safely reported or cleaned.
 
 ## Startup
 
@@ -113,8 +116,8 @@ subagents must not claim issues, edit files, start builds, run tests, or touch t
 Regularly poll every active worker using the available subagent or task interface. If direct polling is unavailable,
 require structured worker updates and summarize the latest update.
 
-After every controller loop iteration, after every claim or pull-request status check, and before dispatching new work,
-print a concise live status table. Include at minimum:
+After every controller loop iteration, cleanup audit, claim or pull-request status check, and before dispatching new
+work, print a concise live status table. Include at minimum:
 
 - worker owner;
 - issue key;
@@ -125,6 +128,8 @@ print a concise live status table. Include at minimum:
 - current validation command if one is running;
 - branch name;
 - pull request number or pending PR state;
+- current RAM and disk state;
+- cleanup state, including prunable worktree registrations and accumulated run/worktree size when known;
 - blockers;
 - next controller action.
 
@@ -133,10 +138,16 @@ structured worker updates are the live-status source.
 
 ## Eligibility and random selection
 
-Before filling each free worker slot, first ensure at least four live subagents are attached to the controller, then
-recalculate the current RAM-safe implementation worker budget from available memory, swap pressure, active worker status,
-and running heavy build/test/coverage/Xvfb/MCP jobs. Four active implementation workers is the default operating target
-and current cap. If current conditions only support fewer implementation workers, keep the extra subagents in standby and
+Before filling each free worker slot, ensure at least four live subagents are attached to the controller, then run:
+
+```bash
+python3 scripts/controller_resource_audit.py --json
+```
+
+Use the audit plus current available memory, swap pressure, active worker status, disk pressure, accumulated
+run/worktree usage, prunable worktree metadata, and running heavy build/test/coverage/Xvfb/MCP jobs to recalculate the
+RAM- and disk-safe implementation worker budget. Four active implementation workers is the default operating target and
+current cap. If current conditions only support fewer implementation workers, keep the extra subagents in standby and
 record the blocker rather than assigning unsafe implementation issues.
 
 For each RAM-approved free slot, fetch the latest merged queue state from `origin/main` and calculate the complete
@@ -173,14 +184,16 @@ For each RAM-approved free subagent slot:
 6. Supervise progress and review the final diff and validation.
 7. Publish and merge the implementation pull request.
 8. Publish and merge the terminal workbook status.
-9. Remove completed worktrees and dispatch the next eligible task.
+9. Remove completed clean worktrees, prune stale worktree metadata after review, rerun the resource audit, and dispatch
+   the next eligible task.
 
 Do not bypass dependencies to keep workers occupied.
 
 Do not start additional workers when live worker status is missing, when the next candidate conflicts with active work,
-or when RAM-safety limits require waiting for heavy validation to finish. If available RAM drops after workers are
-already active, stop refilling implementation slots and pause new heavy validation until the budget recovers. Keep at
-least four subagents alive by assigning standby-only work when fewer than four implementation slots are safe.
+or when RAM- or disk-safety limits require waiting for heavy validation or cleanup to finish. If available RAM drops or
+disk pressure rises after workers are already active, stop refilling implementation slots and pause new heavy validation
+until the budget recovers. Keep at least four subagents alive by assigning standby-only work when fewer than four
+implementation slots are safe.
 
 ## Phase 1: publish an `IN_PROGRESS` claim
 
@@ -487,13 +500,24 @@ Never convert `BLOCKED`, `FAILED`, or `CANCELLED` to `DONE` merely to unlock dep
 
 ## Cleanup
 
+After every controller loop, PR status poll, and merged checkpoint, run the read-only resource audit:
+
+```bash
+python3 scripts/controller_resource_audit.py --json
+```
+
+Use the audit to report free disk, accumulated run/worktrees, and prunable worktree metadata. If disk pressure is high
+or many stale worktree registrations exist, stop refilling worker slots until cleanup is reviewed and completed safely.
+
 After both implementation and terminal-status PRs merge:
 
 1. Verify no uncommitted files remain in the task worktrees.
 2. Remove task worktrees with `git worktree remove <path>`.
 3. Run `git worktree prune`.
-4. Delete local branches only after verifying their commits are reachable from `origin/main`.
-5. Do not remove a branch or worktree that contains unmerged or uncommitted work.
+4. Rerun `python3 scripts/controller_resource_audit.py --json` and record the new disk/worktree state.
+5. Delete local branches only after verifying their commits are reachable from `origin/main` and only when the user has
+   explicitly allowed branch deletion.
+6. Do not remove a branch or worktree that contains unmerged or uncommitted work.
 
 ## Stop conditions
 
@@ -508,6 +532,7 @@ Stop dispatching new tasks when:
 - available subagent capacity is exhausted;
 - live worker status cannot be polled or recovered safely;
 - RAM-safety limits require waiting before more work can start;
+- disk-safety limits or accumulated run/worktree state require cleanup before more work can start;
 - the repository is in an unresolved state.
 
 Before stopping, report:
@@ -517,5 +542,6 @@ Before stopping, report:
 - queue-state PRs and whether they merged;
 - validation status of the workbook;
 - implementation validation status;
+- disk/RAM state and cleanup performed or deferred;
 - worktrees requiring manual review;
 - next eligible issue, when one exists.

--- a/prompts/codex-workflow-optimizer.md
+++ b/prompts/codex-workflow-optimizer.md
@@ -101,14 +101,19 @@ Repeat the following cycle:
 1. Synchronize
    - Verify repository identity and GitHub authentication.
    - Fetch `origin/main`.
-   - Inspect open workflow-related PRs, active worktrees, branches, and dirty state.
+   - Inspect open workflow-related PRs, active worktrees, branches, dirty state, disk usage, and accumulated
+     run/worktrees.
    - Never destroy or overwrite unreviewed work.
 
 2. Establish evidence
    - Run the narrow workflow validation:
      - `python3 scripts/issue_queue.py validate`
      - `python3 -m unittest tests.test_issue_queue`
-   - Collect relevant evidence such as failures, test duration, queue conflicts, stale claims, PR-state errors, unnecessary rebuilds, RAM use, swap pressure, and prompt/document drift.
+     - `python3 -m unittest tests.test_controller_resource_audit`
+     - `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`
+   - Collect relevant evidence such as failures, test duration, queue conflicts, stale claims, PR-state errors,
+     unnecessary rebuilds, RAM use, swap pressure, disk pressure, stale run/worktrees, prunable worktree metadata, and
+     prompt/document drift.
    - Do not claim a bottleneck without measurement or reproducible evidence.
 
 3. Select an optimization
@@ -128,12 +133,16 @@ Repeat the following cycle:
    - Preserve existing CLI contracts, queue statuses, workbook compatibility, branch naming, and public behavior unless explicitly migrating them.
    - Keep documentation, prompts, implementation, and tests synchronized.
 
-6. Conserve RAM
+6. Conserve RAM and disk
    - Workers must not use parallel builds.
    - Use `-j1` for local CMake builds unless the user explicitly authorizes otherwise.
    - Serialize memory-heavy builds, full tests, coverage, Xvfb, and MCP sessions.
    - Allow lightweight inspection and review while heavy validation is running.
    - Inspect available RAM and swap before every heavy command.
+   - Run `python3 scripts/controller_resource_audit.py --json` before dispatch/refill decisions, before heavy
+     validation, after each controller loop, and after merged-checkpoint cleanup.
+   - Treat low free disk, high filesystem usage, large accumulated run/worktrees, or prunable worktree registrations as
+     blockers to new heavy work until safely reported or cleaned.
 
 7. Review
    - Require a separate subagent to review the complete diff.
@@ -162,9 +171,11 @@ Repeat the following cycle:
    - Independent read-only auditing may continue while a PR is pending.
 
 10. Continue from updated `main`
-    - After a PR actually merges, fetch the new `origin/main`.
-    - Remove only clean, merged worktrees and branches.
-    - Re-run baseline workflow validation.
+   - After a PR actually merges, fetch the new `origin/main`.
+   - Remove only clean, merged worktrees.
+   - Run `git worktree prune` only for prunable metadata after reviewing that the worktree directories no longer exist.
+   - Do not delete local or remote branches unless the user explicitly asks.
+   - Re-run baseline workflow validation.
     - Compare behavior with the previous baseline.
     - Start the next optimization cycle.
 
@@ -204,6 +215,7 @@ Stop implementation and provide a final status report when:
 - open conflicts or failing required checks prevent safe progress;
 - live subagents cannot be polled or recovered;
 - RAM safety prevents further validation;
+- disk safety or accumulated run/worktree state prevents further validation or safe dispatch;
 - no concrete, source-backed, testable workflow improvement remains.
 
 Do not manufacture optimization work merely to keep the loop active.
@@ -219,6 +231,7 @@ Print:
 - tests and exact outcomes;
 - PR number and merge commit;
 - baseline before and after;
+- disk/RAM state and cleanup performed or deferred;
 - remaining risks;
 - next proposed optimization;
 - current worker status table.

--- a/scripts/controller_resource_audit.py
+++ b/scripts/controller_resource_audit.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Read-only disk and worktree resource audit for controller workflows."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+DEFAULT_RUN_TREE_PATTERNS = ("nouraajd-*", "fall-of-nouraajd-codex")
+DEFAULT_MIN_FREE_GIB = 5.0
+DEFAULT_MAX_USED_PERCENT = 95.0
+
+
+@dataclass(frozen=True)
+class DiskReport:
+    path: str
+    totalBytes: int
+    usedBytes: int
+    freeBytes: int
+
+    @property
+    def usedPercent(self) -> float:
+        if self.totalBytes <= 0:
+            return 0.0
+        return self.usedBytes * 100.0 / self.totalBytes
+
+
+@dataclass(frozen=True)
+class WorktreeRecord:
+    path: str
+    head: str | None = None
+    branch: str | None = None
+    detached: bool = False
+    prunable: str | None = None
+
+
+@dataclass(frozen=True)
+class RunTreeRecord:
+    path: str
+    sizeBytes: int
+
+
+def bytesToGib(value: int) -> float:
+    return value / (1024.0**3)
+
+
+def formatBytes(value: int) -> str:
+    gib = bytesToGib(value)
+    if gib >= 1.0:
+        return f"{gib:.1f} GiB"
+    mib = value / (1024.0**2)
+    return f"{mib:.1f} MiB"
+
+
+def diskReport(path: Path) -> DiskReport:
+    usage = shutil.disk_usage(path)
+    return DiskReport(
+        path=str(path),
+        totalBytes=usage.total,
+        usedBytes=usage.used,
+        freeBytes=usage.free,
+    )
+
+
+def evaluateDiskReports(
+    reports: Sequence[DiskReport],
+    minFreeBytes: int,
+    maxUsedPercent: float,
+) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    for report in reports:
+        if report.freeBytes < minFreeBytes:
+            errors.append(
+                f"{report.path}: free disk {formatBytes(report.freeBytes)} is below required "
+                f"{formatBytes(minFreeBytes)}"
+            )
+        if report.usedPercent > maxUsedPercent:
+            errors.append(f"{report.path}: disk usage {report.usedPercent:.1f}% exceeds limit {maxUsedPercent:.1f}%")
+        elif report.usedPercent > maxUsedPercent - 5:
+            warnings.append(f"{report.path}: disk usage {report.usedPercent:.1f}% is near limit {maxUsedPercent:.1f}%")
+    return errors, warnings
+
+
+def parseWorktreePorcelain(text: str) -> list[WorktreeRecord]:
+    records: list[WorktreeRecord] = []
+    current: dict[str, Any] | None = None
+
+    def flushCurrent() -> None:
+        nonlocal current
+        if current is None:
+            return
+        records.append(
+            WorktreeRecord(
+                path=current["path"],
+                head=current.get("head"),
+                branch=current.get("branch"),
+                detached=bool(current.get("detached")),
+                prunable=current.get("prunable"),
+            )
+        )
+        current = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        key, _, value = line.partition(" ")
+        if key == "worktree":
+            flushCurrent()
+            current = {"path": value}
+        elif current is None:
+            continue
+        elif key == "HEAD":
+            current["head"] = value
+        elif key == "branch":
+            current["branch"] = value
+        elif key == "detached":
+            current["detached"] = True
+        elif key == "prunable":
+            current["prunable"] = value
+    flushCurrent()
+    return records
+
+
+def worktreeSummary(records: Sequence[WorktreeRecord]) -> dict[str, Any]:
+    prunable = [record for record in records if record.prunable]
+    active = [record for record in records if not record.prunable]
+    return {
+        "total": len(records),
+        "active": len(active),
+        "prunable": len(prunable),
+        "prunableRecords": [worktreePayload(record) for record in prunable],
+    }
+
+
+def worktreePayload(record: WorktreeRecord) -> dict[str, Any]:
+    return {
+        "path": record.path,
+        "head": record.head,
+        "branch": record.branch,
+        "detached": record.detached,
+        "prunable": record.prunable,
+    }
+
+
+def runGitWorktreeList(repoRoot: Path) -> list[WorktreeRecord]:
+    result = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=repoRoot,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return parseWorktreePorcelain(result.stdout)
+
+
+def directorySize(path: Path) -> int:
+    total = 0
+    for root, dirs, files in os.walk(path, topdown=True):
+        dirs[:] = [name for name in dirs if not Path(root, name).is_symlink()]
+        for name in files:
+            file_path = Path(root, name)
+            try:
+                if not file_path.is_symlink():
+                    total += file_path.stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def matchesRunTreePattern(name: str, patterns: Sequence[str] | str) -> bool:
+    if isinstance(patterns, str):
+        patterns = [patterns]
+    return any(fnmatch.fnmatch(name, pattern) for pattern in patterns)
+
+
+def discoverRunTrees(
+    roots: Sequence[Path], patterns: Sequence[str] | str, includeSizes: bool = True
+) -> list[RunTreeRecord]:
+    records: list[RunTreeRecord] = []
+    seen: set[Path] = set()
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for entry in root.iterdir():
+            try:
+                resolved = entry.resolve()
+            except OSError:
+                continue
+            if resolved in seen or not entry.is_dir() or entry.is_symlink():
+                continue
+            if matchesRunTreePattern(entry.name, patterns):
+                seen.add(resolved)
+                size = directorySize(entry) if includeSizes else 0
+                records.append(RunTreeRecord(path=str(entry), sizeBytes=size))
+    return sorted(records, key=lambda record: record.path)
+
+
+def payload(
+    repoRoot: Path,
+    diskReports: Sequence[DiskReport],
+    worktrees: Sequence[WorktreeRecord],
+    runTrees: Sequence[RunTreeRecord],
+    errors: Sequence[str],
+    warnings: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "repoRoot": str(repoRoot),
+        "disk": [
+            {
+                "path": report.path,
+                "totalBytes": report.totalBytes,
+                "usedBytes": report.usedBytes,
+                "freeBytes": report.freeBytes,
+                "usedPercent": round(report.usedPercent, 1),
+                "freeHuman": formatBytes(report.freeBytes),
+            }
+            for report in diskReports
+        ],
+        "worktrees": worktreeSummary(worktrees),
+        "runTrees": {
+            "total": len(runTrees),
+            "totalBytes": sum(record.sizeBytes for record in runTrees),
+            "records": [
+                {"path": record.path, "sizeBytes": record.sizeBytes, "sizeHuman": formatBytes(record.sizeBytes)}
+                for record in runTrees
+            ],
+        },
+        "errors": list(errors),
+        "warnings": list(warnings),
+    }
+
+
+def printHuman(report: dict[str, Any]) -> None:
+    print(f"Repository: {report['repoRoot']}")
+    print("Disk:")
+    for item in report["disk"]:
+        print(f"  {item['path']}: {item['freeHuman']} free, " f"{item['usedPercent']:.1f}% used")
+    worktrees = report["worktrees"]
+    print(f"Worktrees: {worktrees['active']} active, " f"{worktrees['prunable']} prunable, {worktrees['total']} total")
+    runTrees = report["runTrees"]
+    print(f"Run trees: {runTrees['total']} matching, " f"{formatBytes(runTrees['totalBytes'])} total")
+    for warning in report["warnings"]:
+        print(f"WARNING: {warning}")
+    for error in report["errors"]:
+        print(f"ERROR: {error}", file=sys.stderr)
+
+
+def buildParser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="Repository root to inspect.")
+    parser.add_argument(
+        "--disk-path",
+        action="append",
+        default=[],
+        help="Additional path whose filesystem usage should be audited.",
+    )
+    parser.add_argument(
+        "--run-tree-root",
+        action="append",
+        default=[],
+        help="Directory containing controller run/worktrees. Defaults to /tmp.",
+    )
+    parser.add_argument(
+        "--run-tree-pattern",
+        action="append",
+        default=None,
+        help=(
+            "Glob for controller run/worktree directory names. May be repeated. Defaults to "
+            "nouraajd-* and fall-of-nouraajd-codex."
+        ),
+    )
+    parser.add_argument("--min-free-gib", type=float, default=DEFAULT_MIN_FREE_GIB)
+    parser.add_argument("--max-used-percent", type=float, default=DEFAULT_MAX_USED_PERCENT)
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    parser.add_argument(
+        "--skip-run-tree-sizes",
+        action="store_true",
+        help="List matching run/worktrees without recursively sizing them.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = buildParser().parse_args(argv)
+    repoRoot = Path(args.repo_root).resolve()
+    diskPaths = [repoRoot, Path("/tmp"), *[Path(path).resolve() for path in args.disk_path]]
+    uniqueDiskPaths = list(dict.fromkeys(path for path in diskPaths if path.exists()))
+    runTreeRoots = [Path(path).resolve() for path in args.run_tree_root] or [Path("/tmp")]
+    runTreePatterns = args.run_tree_pattern or list(DEFAULT_RUN_TREE_PATTERNS)
+
+    try:
+        diskReports = [diskReport(path) for path in uniqueDiskPaths]
+        worktrees = runGitWorktreeList(repoRoot)
+        runTrees = discoverRunTrees(runTreeRoots, runTreePatterns, includeSizes=not args.skip_run_tree_sizes)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        print(f"controller_resource_audit: {exc}", file=sys.stderr)
+        return 2
+
+    minFreeBytes = int(args.min_free_gib * 1024 * 1024 * 1024)
+    errors, warnings = evaluateDiskReports(diskReports, minFreeBytes, args.max_used_percent)
+    summary = worktreeSummary(worktrees)
+    if summary["prunable"]:
+        warnings.append(f"{summary['prunable']} prunable worktree registration(s); review and run git worktree prune")
+    report = payload(repoRoot, diskReports, worktrees, runTrees, errors, warnings)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        printHuman(report)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_controller_resource_audit.py
+++ b/tests/test_controller_resource_audit.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import controller_resource_audit
+
+
+class ControllerResourceAuditTest(unittest.TestCase):
+    def test_parse_worktree_porcelain_counts_prunable_records(self) -> None:
+        records = controller_resource_audit.parseWorktreePorcelain("""worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /tmp/missing
+HEAD def456
+branch refs/heads/codex/stale
+prunable gitdir file points to non-existent location
+
+worktree /tmp/detached
+HEAD 123abc
+detached
+""")
+
+        summary = controller_resource_audit.worktreeSummary(records)
+
+        self.assertEqual(3, summary["total"])
+        self.assertEqual(2, summary["active"])
+        self.assertEqual(1, summary["prunable"])
+        self.assertEqual("/tmp/missing", summary["prunableRecords"][0]["path"])
+        self.assertTrue(records[2].detached)
+
+    def test_evaluate_disk_reports_flags_threshold_failures_and_near_limit_warnings(self) -> None:
+        reports = [
+            controller_resource_audit.DiskReport(
+                path="/healthy",
+                totalBytes=1000,
+                usedBytes=500,
+                freeBytes=500,
+            ),
+            controller_resource_audit.DiskReport(
+                path="/full",
+                totalBytes=1000,
+                usedBytes=970,
+                freeBytes=30,
+            ),
+            controller_resource_audit.DiskReport(
+                path="/nearly-full",
+                totalBytes=1000,
+                usedBytes=910,
+                freeBytes=90,
+            ),
+        ]
+
+        errors, warnings = controller_resource_audit.evaluateDiskReports(
+            reports,
+            minFreeBytes=50,
+            maxUsedPercent=95.0,
+        )
+
+        self.assertTrue(any("/full: free disk" in error for error in errors), errors)
+        self.assertTrue(any("/full: disk usage 97.0%" in error for error in errors), errors)
+        self.assertTrue(any("/nearly-full: disk usage 91.0%" in warning for warning in warnings), warnings)
+
+    def test_discover_run_trees_reports_matching_directory_sizes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_tree = root / "nouraajd-controller-audit"
+            run_tree.mkdir()
+            (run_tree / "artifact.txt").write_text("x" * 17, encoding="utf-8")
+            ignored = root / "other-worktree"
+            ignored.mkdir()
+            (ignored / "artifact.txt").write_text("x" * 100, encoding="utf-8")
+
+            records = controller_resource_audit.discoverRunTrees([root], "nouraajd-*")
+
+        self.assertEqual(1, len(records))
+        self.assertTrue(records[0].path.endswith("nouraajd-controller-audit"))
+        self.assertEqual(17, records[0].sizeBytes)
+
+    def test_discover_run_trees_includes_documented_controller_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_tree = root / "fall-of-nouraajd-codex"
+            nested_worktree = run_tree / "controller" / "purpose"
+            nested_worktree.mkdir(parents=True)
+            (nested_worktree / "artifact.txt").write_text("x" * 23, encoding="utf-8")
+
+            records = controller_resource_audit.discoverRunTrees(
+                [root],
+                controller_resource_audit.DEFAULT_RUN_TREE_PATTERNS,
+            )
+
+        self.assertEqual(1, len(records))
+        self.assertTrue(records[0].path.endswith("fall-of-nouraajd-codex"))
+        self.assertEqual(23, records[0].sizeBytes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a read-only `scripts/controller_resource_audit.py` helper that reports disk usage, active/prunable Git worktree registrations, and controller run-tree sizes.
- Cover both `/tmp/nouraajd-*` and the documented `/tmp/fall-of-nouraajd-codex` controller root.
- Update controller docs/prompts to require disk-aware dispatch, pre-validation audits, and periodic reviewed cleanup.
- Add focused unit coverage for disk threshold evaluation, prunable worktree parsing, and controller-root run-tree discovery.

## Why

The controller workflow was RAM-aware but had no repeatable disk-space gate or durable way to see accumulated run/worktrees before dispatching workers or starting heavy validation.

## Validation

- `python3 -m unittest tests.test_issue_queue tests.test_controller_resource_audit`: PASS
- `python3 scripts/issue_queue.py validate`: PASS
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`: PASS
- `python3 scripts/controller_resource_audit.py --json`: PASS, reported `/tmp` at 895.1 GiB free and 6.0% used, 2 active worktrees, 0 prunable registrations, and 3 matching run-tree roots.
- `timeout 10s python3 -m black --check --diff -l 120 scripts/controller_resource_audit.py tests/test_controller_resource_audit.py`: PASS
- `python3 test.py GameTest.test_python_black_formatting GameTest.test_indentation`: PASS
- `git diff --check`: PASS

## Known Limitations

- The audit helper is report-only; it does not delete files, worktrees, or branches.
- Full native/game validation was not rerun for this workflow-only checkpoint because the branch has no `cmake-build-release` tree and does not touch game runtime paths.
