### PR TITLE
Summarize stale reclaim dry runs

### DIFF
--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -326,12 +326,14 @@ python3 scripts/issue_queue.py reclaim-stale --dry-run --older-than-minutes 30
 python3 scripts/issue_queue.py reclaim-stale --older-than-minutes 30
 ```
 
-The dry run lists stale rows without modifying the workbook. Inspect the worker worktree, branch, pull request, and any
-recoverable changes before running the mutating command. Run the mutating command only from a fresh workbook-only branch
-and publish it through the same serialized queue-state PR process as claims and terminal statuses. Reclaimed rows are
-not eligible for dispatch until that reclaim PR actually merges. The mutating command only reclaims rows whose lease is
-already expired and whose last update is at least the specified age. Reclaimed rows return to `NOT_STARTED`, retain the
-incremented `Attempt`, and receive an audit note describing the previous owner and claim.
+The dry run lists stale rows without modifying the workbook and reports `activeClaims`, `staleCount`, and
+`reclaimableStaleCount`. `staleCount` is the total expired active-claim count; `reclaimableStaleCount` is the number of
+rows returned by the current `--older-than-minutes` threshold. Inspect the worker worktree, branch, pull request, and
+any recoverable changes before running the mutating command. Run the mutating command only from a fresh workbook-only
+branch and publish it through the same serialized queue-state PR process as claims and terminal statuses. Reclaimed rows
+are not eligible for dispatch until that reclaim PR actually merges. The mutating command only reclaims rows whose lease
+is already expired and whose last update is at least the specified age. Reclaimed rows return to `NOT_STARTED`, retain
+the incremented `Attempt`, and receive an audit note describing the previous owner and claim.
 
 `validate` warns about expired `IN_PROGRESS` leases without failing the workbook, and `list --status IN_PROGRESS --json`
 includes derived lease-expiration fields for read-only controller status checks.

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -421,10 +421,11 @@ Commit and merge that workbook-only change using the same status-PR process as c
 
 If a worker disappears, do not overwrite the active claim. Inspect its worktree and branch, wait for lease expiry, and
 run `python3 scripts/issue_queue.py reclaim-stale --dry-run --older-than-minutes <minutes>` to list stale
-`IN_PROGRESS` claims without mutating the workbook. Use mutating `reclaim-stale` only when the claim is genuinely stale
-and no recoverable work remains. Treat `validate` warnings about expired `IN_PROGRESS` leases and derived
-`list --status IN_PROGRESS --json` lease-expiration fields as read-only recovery signals, not permission to reclaim
-without inspection.
+`IN_PROGRESS` claims without mutating the workbook. The dry-run output includes `activeClaims`, `staleCount`, and
+`reclaimableStaleCount`; use those fields to distinguish all expired active leases from rows eligible under the current
+age threshold. Use mutating `reclaim-stale` only when the claim is genuinely stale and no recoverable work remains.
+Treat `validate` warnings about expired `IN_PROGRESS` leases and derived `list --status IN_PROGRESS --json`
+lease-expiration fields as read-only recovery signals, not permission to reclaim without inspection.
 
 ## Resource-aware validation
 

--- a/scripts/issue_queue.py
+++ b/scripts/issue_queue.py
@@ -779,6 +779,16 @@ def statusCounts(state: QueueState) -> dict[str, int]:
     return dict(sorted(counts.items()))
 
 
+def activeClaimSummary(state: QueueState, stale: Sequence[dict[str, Any]]) -> dict[str, int]:
+    activeCount = statusCounts(state).get(STATUS_IN_PROGRESS, 0)
+    staleCount = len(stale)
+    return {
+        "total": activeCount,
+        "unexpired": max(0, activeCount - staleCount),
+        "stale": staleCount,
+    }
+
+
 def storyKey(task: TaskRecord) -> tuple[str, str]:
     return (
         str(task.values.get("Epic #") or "").strip(),
@@ -837,10 +847,8 @@ def shortlistTasks(
         allowFileOverlap=allowFileOverlap,
     )
     counts = statusCounts(state)
-    activeCount = counts.get(STATUS_IN_PROGRESS, 0)
     stale = staleClaims(state)
-    staleClaimCount = len(stale)
-    unexpiredActiveCount = max(0, activeCount - staleClaimCount)
+    activeClaims = activeClaimSummary(state, stale)
     selectionSeed = seed or uuid.uuid4().hex
     fileOverlapFilter = (
         "direct target-file overlap allowed by --allow-file-overlap"
@@ -857,14 +865,10 @@ def shortlistTasks(
         "storyGroups": [],
         "selected": None,
         "statusCounts": counts,
-        "activeCount": activeCount,
-        "unexpiredActiveCount": unexpiredActiveCount,
-        "staleClaimCount": staleClaimCount,
-        "activeClaims": {
-            "total": activeCount,
-            "unexpired": unexpiredActiveCount,
-            "stale": staleClaimCount,
-        },
+        "activeCount": activeClaims["total"],
+        "unexpiredActiveCount": activeClaims["unexpired"],
+        "staleClaimCount": activeClaims["stale"],
+        "activeClaims": activeClaims,
         "staleClaims": stale,
         "rejectedCount": len(rejected),
         "rejectionSummary": rejectionSummary(rejected),
@@ -1775,7 +1779,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             if args.dry_run:
                 state = loadQueue(workbookPath, writable=False)
                 try:
-                    printJson({"stale": staleClaims(state, olderThanMinutes=args.older_than_minutes)})
+                    now = utcNow()
+                    allStale = staleClaims(state, now=now)
+                    stale = staleClaims(state, olderThanMinutes=args.older_than_minutes, now=now)
+                    printJson(
+                        {
+                            "workbook": str(workbookPath),
+                            "olderThanMinutes": args.older_than_minutes,
+                            "reclaimableStaleCount": len(stale),
+                            "staleCount": len(allStale),
+                            "activeClaims": activeClaimSummary(state, allStale),
+                            "stale": stale,
+                        }
+                    )
                 finally:
                     state.workbook.close()
             else:

--- a/tests/test_issue_queue.py
+++ b/tests/test_issue_queue.py
@@ -535,7 +535,10 @@ class IssueQueueTest(unittest.TestCase):
     def test_reclaim_stale_dry_run_reports_without_mutating(self) -> None:
         claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
         self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=10)
+        recent_claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-2", leaseMinutes=1)
+        self.set_claim_times(recent_claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=1)
 
+        before = self.workbook_path.read_bytes()
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):
             exit_code = issue_queue.main(
@@ -551,11 +554,20 @@ class IssueQueueTest(unittest.TestCase):
         payload = json.loads(stdout.getvalue())
 
         self.assertEqual(0, exit_code)
+        self.assertEqual(str(self.workbook_path.resolve()), payload["workbook"])
+        self.assertEqual(5, payload["olderThanMinutes"])
+        self.assertEqual(2, payload["staleCount"])
+        self.assertEqual(1, payload["reclaimableStaleCount"])
+        self.assertEqual({"total": 2, "unexpired": 0, "stale": 2}, payload["activeClaims"])
         self.assertEqual([claim["Issue Name"]], [item["issueName"] for item in payload["stale"]])
+        self.assertEqual(before, self.workbook_path.read_bytes())
         state = issue_queue.loadQueue(self.workbook_path)
         task = issue_queue.taskByName(state, claim["Issue Name"])
+        recent_task = issue_queue.taskByName(state, recent_claim["Issue Name"])
         self.assertEqual(issue_queue.STATUS_IN_PROGRESS, task.status)
         self.assertEqual(claim["claimId"], task.values["Claim ID"])
+        self.assertEqual(issue_queue.STATUS_IN_PROGRESS, recent_task.status)
+        self.assertEqual(recent_claim["claimId"], recent_task.values["Claim ID"])
 
     def test_list_table_marks_expired_in_progress_lease(self) -> None:
         claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)


### PR DESCRIPTION
Summary:
- enrich issue_queue.py reclaim-stale --dry-run with workbook, threshold, stale count, reclaimable stale count, and active claim freshness summary
- reuse the active-claim summary helper used by shortlist
- document how controllers should interpret staleCount versus reclaimableStaleCount

Why:
- current queue evidence has expired IN_PROGRESS rows, and dry-run previously returned only a stale list
- controllers need a non-mutating summary before deciding whether a reclaim PR is safe

Validation:
- python3 scripts/issue_queue.py validate (passes with existing expired lease warnings on rows 3, 25, and 131)
- python3 -m unittest tests.test_issue_queue tests.test_prompt_inventory
- python3 -m unittest tests.test_prompt_inventory tests.test_controller_resource_audit
- python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes
- timeout 90s python3 test.py GameTest.test_python_black_formatting GameTest.test_indentation
- timeout 20s python3 -m black --check -l 120 scripts/issue_queue.py tests/test_issue_queue.py
- git diff --check
- python3 scripts/issue_queue.py reclaim-stale --dry-run --older-than-minutes 30

Review:
- read-only auditor and PM scout recommended this bounded dry-run evidence checkpoint
- QA reviewed the diff and found no blocking findings; the suggested single-timestamp consistency tweak was applied

Known limitations:
- this is read-only evidence only; it does not inspect worker branches/PRs or mutate/reclaim workbook rows
- native builds, ctest, full Python suite, and coverage were intentionally not run locally; PR checks are used for heavy validation