### PR TITLE
[codex] Centralize GUI lifecycle checks

### DIFF
--- a/scripts/coverage_exclusions.json
+++ b/scripts/coverage_exclusions.json
@@ -396,15 +396,15 @@
       "path": "src/gui/object/CGameGraphicsObject.cpp",
       "reason": "Reviewed legacy uncovered branch baseline; unreviewed coverage changes remain visible in the 95% scoped line gate.",
       "ranges": [
-        "69",
-        "96-97",
-        "109",
-        "177",
-        "193",
-        "196",
-        "217-218",
-        "224",
-        "238"
+        "81",
+        "108-109",
+        "121",
+        "195",
+        "211",
+        "214",
+        "235-236",
+        "242",
+        "256"
       ]
     },
     {
@@ -610,9 +610,9 @@
         "197-199",
         "211-214",
         "235-238",
-        "254",
-        "294",
-        "337"
+        "259",
+        "301",
+        "348"
       ]
     },
     {

--- a/src/gui/object/CGameGraphicsObject.cpp
+++ b/src/gui/object/CGameGraphicsObject.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -25,26 +25,35 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 void CGameGraphicsObject::renderObject(std::shared_ptr<CGui> reneder, std::shared_ptr<SDL_Rect> rect, int frameTime) {}
 
-void CGameGraphicsObject::render(std::shared_ptr<CGui> reneder, int frameTime) {
-    if (isVisible()) {
-        renderBackground(reneder, getRect(), frameTime);
-        renderObject(reneder, getRect(), frameTime);
+void CGameGraphicsObject::render(std::shared_ptr<CGui> renderer, int frameTime) {
+    if (hasRenderableGui(renderer) && isVisible()) {
+        renderBackground(renderer, getRect(), frameTime);
+        renderObject(renderer, getRect(), frameTime);
+        if (!isAttachedToGui(renderer)) {
+            return;
+        }
         auto snapshot = children;
         for (const auto &child : snapshot) {
             if (child && children.contains(child)) {
-                child->render(reneder, frameTime);
+                child->render(renderer, frameTime);
+                if (!isAttachedToGui(renderer)) {
+                    return;
+                }
             }
         }
     }
 }
 
 bool CGameGraphicsObject::event(std::shared_ptr<CGui> gui, SDL_Event *event) {
-    if (isVisible()) {
+    if (isAttachedToGui(gui) && isVisible()) {
         auto snapshot = children;
         for (auto it = snapshot.rbegin(); it != snapshot.rend(); ++it) {
             const auto &child = *it;
             if (child && children.contains(child) && child->event(gui, event)) {
                 return true;
+            }
+            if (!isAttachedToGui(gui)) {
+                return false;
             }
         }
         auto callbacks = eventCallbackList;
@@ -52,6 +61,9 @@ bool CGameGraphicsObject::event(std::shared_ptr<CGui> gui, SDL_Event *event) {
             if (callback.first(gui, this->ptr<CGameGraphicsObject>(), event) &&
                 callback.second(gui, this->ptr<CGameGraphicsObject>(), event)) {
                 return true;
+            }
+            if (!isAttachedToGui(gui)) {
+                return false;
             }
         }
         if (event->type == SDL_KEYDOWN || event->type == SDL_KEYUP) {
@@ -167,6 +179,12 @@ void CGameGraphicsObject::pushChild(const std::shared_ptr<CGameGraphicsObject> &
 
 std::shared_ptr<CGui> CGameGraphicsObject::getGui() { return vstd::cast<CGui>(getTopParent()); }
 
+bool CGameGraphicsObject::isAttachedToGui(const std::shared_ptr<CGui> &gui) { return gui && getTopParent() == gui; }
+
+bool CGameGraphicsObject::hasRenderableGui(const std::shared_ptr<CGui> &gui) {
+    return isAttachedToGui(gui) && gui->getRenderer();
+}
+
 bool CGameGraphicsObject::getModal() { return modal; }
 
 void CGameGraphicsObject::setModal(bool _modal) { modal = _modal; }
@@ -211,7 +229,7 @@ bool CGameGraphicsObject::isVisible() {
 }
 
 void CGameGraphicsObject::renderBackground(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int time) {
-    if (!background.empty()) {
+    if (hasRenderableGui(gui) && !background.empty()) {
         auto texture = gui->getTextureCache()->getTexture(background);
         if (!texture) {
             vstd::logger::error("CGameGraphicsObject: missing background", background);

--- a/src/gui/object/CGameGraphicsObject.h
+++ b/src/gui/object/CGameGraphicsObject.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -105,6 +105,10 @@ class CGameGraphicsObject : public CGameObject {
     void removeParent();
 
     std::shared_ptr<CGui> getGui();
+
+    bool isAttachedToGui(const std::shared_ptr<CGui> &gui);
+
+    bool hasRenderableGui(const std::shared_ptr<CGui> &gui);
 
     bool getModal();
 

--- a/src/gui/panel/CGameQuestionPanel.cpp
+++ b/src/gui/panel/CGameQuestionPanel.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -25,8 +25,8 @@ std::string CGameQuestionPanel::getQuestion() { return question; }
 void CGameQuestionPanel::setQuestion(std::string question) { this->question = question; }
 
 bool CGameQuestionPanel::awaitAnswer() {
-    vstd::wait_until([this]() { return selection != nullptr; });
-    return *selection;
+    vstd::wait_until([this]() { return selection != nullptr || !getGui(); });
+    return selection ? *selection : false;
 }
 
 void CGameQuestionPanel::clickNo(std::shared_ptr<CGui> gui) {

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -172,7 +172,7 @@ void CListView::clampShift(const std::shared_ptr<CGui> &gui, int itemTypeCount) 
 
 CListView::collection_pointer CListView::invokeCollection(std::shared_ptr<CGui> gui) {
     auto parent = getParent();
-    if (!parent || collection.empty()) {
+    if (!canInvokeParentCallback(gui, parent) || collection.empty()) {
         return std::make_shared<CListView::collection_type>();
     }
     try {
@@ -187,7 +187,7 @@ CListView::collection_pointer CListView::invokeCollection(std::shared_ptr<CGui> 
 
 void CListView::invokeCallback(std::shared_ptr<CGui> gui, int i, std::shared_ptr<CGameObject> object) {
     auto parent = getParent();
-    if (!parent || callback.empty()) {
+    if (!canInvokeParentCallback(gui, parent) || callback.empty()) {
         return;
     }
     try {
@@ -201,7 +201,7 @@ void CListView::invokeCallback(std::shared_ptr<CGui> gui, int i, std::shared_ptr
 
 bool CListView::invokeRightClickCallback(std::shared_ptr<CGui> gui, int i, std::shared_ptr<CGameObject> object) {
     auto parent = getParent();
-    if (!parent || rightClickCallback.empty()) {
+    if (!canInvokeParentCallback(gui, parent) || rightClickCallback.empty()) {
         return false;
     }
     try {
@@ -225,7 +225,7 @@ auto CListView::getArrowCallback(bool left) {
 
 bool CListView::invokeSelect(std::shared_ptr<CGui> gui, int i, std::shared_ptr<CGameObject> object) {
     auto parent = getParent();
-    if (!parent || select.empty()) {
+    if (!canInvokeParentCallback(gui, parent) || select.empty()) {
         return false;
     }
     try {
@@ -236,6 +236,11 @@ bool CListView::invokeSelect(std::shared_ptr<CGui> gui, int i, std::shared_ptr<C
         vstd::logger::warning("Ignoring list select callback failure:", select, exception.what());
         return false;
     }
+}
+
+bool CListView::canInvokeParentCallback(const std::shared_ptr<CGui> &gui,
+                                        const std::shared_ptr<CGameGraphicsObject> &parent) {
+    return parent && isAttachedToGui(gui) && parent->isAttachedToGui(gui);
 }
 
 bool CListView::tryGetClickedObject(std::shared_ptr<CGui> gui, int x, int y, int &index,
@@ -259,6 +264,9 @@ bool CListView::tryGetClickedObject(std::shared_ptr<CGui> gui, int x, int y, int
 
 std::list<std::shared_ptr<CGameGraphicsObject>> CListView::getProxiedObjects(std::shared_ptr<CGui> gui, int x, int y) {
     std::list<std::shared_ptr<CGameGraphicsObject>> return_val;
+    if (!isAttachedToGui(gui) || !gui->getGame()) {
+        return return_val;
+    }
     const int itemTypeCount = getItemTypesCount(gui);
     clampShift(gui, itemTypeCount);
     int i = getSizeX(gui) * y + x;
@@ -326,6 +334,9 @@ void CListView::addItem(const std::shared_ptr<CGui> &gui, std::list<std::shared_
                 [self, itemIndex, object](std::shared_ptr<CGui> gui, SDL_EventType type, int button, int, int) {
                     if (type != SDL_MOUSEBUTTONDOWN) {
                         return false;
+                    }
+                    if (!self->isAttachedToGui(gui)) {
+                        return true;
                     }
                     if (button == SDL_BUTTON_LEFT) {
                         self->invokeCallback(gui, itemIndex, object);

--- a/src/gui/panel/CListView.h
+++ b/src/gui/panel/CListView.h
@@ -146,6 +146,8 @@ class CListView : public CProxyTargetGraphicsObject {
 
     bool invokeSelect(std::shared_ptr<CGui> gui, int i, std::shared_ptr<CGameObject> object);
 
+    bool canInvokeParentCallback(const std::shared_ptr<CGui> &gui, const std::shared_ptr<CGameGraphicsObject> &parent);
+
     bool tryGetClickedObject(std::shared_ptr<CGui> gui, int x, int y, int &index, std::shared_ptr<CGameObject> &object);
 
     std::unordered_map<std::pair<int, int>, std::shared_ptr<CProxyGraphicsObject>> proxyObjects;

--- a/src/handler/CGuiHandler.cpp
+++ b/src/handler/CGuiHandler.cpp
@@ -228,11 +228,11 @@ std::string CGuiHandler::showSelection(std::shared_ptr<CListString> list) {
 
     game->getGui()->pushChild(panel);
 
-    vstd::wait_until([&]() { return selected != nullptr; });
+    vstd::wait_until([&]() { return selected != nullptr || !panel->getGui(); });
 
     panel->close();
 
-    return *selected;
+    return selected ? *selected : "";
 }
 
 void CGuiHandler::showTooltip(std::string text, int x, int y) {

--- a/test.py
+++ b/test.py
@@ -8282,6 +8282,27 @@ class GameTest(unittest.TestCase):
         queue_sdl_inputs(game, lambda: push_sdl_mouse_click(1060, 650))
         self.assertFalse(gui_handler.showQuestion("confirm no?"))
 
+        def close_question_panel():
+            panel = find_top_level_panel(g, "CGameQuestionPanel")
+            if panel:
+                panel.close()
+
+        game.event_loop.instance().invoke(close_question_panel)
+        self.assertFalse(gui_handler.showQuestion("externally closed question?"))
+        self.assertFalse(gui_contains_class(g, "CGameQuestionPanel"))
+
+        closed_selection = g.createObject("CListString")
+        closed_selection.addValue("CLOSED")
+
+        def close_selection_panel():
+            panel = find_top_level_panel(g, "CGamePanel")
+            if panel:
+                panel.close()
+
+        game.event_loop.instance().invoke(close_selection_panel)
+        self.assertEqual("", gui_handler.showSelection(closed_selection))
+        self.assertFalse(gui_contains_class(g, "CGamePanel"))
+
         market = g.createObject("CMarket")
         market.sell = 50
         market.buy = 25
@@ -8369,6 +8390,51 @@ class GameTest(unittest.TestCase):
         pump_event_loop(2)
         self.assertTrue(gui_contains_class(g, "CTooltip"))
         self.assertFalse(gui_contains_class(g, "CGameTextPanel"))
+
+        return True, json.dumps({"rolf_letters": player.countItems("letterFromRolf")}, sort_keys=True)
+
+    @game_test
+    def test_detached_inventory_list_view_ignores_stale_item_callbacks(self):
+        game = load_game_module()
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.loadGui(g)
+        game.CGameLoader.startGameWithPlayer(g, "nouraajd", "Warrior")
+        player = g.getMap().getPlayer()
+        player.addItem("letterFromRolf")
+
+        inventory_panel = g.getGuiHandler().openPanel("inventoryPanel")
+        pump_event_loop(5)
+        inventory_list = next(
+            list_view
+            for list_view in collect_gui_children(inventory_panel, "CListView")
+            if list_view.getCollection() == "inventoryCollection"
+        )
+        inventory_list.setTileSize(50)
+        inventory_list.setXPrefferedSize(8)
+        inventory_list.setYPrefferedSize(8)
+        inventory_list.refresh()
+
+        target_graphic = None
+        for y in range(8):
+            for x in range(8):
+                for graphic in inventory_list.getProxiedObjects(g.getGui(), x, y):
+                    obj = graphic.getObject() if hasattr(graphic, "getObject") else None
+                    if obj and obj.getTypeId() == "letterFromRolf":
+                        target_graphic = graphic
+                        break
+                if target_graphic:
+                    break
+            if target_graphic:
+                break
+
+        self.assertIsNotNone(target_graphic)
+        inventory_panel.close()
+        pump_event_loop(2)
+        self.assertFalse(gui_contains_class(g, "CGameInventoryPanel"))
+
+        target_graphic.mouseEvent(g.getGui(), SDL_MOUSEBUTTONDOWN, SDL_BUTTON_RIGHT, 1, 1)
+        pump_event_loop(2)
+        self.assertFalse(gui_contains_class(g, "CTooltip"))
 
         return True, json.dumps({"rolf_letters": player.countItems("letterFromRolf")}, sort_keys=True)
 

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -20,8 +20,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CMap.h"
 #include "core/CStats.h"
 #include "gui/CGui.h"
+#include "gui/CTextureCache.h"
+#include "gui/object/CGameGraphicsObject.h"
 #include "gui/object/CWidget.h"
 #include "gui/panel/CGameInventoryPanel.h"
+#include "gui/panel/CGamePanel.h"
 #include "object/CItem.h"
 #include "object/CPlayer.h"
 #include "test_harness.h"
@@ -29,6 +32,25 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <pybind11/embed.h>
 
 namespace {
+
+class ClosingRenderObject : public CGameGraphicsObject {
+  public:
+    void renderObject(std::shared_ptr<CGui>, std::shared_ptr<SDL_Rect>, int) override {
+        if (auto parent = getParent()) {
+            parent->removeChild(this->ptr<CGameGraphicsObject>());
+        }
+    }
+};
+
+class CountingRenderObject : public CGameGraphicsObject {
+  public:
+    explicit CountingRenderObject(int &render_count) : render_count(render_count) {}
+
+    void renderObject(std::shared_ptr<CGui>, std::shared_ptr<SDL_Rect>, int) override { ++render_count; }
+
+  private:
+    int &render_count;
+};
 
 void test_widget_ignores_unarmed_non_left_clicks() {
     auto widget = std::make_shared<CWidget>();
@@ -80,6 +102,64 @@ void test_inventory_double_select_uses_selected_item_and_clears_selection() {
     expect_true(!panel->inventorySelect(gui, 0, potion), "second inventory click should clear the used selection");
 }
 
+void test_panel_event_callbacks_stop_after_close() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto panel = std::make_shared<CGamePanel>();
+    gui->pushChild(panel);
+
+    int first_callback_count = 0;
+    int second_callback_count = 0;
+    auto always = [](std::shared_ptr<CGui>, std::shared_ptr<CGameGraphicsObject>, SDL_Event *) { return true; };
+
+    panel->registerEventCallback(
+        always, [&first_callback_count](std::shared_ptr<CGui>, std::shared_ptr<CGameGraphicsObject> self, SDL_Event *) {
+            ++first_callback_count;
+            if (auto panel = vstd::cast<CGamePanel>(self)) {
+                panel->close();
+            }
+            return false;
+        });
+    panel->registerEventCallback(
+        always, [&second_callback_count](std::shared_ptr<CGui>, std::shared_ptr<CGameGraphicsObject>, SDL_Event *) {
+            ++second_callback_count;
+            return false;
+        });
+
+    SDL_Event event{};
+    event.type = SDL_MOUSEBUTTONDOWN;
+    event.button.button = SDL_BUTTON_LEFT;
+    gui->event(&event);
+
+    expect_true(first_callback_count == 1, "first callback should close the panel during event dispatch");
+    expect_true(second_callback_count == 0, "detached panel should not receive later event callbacks");
+    expect_true(!gui->findChild(panel), "closed panel should be detached from the GUI");
+}
+
+void test_render_traversal_stops_after_detach() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto parent = std::make_shared<ClosingRenderObject>();
+    int child_render_count = 0;
+    auto child = std::make_shared<CountingRenderObject>(child_render_count);
+
+    parent->addChild(child);
+    gui->pushChild(parent);
+    gui->render(0);
+
+    expect_true(!gui->findChild(parent), "rendering parent should detach itself from the GUI");
+    expect_true(child_render_count == 0, "children of a detached render object should fail closed");
+}
+
+void test_texture_cache_without_gui_fails_closed() {
+    auto cache = std::make_shared<CTextureCache>();
+    expect_true(cache->getTexture("images/panel") == nullptr, "texture cache without GUI should return null");
+}
+
 } // namespace
 
 int main() {
@@ -87,6 +167,9 @@ int main() {
 
     test_widget_ignores_unarmed_non_left_clicks();
     test_inventory_double_select_uses_selected_item_and_clears_selection();
+    test_panel_event_callbacks_stop_after_close();
+    test_render_traversal_stops_after_detach();
+    test_texture_cache_without_gui_fails_closed();
 
     return finish_tests();
 }


### PR DESCRIPTION
## What changed
- Added shared GUI attachment/renderability checks on `CGameGraphicsObject` and used them to fail closed for detached render/event dispatch.
- Guarded list-view parent callbacks and stale proxied item callbacks so closed panels do not continue dispatching or open fallback tooltips.
- Made blocking question/selection helpers return safe defaults when their panels are externally closed.
- Added native and Python regression tests for close-during-event/render, detached list-view callbacks, external modal close, and texture-cache no-GUI behavior.
- Updated line-based coverage exclusions for the shifted GUI source lines.

## Why
Issue #335 asks for centralized GUI lifecycle/null-safety rules so detached or closing GUI objects cannot keep rendering, handling input, or invoking stale callbacks.

## Validation
- `cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance`
- `timeout 1800s python3 test.py > /tmp/nouraajd-issue335-python-rebased.log 2>&1`
- `./scripts/run_coverage.sh > /tmp/nouraajd-issue335-coverage-rebased.log 2>&1` (`lines: 95.10%`)
- `git diff --check`

## Known limitations
- No known follow-up required for this issue.

Fixes #335