### PR TITLE
Expose stale queue claims safely

### DIFF
--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -237,10 +237,19 @@ python3 scripts/issue_queue.py release ... --note 'Returned before editing'
 An `IN_PROGRESS` row has a `Lease Until UTC`. The controller can reclaim expired work:
 
 ```bash
+python3 scripts/issue_queue.py reclaim-stale --dry-run --older-than-minutes 30
 python3 scripts/issue_queue.py reclaim-stale --older-than-minutes 30
 ```
 
-This only reclaims rows whose lease is already expired and whose last update is at least the specified age. Reclaimed rows return to `NOT_STARTED`, retain the incremented `Attempt`, and receive an audit note describing the previous owner and claim.
+The dry run lists stale rows without modifying the workbook. Inspect the worker worktree, branch, pull request, and any
+recoverable changes before running the mutating command. Run the mutating command only from a fresh workbook-only branch
+and publish it through the same serialized queue-state PR process as claims and terminal statuses. Reclaimed rows are
+not eligible for dispatch until that reclaim PR actually merges. The mutating command only reclaims rows whose lease is
+already expired and whose last update is at least the specified age. Reclaimed rows return to `NOT_STARTED`, retain the
+incremented `Attempt`, and receive an audit note describing the previous owner and claim.
+
+`validate` warns about expired `IN_PROGRESS` leases without failing the workbook, and `list --status IN_PROGRESS --json`
+includes derived lease-expiration fields for read-only controller status checks.
 
 ## Inspection commands
 

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -363,7 +363,12 @@ python3 scripts/issue_queue.py heartbeat \
 
 Commit and merge that workbook-only change using the same status-PR process as claim publication.
 
-If a worker disappears, do not overwrite the active claim. Inspect its worktree and branch, wait for lease expiry, and use `reclaim-stale` only when the claim is genuinely stale and no recoverable work remains.
+If a worker disappears, do not overwrite the active claim. Inspect its worktree and branch, wait for lease expiry, and
+run `python3 scripts/issue_queue.py reclaim-stale --dry-run --older-than-minutes <minutes>` to list stale
+`IN_PROGRESS` claims without mutating the workbook. Use mutating `reclaim-stale` only when the claim is genuinely stale
+and no recoverable work remains. Treat `validate` warnings about expired `IN_PROGRESS` leases and derived
+`list --status IN_PROGRESS --json` lease-expiration fields as read-only recovery signals, not permission to reclaim
+without inspection.
 
 ## RAM-safe validation
 
@@ -494,6 +499,8 @@ Do not merge partial implementation code merely to publish a queue status. If co
 - Authentication or permission failure: stop Git publication and report the exact command and error.
 - Dirty user worktree: do not clean or reset it; operate only in new worktrees.
 - Stale worktree: inspect commits and uncommitted files before removal.
+- Stale `IN_PROGRESS` claim: run `reclaim-stale --dry-run`, inspect the worker branch/worktree/PR state, and only then
+  publish a workbook-only reclaim change when no recoverable work remains.
 - Queue workbook conflict: close or resolve the older queue PR first; never attempt a binary merge by combining workbook copies.
 
 Never convert `BLOCKED`, `FAILED`, or `CANCELLED` to `DONE` merely to unlock dependencies.

--- a/scripts/issue_queue.py
+++ b/scripts/issue_queue.py
@@ -725,6 +725,7 @@ def eligibleTasks(
 def validateQueueState(state: QueueState) -> tuple[list[str], list[str]]:
     errors: list[str] = []
     warnings: list[str] = []
+    now = utcNow()
 
     missing = [header for header in ALL_HEADERS if header not in state.headers]
     if missing:
@@ -776,6 +777,11 @@ def validateQueueState(state: QueueState) -> tuple[list[str], list[str]]:
                 errors.append(f"Row {task.row}: IN_PROGRESS requires valid Updated At UTC")
             if leaseUntil is None:
                 errors.append(f"Row {task.row}: IN_PROGRESS requires valid Lease Until UTC")
+            elif leaseUntil <= now:
+                warnings.append(
+                    f"Row {task.row}: IN_PROGRESS lease expired at {formatUtc(leaseUntil)}; "
+                    "inspect the worker and run reclaim-stale --dry-run before reclaiming"
+                )
             if attempt < 1:
                 errors.append(f"Row {task.row}: IN_PROGRESS requires Attempt >= 1")
             if progress >= 100:
@@ -840,7 +846,62 @@ def taskPayload(task: TaskRecord) -> dict[str, Any]:
     payload["Status"] = task.status
     payload["Dependencies Parsed"] = task.dependencies
     payload["Target Files Parsed"] = sorted(task.targetFiles)
+    payload.update(taskLeasePayload(task, utcNow()))
     return payload
+
+
+def ageMinutes(now: datetime, then: datetime | None) -> int | None:
+    if then is None:
+        return None
+    return max(0, int((now - then).total_seconds() // 60))
+
+
+def taskLeasePayload(task: TaskRecord, now: datetime) -> dict[str, Any]:
+    if task.status != STATUS_IN_PROGRESS:
+        return {}
+    lease = parseUtc(task.values.get("Lease Until UTC"))
+    updated = parseUtc(task.values.get("Updated At UTC")) or parseUtc(task.values.get("Claimed At UTC"))
+    expired = lease is None or lease <= now
+    return {
+        "leaseExpired": expired,
+        "leaseExpiredMinutes": ageMinutes(now, lease) if expired else None,
+        "updatedAgeMinutes": ageMinutes(now, updated),
+        "staleReason": "missing lease" if lease is None else "lease expired" if expired else None,
+    }
+
+
+def staleClaimPayload(task: TaskRecord, now: datetime, olderThanMinutes: int = 0) -> dict[str, Any] | None:
+    if task.status != STATUS_IN_PROGRESS:
+        return None
+    lease = parseUtc(task.values.get("Lease Until UTC"))
+    updated = parseUtc(task.values.get("Updated At UTC")) or parseUtc(task.values.get("Claimed At UTC"))
+    leasePayload = taskLeasePayload(task, now)
+    expired = bool(leasePayload.get("leaseExpired"))
+    oldEnough = updated is None or updated <= now - timedelta(minutes=olderThanMinutes)
+    if not expired or not oldEnough:
+        return None
+
+    return {
+        "issueName": task.issueName,
+        "row": task.row,
+        "owner": str(task.values.get("Owner") or ""),
+        "claimId": str(task.values.get("Claim ID") or ""),
+        "updatedAtUtc": formatUtc(updated) if updated else None,
+        "leaseUntilUtc": formatUtc(lease) if lease else None,
+        **leasePayload,
+    }
+
+
+def staleClaims(state: QueueState, olderThanMinutes: int = 0, now: datetime | None = None) -> list[dict[str, Any]]:
+    if olderThanMinutes < 0:
+        raise QueueError("--older-than-minutes must be non-negative")
+    now = now or utcNow()
+    records = [
+        record
+        for task in sorted(state.tasks, key=taskSortKey)
+        if (record := staleClaimPayload(task, now, olderThanMinutes)) is not None
+    ]
+    return records
 
 
 def claimTask(
@@ -1062,15 +1123,8 @@ def reclaimStaleTasks(
             ensureWorkflowSchema(state)
             state = refreshTasks(state)
             now = utcNow()
-            for task in state.tasks:
-                if task.status != STATUS_IN_PROGRESS:
-                    continue
-                lease = parseUtc(task.values.get("Lease Until UTC"))
-                updated = parseUtc(task.values.get("Updated At UTC")) or parseUtc(task.values.get("Claimed At UTC"))
-                expired = lease is None or lease <= now
-                oldEnough = updated is None or updated <= now - timedelta(minutes=olderThanMinutes)
-                if not expired or not oldEnough:
-                    continue
+            for stale in staleClaims(state, olderThanMinutes=olderThanMinutes, now=now):
+                task = taskByName(state, stale["issueName"])
                 priorOwner = str(task.values.get("Owner") or "unknown")
                 priorClaim = str(task.values.get("Claim ID") or "unknown")
                 setValue(state, task.row, "Status", STATUS_NOT_STARTED)
@@ -1089,7 +1143,13 @@ def reclaimStaleTasks(
                 )
                 setValue(state, task.row, "Result Summary", None)
                 setValue(state, task.row, "Validation Results", None)
-                reclaimed.append({"issueName": task.issueName, "priorOwner": priorOwner, "priorClaimId": priorClaim})
+                reclaimed.append(
+                    {
+                        **stale,
+                        "priorOwner": priorOwner,
+                        "priorClaimId": priorClaim,
+                    }
+                )
             if reclaimed:
                 atomicSave(state, workbookPath)
             return reclaimed
@@ -1188,22 +1248,24 @@ def printTable(tasks: Sequence[TaskRecord]) -> None:
     if not tasks:
         print("No tasks.")
         return
+    now = utcNow()
     rows = [
         (
             task.status,
             task.priority,
             str(task.values.get("Owner") or ""),
             str(task.values.get("Progress %") or 0),
+            "expired" if taskLeasePayload(task, now).get("leaseExpired") else "",
             task.issueName,
         )
         for task in tasks
     ]
-    widths = [max(len(row[index]) for row in rows + [("STATUS", "PRI", "OWNER", "%", "ISSUE")]) for index in range(5)]
-    header = ("STATUS", "PRI", "OWNER", "%", "ISSUE")
-    print("  ".join(header[index].ljust(widths[index]) for index in range(5)))
-    print("  ".join("-" * widths[index] for index in range(5)))
+    header = ("STATUS", "PRI", "OWNER", "%", "LEASE", "ISSUE")
+    widths = [max(len(row[index]) for row in rows + [header]) for index in range(len(header))]
+    print("  ".join(header[index].ljust(widths[index]) for index in range(len(header))))
+    print("  ".join("-" * widths[index] for index in range(len(header))))
     for row in rows:
-        print("  ".join(row[index].ljust(widths[index]) for index in range(5)))
+        print("  ".join(row[index].ljust(widths[index]) for index in range(len(header))))
 
 
 def addCommonArguments(parser: argparse.ArgumentParser) -> None:
@@ -1304,6 +1366,7 @@ def buildParser() -> argparse.ArgumentParser:
     reclaimParser = subparsers.add_parser("reclaim-stale", help="Release expired IN_PROGRESS claims")
     addCommonArguments(reclaimParser)
     reclaimParser.add_argument("--older-than-minutes", type=int, default=0)
+    reclaimParser.add_argument("--dry-run", action="store_true", help="Report stale claims without modifying the queue")
 
     return parser
 
@@ -1460,15 +1523,22 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
         if args.command == "reclaim-stale":
-            printJson(
-                {
-                    "reclaimed": reclaimStaleTasks(
-                        workbookPath,
-                        olderThanMinutes=args.older_than_minutes,
-                        lockTimeoutSeconds=args.lock_timeout_seconds,
-                    )
-                }
-            )
+            if args.dry_run:
+                state = loadQueue(workbookPath, writable=False)
+                try:
+                    printJson({"stale": staleClaims(state, olderThanMinutes=args.older_than_minutes)})
+                finally:
+                    state.workbook.close()
+            else:
+                printJson(
+                    {
+                        "reclaimed": reclaimStaleTasks(
+                            workbookPath,
+                            olderThanMinutes=args.older_than_minutes,
+                            lockTimeoutSeconds=args.lock_timeout_seconds,
+                        )
+                    }
+                )
             return 0
 
         raise QueueError(f"Unsupported command {args.command}")

--- a/tests/test_issue_queue.py
+++ b/tests/test_issue_queue.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import contextlib
+import io
+import json
 import multiprocessing
 import tempfile
 import unittest
@@ -192,6 +195,26 @@ class IssueQueueTest(unittest.TestCase):
     def xml_bytes(element: ET.Element) -> bytes:
         return ET.tostring(element, encoding="utf-8", xml_declaration=True)
 
+    def set_claim_times(
+        self,
+        issue_name: str,
+        *,
+        lease_minutes_from_now: int | None,
+        updated_minutes_ago: int | None = None,
+    ) -> None:
+        document = issue_queue.XlsxDocument.load(self.workbook_path)
+        state = issue_queue.loadQueue(self.workbook_path)
+        task = issue_queue.taskByName(state, issue_name)
+        if lease_minutes_from_now is None:
+            document.setCell(task.row, state.headers["Lease Until UTC"], None)
+        else:
+            lease = issue_queue.formatUtc(issue_queue.utcNow() + timedelta(minutes=lease_minutes_from_now))
+            document.setCell(task.row, state.headers["Lease Until UTC"], lease)
+        if updated_minutes_ago is not None:
+            updated = issue_queue.formatUtc(issue_queue.utcNow() - timedelta(minutes=updated_minutes_ago))
+            document.setCell(task.row, state.headers["Updated At UTC"], updated)
+        document.save(self.workbook_path)
+
     def test_claim_respects_priority_dependency_and_active_file_overlap(self) -> None:
         first = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1")
         self.assertEqual(self.issue_b, first["Issue Name"])
@@ -262,20 +285,163 @@ class IssueQueueTest(unittest.TestCase):
 
     def test_reclaim_stale_claim(self) -> None:
         claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
-        document = issue_queue.XlsxDocument.load(self.workbook_path)
-        state = issue_queue.loadQueue(self.workbook_path)
-        task = issue_queue.taskByName(state, claim["Issue Name"])
-        past = issue_queue.formatUtc(issue_queue.utcNow() - timedelta(minutes=10))
-        document.setCell(task.row, state.headers["Lease Until UTC"], past)
-        document.setCell(task.row, state.headers["Updated At UTC"], past)
-        document.save(self.workbook_path)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=10)
 
         reclaimed = issue_queue.reclaimStaleTasks(self.workbook_path, olderThanMinutes=5)
         self.assertEqual([claim["Issue Name"]], [item["issueName"] for item in reclaimed])
         state = issue_queue.loadQueue(self.workbook_path)
         task = issue_queue.taskByName(state, claim["Issue Name"])
         self.assertEqual(issue_queue.STATUS_NOT_STARTED, task.status)
+        self.assertFalse(task.values["Owner"])
         self.assertFalse(task.values["Claim ID"])
+        self.assertFalse(task.values["Claimed At UTC"])
+        self.assertFalse(task.values["Lease Until UTC"])
+        self.assertFalse(task.values["Completed At UTC"])
+        self.assertEqual(0, task.values["Progress %"])
+        self.assertEqual(1, task.values["Attempt"])
+        self.assertIn("controller/subagent-1", task.values["Last Note"])
+        self.assertIn(claim["claimId"], task.values["Last Note"])
+        self.assertFalse(task.values["Result Summary"])
+        self.assertFalse(task.values["Validation Results"])
+        errors, warnings = issue_queue.validateQueueState(state)
+        self.assertEqual([], errors)
+        self.assertEqual([], warnings)
+
+    def test_stale_claims_detect_expired_in_progress_without_mutating(self) -> None:
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=10)
+
+        state = issue_queue.loadQueue(self.workbook_path)
+        stale = issue_queue.staleClaims(state, olderThanMinutes=5)
+
+        self.assertEqual([claim["Issue Name"]], [item["issueName"] for item in stale])
+        self.assertEqual("controller/subagent-1", stale[0]["owner"])
+        self.assertEqual(claim["claimId"], stale[0]["claimId"])
+        self.assertEqual("lease expired", stale[0]["staleReason"])
+        self.assertTrue(stale[0]["leaseExpired"])
+        state = issue_queue.loadQueue(self.workbook_path)
+        task = issue_queue.taskByName(state, claim["Issue Name"])
+        payload = issue_queue.taskPayload(task)
+        self.assertTrue(payload["leaseExpired"])
+        self.assertEqual("lease expired", payload["staleReason"])
+        self.assertEqual(issue_queue.STATUS_IN_PROGRESS, task.status)
+        self.assertEqual(claim["claimId"], task.values["Claim ID"])
+
+    def test_validate_warns_about_expired_in_progress_lease(self) -> None:
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=-10)
+
+        state = issue_queue.loadQueue(self.workbook_path)
+        errors, warnings = issue_queue.validateQueueState(state)
+
+        self.assertEqual([], errors)
+        self.assertTrue(any("IN_PROGRESS lease expired" in warning for warning in warnings), warnings)
+
+    def test_reclaim_stale_claim_ignores_unexpired_lease(self) -> None:
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=10, updated_minutes_ago=30)
+
+        reclaimed = issue_queue.reclaimStaleTasks(self.workbook_path, olderThanMinutes=5)
+
+        self.assertEqual([], reclaimed)
+        state = issue_queue.loadQueue(self.workbook_path)
+        task = issue_queue.taskByName(state, claim["Issue Name"])
+        self.assertEqual(issue_queue.STATUS_IN_PROGRESS, task.status)
+        self.assertEqual(claim["claimId"], task.values["Claim ID"])
+        self.assertFalse(issue_queue.taskPayload(task)["leaseExpired"])
+
+    def test_reclaim_stale_claim_respects_older_than_grace_period(self) -> None:
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=1)
+
+        reclaimed = issue_queue.reclaimStaleTasks(self.workbook_path, olderThanMinutes=5)
+
+        self.assertEqual([], reclaimed)
+        state = issue_queue.loadQueue(self.workbook_path)
+        task = issue_queue.taskByName(state, claim["Issue Name"])
+        self.assertEqual(issue_queue.STATUS_IN_PROGRESS, task.status)
+        self.assertEqual(claim["claimId"], task.values["Claim ID"])
+
+    def test_reclaimed_claim_rejects_prior_credentials_and_can_be_reclaimed(self) -> None:
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=10)
+        issue_queue.reclaimStaleTasks(self.workbook_path, olderThanMinutes=5)
+
+        with self.assertRaises(issue_queue.QueueError):
+            issue_queue.heartbeatTask(
+                self.workbook_path,
+                issueName=claim["Issue Name"],
+                claimId=claim["claimId"],
+                owner="controller/subagent-1",
+                progress=20,
+                note="old claim should fail",
+            )
+        next_claim = issue_queue.claimTask(
+            self.workbook_path,
+            owner="controller/subagent-2",
+            issueName=claim["Issue Name"],
+        )
+
+        self.assertNotEqual(claim["claimId"], next_claim["claimId"])
+        self.assertEqual(2, next_claim["Attempt"])
+
+    def test_reclaim_stale_rejects_negative_age_threshold(self) -> None:
+        with self.assertRaises(issue_queue.QueueError):
+            issue_queue.staleClaims(issue_queue.loadQueue(self.workbook_path), olderThanMinutes=-1)
+        with self.assertRaises(issue_queue.QueueError):
+            issue_queue.reclaimStaleTasks(self.workbook_path, olderThanMinutes=-1)
+
+    def test_reclaim_stale_dry_run_reports_without_mutating(self) -> None:
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=10)
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = issue_queue.main(
+                [
+                    "reclaim-stale",
+                    "--workbook",
+                    str(self.workbook_path),
+                    "--older-than-minutes",
+                    "5",
+                    "--dry-run",
+                ]
+            )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(0, exit_code)
+        self.assertEqual([claim["Issue Name"]], [item["issueName"] for item in payload["stale"]])
+        state = issue_queue.loadQueue(self.workbook_path)
+        task = issue_queue.taskByName(state, claim["Issue Name"])
+        self.assertEqual(issue_queue.STATUS_IN_PROGRESS, task.status)
+        self.assertEqual(claim["claimId"], task.values["Claim ID"])
+
+    def test_list_table_marks_expired_in_progress_lease(self) -> None:
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=10)
+        state = issue_queue.loadQueue(self.workbook_path)
+        tasks = issue_queue.listTasks(state, {issue_queue.STATUS_IN_PROGRESS}, None, None)
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            issue_queue.printTable(tasks)
+
+        output = stdout.getvalue()
+        self.assertIn("LEASE", output)
+        self.assertIn("expired", output)
+
+    def test_stale_claims_treat_missing_lease_as_recoverable_stale_state(self) -> None:
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=None, updated_minutes_ago=10)
+        state = issue_queue.loadQueue(self.workbook_path)
+
+        errors, warnings = issue_queue.validateQueueState(state)
+        stale = issue_queue.staleClaims(state, olderThanMinutes=5)
+
+        self.assertTrue(any("requires valid Lease Until UTC" in error for error in errors), errors)
+        self.assertEqual([], warnings)
+        self.assertEqual([claim["Issue Name"]], [item["issueName"] for item in stale])
+        self.assertEqual("missing lease", stale[0]["staleReason"])
 
     def test_validate_detects_dependency_cycle(self) -> None:
         self.create_workbook(


### PR DESCRIPTION
## Summary

- Add derived stale-claim visibility for `IN_PROGRESS` queue rows.
- Warn during `issue_queue.py validate` when a lease is expired, without failing validation.
- Add `reclaim-stale --dry-run` so controllers can inspect stale rows before mutating the workbook.
- Expose derived lease fields in `show`/`list --json` and mark expired leases in the human `list` table.
- Document the safe recovery flow: dry-run first, inspect worker branch/worktree/PR state, then reclaim only through a fresh workbook-only PR.

## Why

The live queue already has expired `IN_PROGRESS` leases, but they were invisible in normal read-only checks. Controllers had to know to run the mutating reclaim path before they could see stale claims clearly.

## Validation

- `python3 -m unittest tests.test_issue_queue tests.test_controller_resource_audit`: PASS
- `python3 scripts/issue_queue.py validate`: PASS with expected stale-claim warnings for rows 25 and 131
- `python3 scripts/issue_queue.py reclaim-stale --dry-run --older-than-minutes 30`: PASS, reported rows 25 and 131 without mutating the workbook
- `python3 scripts/issue_queue.py list --status IN_PROGRESS`: PASS, marked the two expired leases as `expired`
- `python3 scripts/issue_queue.py show --issue "[EPIC_02][STORY_01][SUBSTORY_01]Add context-owned providers"`: PASS, included derived `leaseExpired` fields
- `timeout 10s python3 -m black --check --diff -l 120 scripts/issue_queue.py tests/test_issue_queue.py`: PASS
- `python3 test.py GameTest.test_python_black_formatting GameTest.test_indentation`: PASS
- `git diff --check`: PASS
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`: PASS

## Known Limitations

- This PR does not reclaim any stale rows. It only makes stale claims visible and documents the safe reclaim workflow.
- Full native/game validation was not rerun because this is queue tooling and documentation only; no game runtime paths are touched.
