### PR TITLE
Add map navigation edge model

### DIFF
--- a/scripts/coverage_exclusions.json
+++ b/scripts/coverage_exclusions.json
@@ -98,16 +98,16 @@
       "reason": "Reviewed legacy uncovered branch baseline; unreviewed coverage changes remain visible in the 95% scoped line gate.",
       "ranges": [
         "65",
-        "263",
-        "412",
-        "538",
-        "574",
-        "605",
-        "658",
-        "725",
-        "761",
-        "768",
-        "774"
+        "286",
+        "435",
+        "561",
+        "597",
+        "628",
+        "681",
+        "748",
+        "784",
+        "791",
+        "797"
       ]
     },
     {

--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -184,6 +184,29 @@ std::shared_ptr<CEventHandler> CMap::getEventHandler() {
 
 std::uint64_t CMap::getNavigationRevision() const { return navigationRevision; }
 
+const std::vector<CNavigationEdge> &CMap::getNavigationEdges() const { return navigationEdges; }
+
+void CMap::addNavigationEdge(CNavigationEdge edge) {
+    edge.source = normalizeCoords(edge.source);
+    edge.target = normalizeCoords(edge.target);
+    navigationEdges.push_back(std::move(edge));
+    bumpNavigationRevision();
+}
+
+bool CMap::removeNavigationEdge(Coords source, Coords target, std::optional<std::string> sourceObjectName) {
+    source = normalizeCoords(source);
+    target = normalizeCoords(target);
+    auto it = std::ranges::find_if(navigationEdges, [&](const CNavigationEdge &edge) {
+        return edge.source == source && edge.target == target && edge.sourceObjectName == sourceObjectName;
+    });
+    if (it == navigationEdges.end()) {
+        return false;
+    }
+    navigationEdges.erase(it);
+    bumpNavigationRevision();
+    return true;
+}
+
 std::size_t CMap::getObjectCacheEntryCountForTesting() const { return mapObjectsCache.size(); }
 
 void performance_guard::resetMapCoordinateLookupProbe() {

--- a/src/core/CMap.h
+++ b/src/core/CMap.h
@@ -44,6 +44,17 @@ class CTrigger;
 
 class CGame;
 
+struct CNavigationEdge {
+    Coords source;
+    Coords target;
+    bool enabled = true;
+    bool bidirectional = false;
+    int movementCost = 1;
+    std::optional<std::string> sourceObjectName;
+
+    bool operator==(const CNavigationEdge &other) const = default;
+};
+
 class CMap : public CGameObject {
     using StringMap = std::map<int, std::string>;
     using IntMap = std::map<int, int>;
@@ -183,6 +194,12 @@ class CMap : public CGameObject {
 
     std::uint64_t getNavigationRevision() const;
 
+    const std::vector<CNavigationEdge> &getNavigationEdges() const;
+
+    void addNavigationEdge(CNavigationEdge edge);
+
+    bool removeNavigationEdge(Coords source, Coords target, std::optional<std::string> sourceObjectName = std::nullopt);
+
     std::size_t getObjectCacheEntryCountForTesting() const;
 
     // TODO: accept predicate, can be used in siege map
@@ -214,6 +231,7 @@ class CMap : public CGameObject {
     std::unordered_multimap<Coords, std::string> mapObjectsCache;
 
     std::unordered_map<Coords, std::shared_ptr<CTile>> tiles;
+    std::vector<CNavigationEdge> navigationEdges;
 
     std::shared_ptr<CPlayer> player;
     StringMap defaultTiles;

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -387,6 +387,49 @@ void test_map_tiles_bounds_wrapping_and_object_cache() {
     expect_true(map->getObjects().empty(), "removeObjects should erase matching objects from a cloned iteration");
 }
 
+void test_map_navigation_edges_update_revision() {
+    auto map = std::make_shared<CMap>();
+    map->setXBounds({{0, 4}});
+    map->setYBounds({{0, 4}});
+    map->setWrapX({{0, 1}});
+
+    const auto initial_revision = map->getNavigationRevision();
+    CNavigationEdge bridge;
+    bridge.source = Coords(-1, 2, 0);
+    bridge.target = Coords(1, 2, 0);
+    bridge.enabled = true;
+    bridge.bidirectional = true;
+    bridge.movementCost = 3;
+    bridge.sourceObjectName = "ropeBridge";
+
+    map->addNavigationEdge(bridge);
+    expect_true(map->getNavigationRevision() > initial_revision,
+                "adding a navigation edge should bump navigation revision");
+
+    const auto revision_after_add = map->getNavigationRevision();
+    const auto &edges = map->getNavigationEdges();
+    expect_true(edges.size() == 1, "added navigation edge should be stored by the map");
+    expect_true(edges.front().source == Coords(4, 2, 0), "navigation edge source should be normalized");
+    expect_true(edges.front().target == Coords(1, 2, 0), "navigation edge target should be normalized");
+    expect_true(edges.front().enabled, "navigation edge should preserve enabled state");
+    expect_true(edges.front().bidirectional, "navigation edge should preserve directionality");
+    expect_true(edges.front().movementCost == 3, "navigation edge should preserve movement cost");
+    expect_true(edges.front().sourceObjectName == std::optional<std::string>("ropeBridge"),
+                "navigation edge should preserve source object name");
+
+    const std::optional<std::string> bridge_name = "ropeBridge";
+    expect_true(!map->removeNavigationEdge(Coords(4, 2, 0), Coords(0, 2, 0), bridge_name),
+                "removing a missing navigation edge should report false");
+    expect_true(map->getNavigationRevision() == revision_after_add,
+                "removing a missing navigation edge should not bump navigation revision");
+
+    expect_true(map->removeNavigationEdge(Coords(-1, 2, 0), Coords(1, 2, 0), bridge_name),
+                "removing an existing navigation edge should report true");
+    expect_true(map->getNavigationEdges().empty(), "removed navigation edge should leave map storage");
+    expect_true(map->getNavigationRevision() > revision_after_add,
+                "removing an existing navigation edge should bump navigation revision");
+}
+
 void test_map_defensive_branches_and_strict_validation() {
     auto map = std::make_shared<CMap>();
     map->setXBounds({{0, -1}});
@@ -636,6 +679,7 @@ int main() {
     test_scene_manager_null_and_legacy_missing_target_behavior();
     test_scene_manager_rejects_cross_game_requests();
     test_map_tiles_bounds_wrapping_and_object_cache();
+    test_map_navigation_edges_update_revision();
     test_map_defensive_branches_and_strict_validation();
     test_map_move_interrupts_invalid_planned_steps();
     test_map_player_trigger_registration_is_idempotent();


### PR DESCRIPTION
## What changed

- Added `CNavigationEdge` with source/target coordinates, enabled state, directionality, movement cost, and optional source object name.
- Added non-serialized map-owned navigation edge storage to `CMap`.
- Added APIs to add/remove edges while normalizing coordinates and bumping `navigationRevision` only on real topology changes.
- Added focused native unit coverage for edge storage, normalization, removal, and revision changes.

## Why

`CMap` had a navigation revision counter but no explicit representation for authored or runtime non-cardinal navigation edges.

## Validation

- `git diff --check`: PASS
- Native build and tests: delegated to GitHub Actions per controller policy.

## Known limitations

- Local native compilation/tests were skipped by request; CI must validate compile and runtime behavior.
- Edges are intentionally not serialized in this change.
