### PR TITLE
Parse native plugin registrations in validator

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -268,6 +268,7 @@ class ContentValidator:
         self.metadata_declared_classes: set[str] = set()
         self.static_registered_classes: set[str] = set()
         self.native_plugin_registered_classes: set[str] = set()
+        self.native_plugin_declared_class_sources: dict[str, set[str]] = {}
         self.python_registered_classes: set[str] = set()
         self.reviewed_abstract_internal_classes: set[str] = set(REVIEWED_ABSTRACT_INTERNAL_CLASSES)
 
@@ -297,13 +298,79 @@ class ContentValidator:
                     self.metadata_declared_classes.add(class_name)
                 for class_name in iter_cpp_template_type_names(text, "register_type"):
                     if path.name == "NativePlugin.cpp":
-                        self.native_plugin_registered_classes.add(class_name)
-                    else:
+                        continue
+                    if path.name.endswith("TypeRegistration.cpp"):
                         self.static_registered_classes.add(class_name)
                 for match in re.finditer(r"V_META\(\s*([A-Za-z_]\w*)", text):
                     class_name = match.group(1)
                     if is_concrete_cpp_class_name(class_name):
                         self.metadata_declared_classes.add(class_name)
+        self._collect_native_plugin_classes()
+
+    def _collect_native_plugin_classes(self) -> None:
+        helper_classes = self._native_plugin_helper_classes()
+        entry_helpers = self._native_plugin_entry_helpers(helper_classes)
+        loaded_entries = self._manifest_native_plugin_entries()
+        for library, entry in loaded_entries:
+            for class_name in entry_helpers.get((library, entry), set()):
+                self.native_plugin_registered_classes.add(class_name)
+
+    def _native_plugin_helper_classes(self) -> dict[str, set[str]]:
+        path = self.repo_root / "src" / "plugin" / "NativePlugin.cpp"
+        if not path.exists():
+            return {}
+        text = read_text_lossy(path)
+        helper_classes: dict[str, set[str]] = {}
+        for name, body in iter_cpp_function_bodies(text):
+            if not name.startswith("register_"):
+                continue
+            classes = iter_cpp_template_type_names(body, "register_type")
+            if classes:
+                helper_classes[name] = classes
+                for class_name in classes:
+                    self.native_plugin_declared_class_sources.setdefault(class_name, set()).add(
+                        f"native_plugin::{name}"
+                    )
+        return helper_classes
+
+    def _native_plugin_entry_helpers(self, helper_classes: dict[str, set[str]]) -> dict[tuple[str, str], set[str]]:
+        native_dir = self.repo_root / "native_plugins"
+        entry_helpers: dict[tuple[str, str], set[str]] = {}
+        if not native_dir.exists():
+            return entry_helpers
+        for path in sorted(native_dir.glob("*.cpp")):
+            text = read_text_lossy(path)
+            library = path.stem
+            for entry, body in iter_cpp_function_bodies(text):
+                classes = iter_cpp_template_type_names(body, "register_type")
+                for helper_name in re.findall(r"\bnative_plugin::(register_[A-Za-z_]\w*)\s*\(", body):
+                    classes.update(helper_classes.get(helper_name, set()))
+                if classes:
+                    entry_helpers[(library, entry)] = classes
+                    for class_name in classes:
+                        self.native_plugin_declared_class_sources.setdefault(class_name, set()).add(
+                            f"{library}:{entry}"
+                        )
+        return entry_helpers
+
+    def _manifest_native_plugin_entries(self) -> set[tuple[str, str]]:
+        manifest_path = self.repo_root / "res" / "plugins" / "manifest.json"
+        if not manifest_path.exists():
+            return set()
+        data = self._load_json(manifest_path)
+        loaded_entries: set[tuple[str, str]] = set()
+        if not isinstance(data, dict):
+            return loaded_entries
+        for entry in iter_manifest_plugin_entries(data):
+            if entry.get("kind") != "dynamic":
+                continue
+            library = entry.get("library")
+            if not isinstance(library, str) or not library:
+                continue
+            function_name = entry.get("entry", "game_plugin_load_v1")
+            if isinstance(function_name, str) and function_name:
+                loaded_entries.add((Path(library).name, function_name))
+        return loaded_entries
 
     def _collect_plugin_classes(self) -> None:
         plugin_dir = self.repo_root / "res" / "plugins"
@@ -870,6 +937,9 @@ class ContentValidator:
     def _class_reference_message(self, class_name: str, label: str) -> str:
         if class_name in self.reviewed_abstract_internal_classes:
             return f'{label} "{class_name}" is reviewed as abstract/internal and cannot be used as content'
+        if class_name in self.native_plugin_declared_class_sources:
+            owners = ", ".join(sorted(self.native_plugin_declared_class_sources[class_name]))
+            return f'{label} "{class_name}" is registered by native plugin code but no manifest entry loads {owners}'
         if class_name in self.metadata_declared_classes:
             return f'{label} "{class_name}" is declared in metadata but is not registered as constructible content'
         return f'unknown {label} "{class_name}"'
@@ -919,6 +989,34 @@ def normalize_cpp_type(raw: str) -> str:
     return re.sub(r"\s+", "", name)
 
 
+def read_text_lossy(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def iter_cpp_function_bodies(text: str) -> list[tuple[str, str]]:
+    functions: list[tuple[str, str]] = []
+    pattern = re.compile(
+        r"(?:extern\s+\"C\"\s+)?(?:[A-Z_]+\s+)*bool\s+([A-Za-z_]\w*)\s*\([^)]*\)\s*\{",
+        re.MULTILINE,
+    )
+    for match in pattern.finditer(text):
+        body_start = match.end()
+        depth = 1
+        index = body_start
+        while index < len(text) and depth:
+            if text[index] == "{":
+                depth += 1
+            elif text[index] == "}":
+                depth -= 1
+            index += 1
+        if depth == 0:
+            functions.append((match.group(1), text[body_start : index - 1]))
+    return functions
+
+
 def iter_cpp_template_type_names(text: str, call_name: str) -> set[str]:
     names: set[str] = set()
     pattern = re.compile(rf"\b{re.escape(call_name)}\s*<\s*([^,;\n]+)")
@@ -927,6 +1025,19 @@ def iter_cpp_template_type_names(text: str, call_name: str) -> set[str]:
         if is_concrete_cpp_class_name(name):
             names.add(name)
     return names
+
+
+def iter_manifest_plugin_entries(data: dict[str, Any]) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    global_entries = data.get("global")
+    if isinstance(global_entries, list):
+        entries.extend(entry for entry in global_entries if isinstance(entry, dict))
+    map_entries = data.get("maps")
+    if isinstance(map_entries, dict):
+        for map_plugins in map_entries.values():
+            if isinstance(map_plugins, list):
+                entries.extend(entry for entry in map_plugins if isinstance(entry, dict))
+    return entries
 
 
 def is_concrete_cpp_class_name(name: str) -> bool:

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -208,6 +208,108 @@ class ContentValidatorTest(unittest.TestCase):
             'class "CDeclaredOnly" is declared in metadata but is not registered as constructible content',
         )
 
+    def test_static_type_registration_makes_class_constructible(self):
+        root = self.make_fixture()
+        self.write_declared_cpp_class(root, "CStaticRegistered")
+        type_registration = root / "src/object/CObjectTypeRegistration.cpp"
+        type_registration.parent.mkdir(parents=True, exist_ok=True)
+        type_registration.write_text(
+            "void registerObjectTypes() { CTypes::register_type<CStaticRegistered, CGameObject>(); }\n",
+            encoding="utf-8",
+        )
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["staticRegistered"] = {"class": "CStaticRegistered"}
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
+    def test_manifest_native_plugin_registration_makes_class_constructible(self):
+        root = self.make_fixture()
+        self.write_native_registration_fixture(root, "CManifestNative")
+        write_json(
+            root / "res/plugins/manifest.json",
+            {
+                "global": [
+                    {
+                        "kind": "dynamic",
+                        "id": "nativeOptional",
+                        "library": "plugins/native/native_optional",
+                        "entry": "native_optional_load_v1",
+                    }
+                ],
+                "maps": {},
+            },
+        )
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["manifestNative"] = {"class": "CManifestNative"}
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
+    def test_unloaded_native_plugin_registration_reports_manifest_diagnostic(self):
+        root = self.make_fixture()
+        self.write_native_registration_fixture(root, "CUnloadedNative")
+        write_json(root / "res/plugins/manifest.json", {"global": [], "maps": {}})
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["unloadedNative"] = {"class": "CUnloadedNative"}
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "unloadedNative.class",
+            'class "CUnloadedNative" is registered by native plugin code',
+            "native_optional:native_optional_load_v1",
+        )
+
+    def write_declared_cpp_class(self, root, class_name):
+        declared_header = root / "src/object/CDeclaredOnly.h"
+        declared_header.parent.mkdir(parents=True, exist_ok=True)
+        declared_header.write_text(
+            textwrap.dedent(f"""
+                class {class_name} {{
+                    V_META({class_name}, CGameObject, vstd::meta::empty())
+                }};
+            """).lstrip(),
+            encoding="utf-8",
+        )
+
+    def write_native_registration_fixture(self, root, class_name):
+        self.write_declared_cpp_class(root, class_name)
+        native_plugin = root / "src/plugin/NativePlugin.cpp"
+        native_plugin.parent.mkdir(parents=True, exist_ok=True)
+        native_plugin.write_text(
+            textwrap.dedent(f"""
+                namespace native_plugin {{
+                bool register_optional(const NativePluginHostV1 *host) {{
+                    bool registered = true;
+                    registered = register_type<{class_name}, CGameObject>(host) && registered;
+                    return registered;
+                }}
+                }}
+            """).lstrip(),
+            encoding="utf-8",
+        )
+        native_entry = root / "native_plugins/native_optional.cpp"
+        native_entry.parent.mkdir(parents=True, exist_ok=True)
+        native_entry.write_text(
+            textwrap.dedent("""
+                extern "C" NATIVE_PLUGIN_EXPORT bool native_optional_load_v1(const NativePluginHostV1 *host) {
+                    return native_plugin::register_optional(host);
+                }
+            """).lstrip(),
+            encoding="utf-8",
+        )
+
     def assertIssueContains(self, issues, *substrings):
         issue_text = "\n".join(str(issue) for issue in issues)
         for substring in substrings:


### PR DESCRIPTION
## What changed

- Updated the content validator to distinguish static type registrations from native plugin helper registrations.
- Added parsing for native plugin entry points and manifest-loaded dynamic plugin entries.
- Improved diagnostics for native classes registered by code but not loaded by the manifest.
- Added focused validator tests for static registration, manifest-loaded native registration, and unloaded native registration.

## Why

The validator previously treated helper registrations in `NativePlugin.cpp` as always constructible. That hid missing manifest entries and made diagnostics less actionable.

## Validation

- `python3 -m unittest tests.test_content_validator`: PASS
- `python3 scripts/validate_content.py --repo-root .`: PASS
- `python3 -m py_compile scripts/validate_content.py tests/test_content_validator.py`: PASS
- `git diff --check`: PASS
- Full repository validation: delegated to GitHub Actions.

## Known limitations

- Native registration parsing is lightweight source parsing, not a full C++ AST. It covers current registration patterns and can be extended if future plugin entry shapes change.
