### PR TITLE
Refactor fightMany into detailed resolver

### DIFF
--- a/src/handler/CFightHandler.cpp
+++ b/src/handler/CFightHandler.cpp
@@ -317,28 +317,7 @@ std::string final_status_message(CFightOutcome outcome, const std::string &attac
     return "";
 }
 
-} // namespace
-
-bool CFightResult::resolved() const {
-    return outcome == CFightOutcome::AttackerVictory || outcome == CFightOutcome::AttackerDefeat;
-}
-
-bool CFightResult::attackerSucceeded() const { return outcome == CFightOutcome::AttackerVictory; }
-
-bool CFightHandler::fight(std::shared_ptr<CCreature> a, std::shared_ptr<CCreature> b) { return fightMany(a, {b}); }
-
-bool CFightHandler::fightMany(std::shared_ptr<CCreature> attacker,
-                              const std::vector<std::shared_ptr<CCreature>> &encounterOpponents) {
-    return fightManyResult(attacker, encounterOpponents).resolved();
-}
-
-CFightOutcome CFightHandler::fightManyOutcome(std::shared_ptr<CCreature> attacker,
-                                              const std::vector<std::shared_ptr<CCreature>> &encounterOpponents) {
-    return fightManyResult(attacker, encounterOpponents).outcome;
-}
-
-CFightResult CFightHandler::fightManyResult(std::shared_ptr<CCreature> attacker,
-                                            const std::vector<std::shared_ptr<CCreature>> &encounterOpponents) {
+CFightResult resolve_fight_many(std::shared_ptr<CCreature> attacker, const encounter_type &encounterOpponents) {
     CFightResult result;
     if (!attacker) {
         return result;
@@ -548,6 +527,31 @@ CFightResult CFightHandler::fightManyResult(std::shared_ptr<CCreature> attacker,
     }
 
     return result;
+}
+
+} // namespace
+
+bool CFightResult::resolved() const {
+    return outcome == CFightOutcome::AttackerVictory || outcome == CFightOutcome::AttackerDefeat;
+}
+
+bool CFightResult::attackerSucceeded() const { return outcome == CFightOutcome::AttackerVictory; }
+
+bool CFightHandler::fight(std::shared_ptr<CCreature> a, std::shared_ptr<CCreature> b) { return fightMany(a, {b}); }
+
+bool CFightHandler::fightMany(std::shared_ptr<CCreature> attacker,
+                              const std::vector<std::shared_ptr<CCreature>> &encounterOpponents) {
+    return fightManyResult(attacker, encounterOpponents).resolved();
+}
+
+CFightOutcome CFightHandler::fightManyOutcome(std::shared_ptr<CCreature> attacker,
+                                              const std::vector<std::shared_ptr<CCreature>> &encounterOpponents) {
+    return fightManyResult(attacker, encounterOpponents).outcome;
+}
+
+CFightResult CFightHandler::fightManyResult(std::shared_ptr<CCreature> attacker,
+                                            const std::vector<std::shared_ptr<CCreature>> &encounterOpponents) {
+    return resolve_fight_many(attacker, encounterOpponents);
 }
 
 void CFightHandler::defeatedCreature(const std::shared_ptr<CCreature> &a, const std::shared_ptr<CCreature> &b) {


### PR DESCRIPTION
## Issue
- [EPIC_01][STORY_01][SUBSTORY_02]Refactor fightMany into detailed resolver
- Claim ID: 2f8b46b4-18fe-4c58-a43b-a5d3b3fcc60b

## Root cause
- `CFightHandler::fightManyResult` still owned the detailed combat loop directly, so the result-producing resolver contract was coupled to the public wrapper.

## What changed
- Moved the existing fightMany result loop into an anonymous-namespace `resolve_fight_many(...)` helper returning `CFightResult`.
- Kept `fight()`, `fightMany()`, `fightManyOutcome()`, and `fightManyResult()` delegating through the existing public result semantics.
- Preserved encounter sanitization, initiative ordering, effect application, dead-opponent removal, reward handling, status updates, controller cleanup, and playtest trace emission.

## Files changed
- `src/handler/CFightHandler.cpp`

## Validation
- `clang-format -i src/handler/CFightHandler.cpp`
- `git diff --check`
- `git diff --exit-code -- planning/fall_of_nouraajd_issue_proposals.xlsx`
- `git diff --cached --check`

## Skipped local checks
- Local native builds, `ctest`, full Python suites, and coverage were not run per controller guidance; GitHub Actions Linux validation is expected to cover compile/tests/coverage.

## Manual review
- This is intended to be extraction-only; review should focus on preserving the original control flow.
