### PR TITLE
Defer sealed siege gate blocking while occupied

### DIFF
--- a/res/maps/siege/script.py
+++ b/res/maps/siege/script.py
@@ -1,5 +1,6 @@
 def load(self, context):
     from game import CTag
+    from game import CCreature
     from game import CEvent
     from game import CQuest
     from game import CTrigger
@@ -71,8 +72,36 @@ def load(self, context):
             self.setStringProperty("animation", "images/misc/closed_door")
             self.setBoolProperty("enabled", False)
             self.setBoolProperty("destroyed", False)
+            self.setBoolProperty("pendingSeal", False)
+
+        def hasCreatureAtGate(self):
+            gate_coords = self.getCoords()
+            occupied = False
+
+            def checkObject(ob):
+                nonlocal occupied
+                coords = ob.getCoords()
+                if (
+                    isinstance(ob, CCreature)
+                    and coords.x == gate_coords.x
+                    and coords.y == gate_coords.y
+                    and coords.z == gate_coords.z
+                ):
+                    occupied = True
+
+            self.getMap().forObjects(checkObject, lambda ob: not occupied)
+            return occupied
+
+        def completePendingSeal(self):
+            if self.hasCreatureAtGate():
+                return
+            self.setBoolProperty("canStep", False)
+            self.setBoolProperty("pendingSeal", False)
 
         def onTurn(self, event):
+            if self.getBoolProperty("destroyed") and self.getBoolProperty("pendingSeal"):
+                self.completePendingSeal()
+                return
             if self.getBoolProperty("enabled") and not self.getBoolProperty("destroyed") and randint(1, 10) == 10:
                 logger("Spawning new creature")
                 if randint(1, 10) == 10:
@@ -91,8 +120,9 @@ def load(self, context):
                 if self.getMap().getGame().getGuiHandler().showQuestion("Do You want to seal the gate?"):
                     self.getMap().getPlayer().removeQuestItem(lambda it: it.hasTag(CTag.WAND))
                     self.setBoolProperty("destroyed", True)
+                    self.setBoolProperty("pendingSeal", True)
                     self.setStringProperty("animation", "images/misc/closed_door")
-                    self.setBoolProperty("canStep", False)
+                    self.completePendingSeal()
             else:
                 self.getMap().getGame().getGuiHandler().showInfo("You need a wand to seal the gate!")
 

--- a/test.py
+++ b/test.py
@@ -10883,6 +10883,73 @@ class GameTest(unittest.TestCase):
         return execute_walkthrough("siege")
 
     @game_test
+    def test_siege_spawn_points_start_closed_and_unsealed(self):
+        _g, game_map, _player = load_game_map_with_player("siege")
+        spawn_names = ["spawnPoint1", "spawnPoint2", "spawnPoint3", "spawnPoint4"]
+        spawn_states = {}
+
+        for name in spawn_names:
+            spawn_point = find_runtime_object(game_map, name)
+            spawn_states[name] = {
+                "animation": spawn_point.getStringProperty("animation"),
+                "destroyed": spawn_point.getBoolProperty("destroyed"),
+                "enabled": spawn_point.getBoolProperty("enabled"),
+                "pendingSeal": spawn_point.getBoolProperty("pendingSeal"),
+            }
+            self.assertFalse(spawn_states[name]["enabled"])
+            self.assertFalse(spawn_states[name]["destroyed"])
+            self.assertFalse(spawn_states[name]["pendingSeal"])
+            self.assertEqual("images/misc/closed_door", spawn_states[name]["animation"])
+
+        return True, json.dumps(spawn_states, sort_keys=True)
+
+    @game_test
+    def test_siege_spawn_point_defers_blocking_sealed_occupied_gate(self):
+        class FakeEvent:
+            def __init__(self, cause):
+                self.cause = cause
+
+            def getCause(self):
+                return self.cause
+
+        game = load_game_module()
+        original_show_question = game.CGuiHandler.showQuestion
+
+        try:
+            game.CGuiHandler.showQuestion = lambda self, message: True
+            _g, game_map, player = load_game_map_with_player("siege")
+            spawn_point = find_runtime_object(game_map, "spawnPoint1")
+            spawn_coords = spawn_point.getCoords()
+            player.moveTo(spawn_coords.x, spawn_coords.y, spawn_coords.z)
+            player.addItem("magicWand")
+            spawn_point.setBoolProperty("enabled", True)
+            spawn_point.setBoolProperty("canStep", True)
+            spawn_point.onEnter(FakeEvent(player))
+
+            self.assertTrue(spawn_point.getBoolProperty("destroyed"))
+            self.assertTrue(spawn_point.getBoolProperty("pendingSeal"))
+            self.assertTrue(spawn_point.getBoolProperty("canStep"))
+
+            exit_coords = find_adjacent_walkable_tile(game_map, spawn_coords)
+            player.moveTo(exit_coords.x, exit_coords.y, exit_coords.z)
+            spawn_point.onTurn(None)
+
+            self.assertTrue(spawn_point.getBoolProperty("destroyed"))
+            self.assertFalse(spawn_point.getBoolProperty("pendingSeal"))
+            self.assertFalse(spawn_point.getBoolProperty("canStep"))
+        finally:
+            game.CGuiHandler.showQuestion = original_show_question
+
+        return True, json.dumps(
+            {
+                "canStep": spawn_point.getBoolProperty("canStep"),
+                "destroyed": spawn_point.getBoolProperty("destroyed"),
+                "pendingSeal": spawn_point.getBoolProperty("pendingSeal"),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_map_walkthrough_test(self):
         return execute_walkthrough("test")
 


### PR DESCRIPTION
## What changed
- Track siege spawn points with a `pendingSeal` flag after sealing.
- Keep a sealed gate passable while a creature is still standing on the gate tile.
- Finish the seal on later turns once the gate tile is clear.
- Add regression tests for the initial spawn point state and occupied-gate sealing flow.

## Why
Sealing a spawn gate immediately flipped `canStep` to false even when the player or another creature occupied the tile. That could strand the actor on an impassable cell. The seal now completes only after the gate is clear.

## Validation
- `python3 -m py_compile res/maps/siege/script.py test.py`
- `timeout 20s black --check -l 120 res/maps/siege/script.py test.py`
- `git diff --check`

Runtime/native validation is delegated to GitHub Actions per current workflow guidance.