### PR TITLE
Add chest loot regression test

### DIFF
--- a/test.py
+++ b/test.py
@@ -3476,14 +3476,22 @@ class GameTest(unittest.TestCase):
 
     @game_test
     def test_chest_on_enter_grants_random_loot_to_real_player(self):
-        _g, game_map, player = load_game_map_with_player("test", "Warrior")
+        g, game_map, player = load_game_map_with_player("test", "Warrior")
         chest = game_map.getGame().createObject("chest")
         self.assertIsNotNone(chest)
         chest.setNumericProperty("value", 20)
         game_map.addObject(chest)
 
+        class FakeEvent:
+            def __init__(self, cause):
+                self.cause = cause
+
+            def getCause(self):
+                return self.cause
+
         before_items = len(player.getItems())
-        chest.onEnter(None)
+        self.assertFalse(hasattr(g, "getLootHandler"))
+        chest.onEnter(FakeEvent(player))
         after_items = len(player.getItems())
 
         self.assertGreater(after_items, before_items)


### PR DESCRIPTION
## What changed

- Updated the Chest regression to invoke `Chest.onEnter` with a player-backed event.
- Asserted the game object does not expose the old invalid `getLootHandler` path before invoking the plugin.

## Why

This protects the Chest plugin contract after the loot handler API fix and will fail if the plugin regresses to a non-existent `CGame.getLootHandler()` call.

## Validation

- `python3 -m py_compile test.py res/plugins/object.py`: PASS
- `git diff --check`: PASS
- `python3 test.py GameTest.test_chest_on_enter_grants_random_loot_to_real_player`: blocked locally because `_game` is not built in this worktree.
- Full runtime validation: delegated to GitHub Actions.

## Known limitations

- Local runtime test was not run because `_game` was unavailable; CI will run with a prepared build.
