### PR TITLE
Add claim_once gameplay helper

### DIFF
--- a/res/game.py
+++ b/res/game.py
@@ -37,6 +37,13 @@ def record_playtest_trace(event, **fields):
         _native_record_playtest_trace_json(event, json.dumps(fields, sort_keys=True))
 
 
+def claim_once(owner, property_name):
+    if owner.getBoolProperty(property_name):
+        return False
+    owner.setBoolProperty(property_name, True)
+    return True
+
+
 def playtest_object_ref(obj):
     if obj is None:
         return None

--- a/tests/test_claim_once_helper.py
+++ b/tests/test_claim_once_helper.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# fall-of-nouraajd c++ dark fantasy game
+# Copyright (C) 2026  Andrzej Lis
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class BoolPropertyOwner:
+    def __init__(self):
+        self.bool_properties = {}
+
+    def getBoolProperty(self, name):
+        return self.bool_properties.get(name, False)
+
+    def setBoolProperty(self, name, value):
+        self.bool_properties[name] = bool(value)
+
+
+def load_game_with_native_stub():
+    native = types.ModuleType("_game")
+    native.CDialogBase2 = type("CDialogBase2", (), {})
+    native.configure_playtest_trace = lambda *args, **kwargs: None
+    native.get_playtest_trace_records = lambda: []
+    native.drain_playtest_trace_records = lambda: []
+    native.record_playtest_trace_json = lambda *args, **kwargs: None
+    native.playtest_trace_enabled = lambda: False
+    native.set_logger_sink = lambda *args, **kwargs: None
+
+    original_native = sys.modules.get("_game")
+    sys.modules["_game"] = native
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+
+    try:
+        spec = importlib.util.spec_from_file_location("claim_once_game_under_test", REPO_ROOT / "res" / "game.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if original_native is None:
+            sys.modules.pop("_game", None)
+        else:
+            sys.modules["_game"] = original_native
+
+
+class ClaimOnceHelperTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.game = load_game_with_native_stub()
+
+    def test_claim_once_sets_unclaimed_bool_property(self):
+        owner = BoolPropertyOwner()
+
+        self.assertTrue(self.game.claim_once(owner, "reward_claimed"))
+        self.assertTrue(owner.getBoolProperty("reward_claimed"))
+
+    def test_claim_once_rejects_repeated_claim_without_clearing_property(self):
+        owner = BoolPropertyOwner()
+
+        self.assertTrue(self.game.claim_once(owner, "reward_claimed"))
+        self.assertFalse(self.game.claim_once(owner, "reward_claimed"))
+        self.assertTrue(owner.getBoolProperty("reward_claimed"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- Added a shared `claim_once(owner, property_name)` helper in `res/game.py`.
- Added focused unit coverage for first-claim and repeated-claim behavior with a stubbed game module.

## Why
- Row 131 / [EPIC_07][STORY_02][SUBSTORY_01] needs a reusable idempotency helper before map scripts migrate one-shot reward claims.

## Validation
- `python3 -m unittest tests.test_claim_once_helper`
- `timeout 20s black -l 120 --check res/game.py tests/test_claim_once_helper.py`
- `git diff --check`
- Earlier focused checks on this branch also passed: `python3 -m unittest tests.security.test_resource_and_gui_hardening`

## Known limitations
- `python3 -m unittest tests.security.test_python_plugin_sandbox` currently fails on an existing `src/core/CProvider.cpp` assertion that this branch does not touch.
- Heavy native, full Python, and coverage validation are delegated to the PR `build / linux` workflow.