### PR TITLE
Stop sealed siege spawn points immediately

### DIFF
--- a/res/maps/siege/script.py
+++ b/res/maps/siege/script.py
@@ -114,11 +114,16 @@ def load(self, context):
         def onEnter(self, event):
             if not event.getCause().isPlayer():
                 return
-            if not self.getBoolProperty("enabled") or self.getBoolProperty("destroyed"):
+            if (
+                not self.getBoolProperty("enabled")
+                or self.getBoolProperty("pendingSeal")
+                or self.getBoolProperty("destroyed")
+            ):
                 return
             if self.getMap().getPlayer().hasItem(lambda it: it.hasTag(CTag.WAND)):
                 if self.getMap().getGame().getGuiHandler().showQuestion("Do You want to seal the gate?"):
                     self.getMap().getPlayer().removeQuestItem(lambda it: it.hasTag(CTag.WAND))
+                    self.setBoolProperty("enabled", False)
                     self.setBoolProperty("destroyed", True)
                     self.setBoolProperty("pendingSeal", True)
                     self.setStringProperty("animation", "images/misc/closed_door")
@@ -144,5 +149,6 @@ def load(self, context):
                     enableSpawn,
                     lambda ob: event.cont
                     and ob.getStringProperty("type") == "SpawnPoint"
-                    and not ob.getBoolProperty("enabled"),
+                    and not ob.getBoolProperty("enabled")
+                    and not ob.getBoolProperty("destroyed"),
                 )

--- a/test.py
+++ b/test.py
@@ -10950,6 +10950,63 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_siege_spawn_point_seal_consumes_one_wand_once_while_pending(self):
+        class FakeEvent:
+            def __init__(self, cause):
+                self.cause = cause
+
+            def getCause(self):
+                return self.cause
+
+        game = load_game_module()
+        original_show_question = game.CGuiHandler.showQuestion
+        question_calls = []
+
+        def confirm_seal(_self, _message):
+            question_calls.append(True)
+            return True
+
+        try:
+            game.CGuiHandler.showQuestion = confirm_seal
+            _g, game_map, player = load_game_map_with_player("siege")
+            spawn_point = find_runtime_object(game_map, "spawnPoint1")
+            spawn_coords = spawn_point.getCoords()
+            player.moveTo(spawn_coords.x, spawn_coords.y, spawn_coords.z)
+            player.addItem("magicWand")
+            player.addItem("magicWand")
+            starting_wands = player.countItems("magicWand")
+            spawn_point.setBoolProperty("enabled", True)
+            spawn_point.setBoolProperty("canStep", True)
+
+            spawn_point.onEnter(FakeEvent(player))
+            after_first_seal_wands = player.countItems("magicWand")
+            spawn_point.onEnter(FakeEvent(player))
+            after_second_enter_wands = player.countItems("magicWand")
+
+            self.assertEqual(starting_wands - 1, after_first_seal_wands)
+            self.assertEqual(after_first_seal_wands, after_second_enter_wands)
+            self.assertEqual(1, len(question_calls))
+            self.assertFalse(spawn_point.getBoolProperty("enabled"))
+            self.assertTrue(spawn_point.getBoolProperty("destroyed"))
+            self.assertTrue(spawn_point.getBoolProperty("pendingSeal"))
+            self.assertEqual("images/misc/closed_door", spawn_point.getStringProperty("animation"))
+        finally:
+            game.CGuiHandler.showQuestion = original_show_question
+
+        return True, json.dumps(
+            {
+                "after_first_seal_wands": after_first_seal_wands,
+                "after_second_enter_wands": after_second_enter_wands,
+                "destroyed": spawn_point.getBoolProperty("destroyed"),
+                "enabled": spawn_point.getBoolProperty("enabled"),
+                "pendingSeal": spawn_point.getBoolProperty("pendingSeal"),
+                "question_calls": len(question_calls),
+                "starting_wands": starting_wands,
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_map_walkthrough_test(self):
         return execute_walkthrough("test")
 


### PR DESCRIPTION
## Issue
- `[EPIC_01][STORY_04][SUBSTORY_02]Consume wand and stop spawning once`
- Claim ID: `17c1b1bc-1e1f-4847-855e-7a70c95fc90c`
- Owner: `controller/ctrl-lis-2-0999ec10/subagent-1`

## What changed
- Guarded `SpawnPoint.onEnter()` against repeat activation while `pendingSeal` or `destroyed` is set.
- Marked a sealed spawn point `enabled=False` immediately after consuming one wand.
- Prevented the siege turn trigger from reopening disabled spawn points that are already destroyed.
- Added a focused regression that calls `onEnter()` twice while pending and verifies one prompt, one wand removal, and the stopped state.

## Why
- Sealing previously consumed a wand and marked the point destroyed/pending, but left `enabled=True`, so the spawn point did not enter an explicit stopped state immediately.
- The turn trigger also selected disabled spawn points without excluding destroyed ones.

## Validation
- `timeout 60s python3 -m black --check -l 120 res/maps/siege/script.py test.py`
- `python3 -m py_compile res/maps/siege/script.py test.py`
- `python3 test.py GameTest.test_siege_spawn_point_seal_consumes_one_wand_once_while_pending GameTest.test_siege_spawn_point_defers_blocking_sealed_occupied_gate McpServerTest.test_stdio_map_walkthrough_siege`
- `git diff --check origin/main`

## Skipped local heavy validation
- Local full native builds, full `ctest`, full `python3 test.py`, and full coverage were not rerun by the controller; GitHub Actions will provide heavy Linux validation and coverage evidence.

## Known limitations / follow-up
- None known.