### PR TITLE
Optimize Linux CI workflow caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,11 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  linux:
+  linux-fast:
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    timeout-minutes: 30
+    outputs:
+      coverage-needed: ${{ steps.coverage-needed.outputs.run }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -22,6 +24,8 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
       - name: Install Python deps
         run: python3 -m pip install --upgrade -r requirements-dev.txt
       - name: Smoke test Python deps
@@ -71,20 +75,61 @@ jobs:
           else
             echo "Coverage is not required for the changed paths."
           fi
-      - name: submodules
-        run: git submodule update --init --recursive
-      - name: configure
-        run: GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh
-      - name: detect ccache directory
-        id: ccache-dir
+
+  linux:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    env:
+      GAME_CONFIGURE_SKIP_APT: "1"
+      GAME_CONFIGURE_SKIP_SUBMODULES: "1"
+      GAME_TEST_TIMINGS_FILE: test/test-timings-linux.json
+      GAME_XVFB_JOBS: "4"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+      - name: Install Python deps
+        run: python3 -m pip install --upgrade -r requirements-dev.txt
+      - name: Smoke test Python deps
+        run: python3 -c "from PIL import Image; import black; print('python deps ok')"
+      - name: Install native deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake ninja-build ccache clang-format black \
+            python3 python3-dev python3-pip python3-venv pybind11-dev python3-pil \
+            libboost-dev \
+            libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
+            xvfb xauth
+      - name: Detect ccache metadata
+        id: ccache
         shell: bash
-        run: echo "dir=$(ccache --get-config cache_dir)" >> "${GITHUB_OUTPUT}"
-      - name: Cache ccache
+        run: |
+          compiler_id="$(c++ -dumpmachine)-$(c++ -dumpfullversion -dumpversion)"
+          compiler_id="${compiler_id//[^A-Za-z0-9_.-]/-}"
+          echo "dir=$(ccache --get-config cache_dir)" >> "${GITHUB_OUTPUT}"
+          echo "prefix=${{ runner.os }}-ccache-release-${compiler_id}-" >> "${GITHUB_OUTPUT}"
+      - name: Restore ccache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ steps.ccache.outputs.dir }}
+          key: ${{ steps.ccache.outputs.prefix }}${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ steps.ccache.outputs.prefix }}
+            ${{ runner.os }}-ccache-
+      - name: Cache Python test timings
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
-          path: ${{ steps.ccache-dir.outputs.dir }}
-          key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: ${{ runner.os }}-ccache-
+          path: ${{ env.GAME_TEST_TIMINGS_FILE }}
+          key: ${{ runner.os }}-test-timings-linux-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-test-timings-linux-
+      - name: configure
+        run: GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh
       - name: build test targets
         run: cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j"$(nproc)"
       - name: Smoke test game imports
@@ -105,18 +150,7 @@ jobs:
         run: python3 test.py --suite gameplay --jobs "$(nproc)"
       - name: test (python ui)
         timeout-minutes: 45
-        run: GAME_XVFB_JOBS=4 python3 test.py --suite ui --jobs "$(nproc)"
-      - name: coverage
-        if: steps.coverage-needed.outputs.run == 'true'
-        timeout-minutes: 60
-        run: ./scripts/run_coverage.sh
-      - name: ccache stats after coverage
-        if: always()
-        shell: bash
-        run: |
-          if command -v ccache >/dev/null 2>&1; then
-            ccache --show-stats
-          fi
+        run: python3 test.py --suite ui --jobs "$(nproc)"
       - name: package
         if: github.event_name != 'pull_request'
         run: cmake --build cmake-build-release --target package -j"$(nproc)"
@@ -126,6 +160,85 @@ jobs:
         with:
           name: fall-of-nouraajd-linux
           path: cmake-build-release/fall-of-nouraajd-*.tar.gz
+      - name: Save ccache
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ steps.ccache.outputs.dir }}
+          key: ${{ steps.ccache.outputs.prefix }}${{ github.run_id }}-${{ github.run_attempt }}
+
+  linux-coverage:
+    needs: linux-fast
+    if: needs.linux-fast.outputs.coverage-needed == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 75
+    env:
+      COVERAGE_INCLUDE_PREFIXES: src native_plugins
+      COVERAGE_REPORTER: python
+      GAME_TEST_TIMINGS_FILE: test/test-timings-linux-coverage.json
+      GAME_XVFB_JOBS: "4"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+      - name: Install Python deps
+        run: python3 -m pip install --upgrade -r requirements-dev.txt
+      - name: Smoke test Python deps
+        run: python3 -c "from PIL import Image; import black; print('python deps ok')"
+      - name: Install native deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake ninja-build ccache clang-format black \
+            python3 python3-dev python3-pip python3-venv pybind11-dev python3-pil \
+            libboost-dev \
+            libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
+            xvfb xauth
+      - name: Detect ccache metadata
+        id: ccache
+        shell: bash
+        run: |
+          compiler_id="$(c++ -dumpmachine)-$(c++ -dumpfullversion -dumpversion)"
+          compiler_id="${compiler_id//[^A-Za-z0-9_.-]/-}"
+          echo "dir=$(ccache --get-config cache_dir)" >> "${GITHUB_OUTPUT}"
+          echo "prefix=${{ runner.os }}-ccache-coverage-${compiler_id}-" >> "${GITHUB_OUTPUT}"
+      - name: Restore ccache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ steps.ccache.outputs.dir }}
+          key: ${{ steps.ccache.outputs.prefix }}${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ steps.ccache.outputs.prefix }}
+            ${{ runner.os }}-ccache-
+      - name: Cache Python test timings
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ env.GAME_TEST_TIMINGS_FILE }}
+          key: ${{ runner.os }}-test-timings-linux-coverage-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-test-timings-linux-coverage-
+      - name: coverage
+        timeout-minutes: 60
+        run: ./scripts/run_coverage.sh
+      - name: ccache stats after coverage
+        if: always()
+        shell: bash
+        run: |
+          if command -v ccache >/dev/null 2>&1; then
+            ccache --show-stats
+          fi
+      - name: Save ccache
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ steps.ccache.outputs.dir }}
+          key: ${{ steps.ccache.outputs.prefix }}${{ github.run_id }}-${{ github.run_attempt }}
 
   windows-deps:
     runs-on: windows-2022
@@ -153,6 +266,8 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
       - name: Install Python deps
         run: python -m pip install --upgrade -r requirements-dev.txt
       - name: Smoke test Python deps
@@ -358,10 +473,14 @@ jobs:
     env: *windows-env
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
       - name: Install Python deps
         run: python -m pip install --upgrade -r requirements-dev.txt
       - name: Smoke test Python deps
@@ -372,8 +491,6 @@ jobs:
           python -m unittest tests.test_content_validator
       - name: test (python fast)
         run: python test.py --suite fast
-      - name: submodules
-        run: git submodule update --init --recursive
       - *setup-msvc
       - *setup-vcpkg
       - *enable-vcpkg-x-gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,36 +8,63 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    env:
+      GAME_CONFIGURE_SKIP_APT: "1"
+      GAME_CONFIGURE_SKIP_SUBMODULES: "1"
+      GAME_TEST_TIMINGS_FILE: test/test-timings-linux-release.json
+      GAME_XVFB_JOBS: "4"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: .github/workflows/release.yml
       - name: Install Python deps
         run: python3 -m pip install --upgrade pillow==11.2.1
       - name: Smoke test Python deps
         run: python3 -c "from PIL import Image; print(Image.__name__)"
-      - name: submodules
-        run: git submodule update --init --recursive
-      - name: configure
-        run: GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh
-      - name: detect ccache directory
-        id: ccache-dir
+      - name: Install native deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake ninja-build ccache clang-format black \
+            python3 python3-dev python3-pip python3-venv pybind11-dev python3-pil \
+            libboost-dev \
+            libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
+            xvfb xauth
+      - name: Detect ccache metadata
+        id: ccache
         shell: bash
-        run: echo "dir=$(ccache --get-config cache_dir)" >> "${GITHUB_OUTPUT}"
-      - name: Cache ccache
+        run: |
+          compiler_id="$(c++ -dumpmachine)-$(c++ -dumpfullversion -dumpversion)"
+          compiler_id="${compiler_id//[^A-Za-z0-9_.-]/-}"
+          echo "dir=$(ccache --get-config cache_dir)" >> "${GITHUB_OUTPUT}"
+          echo "prefix=${{ runner.os }}-ccache-release-package-${compiler_id}-" >> "${GITHUB_OUTPUT}"
+      - name: Restore ccache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ steps.ccache.outputs.dir }}
+          key: ${{ steps.ccache.outputs.prefix }}${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ steps.ccache.outputs.prefix }}
+            ${{ runner.os }}-ccache-
+      - name: Cache Python test timings
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
-          path: ${{ steps.ccache-dir.outputs.dir }}
-          key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: ${{ runner.os }}-ccache-
+          path: ${{ env.GAME_TEST_TIMINGS_FILE }}
+          key: ${{ runner.os }}-test-timings-linux-release-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-test-timings-linux-release-
+      - name: configure
+        run: GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh
       - name: build test targets
         run: cmake --build cmake-build-release --target _game for_unit_tests -j"$(nproc)"
       - name: test (c++)
         run: ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
       - name: test (python)
-        run: GAME_XVFB_JOBS=4 python3 test.py --suite full --jobs "$(nproc)"
+        run: python3 test.py --suite full --jobs "$(nproc)"
       - name: package
         run: cmake --build cmake-build-release --target package -j"$(nproc)"
       - name: Upload release
@@ -46,3 +73,10 @@ jobs:
           files: cmake-build-release/fall-of-nouraajd-*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Save ccache
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ${{ steps.ccache.outputs.dir }}
+          key: ${{ steps.ccache.outputs.prefix }}${{ github.run_id }}-${{ github.run_attempt }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,6 @@ else ()
     set(CPACK_GENERATOR "TGZ")
 endif ()
 
-include(${CMAKE_SOURCE_DIR}/cmake/cotire.cmake)
-
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_SOURCE_DIR}/cmake")
 
 file(GLOB_RECURSE GAME_SRC ${CMAKE_SOURCE_DIR}/src/**.cpp ${CMAKE_SOURCE_DIR}/src/**.h)

--- a/configure.sh
+++ b/configure.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 
-sudo apt-get update
-sudo apt-get install -y build-essential cmake ninja-build ccache clang-format black \
-    python3 python3-dev python3-pip python3-venv pybind11-dev python3-pil \
-    libboost-dev \
-    libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
-    xvfb xauth
+if [[ "${GAME_CONFIGURE_SKIP_APT:-0}" != "1" ]]; then
+    sudo apt-get update
+    sudo apt-get install -y build-essential cmake ninja-build ccache clang-format black \
+        python3 python3-dev python3-pip python3-venv pybind11-dev python3-pil \
+        libboost-dev \
+        libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
+        xvfb xauth
+fi
 
-git submodule update --init --recursive
+if [[ "${GAME_CONFIGURE_SKIP_SUBMODULES:-0}" != "1" ]]; then
+    git submodule update --init --recursive
+fi
 build_types_raw="${GAME_CONFIGURE_BUILD_TYPES:-Debug Release}"
 read -r -a build_types <<< "${build_types_raw//,/ }"
 if [[ "${#build_types[@]}" -eq 0 ]]; then

--- a/tests/security/test_configure_supply_chain.py
+++ b/tests/security/test_configure_supply_chain.py
@@ -67,8 +67,8 @@ class ConfigureSupplyChainTest(unittest.TestCase):
         self.assertIn("-r requirements-dev.txt", workflow_text)
         self.assertIn("from PIL import Image; import black", workflow_text)
         self.assertIn("import _game; import game", workflow_text)
-        self.assertIn("pillow==11.2.1", requirements_text)
-        self.assertIn("black==25.1.0", requirements_text)
+        self.assertRegex(requirements_text, re.compile(r"^pillow==[0-9]+(?:\.[0-9]+)*$", re.MULTILINE))
+        self.assertRegex(requirements_text, re.compile(r"^black==[0-9]+(?:\.[0-9]+)*$", re.MULTILINE))
         self.assertNotRegex(requirements_text, re.compile(r"^pybind11\b", re.IGNORECASE | re.MULTILINE))
 
 


### PR DESCRIPTION
## What changed

- Split Linux CI into a fast Python/content gate, a Release build/test/package job, and a conditional coverage job.
- Added pip caching, ccache restore/save with run-unique save keys, and Python test timing caches for Linux build, Linux coverage, Linux release, and Windows jobs.
- Moved Linux CI native package installation out of `configure.sh` so the workflow can skip repeated apt/submodule setup after explicit checkout/dependency steps.
- Kept Linux and Windows build behavior aligned by preserving recursive submodule checkout on real build jobs and adding the same pip-cache/smoke-test pattern to Windows.
- Removed an unused CMake `cotire` include.
- Relaxed a stale configure supply-chain test to assert pinned `black` and `pillow` versions without freezing old exact versions.

## Why

Linux Actions was spending repeated time on setup and coverage work that did not always need to run. The new layout front-loads cheap validation, lets coverage run only for coverage-relevant paths, and keeps expensive native/test jobs cache-aware without weakening the Release build, C++ tests, performance guards, Python gameplay/UI tests, packaging, or Windows validation path.

## Validation

- `bash -n configure.sh`
- YAML parse for `.github/workflows/build.yml` and `.github/workflows/release.yml`
- `git diff --check origin/main..HEAD`
- `black -l 120 tests/security/test_configure_supply_chain.py`
- `python3 -m unittest tests.test_content_validator tests.security.test_configure_supply_chain`
- `python3 test.py --suite fast`
- `GAME_CONFIGURE_SKIP_APT=1 GAME_CONFIGURE_SKIP_SUBMODULES=1 GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh`
- `cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`
- `ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance`
- `python3 test.py`
- `./scripts/run_coverage.sh` after rebase: `lines: 95.14% (8177 out of 8595, 715 excluded)`

## Known limitations

- Coverage is skipped only for path-filtered non-coverage changes. Changes under `test.py`, `tests/*`, coverage tooling, native plugins, and core/gameplay source paths still run the canonical coverage gate.
- GitHub-hosted runner cache effectiveness depends on previous successful saves for the matching compiler/job prefix.
