### PR TITLE
Fix coverage step polling across workflow jobs

### DIFF
--- a/scripts/poll_pr_checks.py
+++ b/scripts/poll_pr_checks.py
@@ -84,11 +84,20 @@ def jobsFromRunPayload(payload: dict[str, Any]) -> list[JobRun]:
     return [jobFromPayload(item) for item in payload.get("jobs") or [] if isinstance(item, dict) and item.get("name")]
 
 
+def runStatus(runPayload: dict[str, Any]) -> str:
+    return normalizeStatus(runPayload.get("status"))
+
+
 def selectRunForHead(runs: Sequence[dict[str, Any]], headSha: str) -> dict[str, Any] | None:
     for run in runs:
         if str(run.get("headSha") or "") == headSha:
             return run
     return None
+
+
+def appendUniqueJob(jobs: list[JobRun], job: JobRun) -> None:
+    if not any(existing.name == job.name for existing in jobs):
+        jobs.append(job)
 
 
 def evaluateRun(
@@ -105,7 +114,8 @@ def evaluateRun(
             message="no matching pull_request workflow run found yet",
         )
 
-    jobs_by_name = {job.name: job for job in jobsFromRunPayload(runPayload)}
+    all_jobs = jobsFromRunPayload(runPayload)
+    jobs_by_name = {job.name: job for job in all_jobs}
     selected_jobs: list[JobRun] = []
     missing_jobs: list[str] = []
     missing_steps: list[str] = []
@@ -148,33 +158,59 @@ def evaluateRun(
             message=f"pending job(s): {names}",
         )
 
+    display_jobs = list(selected_jobs)
     for step_name in requiredSteps:
-        for job in selected_jobs:
-            steps_by_name = {step.name: step for step in job.steps}
-            step = steps_by_name.get(step_name)
-            if step is None:
-                missing_steps.append(f"{job.name}/{step_name}")
-            elif step.status != "COMPLETED":
+        matches = [(job, step) for job in all_jobs for step in job.steps if step.name == step_name]
+        if not matches:
+            missing_steps.append(step_name)
+            continue
+        for job, step in matches:
+            appendUniqueJob(display_jobs, job)
+            if step.status != "COMPLETED":
                 return CheckEvaluation(
                     state="pending",
-                    jobs=tuple(selected_jobs),
+                    jobs=tuple(display_jobs),
                     missingJobs=(),
                     missingSteps=(),
-                    message=f"pending step: {job.name}/{step_name}={step.status or 'UNKNOWN'}",
+                    message=f"pending step: {job.name}/{step.name}={step.status or 'UNKNOWN'}",
                 )
-            elif step.conclusion != SUCCESS_CONCLUSION:
+            if step.conclusion != SUCCESS_CONCLUSION:
                 return CheckEvaluation(
                     state="failure",
-                    jobs=tuple(selected_jobs),
+                    jobs=tuple(display_jobs),
                     missingJobs=(),
                     missingSteps=(),
-                    message=f"failed step: {job.name}/{step_name}={step.conclusion or 'UNKNOWN'}",
+                    message=f"failed step: {job.name}/{step.name}={step.conclusion or 'UNKNOWN'}",
+                )
+            if job.status != "COMPLETED":
+                return CheckEvaluation(
+                    state="pending",
+                    jobs=tuple(display_jobs),
+                    missingJobs=(),
+                    missingSteps=(),
+                    message=f"pending job with required step: {job.name}={job.status or 'UNKNOWN'}",
+                )
+            if job.conclusion != SUCCESS_CONCLUSION:
+                return CheckEvaluation(
+                    state="failure",
+                    jobs=tuple(display_jobs),
+                    missingJobs=(),
+                    missingSteps=(),
+                    message=f"failed job with required step: {job.name}={job.conclusion or 'UNKNOWN'}",
                 )
 
     if missing_steps:
+        if runStatus(runPayload) != "COMPLETED":
+            return CheckEvaluation(
+                state="pending",
+                jobs=tuple(display_jobs),
+                missingJobs=(),
+                missingSteps=tuple(missing_steps),
+                message=f"missing required step(s) so far: {', '.join(missing_steps)}",
+            )
         return CheckEvaluation(
             state="failure",
-            jobs=tuple(selected_jobs),
+            jobs=tuple(display_jobs),
             missingJobs=(),
             missingSteps=tuple(missing_steps),
             message=f"missing required step(s): {', '.join(missing_steps)}",
@@ -182,7 +218,7 @@ def evaluateRun(
 
     return CheckEvaluation(
         state="success",
-        jobs=tuple(selected_jobs),
+        jobs=tuple(display_jobs),
         missingJobs=(),
         missingSteps=(),
         message=f"successful job(s): {', '.join(requiredJobs)}",
@@ -293,9 +329,7 @@ def formatJob(job: JobRun, requiredSteps: Sequence[str]) -> list[str]:
         steps_by_name = {step.name: step for step in job.steps}
         for step_name in requiredSteps:
             step = steps_by_name.get(step_name)
-            if step is None:
-                lines.append(f"  {step_name}: missing")
-            else:
+            if step is not None:
                 step_conclusion = f"/{step.conclusion}" if step.conclusion else ""
                 lines.append(f"  {step.name}: {step.status}{step_conclusion}")
     return lines
@@ -392,7 +426,7 @@ def parseArgs(argv: Sequence[str]) -> argparse.Namespace:
         action="append",
         dest="steps",
         default=[],
-        help="Required step name inside every selected job, such as coverage. May be repeated.",
+        help="Required step name that must pass somewhere in the selected workflow run. May be repeated.",
     )
     parser.add_argument(
         "--interval-seconds",

--- a/tests/test_poll_pr_checks.py
+++ b/tests/test_poll_pr_checks.py
@@ -9,12 +9,12 @@ from scripts import poll_pr_checks
 
 
 class PollPrChecksTest(unittest.TestCase):
-    def runPayload(self, jobs: list[dict[str, object]]) -> dict[str, object]:
+    def runPayload(self, jobs: list[dict[str, object]], *, status: str = "completed") -> dict[str, object]:
         return {
             "headSha": "abc123",
             "url": "https://github.com/example/repo/actions/runs/1",
             "workflowName": "build",
-            "status": "completed",
+            "status": status,
             "conclusion": "success",
             "jobs": jobs,
         }
@@ -129,6 +129,65 @@ class PollPrChecksTest(unittest.TestCase):
 
         self.assertTrue(evaluation.succeeded)
 
+    def test_evaluate_run_accepts_required_step_from_non_selected_job(self) -> None:
+        evaluation = poll_pr_checks.evaluateRun(
+            self.runPayload(
+                [
+                    self.jobPayload(name="linux"),
+                    self.jobPayload(
+                        name="linux-coverage",
+                        steps=[
+                            {
+                                "name": "coverage",
+                                "status": "completed",
+                                "conclusion": "success",
+                            }
+                        ],
+                    ),
+                ]
+            ),
+            ["linux"],
+            ["coverage"],
+        )
+
+        self.assertTrue(evaluation.succeeded)
+        self.assertEqual(("linux", "linux-coverage"), tuple(job.name for job in evaluation.jobs))
+
+    def test_evaluate_run_fails_required_step_from_non_selected_job(self) -> None:
+        evaluation = poll_pr_checks.evaluateRun(
+            self.runPayload(
+                [
+                    self.jobPayload(name="linux"),
+                    self.jobPayload(
+                        name="linux-coverage",
+                        steps=[
+                            {
+                                "name": "coverage",
+                                "status": "completed",
+                                "conclusion": "failure",
+                            }
+                        ],
+                    ),
+                ]
+            ),
+            ["linux"],
+            ["coverage"],
+        )
+
+        self.assertTrue(evaluation.failed)
+        self.assertIn("linux-coverage/coverage=FAILURE", evaluation.message)
+
+    def test_evaluate_run_waits_for_missing_required_step_while_workflow_runs(self) -> None:
+        evaluation = poll_pr_checks.evaluateRun(
+            self.runPayload([self.jobPayload(name="linux")], status="in_progress"),
+            ["linux"],
+            ["coverage"],
+        )
+
+        self.assertEqual("pending", evaluation.state)
+        self.assertEqual(("coverage",), evaluation.missingSteps)
+        self.assertIn("missing required step(s) so far", evaluation.message)
+
     def test_evaluate_run_fails_skipped_required_step(self) -> None:
         evaluation = poll_pr_checks.evaluateRun(
             self.runPayload(
@@ -151,6 +210,31 @@ class PollPrChecksTest(unittest.TestCase):
         self.assertTrue(evaluation.failed)
         self.assertIn("linux/coverage=SKIPPED", evaluation.message)
 
+    def test_evaluate_run_fails_required_step_job_failure(self) -> None:
+        evaluation = poll_pr_checks.evaluateRun(
+            self.runPayload(
+                [
+                    self.jobPayload(name="linux"),
+                    self.jobPayload(
+                        name="linux-coverage",
+                        conclusion="failure",
+                        steps=[
+                            {
+                                "name": "coverage",
+                                "status": "completed",
+                                "conclusion": "success",
+                            }
+                        ],
+                    ),
+                ]
+            ),
+            ["linux"],
+            ["coverage"],
+        )
+
+        self.assertTrue(evaluation.failed)
+        self.assertIn("linux-coverage=FAILURE", evaluation.message)
+
     def test_evaluate_run_fails_missing_required_step_after_job_success(self) -> None:
         evaluation = poll_pr_checks.evaluateRun(
             self.runPayload([self.jobPayload()]),
@@ -159,7 +243,7 @@ class PollPrChecksTest(unittest.TestCase):
         )
 
         self.assertTrue(evaluation.failed)
-        self.assertEqual(("linux/coverage",), evaluation.missingSteps)
+        self.assertEqual(("coverage",), evaluation.missingSteps)
 
     def test_evaluate_pr_state_passes_already_merged_pr(self) -> None:
         evaluation = poll_pr_checks.evaluatePrState(


### PR DESCRIPTION
## What changed
- Changed `scripts/poll_pr_checks.py` so `--require-step` checks required workflow steps across the selected workflow run, not only inside the explicitly selected jobs.
- Kept selected job validation intact: requested jobs still must exist, complete, and succeed.
- Added regression coverage for required steps that live in non-selected jobs, pending missing steps while a workflow is still running, required-step job failures, and missing-step failures after completion.

## Why
The build workflow runs coverage in a separate `linux-coverage` job, but the documented coverage polling command uses `--check linux --require-step coverage`. Before this change, that command looked for `linux/coverage` and failed even when the coverage step belonged to `linux-coverage`.

## Validation performed
- `black -l 120 --check scripts/poll_pr_checks.py tests/test_poll_pr_checks.py`: files would be left unchanged
- `python3 -m unittest tests.test_poll_pr_checks`: 18 tests OK
- `python3 scripts/poll_pr_checks.py --help`: passed
- `git diff --check origin/main...HEAD`: passed
- `python3 scripts/issue_queue.py validate`: passed with `errors: []`, `warnings: []`
- `python3 -m unittest tests.test_issue_queue tests.test_controller_resource_audit`: 30 tests OK
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`: no errors or warnings; about 872 GiB free under `/tmp`
- GitHub Actions `build / linux` for head `cfdd423730337f6f76c4994a1ce5fb68b9d3e53a`: passed

## Known limitations / follow-up
- This does not change the default required job set; whether default polling should include `linux-fast` is a separate workflow decision.
- This does not repair repository-wide coverage exclusions or coverage percentage issues in unrelated PRs; it only fixes the poller reporting and required-step selection behavior.
