### PR TITLE
Add explicit fight outcome model

### DIFF
--- a/src/handler/CFightHandler.cpp
+++ b/src/handler/CFightHandler.cpp
@@ -303,15 +303,15 @@ effect_application_result apply_effects_with_result(const std::shared_ptr<CCreat
 
 std::string final_status_message(CFightOutcome outcome, const std::string &attackerName) {
     switch (outcome) {
-    case CFightOutcome::attackerVictory:
+    case CFightOutcome::AttackerVictory:
         return attackerName + " survives the encounter.";
-    case CFightOutcome::attackerDefeat:
+    case CFightOutcome::AttackerDefeat:
         return attackerName + " is defeated.";
-    case CFightOutcome::stalemate:
+    case CFightOutcome::Stalled:
         return "The encounter remains unresolved.";
-    case CFightOutcome::interrupted:
+    case CFightOutcome::Cancelled:
         return "The encounter was interrupted.";
-    case CFightOutcome::invalid:
+    case CFightOutcome::Invalid:
         return "";
     }
     return "";
@@ -319,35 +319,46 @@ std::string final_status_message(CFightOutcome outcome, const std::string &attac
 
 } // namespace
 
+bool CFightResult::resolved() const {
+    return outcome == CFightOutcome::AttackerVictory || outcome == CFightOutcome::AttackerDefeat;
+}
+
+bool CFightResult::attackerSucceeded() const { return outcome == CFightOutcome::AttackerVictory; }
+
 bool CFightHandler::fight(std::shared_ptr<CCreature> a, std::shared_ptr<CCreature> b) { return fightMany(a, {b}); }
 
 bool CFightHandler::fightMany(std::shared_ptr<CCreature> attacker,
                               const std::vector<std::shared_ptr<CCreature>> &encounterOpponents) {
-    const auto outcome = fightManyOutcome(attacker, encounterOpponents);
-    return outcome == CFightOutcome::attackerVictory || outcome == CFightOutcome::attackerDefeat;
+    return fightManyResult(attacker, encounterOpponents).resolved();
 }
 
 CFightOutcome CFightHandler::fightManyOutcome(std::shared_ptr<CCreature> attacker,
                                               const std::vector<std::shared_ptr<CCreature>> &encounterOpponents) {
+    return fightManyResult(attacker, encounterOpponents).outcome;
+}
+
+CFightResult CFightHandler::fightManyResult(std::shared_ptr<CCreature> attacker,
+                                            const std::vector<std::shared_ptr<CCreature>> &encounterOpponents) {
+    CFightResult result;
     if (!attacker) {
-        return CFightOutcome::invalid;
+        return result;
     }
     auto encounterMap = attacker->getMap();
     const auto attackerName = combat_name(attacker);
     if (!is_active_participant(encounterMap, attacker)) {
-        return CFightOutcome::invalid;
+        return result;
     }
 
     auto opponents = sanitize_opponents(encounterMap, attacker, encounterOpponents);
     if (opponents.empty()) {
-        return CFightOutcome::invalid;
+        return result;
     }
 
     auto allOpponents = opponents;
     auto current = opponents.front();
     auto attackerController = attacker->getFightController();
     if (!attackerController) {
-        return CFightOutcome::invalid;
+        return result;
     }
     attackerController->setOpponents(attacker, opponents);
     attackerController->start(attacker, current);
@@ -366,20 +377,22 @@ CFightOutcome CFightHandler::fightManyOutcome(std::shared_ptr<CCreature> attacke
     }
 
     int stale_turns = 0;
-    CFightOutcome outcome = CFightOutcome::invalid;
-    for (int turn = 0; turn < 100 && stale_turns < 20 && outcome == CFightOutcome::invalid &&
+    for (int turn = 0; turn < 100 && stale_turns < 20 && result.outcome == CFightOutcome::Invalid &&
                        is_active_participant(encounterMap, attacker) && !opponents.empty();
          ++turn) {
         if (SDL_HasEvent(SDL_QUIT)) {
-            outcome = CFightOutcome::interrupted;
+            result.outcome = CFightOutcome::Cancelled;
+            result.survivor = attacker;
+            result.opponent = current;
             break;
         }
+        result.rounds = turn + 1;
         update_combat_status(encounterMap, attacker, opponents, "Combat round " + vstd::str(turn + 1) + " begins.");
         auto before = encounter_state(attacker, opponents);
         const auto turnOrder = build_turn_order(encounterMap, attacker, opponents);
 
         for (const auto &actor : turnOrder) {
-            if (outcome != CFightOutcome::invalid || !is_active_participant(encounterMap, attacker) ||
+            if (result.outcome != CFightOutcome::Invalid || !is_active_participant(encounterMap, attacker) ||
                 opponents.empty()) {
                 break;
             }
@@ -391,7 +404,9 @@ CFightOutcome CFightHandler::fightManyOutcome(std::shared_ptr<CCreature> attacke
 
                 auto effect_result = apply_effects_with_result(attacker);
                 if (!attacker->isAlive()) {
-                    outcome = CFightOutcome::attackerDefeat;
+                    result.outcome = CFightOutcome::AttackerDefeat;
+                    result.survivor = effect_result.caster;
+                    result.opponent = attacker;
                     defeat_attacker(encounterMap, attacker, opponents, effect_result.caster);
                     break;
                 }
@@ -400,12 +415,16 @@ CFightOutcome CFightHandler::fightManyOutcome(std::shared_ptr<CCreature> attacke
                     attackerController->control(attacker, current);
                     remove_dead_opponents(encounterMap, attacker, opponents, attacker);
                     if (!attacker->isAlive()) {
-                        outcome = CFightOutcome::attackerDefeat;
+                        result.outcome = CFightOutcome::AttackerDefeat;
+                        result.survivor = current;
+                        result.opponent = attacker;
                         defeat_attacker(encounterMap, attacker, opponents, current);
                         break;
                     }
                     if (opponents.empty()) {
-                        outcome = CFightOutcome::attackerVictory;
+                        result.outcome = CFightOutcome::AttackerVictory;
+                        result.survivor = attacker;
+                        result.opponent = current;
                         break;
                     }
                     current = resolve_target(encounterMap, attacker, opponents, current);
@@ -426,7 +445,9 @@ CFightOutcome CFightHandler::fightManyOutcome(std::shared_ptr<CCreature> attacke
             if (!actor->isAlive()) {
                 if (remove_dead_opponents(encounterMap, attacker, opponents, effect_result.caster)) {
                     if (opponents.empty()) {
-                        outcome = CFightOutcome::attackerVictory;
+                        result.outcome = CFightOutcome::AttackerVictory;
+                        result.survivor = attacker;
+                        result.opponent = actor;
                         break;
                     }
                     current = resolve_target(encounterMap, attacker, opponents, current);
@@ -439,7 +460,9 @@ CFightOutcome CFightHandler::fightManyOutcome(std::shared_ptr<CCreature> attacke
                 }
                 if (!attacker->isAlive()) {
                     remove_dead_opponents(encounterMap, attacker, opponents, attacker);
-                    outcome = CFightOutcome::attackerDefeat;
+                    result.outcome = CFightOutcome::AttackerDefeat;
+                    result.survivor = actor;
+                    result.opponent = attacker;
                     defeat_attacker(encounterMap, attacker, opponents, actor);
                     break;
                 }
@@ -448,18 +471,22 @@ CFightOutcome CFightHandler::fightManyOutcome(std::shared_ptr<CCreature> attacke
             }
             if (remove_dead_opponents(encounterMap, attacker, opponents, attacker)) {
                 if (opponents.empty()) {
-                    outcome = CFightOutcome::attackerVictory;
+                    result.outcome = CFightOutcome::AttackerVictory;
+                    result.survivor = attacker;
+                    result.opponent = actor;
                     break;
                 }
                 current = resolve_target(encounterMap, attacker, opponents, current);
             }
         }
 
-        if (outcome != CFightOutcome::invalid || !is_active_participant(encounterMap, attacker)) {
+        if (result.outcome != CFightOutcome::Invalid || !is_active_participant(encounterMap, attacker)) {
             break;
         }
         if (opponents.empty()) {
-            outcome = CFightOutcome::attackerVictory;
+            result.outcome = CFightOutcome::AttackerVictory;
+            result.survivor = attacker;
+            result.opponent = current;
             break;
         }
 
@@ -467,13 +494,18 @@ CFightOutcome CFightHandler::fightManyOutcome(std::shared_ptr<CCreature> attacke
         stale_turns = after == before ? stale_turns + 1 : 0;
     }
 
-    if (outcome == CFightOutcome::invalid) {
+    if (result.outcome == CFightOutcome::Invalid) {
         if (!is_active_participant(encounterMap, attacker)) {
-            outcome = CFightOutcome::attackerDefeat;
+            result.outcome = CFightOutcome::AttackerDefeat;
+            result.opponent = attacker;
         } else if (opponents.empty()) {
-            outcome = CFightOutcome::attackerVictory;
+            result.outcome = CFightOutcome::AttackerVictory;
+            result.survivor = attacker;
+            result.opponent = current;
         } else {
-            outcome = CFightOutcome::stalemate;
+            result.outcome = CFightOutcome::Stalled;
+            result.survivor = attacker;
+            result.opponent = current;
         }
     }
 
@@ -484,9 +516,9 @@ CFightOutcome CFightHandler::fightManyOutcome(std::shared_ptr<CCreature> attacke
         }
     }
 
-    if (outcome != CFightOutcome::invalid) {
-        const bool include_initiative = outcome != CFightOutcome::attackerDefeat;
-        update_combat_status(encounterMap, attacker, opponents, final_status_message(outcome, attackerName),
+    if (result.outcome != CFightOutcome::Invalid) {
+        const bool include_initiative = result.outcome != CFightOutcome::AttackerDefeat;
+        update_combat_status(encounterMap, attacker, opponents, final_status_message(result.outcome, attackerName),
                              include_initiative);
     }
 
@@ -494,14 +526,16 @@ CFightOutcome CFightHandler::fightManyOutcome(std::shared_ptr<CCreature> attacke
         json fields = {
             {"attacker", CPlaytestTrace::objectRef(attacker)},
             {"opponents", CPlaytestTrace::objectRefs(allOpponents)},
-            {"outcome", static_cast<int>(outcome)},
-            {"outcomeName", final_status_message(outcome, attackerName)},
+            {"outcome", static_cast<int>(result.outcome)},
+            {"outcomeName", final_status_message(result.outcome, attackerName)},
+            {"rounds", result.rounds},
+            {"survivor", CPlaytestTrace::objectRef(result.survivor)},
         };
         CPlaytestTrace::addMapContext(fields, encounterMap);
         CPlaytestTrace::record("combat_finished", fields);
     }
 
-    return outcome;
+    return result;
 }
 
 void CFightHandler::defeatedCreature(const std::shared_ptr<CCreature> &a, const std::shared_ptr<CCreature> &b) {

--- a/src/handler/CFightHandler.h
+++ b/src/handler/CFightHandler.h
@@ -23,7 +23,29 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 class CCreature;
 
-enum class CFightOutcome { invalid, attackerVictory, attackerDefeat, stalemate, interrupted };
+enum class CFightOutcome {
+    Invalid = 0,
+    AttackerVictory = 1,
+    AttackerDefeat = 2,
+    Stalled = 3,
+    Cancelled = 4,
+
+    invalid = Invalid,
+    attackerVictory = AttackerVictory,
+    attackerDefeat = AttackerDefeat,
+    stalemate = Stalled,
+    interrupted = Cancelled,
+};
+
+struct CFightResult {
+    CFightOutcome outcome = CFightOutcome::Invalid;
+    int rounds = 0;
+    std::shared_ptr<CCreature> survivor;
+    std::shared_ptr<CCreature> opponent;
+
+    bool resolved() const;
+    bool attackerSucceeded() const;
+};
 
 class CFightHandler {
   public:
@@ -31,6 +53,9 @@ class CFightHandler {
 
     static bool fightMany(std::shared_ptr<CCreature> attacker,
                           const std::vector<std::shared_ptr<CCreature>> &opponents);
+
+    static CFightResult fightManyResult(std::shared_ptr<CCreature> attacker,
+                                        const std::vector<std::shared_ptr<CCreature>> &opponents);
 
     static CFightOutcome fightManyOutcome(std::shared_ptr<CCreature> attacker,
                                           const std::vector<std::shared_ptr<CCreature>> &opponents);

--- a/tests/unit/test_handler.cpp
+++ b/tests/unit/test_handler.cpp
@@ -30,6 +30,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CItem.h"
 #include "test_harness.h"
 
+#include <SDL.h>
 #include <pybind11/embed.h>
 #include <memory>
 #include <set>
@@ -221,7 +222,7 @@ void test_fight_handler_rejects_stale_and_cross_map_participants() {
     expect_true(map->getObjectByName("unitReplaceableOpponent") == replacement,
                 "removeObject should not erase a same-name replacement through a stale reference");
 
-    expect_true(CFightHandler::fightManyOutcome(attacker, {stale}) == CFightOutcome::invalid,
+    expect_true(CFightHandler::fightManyOutcome(attacker, {stale}) == CFightOutcome::Invalid,
                 "stale same-name opponents should be rejected before combat starts");
     expect_true(map->getObjectByName("unitReplaceableOpponent") == replacement,
                 "combat with a stale opponent should not mutate the replacement");
@@ -232,7 +233,7 @@ void test_fight_handler_rejects_stale_and_cross_map_participants() {
 
     auto second_game = load_empty_game();
     auto cross_map = add_test_creature(second_game, "unitCrossMapOpponent", 1, 0);
-    expect_true(CFightHandler::fightManyOutcome(attacker, {cross_map}) == CFightOutcome::invalid,
+    expect_true(CFightHandler::fightManyOutcome(attacker, {cross_map}) == CFightOutcome::Invalid,
                 "cross-map opponents should fail closed");
     expect_true(map->getObjectByName(attacker->getName()) == attacker,
                 "cross-map rejection should leave the attacker map unchanged");
@@ -250,7 +251,7 @@ void test_fight_handler_attributes_lethal_effects_to_valid_casters() {
 
     const auto outcome = CFightHandler::fightManyOutcome(attacker, {selected, caster});
 
-    expect_true(outcome == CFightOutcome::attackerDefeat, "attacker death from an effect should be attackerDefeat");
+    expect_true(outcome == CFightOutcome::AttackerDefeat, "attacker death from an effect should be AttackerDefeat");
     expect_true(caster->countItems("unitCasterOwnedLoot") == 1,
                 "the effect caster should receive transferable loot from the defeated attacker");
     expect_true(selected->countItems("unitCasterOwnedLoot") == 0,
@@ -264,7 +265,7 @@ void test_fight_handler_attributes_lethal_effects_to_valid_casters() {
 
     const auto victory = CFightHandler::fightManyOutcome(effect_attacker, {effect_victim});
 
-    expect_true(victory == CFightOutcome::attackerVictory, "opponent effect death should resolve as attacker victory");
+    expect_true(victory == CFightOutcome::AttackerVictory, "opponent effect death should resolve as attacker victory");
     expect_true(effect_attacker->countItems("unitDelayedOpponentLoot") == 1,
                 "attacker-owned delayed effects should grant opponent loot once");
     expect_true(second_game->getMap()->getObjectByName(effect_victim->getName()) == nullptr,
@@ -280,7 +281,7 @@ void test_fight_handler_attributes_lethal_effects_to_valid_casters() {
 
     const auto invalid_outcome = CFightHandler::fightManyOutcome(invalid_victim, {unrelated});
 
-    expect_true(invalid_outcome == CFightOutcome::attackerDefeat,
+    expect_true(invalid_outcome == CFightOutcome::AttackerDefeat,
                 "invalid-caster lethal effects should still resolve the loser");
     expect_true(unrelated->countItems("unitInvalidCasterLoot") == 0,
                 "invalid effect casters should not cause unrelated opponents to receive loot");
@@ -289,15 +290,32 @@ void test_fight_handler_attributes_lethal_effects_to_valid_casters() {
 }
 
 void test_fight_handler_reports_explicit_outcomes_and_final_status() {
+    const CFightResult default_result;
+    expect_true(default_result.outcome == CFightOutcome::Invalid && default_result.rounds == 0,
+                "default fight results should construct as invalid with no rounds");
+    expect_true(!default_result.resolved() && !default_result.attackerSucceeded(),
+                "default fight results should not collapse invalid combat into a resolved bool");
+
     auto victory_game = load_empty_game();
     auto victor = add_test_creature(victory_game, "unitOutcomeVictor");
     victor->setFightController(std::make_shared<KillingFightController>());
     auto defeated = add_test_creature(victory_game, "unitOutcomeDefeated", 1, 0);
     auto victory_controller = std::dynamic_pointer_cast<KillingFightController>(victor->getFightController());
+    const CFightResult cancelled_result{CFightOutcome::Cancelled, 3, victor, defeated};
+    expect_true(cancelled_result.outcome == CFightOutcome::Cancelled && cancelled_result.rounds == 3,
+                "fight results should construct with explicit cancelled outcome data");
 
-    const auto victory = CFightHandler::fightManyOutcome(victor, {defeated});
+    const auto victory = CFightHandler::fightManyResult(victor, {defeated});
 
-    expect_true(victory == CFightOutcome::attackerVictory, "direct attacker victory should be reported explicitly");
+    expect_true(victory.outcome == CFightOutcome::AttackerVictory,
+                "direct attacker victory should be reported explicitly");
+    expect_true(victory.rounds == 1, "direct attacker victory should report the completed round count");
+    expect_true(victory.survivor == victor && victory.opponent == defeated,
+                "direct attacker victory should report survivor and opponent metadata");
+    expect_true(victory.resolved() && victory.attackerSucceeded(),
+                "result helpers should identify successful resolved combat");
+    expect_true(CFightHandler::fightManyOutcome(victor, {defeated}) == CFightOutcome::Invalid,
+                "enum compatibility wrapper should still be constructible for invalid post-victory input");
     expect_true(victory_controller->start_count == 1 && victory_controller->end_count == 1,
                 "attacker controller should start and end exactly once on victory");
     expect_true(victory_game->getMap()->getStringProperty("combatStatus").find("survives the encounter") !=
@@ -310,13 +328,25 @@ void test_fight_handler_reports_explicit_outcomes_and_final_status() {
     const auto stalemate_controller =
         std::dynamic_pointer_cast<NoProgressFightController>(stalled_attacker->getFightController());
 
-    const auto stalemate = CFightHandler::fightManyOutcome(stalled_attacker, {stalled_defender});
+    const auto stalemate = CFightHandler::fightManyResult(stalled_attacker, {stalled_defender});
 
-    expect_true(stalemate == CFightOutcome::stalemate, "no-progress combat should report stalemate");
+    expect_true(stalemate.outcome == CFightOutcome::Stalled, "no-progress combat should report stalled outcome");
+    expect_true(stalemate.rounds == 20, "stalled combat should report the stale round budget consumed");
+    expect_true(stalemate.survivor == stalled_attacker && stalemate.opponent == stalled_defender,
+                "stalled combat should keep participant metadata instead of only returning false");
+    expect_true(!stalemate.resolved() && !stalemate.attackerSucceeded(),
+                "result helpers should keep stalled combat separate from resolved combat");
     expect_true(!CFightHandler::fightMany(stalled_attacker, {stalled_defender}),
                 "legacy fightMany should still return false for unresolved combat");
     expect_true(stalemate_controller->start_count == 2 && stalemate_controller->end_count == 2,
                 "controller cleanup should also run for the legacy stalemate call");
+
+    auto legacy_victory_game = load_empty_game();
+    auto legacy_victor = add_test_creature(legacy_victory_game, "unitLegacyOutcomeVictor");
+    legacy_victor->setFightController(std::make_shared<KillingFightController>());
+    auto legacy_defeated = add_test_creature(legacy_victory_game, "unitLegacyOutcomeDefeated", 1, 0);
+    expect_true(CFightHandler::fight(legacy_victor, legacy_defeated),
+                "legacy two-creature bool wrapper should still return true for resolved victory");
 
     auto player_game = CGameLoader::loadGame();
     CGameLoader::startGameWithPlayer(player_game, "empty", "Warrior");
@@ -330,12 +360,41 @@ void test_fight_handler_reports_explicit_outcomes_and_final_status() {
     const auto defeat = CFightHandler::fightManyOutcome(player, {killer});
     const auto status = player_map->getStringProperty("combatStatus");
 
-    expect_true(defeat == CFightOutcome::attackerDefeat, "player defeat should remain visible after respawn");
+    expect_true(defeat == CFightOutcome::AttackerDefeat, "player defeat should remain visible after respawn");
     expect_true(player_map->getObjectByName("player") == player && player->isAlive() && player->getHp() == 1,
                 "player defeat should keep the existing respawn behavior");
     expect_true(status.find("survives the encounter") == std::string::npos,
                 "defeated respawned players must not be reported as surviving");
     expect_true(status.find("defeated") != std::string::npos, "final defeat status should be explicit");
+}
+
+void test_fight_handler_reports_cancelled_quit_event() {
+    expect_true(SDL_InitSubSystem(SDL_INIT_EVENTS) == 0, "SDL event subsystem should initialize for quit events");
+    SDL_FlushEvent(SDL_QUIT);
+
+    auto game = load_empty_game();
+    auto attacker = add_test_creature(game, "unitCancelledAttacker");
+    auto defender = add_test_creature(game, "unitCancelledDefender", 1, 0);
+    const auto attacker_controller =
+        std::dynamic_pointer_cast<NoProgressFightController>(attacker->getFightController());
+
+    SDL_Event quit_event{};
+    quit_event.type = SDL_QUIT;
+    expect_true(SDL_PushEvent(&quit_event) == 1, "SDL_QUIT event should be queued for cancellation coverage");
+
+    const auto result = CFightHandler::fightManyResult(attacker, {defender});
+    SDL_FlushEvent(SDL_QUIT);
+
+    expect_true(result.outcome == CFightOutcome::Cancelled, "queued SDL_QUIT should report cancelled combat");
+    expect_true(result.rounds == 0, "cancelled combat before a turn should report no completed rounds");
+    expect_true(result.survivor == attacker && result.opponent == defender,
+                "cancelled combat should keep participant metadata");
+    expect_true(!result.resolved() && !result.attackerSucceeded(),
+                "cancelled combat should stay distinct from resolved bool outcomes");
+    expect_true(attacker_controller->start_count == 1 && attacker_controller->end_count == 1,
+                "controller cleanup should run when combat is cancelled");
+    expect_true(game->getMap()->getStringProperty("combatStatus").find("interrupted") != std::string::npos,
+                "cancelled combat should publish the interrupted status text");
 }
 
 void test_fight_handler_counts_effect_duration_as_progress() {
@@ -351,7 +410,7 @@ void test_fight_handler_counts_effect_duration_as_progress() {
 
     const auto outcome = CFightHandler::fightManyOutcome(attacker, {defender});
 
-    expect_true(outcome == CFightOutcome::stalemate, "timed no-damage effects should still end in stalemate");
+    expect_true(outcome == CFightOutcome::Stalled, "timed no-damage effects should still end in stalled outcome");
     expect_true(effect->ticks == 25, "duration changes should prevent stale termination before effect expiration");
     expect_true(attacker->getEffects().empty(), "expired effects should be removed before stale termination resumes");
     expect_true(game->getMap()->getObjectByName(attacker->getName()) == attacker &&
@@ -391,6 +450,7 @@ int main() {
     test_fight_handler_rejects_stale_and_cross_map_participants();
     test_fight_handler_attributes_lethal_effects_to_valid_casters();
     test_fight_handler_reports_explicit_outcomes_and_final_status();
+    test_fight_handler_reports_cancelled_quit_event();
     test_fight_handler_counts_effect_duration_as_progress();
     test_player_respawn_normalizes_wrapped_entry_coords();
 


### PR DESCRIPTION
## What changed

- Added `CFightResult` with explicit `CFightOutcome`, round count, survivor, and opponent metadata.
- Kept the existing `fight` and `fightMany` bool APIs as compatibility wrappers.
- Preserved the existing enum names as aliases while adding canonical outcome names.
- Added native coverage for result construction, bool-wrapper behavior, victory, defeat, stalled combat, and SDL_QUIT cancellation.

## Why

The combat path previously collapsed invalid, cancelled, and stalled encounters into the same false-like result. The queue issue calls for an internal detailed outcome model while preserving existing public behavior.

## Validation

- `git diff --check`: PASS
- `cmake --build cmake-build-release --target for_unit_tests -j1`: PASS before latest rebase; superseded by GitHub Actions for final verification.
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`: PASS before latest rebase; superseded by GitHub Actions for final verification.
- Full build, Python suite, and coverage: delegated to GitHub Actions `linux` per controller instruction.

## Known limitations

- `CFightResult` is intentionally internal C++ API for now; Python exposure is deferred until call sites are migrated, per the workbook issue text.
