### PR TITLE
Cancel combat when fight panel closes

### DIFF
--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -490,6 +490,8 @@ void CFightController::start(std::shared_ptr<CCreature> me, std::shared_ptr<CCre
 
 void CFightController::end(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent) {}
 
+bool CFightController::isCancelled(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent) { return false; }
+
 void CFightController::setOpponents(std::shared_ptr<CCreature> me,
                                     const std::vector<std::shared_ptr<CCreature>> &opponents) {}
 
@@ -504,31 +506,56 @@ std::shared_ptr<CCreature> CFightController::selectOpponent(std::shared_ptr<CCre
 }
 
 void CPlayerFightController::start(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent) {
+    cancelled = false;
+    fightPanel = nullptr;
+    encounterMap.reset();
+    controlledCreature.reset();
     if (!me || !me->getMap() || !me->getMap()->getGame()) {
+        cancelled = true;
         return;
     }
-    vstd::if_not_null(me->getMap()->getGame()->getGui(), [&](auto gui) {
-        fightPanel = me->getGame()->createObject<CGameFightPanel>("fightPanel");
-        fightPanel->setEnemies({opponent});
-        gui->pushChild(fightPanel);
-    });
+    encounterMap = me->getMap();
+    controlledCreature = me;
+    auto gui = me->getMap()->getGame()->getGui();
+    if (!gui) {
+        cancelled = true;
+        return;
+    }
+    fightPanel = me->getGame()->createObject<CGameFightPanel>("fightPanel");
+    fightPanel->resetCancellation();
+    fightPanel->setEnemies({opponent});
+    gui->pushChild(fightPanel);
 }
 
 bool CPlayerFightController::control(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent) {
     if (!me || !opponent || !me->getMap() || !me->getMap()->getGame()) {
+        cancelled = true;
+        return false;
+    }
+    if (hasCancelledContext(me)) {
+        cancelled = true;
         return false;
     }
     bool used = false;
-    vstd::if_not_null(me->getMap()->getGame()->getGui(), [&](auto gui) {
-        // TODO: what about mana cost?
-        auto target = fightPanel && fightPanel->getEnemy() ? fightPanel->getEnemy() : opponent;
-        if (fightPanel && target) {
-            if (auto action = fightPanel->selectInteraction()) {
-                me->useAction(action, target);
-                used = true;
-            }
+    auto gui = me->getMap()->getGame()->getGui();
+    if (!gui) {
+        cancelled = true;
+        return false;
+    }
+
+    // TODO: what about mana cost?
+    auto target = fightPanel && fightPanel->getEnemy() ? fightPanel->getEnemy() : opponent;
+    if (fightPanel && target) {
+        if (auto action = fightPanel->selectInteraction()) {
+            me->useAction(action, target);
+            used = true;
         }
-    });
+        if (fightPanel->isCancelled() || hasCancelledContext(me)) {
+            cancelled = true;
+        }
+    } else {
+        cancelled = true;
+    }
     return used;
 }
 
@@ -542,6 +569,14 @@ void CPlayerFightController::end(std::shared_ptr<CCreature> me, std::shared_ptr<
             fightPanel = nullptr;
         }
     });
+}
+
+bool CPlayerFightController::isCancelled(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent) {
+    if (cancelled || hasCancelledContext(me)) {
+        cancelled = true;
+        return true;
+    }
+    return false;
 }
 
 void CPlayerFightController::setOpponents(std::shared_ptr<CCreature> me,
@@ -560,4 +595,21 @@ CPlayerFightController::selectOpponent(std::shared_ptr<CCreature> me,
         return fightPanel->getEnemy();
     }
     return CFightController::selectOpponent(me, opponents, opponent);
+}
+
+bool CPlayerFightController::hasCancelledContext(std::shared_ptr<CCreature> me) {
+    auto startedMap = encounterMap.lock();
+    auto controlled = controlledCreature.lock();
+    if (!me || !startedMap || !controlled || controlled != me || me->getMap() != startedMap ||
+        startedMap->getObjectByName(me->getName()) != me) {
+        return true;
+    }
+
+    auto game = me->getGame();
+    if (!game || game->getMap() != startedMap) {
+        return true;
+    }
+
+    auto gui = game->getGui();
+    return !gui || !fightPanel || fightPanel->isCancelled() || gui->findChild(fightPanel) == nullptr;
 }

--- a/src/core/CController.h
+++ b/src/core/CController.h
@@ -26,6 +26,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CObject.h"
 
 class CGameFightPanel;
+class CMap;
 
 class CController : public CGameObject {
     V_META(CController, CGameObject, vstd::meta::empty())
@@ -80,6 +81,8 @@ class CFightController : public CGameObject {
 
     virtual void end(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent);
 
+    virtual bool isCancelled(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent);
+
     virtual void setOpponents(std::shared_ptr<CCreature> me, const std::vector<std::shared_ptr<CCreature>> &opponents);
 
     virtual std::shared_ptr<CCreature> selectOpponent(std::shared_ptr<CCreature> me,
@@ -107,6 +110,8 @@ class CPlayerFightController : public CFightController {
 
     void end(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent) override;
 
+    bool isCancelled(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent) override;
+
     void setOpponents(std::shared_ptr<CCreature> me, const std::vector<std::shared_ptr<CCreature>> &opponents) override;
 
     std::shared_ptr<CCreature> selectOpponent(std::shared_ptr<CCreature> me,
@@ -115,6 +120,11 @@ class CPlayerFightController : public CFightController {
 
   private:
     std::shared_ptr<CGameFightPanel> fightPanel;
+    std::weak_ptr<CMap> encounterMap;
+    std::weak_ptr<CCreature> controlledCreature;
+    bool cancelled = false;
+
+    bool hasCancelledContext(std::shared_ptr<CCreature> me);
 };
 
 // should accept script

--- a/src/gui/panel/CGameFightPanel.cpp
+++ b/src/gui/panel/CGameFightPanel.cpp
@@ -123,9 +123,15 @@ std::shared_ptr<CInteraction> CGameFightPanel::selectInteraction() {
         while (self->finalSelected.lock() == nullptr) {
             auto gui = self->getGui();
             if (!gui || gui->findChild(self) == nullptr) {
+                self->cancel();
+                return;
+            }
+            if (SDL_HasEvent(SDL_QUIT)) {
+                self->cancel();
                 return;
             }
             if (!vstd::event_loop<>::instance()->run()) {
+                self->cancel();
                 SDL_Event quit_event;
                 SDL_zero(quit_event);
                 quit_event.type = SDL_QUIT;
@@ -140,6 +146,17 @@ std::shared_ptr<CInteraction> CGameFightPanel::selectInteraction() {
     self->refreshEncounterViews();
     return ret;
 }
+
+bool CGameFightPanel::isCancelled() const { return cancelled; }
+
+void CGameFightPanel::cancel() {
+    cancelled = true;
+    finalSelected.reset();
+    selected.reset();
+    selectedItem.reset();
+}
+
+void CGameFightPanel::resetCancellation() { cancelled = false; }
 
 std::shared_ptr<CCreature> CGameFightPanel::getEnemy() { return enemy.lock(); }
 

--- a/src/gui/panel/CGameFightPanel.h
+++ b/src/gui/panel/CGameFightPanel.h
@@ -46,6 +46,12 @@ class CGameFightPanel : public CGamePanel {
 
     std::shared_ptr<CInteraction> selectInteraction();
 
+    bool isCancelled() const;
+
+    void cancel();
+
+    void resetCancellation();
+
     std::shared_ptr<CCreature> getEnemy();
 
     void setEnemy(std::shared_ptr<CCreature> en);
@@ -62,6 +68,7 @@ class CGameFightPanel : public CGamePanel {
     std::weak_ptr<CInteraction> selected;
     std::weak_ptr<CItem> selectedItem;
     std::weak_ptr<CInteraction> finalSelected;
+    bool cancelled = false;
     bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int button, int x, int y) override;
 
     void refreshEncounterViews();

--- a/src/handler/CFightHandler.cpp
+++ b/src/handler/CFightHandler.cpp
@@ -413,6 +413,12 @@ CFightResult CFightHandler::fightManyResult(std::shared_ptr<CCreature> attacker,
 
                 if (!CTags::isTagPresent(attacker->getEffects(), CTag::Stun)) {
                     attackerController->control(attacker, current);
+                    if (attackerController->isCancelled(attacker, current)) {
+                        result.outcome = CFightOutcome::Cancelled;
+                        result.survivor = attacker;
+                        result.opponent = current;
+                        break;
+                    }
                     remove_dead_opponents(encounterMap, attacker, opponents, attacker);
                     if (!attacker->isAlive()) {
                         result.outcome = CFightOutcome::AttackerDefeat;
@@ -457,6 +463,12 @@ CFightResult CFightHandler::fightManyResult(std::shared_ptr<CCreature> attacker,
             if (!CTags::isTagPresent(actor->getEffects(), CTag::Stun)) {
                 if (auto controller = actor->getFightController()) {
                     controller->control(actor, attacker);
+                    if (controller->isCancelled(actor, attacker)) {
+                        result.outcome = CFightOutcome::Cancelled;
+                        result.survivor = attacker;
+                        result.opponent = actor;
+                        break;
+                    }
                 }
                 if (!attacker->isAlive()) {
                     remove_dead_opponents(encounterMap, attacker, opponents, attacker);

--- a/tests/unit/test_handler.cpp
+++ b/tests/unit/test_handler.cpp
@@ -26,12 +26,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CLoader.h"
 #include "core/CMap.h"
 #include "core/CPlaytestTrace.h"
+#include "gui/CGui.h"
+#include "gui/panel/CGamePanel.h"
 #include "object/CCreature.h"
+#include "object/CInteraction.h"
 #include "object/CEffect.h"
 #include "object/CItem.h"
 #include "object/CPlayer.h"
 #include "object/CQuest.h"
 #include "test_harness.h"
+#include "veventloop.h"
 
 #include <SDL.h>
 #include <pybind11/embed.h>
@@ -439,6 +443,44 @@ void test_fight_handler_reports_cancelled_quit_event() {
                 "cancelled combat should publish the interrupted status text");
 }
 
+void test_fight_handler_reports_cancelled_closed_fight_panel() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto game = CGameLoader::loadGame();
+    CGameLoader::loadGui(game);
+    CGameLoader::startGameWithPlayer(game, "empty", "Warrior");
+
+    auto player = game->getMap()->getPlayer();
+    player->setHp(10);
+    auto action = game->createObject<CInteraction>("CInteraction");
+    action->setName("unitPanelCancelledAction");
+    action->setManaCost(0);
+    player->addAction(action);
+
+    auto defender = add_test_creature(game, "unitPanelCancelledDefender", 1, 0);
+    auto gui = game->getGui();
+    bool closed_panel = false;
+    vstd::event_loop<>::instance()->invoke([gui, &closed_panel]() {
+        auto panel = vstd::cast<CGamePanel>(gui->findChild("CGameFightPanel"));
+        expect_true(panel != nullptr, "fight panel should exist while player action selection is waiting");
+        if (panel) {
+            panel->close();
+            closed_panel = true;
+        }
+    });
+
+    const auto result = CFightHandler::fightManyResult(player, {defender});
+
+    expect_true(closed_panel, "test callback should close the fight panel during action selection");
+    expect_true(result.outcome == CFightOutcome::Cancelled, "closed fight panel should cancel combat immediately");
+    expect_true(result.rounds == 1, "panel cancellation during the first action should report the active round");
+    expect_true(result.survivor == player && result.opponent == defender,
+                "panel cancellation should keep participant metadata");
+    expect_true(game->getMap()->getStringProperty("combatStatus").find("interrupted") != std::string::npos,
+                "panel cancellation should publish the interrupted status text");
+}
+
 void test_fight_handler_counts_effect_duration_as_progress() {
     auto game = load_empty_game();
     auto attacker = add_test_creature(game, "unitTimedEffectAttacker");
@@ -583,6 +625,7 @@ int main() {
     test_fight_handler_reports_explicit_outcomes_and_final_status();
     test_fight_handler_reports_invalid_result_metadata();
     test_fight_handler_reports_cancelled_quit_event();
+    test_fight_handler_reports_cancelled_closed_fight_panel();
     test_fight_handler_counts_effect_duration_as_progress();
     test_playtest_trace_records_native_limits_and_quest_completion();
     test_fight_handler_records_outcome_trace_metadata();


### PR DESCRIPTION
## What changed
- Added explicit fight-controller cancellation state for player fight-panel cancellation.
- Marked the fight panel cancelled when it is closed, detached from the GUI, or the event loop requests quit while action selection is waiting.
- Had CFightHandler convert controller cancellation into CFightOutcome::Cancelled while preserving normal cleanup.
- Added a native regression covering a fight panel closed during player action selection.

## Why
Closing or losing the fight panel could make action selection return no action, leaving combat to stall instead of producing an explicit cancelled outcome.

## Validation
- clang-format -i src/core/CController.h src/core/CController.cpp src/gui/panel/CGameFightPanel.h src/gui/panel/CGameFightPanel.cpp src/handler/CFightHandler.cpp tests/unit/test_handler.cpp
- git diff --check
- git diff --cached --check
- Local native build, ctest, full python suite, and coverage not run per queue-controller PR delivery policy; GitHub Actions will supply heavy validation.

## Queue
- Issue: [EPIC_01][STORY_03][SUBSTORY_01]Support cancellation in fight panel
- Claim ID: 8f9033c9-6491-43e3-9b5e-85a7f92a4bf0
- Owner: controller/subagent-9

## Known limitations
- No known follow-up required if CI passes.