### PR TITLE
Treat queue target overlaps as advisory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,20 +37,22 @@ latest `origin/main`, recalculate the full eligible set from the merged workbook
 
 - rows whose status is not `NOT_STARTED`;
 - rows with dependencies that are not `DONE`;
-- direct target-file overlaps with active work;
-- active-scope conflicts, including indirect conflicts through shared headers, bindings, tests, CMake, map scripts,
-  dialog/config files, serialization, generated resources, or shared runtime systems.
+- active-scope conflicts, including source-backed direct or indirect conflicts through shared headers, bindings, tests,
+  CMake, map scripts, dialog/config files, serialization, generated resources, or shared runtime systems.
+
+Treat exact `Target Files / Modules` overlap with active work as advisory scope evidence, not as an automatic exclusion.
+Use it to prioritize review and decide whether a source-backed active-scope conflict exists.
 
 After exclusions, keep only the highest currently available priority tier. Group candidates by `(Epic #, Story #)`,
 randomly select one story with equal probability, then randomly select one eligible substory in that story. Do not fall
 back to spreadsheet order and do not include ineligible rows in the random choice. Use
 `python3 scripts/issue_queue.py shortlist --seed "$CONTROLLER_ID-<utc-cycle-id>" --include-rejected --json` as the
 read-only mechanical selector before each claim; it reports eligible highest-priority story groups, stale claims,
-`activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`, rejection summaries, and a seeded recommendation
-without mutating the workbook. Use the unexpired count, not raw `activeCount`, when deciding whether the active-worker
-floor is genuinely satisfied. The controller and project manager must still exclude source-backed indirect conflicts
-that exact target-file overlap cannot detect, then claim the final exact issue with `claim --issue` so eligibility is
-rechecked under the workbook lock.
+`activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`, target-file overlap advisories, rejection summaries,
+and a seeded recommendation without mutating the workbook. Use the unexpired count, not raw `activeCount`, when deciding
+whether the active-worker floor is genuinely satisfied. The controller and project manager must still inspect target-file
+overlap advisories and exclude source-backed active-scope conflicts, then claim the final exact issue with `claim --issue`
+so eligibility is rechecked under the workbook lock.
 
 Assign a read-only project manager role whenever subagent capacity permits. Before dispatch/refill decisions, the
 project manager should summarize the highest available priority tier, candidate story groups, dependency unlocks, stale

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -25,9 +25,9 @@ The queue uses two different mechanisms:
 Each active row has both an `Owner` and a random `Claim ID`. Heartbeat, completion, block, failure, cancellation, and release operations require both values. A subagent cannot update a task merely by knowing its issue title.
 
 The queue lock prevents duplicate task claims. It does **not** prevent two subagents from editing the same source file.
-By default `claim` skips tasks whose exact `Target Files / Modules` overlap an existing `IN_PROGRESS` row. The
-controller must still inspect scopes and serialize work when shared headers, bindings, tests, CMake, map scripts,
-dialog/config files, serialization, generated resources, or shared runtime systems are coupled.
+Exact `Target Files / Modules` overlap is advisory evidence, not an automatic claim blocker. The controller must inspect
+scopes and serialize work when source-backed direct or indirect conflicts exist through shared headers, bindings, tests,
+CMake, map scripts, dialog/config files, serialization, generated resources, or shared runtime systems.
 
 ## Setup
 
@@ -77,17 +77,18 @@ python3 scripts/issue_queue.py shortlist \
   --json
 ```
 
-The shortlist command does not mutate the workbook. It filters queue status, dependencies, optional CLI filters, and
-direct target-file overlaps, keeps only the highest currently eligible priority tier for `storyGroups`, and emits a
-seeded recommended `selected.issue.issueName`. It also reports `activeClaims.total`, `activeClaims.unexpired`,
-`activeClaims.stale`, `staleClaimCount`, and `staleClaims` so expired leases are not mistaken for live worker capacity.
-Treat that output as mechanical evidence for the controller and project-manager brief, not as an automatic claim. The
-controller and PM must still inspect active-scope conflicts not represented by exact target-file overlap, including:
+The shortlist command does not mutate the workbook. It filters queue status, dependencies, and optional CLI filters,
+keeps only the highest currently eligible priority tier for `storyGroups`, and emits a seeded recommended
+`selected.issue.issueName`. It also reports `activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`,
+`staleClaimCount`, `staleClaims`, `advisoryTargetFileOverlapCount`, `advisoryTargetFileOverlaps`, and per-issue
+`activeFileOverlaps` so expired leases and exact target-file overlaps can inform dispatch decisions without becoming
+automatic blockers. Treat that output as mechanical evidence for the controller and project-manager brief, not as an
+automatic claim. The controller and PM must still inspect source-backed active-scope conflicts, including:
 
 - rows whose status is not `NOT_STARTED`;
 - rows with unfinished dependencies;
-- direct target-file overlaps with active work;
 - active-scope conflicts;
+- target-file overlaps with active work that source inspection confirms are real conflicts;
 - indirect conflicts through shared headers, bindings, tests, CMake, map scripts, dialog/config files, serialization,
   generated resources, or shared runtime systems.
 
@@ -136,8 +137,12 @@ The CLI considers a row mechanically eligible only when:
 
 - status is `NOT_STARTED`;
 - every issue in `Dependencies` is `DONE`;
-- optional priority/epic/component filters match;
-- target files do not overlap currently active rows, unless `--allow-file-overlap` is explicitly supplied.
+- optional priority/epic/component filters match.
+
+The CLI reports target-file overlaps as advisory metadata. The legacy `--allow-file-overlap` flag is still accepted for
+older controller prompts, but exact overlap no longer changes mechanical eligibility by itself. Task payloads from
+`list --json`, `show`, `next`, and `claim` include `Target File Overlap Policy` and `Active File Overlaps` fields for
+direct-command review.
 
 To claim an exact row:
 

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -205,18 +205,22 @@ Use `python3 scripts/issue_queue.py shortlist --seed "$CONTROLLER_ID-<utc-cycle-
 read-only mechanical selector before each claim. The command reports eligible highest-priority story groups, stale
 claims, `activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`, rejection summaries, and a seeded
 recommended issue without mutating the workbook. Use the unexpired count, not raw `activeCount`, when deciding whether
-the active-worker floor is genuinely satisfied. Treat the recommendation as evidence for the project-manager brief and
-final controller review; still exclude source-backed indirect conflicts that the exact target-file filter cannot detect.
+the active-worker floor is genuinely satisfied. It also reports target-file overlap advisories through
+`advisoryTargetFileOverlapCount`, `advisoryTargetFileOverlaps`, and per-issue `activeFileOverlaps`. Treat the
+recommendation and overlap advisories as evidence for the project-manager brief and final controller review; do not
+exclude a task solely because its exact `Target Files / Modules` overlap active work.
 Claim only after final review with `claim --issue`, which revalidates under the workbook lock.
 
 Exclude every row that has:
 
 - a status other than `NOT_STARTED`;
 - any dependency that is not `DONE`;
-- a target-file overlap with active work;
-- an active-scope conflict;
+- a source-backed active-scope conflict;
 - an indirect conflict through shared headers, bindings, tests, CMake, map scripts, dialog/config files, serialization,
   generated resources, or shared runtime systems.
+
+Use exact target-file overlap with active work as an advisory guide for source inspection and sequencing decisions. If
+inspection confirms that the overlap is a real active-scope conflict, exclude or defer it on that basis.
 
 After exclusions:
 
@@ -369,7 +373,7 @@ on XLSX-only controller coordination PRs.
    - a requirement to report progress to the controller rather than directly mutating queue state.
    - a resource-awareness instruction to prefer GitHub Actions polling for heavy Linux validation and report exact local commands.
 
-6. Do not dispatch tasks concurrently when their scopes overlap directly or indirectly through shared headers, tests, bindings, registration units, CMake, shared JSON, map scripts, dialogs, serialization, or generated resources.
+6. Do not dispatch tasks concurrently when source inspection shows their scopes overlap directly or indirectly through shared headers, tests, bindings, registration units, CMake, shared JSON, map scripts, dialogs, serialization, or generated resources.
 
 ## Worker contract
 

--- a/prompts/codex-queue-goal.md
+++ b/prompts/codex-queue-goal.md
@@ -43,18 +43,20 @@ eligible set. Exclude:
 
 - rows whose status is not `NOT_STARTED`;
 - rows with unfinished dependencies;
-- rows with direct target-file overlap against active work;
-- rows with active-scope conflicts;
+- rows with source-backed active-scope conflicts;
 - rows with indirect conflicts through shared headers, bindings, tests, CMake, map scripts, dialog/config files,
   serialization, generated resources, or shared runtime systems.
+
+Treat direct `Target Files / Modules` overlap against active work as advisory scope evidence, not as an automatic
+exclusion. Use it to guide source inspection, sequencing, and project-manager risk notes.
 
 Keep only the highest currently available priority tier. Group remaining candidates by `(Epic #, Story #)`, randomly
 select one story with equal probability, then randomly select one eligible substory in that story. Never default to
 spreadsheet order, and never randomize an ineligible issue into consideration. Use
 `python3 scripts/issue_queue.py shortlist --seed "$CONTROLLER_ID-<utc-cycle-id>" --include-rejected --json` as the
 read-only mechanical selector before each claim. Use its `activeClaims.unexpired` and stale-claim fields for active
-worker capacity decisions, then still review source-backed indirect conflicts before claiming the final exact issue with
-`claim --issue`.
+worker capacity decisions, review target-file overlap advisories, then still exclude source-backed active-scope conflicts
+before claiming the final exact issue with `claim --issue`.
 
 Use the project-manager prioritization brief to decide whether to proceed, publish a queue-state update, or report a
 blocker. Do not use it as an ad hoc override: priority, dependency, status, or scope changes affect dispatch only after

--- a/scripts/issue_queue.py
+++ b/scripts/issue_queue.py
@@ -31,7 +31,7 @@ import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Iterable, Sequence
 
 DEFAULT_WORKBOOK = Path("planning/fall_of_nouraajd_issue_proposals.xlsx")
 ISSUE_SHEET = "Issue Proposals"
@@ -699,12 +699,18 @@ def statusByIssue(state: QueueState) -> dict[str, str]:
     return {task.issueName: task.status for task in state.tasks}
 
 
-def activeTargetFiles(state: QueueState) -> set[str]:
+def activeTargetFiles(state: QueueState, excludeIssueName: str | None = None) -> set[str]:
     files: set[str] = set()
     for task in state.tasks:
+        if excludeIssueName is not None and task.issueName == excludeIssueName:
+            continue
         if task.status == STATUS_IN_PROGRESS:
             files.update(task.targetFiles)
     return files
+
+
+def taskActiveFileOverlaps(state: QueueState, task: TaskRecord) -> list[str]:
+    return sorted(task.targetFiles & activeTargetFiles(state, excludeIssueName=task.issueName))
 
 
 def taskSortKey(task: TaskRecord) -> tuple[Any, ...]:
@@ -729,7 +735,6 @@ def eligibleTasks(
     allowFileOverlap: bool = False,
 ) -> tuple[list[TaskRecord], dict[str, list[str]]]:
     statuses = statusByIssue(state)
-    activeFiles = activeTargetFiles(state)
     eligible: list[TaskRecord] = []
     rejected: dict[str, list[str]] = {}
     for task in state.tasks:
@@ -747,16 +752,24 @@ def eligibleTasks(
         incomplete = [dependency for dependency in task.dependencies if statuses.get(dependency) != STATUS_DONE]
         if incomplete:
             reasons.append("dependencies-not-done:" + ",".join(incomplete))
-        if not allowFileOverlap:
-            overlap = sorted(task.targetFiles & activeFiles)
-            if overlap:
-                reasons.append("active-file-overlap:" + ",".join(overlap))
         if reasons:
             rejected[task.issueName] = reasons
         else:
             eligible.append(task)
     eligible.sort(key=taskSortKey)
     return eligible, rejected
+
+
+def targetFileOverlapAdvisories(state: QueueState, tasks: Iterable[TaskRecord] | None = None) -> dict[str, list[str]]:
+    activeFiles = activeTargetFiles(state)
+    advisories: dict[str, list[str]] = {}
+    for task in tasks if tasks is not None else state.tasks:
+        if task.status != STATUS_NOT_STARTED:
+            continue
+        overlap = sorted(task.targetFiles & activeFiles)
+        if overlap:
+            advisories[task.issueName] = overlap
+    return advisories
 
 
 def rejectionReasonKey(reason: str) -> str:
@@ -812,7 +825,7 @@ def stableChoice(items: Sequence[Any], seed: str, namespace: str, key: Any) -> A
     )
 
 
-def shortTaskPayload(task: TaskRecord) -> dict[str, Any]:
+def shortTaskPayload(task: TaskRecord, activeFiles: set[str] | None = None) -> dict[str, Any]:
     return {
         "issueName": task.issueName,
         "row": task.row,
@@ -825,6 +838,7 @@ def shortTaskPayload(task: TaskRecord) -> dict[str, Any]:
         "substoryTitle": str(task.values.get("Substory Title") or "").strip(),
         "component": str(task.values.get("Component") or "").strip(),
         "targetFiles": sorted(task.targetFiles),
+        "activeFileOverlaps": sorted(task.targetFiles & activeFiles) if activeFiles is not None else [],
         "dependencies": task.dependencies,
         "validation": str(task.values.get("Validation / Tests") or "").strip(),
     }
@@ -849,16 +863,14 @@ def shortlistTasks(
     counts = statusCounts(state)
     stale = staleClaims(state)
     activeClaims = activeClaimSummary(state, stale)
+    activeFiles = activeTargetFiles(state)
+    advisoryOverlaps = targetFileOverlapAdvisories(state)
     selectionSeed = seed or uuid.uuid4().hex
-    fileOverlapFilter = (
-        "direct target-file overlap allowed by --allow-file-overlap"
-        if allowFileOverlap
-        else "direct target-file overlap excluded unless --allow-file-overlap is used"
-    )
     payload: dict[str, Any] = {
         "eligible": bool(eligible),
         "selectionSeed": selectionSeed,
         "allowFileOverlap": allowFileOverlap,
+        "targetFileOverlapPolicy": "advisory",
         "eligibleCount": len(eligible),
         "highestPriority": None,
         "highestPriorityEligibleCount": 0,
@@ -872,14 +884,16 @@ def shortlistTasks(
         "staleClaims": stale,
         "rejectedCount": len(rejected),
         "rejectionSummary": rejectionSummary(rejected),
+        "advisoryTargetFileOverlapCount": len(advisoryOverlaps),
         "mechanicalFilters": [
             "status=NOT_STARTED",
             "dependencies=DONE",
-            fileOverlapFilter,
+            "direct target-file overlaps reported as advisory metadata",
         ],
     }
     if includeRejected:
         payload["rejected"] = rejected
+        payload["advisoryTargetFileOverlaps"] = advisoryOverlaps
     if not eligible:
         payload["reason"] = "No eligible task"
         return payload
@@ -916,7 +930,7 @@ def shortlistTasks(
                 "priority": highestPriority,
                 "eligibleCount": len(tasks),
                 "selected": key == selectedStoryKey,
-                "issues": [shortTaskPayload(task) for task in tasks],
+                "issues": [shortTaskPayload(task, activeFiles=activeFiles) for task in tasks],
             }
         )
 
@@ -927,7 +941,7 @@ def shortlistTasks(
             "storyGroups": storyGroups,
             "selected": {
                 "storyKey": storyKeyText(selectedStoryKey),
-                "issue": shortTaskPayload(selectedTask),
+                "issue": shortTaskPayload(selectedTask, activeFiles=activeFiles),
             },
         }
     )
@@ -1052,12 +1066,14 @@ def validateQueueState(state: QueueState) -> tuple[list[str], list[str]]:
     return errors, warnings
 
 
-def taskPayload(task: TaskRecord) -> dict[str, Any]:
+def taskPayload(task: TaskRecord, state: QueueState | None = None) -> dict[str, Any]:
     payload = {key: value for key, value in task.values.items()}
     payload["Row"] = task.row
     payload["Status"] = task.status
     payload["Dependencies Parsed"] = task.dependencies
     payload["Target Files Parsed"] = sorted(task.targetFiles)
+    payload["Target File Overlap Policy"] = "advisory"
+    payload["Active File Overlaps"] = taskActiveFileOverlaps(state, task) if state is not None else []
     payload.update(taskLeasePayload(task, utcNow()))
     return payload
 
@@ -1195,7 +1211,7 @@ def claimTask(
 
             state = refreshTasks(state)
             claimed = taskByName(state, task.issueName)
-            payload = taskPayload(claimed)
+            payload = taskPayload(claimed, state=state)
             payload.update({"claimed": True, "claimId": claimId, "owner": owner})
             return payload
         finally:
@@ -1244,7 +1260,7 @@ def heartbeatTask(
             setValue(state, task.row, "Lease Until UTC", formatUtc(now + timedelta(minutes=leaseMinutes)))
             atomicSave(state, workbookPath)
             state = refreshTasks(state)
-            return taskPayload(taskByName(state, issueName))
+            return taskPayload(taskByName(state, issueName), state=state)
         finally:
             state.workbook.close()
 
@@ -1292,7 +1308,7 @@ def finishTask(
                 setValue(state, task.row, "Last Note", note.strip() or status.title())
             atomicSave(state, workbookPath)
             state = refreshTasks(state)
-            return taskPayload(taskByName(state, issueName))
+            return taskPayload(taskByName(state, issueName), state=state)
         finally:
             state.workbook.close()
 
@@ -1327,7 +1343,7 @@ def releaseTask(
             setValue(state, task.row, "Validation Results", None)
             atomicSave(state, workbookPath)
             state = refreshTasks(state)
-            return taskPayload(taskByName(state, issueName))
+            return taskPayload(taskByName(state, issueName), state=state)
         finally:
             state.workbook.close()
 
@@ -1533,7 +1549,11 @@ def buildParser() -> argparse.ArgumentParser:
     nextParser.add_argument("--priority", action="append", default=[])
     nextParser.add_argument("--epic")
     nextParser.add_argument("--component")
-    nextParser.add_argument("--allow-file-overlap", action="store_true")
+    nextParser.add_argument(
+        "--allow-file-overlap",
+        action="store_true",
+        help="Compatibility no-op; target-file overlaps are advisory.",
+    )
 
     shortlistParser = subparsers.add_parser(
         "shortlist",
@@ -1543,7 +1563,11 @@ def buildParser() -> argparse.ArgumentParser:
     shortlistParser.add_argument("--priority", action="append", default=[])
     shortlistParser.add_argument("--epic")
     shortlistParser.add_argument("--component")
-    shortlistParser.add_argument("--allow-file-overlap", action="store_true")
+    shortlistParser.add_argument(
+        "--allow-file-overlap",
+        action="store_true",
+        help="Compatibility no-op; target-file overlaps are advisory.",
+    )
     shortlistParser.add_argument("--seed", help="Stable seed for reproducible story and substory selection")
     shortlistParser.add_argument("--include-rejected", action="store_true", help="Include per-issue rejection reasons")
     shortlistParser.add_argument("--json", action="store_true", help="Output JSON (default)")
@@ -1556,7 +1580,11 @@ def buildParser() -> argparse.ArgumentParser:
     claimParser.add_argument("--priority", action="append", default=[])
     claimParser.add_argument("--epic")
     claimParser.add_argument("--component")
-    claimParser.add_argument("--allow-file-overlap", action="store_true")
+    claimParser.add_argument(
+        "--allow-file-overlap",
+        action="store_true",
+        help="Compatibility no-op; target-file overlaps are advisory.",
+    )
     claimParser.add_argument("--format", choices=("json", "prompt"), default="json")
 
     heartbeatParser = subparsers.add_parser("heartbeat", help="Update progress and extend an active claim lease")
@@ -1655,12 +1683,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                     statuses = {normalizeStatus(item) for item in args.status} if args.status else None
                     tasks = listTasks(state, statuses, args.owner, args.epic)
                     if args.json:
-                        printJson([taskPayload(task) for task in tasks])
+                        printJson([taskPayload(task, state=state) for task in tasks])
                     else:
                         printTable(tasks)
                     return 0
                 if args.command == "show":
-                    printJson(taskPayload(taskByName(state, args.issue)))
+                    printJson(taskPayload(taskByName(state, args.issue), state=state))
                     return 0
                 if args.command == "next":
                     priorities = {item.upper() for item in args.priority} or None
@@ -1674,7 +1702,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     if not eligible:
                         printJson({"eligible": False, "reason": "No eligible task", "rejected": rejected})
                         return 3
-                    printJson({"eligible": True, "task": taskPayload(eligible[0])})
+                    printJson({"eligible": True, "task": taskPayload(eligible[0], state=state)})
                     return 0
                 if args.command == "shortlist":
                     priorities = {item.upper() for item in args.priority} or None

--- a/tests/test_issue_queue.py
+++ b/tests/test_issue_queue.py
@@ -221,18 +221,32 @@ class IssueQueueTest(unittest.TestCase):
             document.setCell(task.row, state.headers["Updated At UTC"], updated)
         document.save(self.workbook_path)
 
-    def test_claim_respects_priority_dependency_and_active_file_overlap(self) -> None:
+    def test_claim_treats_target_file_overlap_as_advisory(self) -> None:
         first = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1")
         self.assertEqual(self.issue_b, first["Issue Name"])
-
-        second = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-2")
-        self.assertEqual(self.issue_a, second["Issue Name"])
+        self.assertEqual("advisory", first["Target File Overlap Policy"])
+        self.assertEqual([], first["Active File Overlaps"])
 
         state = issue_queue.loadQueue(self.workbook_path)
         eligible, rejected = issue_queue.eligibleTasks(state)
-        self.assertEqual([], eligible)
+        self.assertEqual([self.issue_d, self.issue_a], [task.issueName for task in eligible])
         self.assertIn("dependencies-not-done", rejected[self.issue_c][0])
-        self.assertTrue(any(reason.startswith("active-file-overlap") for reason in rejected[self.issue_d]))
+        self.assertNotIn(self.issue_d, rejected)
+        self.assertEqual(
+            {"[EPIC_01][STORY_01][SUBSTORY_04]Overlaps active file": ["src/shared.cpp"]},
+            issue_queue.targetFileOverlapAdvisories(state),
+        )
+
+        second = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-2")
+        self.assertEqual(self.issue_d, second["Issue Name"])
+        self.assertEqual("advisory", second["Target File Overlap Policy"])
+        self.assertEqual(["src/shared.cpp"], second["Active File Overlaps"])
+
+        state = issue_queue.loadQueue(self.workbook_path)
+        eligible, rejected = issue_queue.eligibleTasks(state)
+        self.assertEqual([self.issue_a], [task.issueName for task in eligible])
+        self.assertIn("dependencies-not-done", rejected[self.issue_c][0])
+        self.assertNotIn("active-file-overlap", issue_queue.rejectionSummary(rejected))
 
     def test_shortlist_groups_highest_priority_and_selects_seeded_issue(self) -> None:
         first_story = "[EPIC_01][STORY_01][SUBSTORY_01]First high priority story"
@@ -274,8 +288,9 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual(second_story, story_two_payload["selected"]["issue"]["issueName"])
         allow_overlap_payload = issue_queue.shortlistTasks(state, seed="demo-seed", allowFileOverlap=True)
         self.assertTrue(allow_overlap_payload["allowFileOverlap"])
+        self.assertEqual("advisory", allow_overlap_payload["targetFileOverlapPolicy"])
         self.assertIn(
-            "direct target-file overlap allowed by --allow-file-overlap",
+            "direct target-file overlaps reported as advisory metadata",
             allow_overlap_payload["mechanicalFilters"],
         )
         self.assertNotIn(
@@ -284,6 +299,25 @@ class IssueQueueTest(unittest.TestCase):
         )
         self.assertIn(blocked, payload["rejected"])
         self.assertEqual(1, payload["rejectionSummary"]["dependencies-not-done"])
+        self.assertEqual(0, payload["advisoryTargetFileOverlapCount"])
+
+    def test_shortlist_reports_target_file_overlap_advisory_without_rejecting(self) -> None:
+        issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1")
+        state = issue_queue.loadQueue(self.workbook_path)
+
+        payload = issue_queue.shortlistTasks(state, seed="overlap-advisory", includeRejected=True)
+
+        self.assertTrue(payload["eligible"])
+        self.assertEqual("advisory", payload["targetFileOverlapPolicy"])
+        self.assertEqual("P0", payload["highestPriority"])
+        self.assertEqual(2, payload["eligibleCount"])
+        self.assertEqual(1, payload["highestPriorityEligibleCount"])
+        self.assertEqual(self.issue_d, payload["selected"]["issue"]["issueName"])
+        self.assertEqual(["src/shared.cpp"], payload["selected"]["issue"]["activeFileOverlaps"])
+        self.assertEqual(1, payload["advisoryTargetFileOverlapCount"])
+        self.assertEqual({self.issue_d: ["src/shared.cpp"]}, payload["advisoryTargetFileOverlaps"])
+        self.assertNotIn(self.issue_d, payload["rejected"])
+        self.assertNotIn("active-file-overlap", payload["rejectionSummary"])
 
     def test_shortlist_cli_reports_without_mutating_workbook(self) -> None:
         before = self.workbook_path.read_bytes()
@@ -308,12 +342,14 @@ class IssueQueueTest(unittest.TestCase):
         self.assertTrue(payload["eligible"])
         self.assertEqual("P0", payload["highestPriority"])
         self.assertFalse(payload["allowFileOverlap"])
+        self.assertEqual("advisory", payload["targetFileOverlapPolicy"])
         self.assertEqual(0, payload["activeCount"])
         self.assertEqual(0, payload["unexpiredActiveCount"])
         self.assertEqual(0, payload["staleClaimCount"])
         self.assertEqual({"total": 0, "unexpired": 0, "stale": 0}, payload["activeClaims"])
+        self.assertEqual(0, payload["advisoryTargetFileOverlapCount"])
         self.assertIn(
-            "direct target-file overlap excluded unless --allow-file-overlap is used",
+            "direct target-file overlaps reported as advisory metadata",
             payload["mechanicalFilters"],
         )
         self.assertIn("storyGroups", payload)


### PR DESCRIPTION
## What changed
- Changed queue eligibility so exact `Target Files / Modules` overlap with active work is advisory metadata instead of a hard rejection.
- Added advisory overlap fields to shortlist issue payloads and general task payloads used by `list --json`, `show`, `next`, `claim`, heartbeat, finish, and release paths.
- Kept `--allow-file-overlap` accepted as a compatibility no-op.
- Updated controller docs/prompts to preserve source-backed conflict review while removing spreadsheet-overlap veto language.
- Removed `prompts/codex-queue-goal.md` and moved the full queue-goal prompt content into `prompts/codex-queue-goal.txt`.

## Why
The user requested that target-file/module conflicts guide controller review rather than mechanically rejecting issues. The previous selector rejected `active-file-overlap` before randomized story/substory selection and before exact `claim --issue`, which could hide otherwise eligible work.

## Validation performed
- `black -l 120 scripts/issue_queue.py tests/test_issue_queue.py`: unchanged
- `python3 scripts/issue_queue.py validate`: 0 errors, 0 warnings
- `python3 -m unittest tests.test_issue_queue`: 23 tests OK
- `python3 -m unittest tests.test_controller_resource_audit`: 4 tests OK
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`: no errors or warnings
- `python3 scripts/issue_queue.py next`: returned an eligible P0 task with `Target File Overlap Policy: advisory` and populated `Active File Overlaps`
- `python3 scripts/issue_queue.py shortlist --seed advisory-overlap-smoke --include-rejected --json`: returned `eligible=true`, `targetFileOverlapPolicy=advisory`, and advisory overlap metadata
- `rg -n "codex-queue-goal\\.md" .`: no matches after deleting `prompts/codex-queue-goal.md`
- `ls prompts/codex-queue-goal.txt`: file exists
- Read-only reviewer subagent found no blocking issues after the final delta.

## Known limitations / follow-up
- `taskPayload(task)` callers that do not provide queue state still receive an empty `Active File Overlaps` list by design; reviewed CLI and mutating paths now pass state.
- Source-backed active-scope conflicts still require controller judgment and serialization before dispatch.
