### PR TITLE
Enforce queue reclaim and controller capacity defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,10 @@ free disk space, existing run/worktree usage, and running heavy jobs so the cont
 but do not impose a fixed RAM cap or rewrite build parallelism solely by workflow policy. Dispatch work whenever issue
 eligibility, live worker status, and repository safety allow it. Use standby subagents only when fewer than eight
 implementation issues can safely run; they may do lightweight status, eligibility, or review-prep tasks, but must not
-claim issues, edit files, or run heavy validation. Before filling each free worker slot, fetch the
-latest `origin/main`, recalculate the full eligible set from the merged workbook, and exclude:
+claim issues, edit files, or run heavy validation. Each controller instance must also keep at least four non-stale
+implementation claims under its own `controller/<controller-id>` owner prefix whenever four eligible issues can safely
+be claimed by that controller. Stale owned claims do not count toward this floor. Before filling each free worker slot,
+fetch the latest `origin/main`, recalculate the full eligible set from the merged workbook, and exclude:
 
 - rows whose status is not `NOT_STARTED`;
 - rows with dependencies that are not `DONE`;
@@ -46,13 +48,15 @@ Use it to prioritize review and decide whether a source-backed active-scope conf
 After exclusions, keep only the highest currently available priority tier. Group candidates by `(Epic #, Story #)`,
 randomly select one story with equal probability, then randomly select one eligible substory in that story. Do not fall
 back to spreadsheet order and do not include ineligible rows in the random choice. Use
-`python3 scripts/issue_queue.py shortlist --seed "$CONTROLLER_ID-<utc-cycle-id>" --include-rejected --json` as the
-read-only mechanical selector before each claim; it reports eligible highest-priority story groups, stale claims,
-`activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`, target-file overlap advisories, rejection summaries,
-and a seeded recommendation without mutating the workbook. Use the unexpired count, not raw `activeCount`, when deciding
-whether the active-worker floor is genuinely satisfied. The controller and project manager must still inspect target-file
-overlap advisories and exclude source-backed active-scope conflicts, then claim the final exact issue with `claim --issue`
-so eligibility is rechecked under the workbook lock.
+`python3 scripts/issue_queue.py shortlist --seed "$CONTROLLER_ID-<utc-cycle-id>" --controller-id "$CONTROLLER_ID" --include-rejected --json`
+as the read-only mechanical selector before each claim; it reports eligible highest-priority story groups, stale claims,
+`activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`, `controllerCapacity`, target-file overlap advisories,
+rejection summaries, and a seeded recommendation without mutating the workbook. Use the unexpired count, not raw
+`activeCount`, when deciding whether the global active-worker floor is genuinely satisfied. Use
+`controllerCapacity.deficitToFloor` and `controllerCapacity.fillableDeficit` to decide whether this controller must keep
+claiming to satisfy its four-owned-issue floor. The controller and project manager must still inspect target-file overlap
+advisories and exclude source-backed active-scope conflicts, then claim the final exact issue with `claim --issue` so
+eligibility is rechecked under the workbook lock.
 
 Assign a read-only project manager role whenever subagent capacity permits. Before dispatch/refill decisions, the
 project manager should summarize the highest available priority tier, candidate story groups, dependency unlocks, stale

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -73,6 +73,7 @@ merged workbook, and generate a read-only mechanical shortlist:
 ```bash
 python3 scripts/issue_queue.py shortlist \
   --seed "${CONTROLLER_ID}-$(date -u +%Y%m%dT%H%M%SZ)" \
+  --controller-id "$CONTROLLER_ID" \
   --include-rejected \
   --json
 ```
@@ -81,8 +82,10 @@ The shortlist command does not mutate the workbook. It filters queue status, dep
 keeps only the highest currently eligible priority tier for `storyGroups`, and emits a seeded recommended
 `selected.issue.issueName`. It also reports `activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`,
 `staleClaimCount`, `staleClaims`, `advisoryTargetFileOverlapCount`, `advisoryTargetFileOverlaps`, and per-issue
-`activeFileOverlaps` so expired leases and exact target-file overlaps can inform dispatch decisions without becoming
-automatic blockers. Treat that output as mechanical evidence for the controller and project-manager brief, not as an
+`activeFileOverlaps` so stale claims and exact target-file overlaps can inform dispatch decisions without becoming
+automatic blockers. When `--controller-id` is provided, it also reports `controllerCapacity`: the current controller's
+non-stale active issues, stale owned issues, deficit to the four-issue controller floor, and fillable deficit from the
+current eligible set. Treat that output as mechanical evidence for the controller and project-manager brief, not as an
 automatic claim. The controller and PM must still inspect source-backed active-scope conflicts, including:
 
 - rows whose status is not `NOT_STARTED`;
@@ -171,6 +174,12 @@ refilling implementation workers, note current RAM, free disk, accumulated run/w
 and running heavy build/test/coverage/Xvfb/MCP jobs so the controller avoids obvious resource pressure without imposing
 a fixed RAM cap. If the controller cannot keep eight issue workers active, report the concrete eligibility, conflict,
 status, resource, disk, cleanup, or repository-safety blocker.
+
+Each controller instance must also keep at least four of its own non-stale workbook claims active whenever four eligible
+issues are available for that controller to claim safely. Stale owned claims do not count toward that per-controller
+floor; run `shortlist --controller-id "$CONTROLLER_ID"` before every refill and keep claiming until
+`controllerCapacity.deficitToFloor` is zero, `controllerCapacity.fillableDeficit` is zero, or a concrete blocker is
+reported.
 
 Standby subagents may help with lightweight status polling, eligibility summaries, or review preparation only when fewer
 than eight implementation issues can safely run. They must not claim issues, edit files, touch the workbook, start builds,
@@ -330,22 +339,23 @@ python3 scripts/issue_queue.py release ... --note 'Returned before editing'
 
 ## Crash recovery
 
-An `IN_PROGRESS` row has a `Lease Until UTC`. The controller can reclaim expired work:
+An `IN_PROGRESS` row has `Updated At UTC` and `Lease Until UTC` fields. The controller can reclaim stale work:
 
 ```bash
-python3 scripts/issue_queue.py reclaim-stale --dry-run --older-than-minutes 30
-python3 scripts/issue_queue.py reclaim-stale --older-than-minutes 30
+python3 scripts/issue_queue.py reclaim-stale --dry-run
+python3 scripts/issue_queue.py reclaim-stale
 ```
 
 The dry run lists stale rows without modifying the workbook and reports `activeClaims`, `staleCount`,
-`reclaimableStaleCount`, and `reclaimSafety`. `staleCount` is the total expired active-claim count;
-`reclaimableStaleCount` is the number of rows returned by the current `--older-than-minutes` threshold. Dry-run rows are
-lease-timing candidates only and include `reclaimReady: false`; inspect the worker worktree, branch, pull request, and
-any recoverable changes before running the mutating command. Run the mutating command only from a fresh workbook-only
-branch and publish it through the same serialized queue-state PR process as claims and terminal statuses. Reclaimed rows
-are not eligible for dispatch until that reclaim PR actually merges. The mutating command only reclaims rows whose lease
-is already expired and whose last update is at least the specified age. Reclaimed rows return to `NOT_STARTED`, retain
-the incremented `Attempt`, and receive an audit note describing the previous owner and claim.
+`reclaimableStaleCount`, and `reclaimSafety`. `staleCount` and `reclaimableStaleCount` are the rows returned by the
+current `--older-than-minutes` threshold. The default threshold is 240 minutes; pass `--older-than-minutes` only when the
+controller has an explicit reason to use a different age. Dry-run rows are queue-timing candidates only and include
+`reclaimReady: false`; inspect the worker worktree, branch, pull request, and any recoverable changes before running the
+mutating command. Run the mutating command only from a fresh workbook-only branch and publish it through the same
+serialized queue-state PR process as claims and terminal statuses. Reclaimed rows are not eligible for dispatch until
+that reclaim PR actually merges. The mutating command reclaims rows whose last update is at least the threshold age,
+even if their lease is still in the future. Reclaimed rows return to `NOT_STARTED`, retain the incremented `Attempt`,
+and receive an audit note describing the previous owner and claim.
 
 `validate` warns about expired `IN_PROGRESS` leases without failing the workbook, and `list --status IN_PROGRESS --json`
 includes derived lease-expiration fields for read-only controller status checks.

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -19,20 +19,22 @@ Explicitly spawn worker subagents for implementation tasks. Do not merely descri
 9. Keep at least eight live subagents attached to the controller whenever the subagent interface is available.
 10. Keep at least eight implementation issues active whenever eight safe, eligible, non-conflicting issues exist. Treat
    eight active issues as the minimum operating target, not a best-effort aspiration.
-11. Serialize all workbook pull requests. The XLSX file is binary and must never be modified concurrently on multiple branches intended to merge.
-12. Claim and terminal-status pull requests normally update exactly one issue. Do not batch workbook edits unless this workflow explicitly permits it and all selected issues are proven independent.
-13. Preserve public identifiers and backward compatibility unless source evidence proves they are broken.
-14. Do not run local native builds, `ctest`, full Python suites, or coverage for PR delivery unless a focused local
+11. Keep at least four non-stale implementation issues active under this controller's own owner prefix whenever four
+   eligible issues can safely be claimed by this controller. Stale owned claims do not count toward that floor.
+12. Serialize all workbook pull requests. The XLSX file is binary and must never be modified concurrently on multiple branches intended to merge.
+13. Claim and terminal-status pull requests normally update exactly one issue. Do not batch workbook edits unless this workflow explicitly permits it and all selected issues are proven independent.
+14. Preserve public identifiers and backward compatibility unless source evidence proves they are broken.
+15. Do not run local native builds, `ctest`, full Python suites, or coverage for PR delivery unless a focused local
    reproduction is necessary or GitHub Actions cannot provide the needed evidence. Outsource heavy validation to GitHub
    Actions polling.
-15. If fewer than eight issue workers are active, document the concrete eligibility, conflict, status, resource, or
-   repository safety blocker that prevents filling the slot.
-16. Run the controller resource audit before dispatch/refill decisions, before heavy validation, after each controller
+16. If fewer than eight issue workers are active or this controller has fewer than four non-stale owned claims, document
+   the concrete eligibility, conflict, status, resource, or repository safety blocker that prevents filling the slot.
+17. Run the controller resource audit before dispatch/refill decisions, before heavy validation, after each controller
    loop, and after merged-checkpoint cleanup. Treat low free disk or stale run/worktree pressure as blockers to new work
    until safely reported or cleaned.
-17. Keep issue prioritization explicit. A project-manager role may recommend sequencing and priority changes, but those
+18. Keep issue prioritization explicit. A project-manager role may recommend sequencing and priority changes, but those
    recommendations are advisory until the controller or user approves a serialized workbook-only queue update.
-18. Every controller instance must have a unique controller ID. Use it in every worker owner string so multiple
+19. Every controller instance must have a unique controller ID. Use it in every worker owner string so multiple
    controllers can run without owner collisions.
 
 ## Startup
@@ -126,6 +128,11 @@ Maintain at least eight live subagents and keep at least eight implementation is
 implementation issues can safely run, assign the excess subagents only lightweight standby roles such as status polling,
 eligibility summaries, or review preparation, and print the exact blocker preventing eight active issues. Standby
 subagents must not claim issues, edit files, start builds, run tests, or touch the workbook.
+Each controller must also keep at least four of its own non-stale workbook claims active when four eligible issues can
+be safely claimed. Use `controllerCapacity` from `shortlist --controller-id "$CONTROLLER_ID"` to measure the current
+controller's floor; stale owned claims do not count. Continue claim/refill iterations until
+`controllerCapacity.deficitToFloor` is zero, `controllerCapacity.fillableDeficit` is zero, or a concrete eligibility,
+resource, repository-safety, or worker-status blocker is printed.
 
 When subagent capacity permits, keep one read-only project manager attached to the controller. The project manager may
 be an extra subagent beyond active implementation workers, or a standby role when fewer than eight implementation issues
@@ -201,11 +208,14 @@ eligible set yourself. The `claim` command is deterministic by workbook order, s
 issue. Refresh the project-manager prioritization brief before selecting, and use it to decide whether to proceed,
 pause for a priority/status update, or report a blocker. Do not use the brief as an ad hoc priority override.
 
-Use `python3 scripts/issue_queue.py shortlist --seed "$CONTROLLER_ID-<utc-cycle-id>" --include-rejected --json` as the
-read-only mechanical selector before each claim. The command reports eligible highest-priority story groups, stale
-claims, `activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`, rejection summaries, and a seeded
+Use
+`python3 scripts/issue_queue.py shortlist --seed "$CONTROLLER_ID-<utc-cycle-id>" --controller-id "$CONTROLLER_ID" --include-rejected --json`
+as the read-only mechanical selector before each claim. The command reports eligible highest-priority story groups,
+stale claims, `activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`, rejection summaries, and a seeded
 recommended issue without mutating the workbook. Use the unexpired count, not raw `activeCount`, when deciding whether
-the active-worker floor is genuinely satisfied. It also reports target-file overlap advisories through
+the global active-worker floor is genuinely satisfied. Use `controllerCapacity.activeNonStale`,
+`controllerCapacity.deficitToFloor`, and `controllerCapacity.fillableDeficit` to enforce this controller's four-issue
+owned-claim floor before stopping a refill loop. It also reports target-file overlap advisories through
 `advisoryTargetFileOverlapCount`, `advisoryTargetFileOverlaps`, and per-issue `activeFileOverlaps`. Treat the
 recommendation and overlap advisories as evidence for the project-manager brief and final controller review; do not
 exclude a task solely because its exact `Target Files / Modules` overlap active work.
@@ -428,11 +438,12 @@ python3 scripts/issue_queue.py heartbeat \
 
 Commit and merge that workbook-only change using the same status-PR process as claim publication.
 
-If a worker disappears, do not overwrite the active claim. Inspect its worktree and branch, wait for lease expiry, and
-run `python3 scripts/issue_queue.py reclaim-stale --dry-run --older-than-minutes <minutes>` to list stale
-`IN_PROGRESS` claims without mutating the workbook. The dry-run output includes `activeClaims`, `staleCount`, and
-`reclaimableStaleCount`; use those fields to distinguish all expired active leases from rows eligible under the current
-age threshold. Dry-run rows are lease-timing candidates only and include `reclaimReady: false`; use mutating
+If a worker disappears, do not overwrite the active claim. Inspect its worktree and branch, then run
+`python3 scripts/issue_queue.py reclaim-stale --dry-run` to list stale `IN_PROGRESS` claims without mutating the
+workbook. The default reclaim age threshold is 240 minutes; pass `--older-than-minutes <minutes>` only when the
+controller has an explicit reason to override it. The dry-run output includes `activeClaims`, `staleCount`, and
+`reclaimableStaleCount`; use those fields to distinguish active claims from rows eligible under the current
+heartbeat-age threshold. Dry-run rows are queue-timing candidates only and include `reclaimReady: false`; use mutating
 `reclaim-stale` only when the claim is genuinely stale and no recoverable work remains. Treat `validate` warnings about
 expired `IN_PROGRESS` leases and derived `list --status IN_PROGRESS --json` lease-expiration fields as read-only
 recovery signals, not permission to reclaim without inspection.
@@ -444,7 +455,9 @@ delivery, do not run local native builds, `ctest`, full Python suites, or covera
 necessary or GitHub Actions cannot provide the needed evidence. Before any necessary local heavy command, note current
 available RAM, disk pressure, running heavy jobs, and worker status. Treat eight active issue workers as the minimum
 target whenever safe eligible work exists; record the concrete blocker if actual resource pressure prevents eight active
-issues.
+issues. Also treat four non-stale owned claims as this controller's minimum active target whenever
+`controllerCapacity.fillableDeficit` is greater than zero; record the concrete blocker if the controller cannot close
+that deficit.
 
 Repository instructions may show local build examples such as `-j$(nproc)`. Treat them as local equivalents, not the
 default PR delivery path. Record the reason and exact command in worker reports and PR bodies whenever local heavy

--- a/prompts/codex-queue-goal.txt
+++ b/prompts/codex-queue-goal.txt
@@ -15,6 +15,10 @@ least eight implementation issues active whenever eight safe, eligible, non-conf
 issues as the minimum operating target, not a best-effort aspiration. Before every dispatch, refill, or heavy validation
 decision, note current RAM, active worker status, disk/run-worktree state, and running build/test/coverage/Xvfb/MCP jobs
 so the controller avoids obvious resource pressure without imposing a fixed RAM cap.
+Each controller instance must also keep at least four non-stale active claims under its own owner prefix whenever four
+eligible issues can safely be claimed by that controller. Stale owned claims do not count toward this floor; use
+`controllerCapacity` from `shortlist --controller-id "$CONTROLLER_ID"` before every refill, and keep claiming until the
+deficit is zero, the fillable deficit is zero, or a concrete blocker is printed.
 
 When worker status is missing, conflicts block selection, no safe eligible issue exists, or the machine is under actual
 resource pressure, keep excess subagents in standby instead of assigning unsafe implementation work. Refill active
@@ -53,10 +57,10 @@ exclusion. Use it to guide source inspection, sequencing, and project-manager ri
 Keep only the highest currently available priority tier. Group remaining candidates by (Epic #, Story #), randomly
 select one story with equal probability, then randomly select one eligible substory in that story. Never default to
 spreadsheet order, and never randomize an ineligible issue into consideration. Use
-`python3 scripts/issue_queue.py shortlist --seed "$CONTROLLER_ID-<utc-cycle-id>" --include-rejected --json` as the
-read-only mechanical selector before each claim. Use its activeClaims.unexpired and stale-claim fields for active worker
-capacity decisions, review target-file overlap advisories, then still exclude source-backed active-scope conflicts before
-claiming the final exact issue with `claim --issue`.
+`python3 scripts/issue_queue.py shortlist --seed "$CONTROLLER_ID-<utc-cycle-id>" --controller-id "$CONTROLLER_ID" --include-rejected --json`
+as the read-only mechanical selector before each claim. Use its activeClaims.unexpired, stale-claim, and
+controllerCapacity fields for active worker capacity decisions, review target-file overlap advisories, then still exclude
+source-backed active-scope conflicts before claiming the final exact issue with `claim --issue`.
 
 Use the project-manager prioritization brief to decide whether to proceed, publish a queue-state update, or report a
 blocker. Do not use it as an ad hoc override: priority, dependency, status, or scope changes affect dispatch only after

--- a/scripts/issue_queue.py
+++ b/scripts/issue_queue.py
@@ -99,6 +99,8 @@ WORKFLOW_HEADERS = (
 ALL_HEADERS = REQUIRED_HEADERS + WORKFLOW_HEADERS
 ISSUE_NAME_PATTERN = re.compile(r"^\[EPIC_\d{2}\]\[STORY_\d{2}\]\[SUBSTORY_\d{2}\].+")
 PRIORITY_ORDER = {"P0": 0, "P1": 1, "P2": 2}
+DEFAULT_RECLAIM_AGE_MINUTES = 240
+DEFAULT_CONTROLLER_ACTIVE_ISSUE_FLOOR = 4
 
 
 class QueueError(RuntimeError):
@@ -802,6 +804,52 @@ def activeClaimSummary(state: QueueState, stale: Sequence[dict[str, Any]]) -> di
     }
 
 
+def ownerMatchesPrefix(owner: str, ownerPrefix: str) -> bool:
+    return owner == ownerPrefix or owner.startswith(f"{ownerPrefix}/")
+
+
+def controllerCapacityPayload(
+    state: QueueState,
+    controllerId: str,
+    activeFloor: int = DEFAULT_CONTROLLER_ACTIVE_ISSUE_FLOOR,
+    eligibleCount: int | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    if activeFloor < 0:
+        raise QueueError("--controller-active-floor must be non-negative")
+    controllerId = controllerId.strip()
+    if not controllerId:
+        raise QueueError("--controller-id must be non-empty")
+    now = now or utcNow()
+    ownerPrefix = controllerOwnerPrefix(controllerId)
+    stale = staleClaims(state, now=now)
+    staleIssues = {record["issueName"] for record in stale}
+    activeTasks = [
+        task
+        for task in state.tasks
+        if task.status == STATUS_IN_PROGRESS
+        and ownerMatchesPrefix(str(task.values.get("Owner") or "").strip(), ownerPrefix)
+    ]
+    staleTasks = [task for task in activeTasks if task.issueName in staleIssues]
+    liveTasks = [task for task in activeTasks if task.issueName not in staleIssues]
+    deficit = max(0, activeFloor - len(liveTasks))
+    fillable = min(deficit, eligibleCount) if eligibleCount is not None else deficit
+    return {
+        "controllerId": controllerId,
+        "ownerPrefix": ownerPrefix,
+        "activeFloor": activeFloor,
+        "activeTotal": len(activeTasks),
+        "activeNonStale": len(liveTasks),
+        "staleOwned": len(staleTasks),
+        "deficitToFloor": deficit,
+        "eligibleCount": eligibleCount,
+        "fillableDeficit": fillable,
+        "needsRefill": fillable > 0,
+        "activeIssues": [task.issueName for task in sorted(liveTasks, key=taskSortKey)],
+        "staleIssues": [task.issueName for task in sorted(staleTasks, key=taskSortKey)],
+    }
+
+
 def storyKey(task: TaskRecord) -> tuple[str, str]:
     return (
         str(task.values.get("Epic #") or "").strip(),
@@ -852,6 +900,8 @@ def shortlistTasks(
     allowFileOverlap: bool = False,
     seed: str | None = None,
     includeRejected: bool = False,
+    controllerId: str | None = None,
+    controllerActiveFloor: int = DEFAULT_CONTROLLER_ACTIVE_ISSUE_FLOOR,
 ) -> dict[str, Any]:
     eligible, rejected = eligibleTasks(
         state,
@@ -891,6 +941,13 @@ def shortlistTasks(
             "direct target-file overlaps reported as advisory metadata",
         ],
     }
+    if controllerId:
+        payload["controllerCapacity"] = controllerCapacityPayload(
+            state,
+            controllerId=controllerId,
+            activeFloor=controllerActiveFloor,
+            eligibleCount=len(eligible),
+        )
     if includeRejected:
         payload["rejected"] = rejected
         payload["advisoryTargetFileOverlaps"] = advisoryOverlaps
@@ -1098,16 +1155,25 @@ def taskLeasePayload(task: TaskRecord, now: datetime) -> dict[str, Any]:
     }
 
 
-def staleClaimPayload(task: TaskRecord, now: datetime, olderThanMinutes: int = 0) -> dict[str, Any] | None:
+def staleClaimPayload(
+    task: TaskRecord,
+    now: datetime,
+    olderThanMinutes: int = DEFAULT_RECLAIM_AGE_MINUTES,
+) -> dict[str, Any] | None:
     if task.status != STATUS_IN_PROGRESS:
         return None
     lease = parseUtc(task.values.get("Lease Until UTC"))
     updated = parseUtc(task.values.get("Updated At UTC")) or parseUtc(task.values.get("Claimed At UTC"))
     leasePayload = taskLeasePayload(task, now)
-    expired = bool(leasePayload.get("leaseExpired"))
     oldEnough = updated is None or updated <= now - timedelta(minutes=olderThanMinutes)
-    if not expired or not oldEnough:
+    if not oldEnough:
         return None
+    if lease is None:
+        staleReason = "missing lease"
+    elif bool(leasePayload.get("leaseExpired")):
+        staleReason = "lease expired"
+    else:
+        staleReason = f"no heartbeat for {olderThanMinutes} minutes"
 
     return {
         "issueName": task.issueName,
@@ -1117,10 +1183,16 @@ def staleClaimPayload(task: TaskRecord, now: datetime, olderThanMinutes: int = 0
         "updatedAtUtc": formatUtc(updated) if updated else None,
         "leaseUntilUtc": formatUtc(lease) if lease else None,
         **leasePayload,
+        "staleReason": staleReason,
+        "staleThresholdMinutes": olderThanMinutes,
     }
 
 
-def staleClaims(state: QueueState, olderThanMinutes: int = 0, now: datetime | None = None) -> list[dict[str, Any]]:
+def staleClaims(
+    state: QueueState,
+    olderThanMinutes: int = DEFAULT_RECLAIM_AGE_MINUTES,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
     if olderThanMinutes < 0:
         raise QueueError("--older-than-minutes must be non-negative")
     now = now or utcNow()
@@ -1350,7 +1422,7 @@ def releaseTask(
 
 def reclaimStaleTasks(
     workbookPath: Path,
-    olderThanMinutes: int = 0,
+    olderThanMinutes: int = DEFAULT_RECLAIM_AGE_MINUTES,
     lockTimeoutSeconds: float = 30.0,
 ) -> list[dict[str, Any]]:
     if olderThanMinutes < 0:
@@ -1571,6 +1643,16 @@ def buildParser() -> argparse.ArgumentParser:
     shortlistParser.add_argument("--seed", help="Stable seed for reproducible story and substory selection")
     shortlistParser.add_argument("--include-rejected", action="store_true", help="Include per-issue rejection reasons")
     shortlistParser.add_argument("--json", action="store_true", help="Output JSON (default)")
+    shortlistParser.add_argument("--controller-id", help="Include active-worker floor status for this controller")
+    shortlistParser.add_argument(
+        "--controller-active-floor",
+        type=int,
+        default=DEFAULT_CONTROLLER_ACTIVE_ISSUE_FLOOR,
+        help=(
+            "Minimum non-stale active issues this controller should keep when eligible work exists "
+            f"(default: {DEFAULT_CONTROLLER_ACTIVE_ISSUE_FLOOR})"
+        ),
+    )
 
     claimParser = subparsers.add_parser("claim", help="Atomically claim an eligible task")
     addCommonArguments(claimParser)
@@ -1633,9 +1715,17 @@ def buildParser() -> argparse.ArgumentParser:
     releaseParser.add_argument("--owner", required=True)
     releaseParser.add_argument("--note", default="")
 
-    reclaimParser = subparsers.add_parser("reclaim-stale", help="Release expired IN_PROGRESS claims")
+    reclaimParser = subparsers.add_parser("reclaim-stale", help="Release stale IN_PROGRESS claims")
     addCommonArguments(reclaimParser)
-    reclaimParser.add_argument("--older-than-minutes", type=int, default=0)
+    reclaimParser.add_argument(
+        "--older-than-minutes",
+        type=int,
+        default=DEFAULT_RECLAIM_AGE_MINUTES,
+        help=(
+            "Only reclaim claims whose last update is at least this many minutes old "
+            f"(default: {DEFAULT_RECLAIM_AGE_MINUTES})"
+        ),
+    )
     reclaimParser.add_argument("--dry-run", action="store_true", help="Report stale claims without modifying the queue")
 
     return parser
@@ -1715,6 +1805,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                             allowFileOverlap=args.allow_file_overlap,
                             seed=args.seed,
                             includeRejected=args.include_rejected,
+                            controllerId=args.controller_id,
+                            controllerActiveFloor=args.controller_active_floor,
                         )
                     )
                     return 0
@@ -1819,20 +1911,19 @@ def main(argv: Sequence[str] | None = None) -> int:
                 state = loadQueue(workbookPath, writable=False)
                 try:
                     now = utcNow()
-                    allStale = staleClaims(state, now=now)
                     stale = staleClaims(state, olderThanMinutes=args.older_than_minutes, now=now)
                     printJson(
                         {
                             "workbook": str(workbookPath),
                             "olderThanMinutes": args.older_than_minutes,
                             "reclaimSafety": {
-                                "leaseOnly": True,
+                                "timingOnly": True,
                                 "requiresInspection": True,
-                                "message": "Dry-run rows satisfy lease timing only; inspect worker state and PRs before mutating.",
+                                "message": "Dry-run rows satisfy queue timing only; inspect worker state and PRs before mutating.",
                             },
                             "reclaimableStaleCount": len(stale),
-                            "staleCount": len(allStale),
-                            "activeClaims": activeClaimSummary(state, allStale),
+                            "staleCount": len(stale),
+                            "activeClaims": activeClaimSummary(state, stale),
                             "stale": markStaleClaimsForInspection(stale),
                         }
                     )

--- a/tests/test_issue_queue.py
+++ b/tests/test_issue_queue.py
@@ -330,6 +330,8 @@ class IssueQueueTest(unittest.TestCase):
                     str(self.workbook_path),
                     "--seed",
                     "demo-seed",
+                    "--controller-id",
+                    "ctrl-demo",
                     "--include-rejected",
                     "--json",
                 ]
@@ -347,6 +349,10 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual(0, payload["unexpiredActiveCount"])
         self.assertEqual(0, payload["staleClaimCount"])
         self.assertEqual({"total": 0, "unexpired": 0, "stale": 0}, payload["activeClaims"])
+        self.assertEqual(4, payload["controllerCapacity"]["activeFloor"])
+        self.assertEqual(0, payload["controllerCapacity"]["activeNonStale"])
+        self.assertEqual(4, payload["controllerCapacity"]["deficitToFloor"])
+        self.assertEqual(3, payload["controllerCapacity"]["fillableDeficit"])
         self.assertEqual(0, payload["advisoryTargetFileOverlapCount"])
         self.assertIn(
             "direct target-file overlaps reported as advisory metadata",
@@ -357,7 +363,7 @@ class IssueQueueTest(unittest.TestCase):
 
     def test_shortlist_reports_unexpired_and_stale_active_counts(self) -> None:
         expired = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
-        self.set_claim_times(expired["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=10)
+        self.set_claim_times(expired["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=241)
         unexpired = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-2", leaseMinutes=30)
         state = issue_queue.loadQueue(self.workbook_path)
 
@@ -369,6 +375,33 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual({"total": 2, "unexpired": 1, "stale": 1}, payload["activeClaims"])
         self.assertEqual([expired["Issue Name"]], [item["issueName"] for item in payload["staleClaims"]])
         self.assertNotIn(unexpired["Issue Name"], [item["issueName"] for item in payload["staleClaims"]])
+
+    def test_shortlist_reports_controller_capacity_floor(self) -> None:
+        live = issue_queue.claimTask(self.workbook_path, owner="controller/ctrl-demo/subagent-1", leaseMinutes=30)
+        stale = issue_queue.claimTask(self.workbook_path, owner="controller/ctrl-demo/subagent-2", leaseMinutes=30)
+        self.set_claim_times(stale["Issue Name"], lease_minutes_from_now=30, updated_minutes_ago=241)
+        state = issue_queue.loadQueue(self.workbook_path)
+
+        payload = issue_queue.shortlistTasks(
+            state,
+            seed="capacity",
+            controllerId="ctrl-demo",
+            controllerActiveFloor=4,
+        )
+
+        capacity = payload["controllerCapacity"]
+        self.assertEqual("ctrl-demo", capacity["controllerId"])
+        self.assertEqual("controller/ctrl-demo", capacity["ownerPrefix"])
+        self.assertEqual(4, capacity["activeFloor"])
+        self.assertEqual(2, capacity["activeTotal"])
+        self.assertEqual(1, capacity["activeNonStale"])
+        self.assertEqual(1, capacity["staleOwned"])
+        self.assertEqual(3, capacity["deficitToFloor"])
+        self.assertEqual(payload["eligibleCount"], capacity["eligibleCount"])
+        self.assertEqual(min(3, payload["eligibleCount"]), capacity["fillableDeficit"])
+        self.assertTrue(capacity["needsRefill"])
+        self.assertEqual([live["Issue Name"]], capacity["activeIssues"])
+        self.assertEqual([stale["Issue Name"]], capacity["staleIssues"])
 
     def test_controller_id_generates_unique_owner_prefix(self) -> None:
         first = issue_queue.generateControllerId(hostname="Build Host.local", pid=1234, unique="ABCDEF12")
@@ -484,6 +517,23 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual([], errors)
         self.assertEqual([], warnings)
 
+    def test_reclaim_stale_claim_uses_four_hour_default(self) -> None:
+        old_claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
+        self.set_claim_times(old_claim["Issue Name"], lease_minutes_from_now=10, updated_minutes_ago=241)
+        recent_claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-2", leaseMinutes=1)
+        self.set_claim_times(recent_claim["Issue Name"], lease_minutes_from_now=10, updated_minutes_ago=239)
+
+        reclaimed = issue_queue.reclaimStaleTasks(self.workbook_path)
+
+        self.assertEqual(240, issue_queue.DEFAULT_RECLAIM_AGE_MINUTES)
+        self.assertEqual([old_claim["Issue Name"]], [item["issueName"] for item in reclaimed])
+        state = issue_queue.loadQueue(self.workbook_path)
+        old_task = issue_queue.taskByName(state, old_claim["Issue Name"])
+        recent_task = issue_queue.taskByName(state, recent_claim["Issue Name"])
+        self.assertEqual(issue_queue.STATUS_NOT_STARTED, old_task.status)
+        self.assertEqual(issue_queue.STATUS_IN_PROGRESS, recent_task.status)
+        self.assertEqual(recent_claim["claimId"], recent_task.values["Claim ID"])
+
     def test_stale_claims_detect_expired_in_progress_without_mutating(self) -> None:
         claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
         self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=10)
@@ -514,9 +564,9 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual([], errors)
         self.assertTrue(any("IN_PROGRESS lease expired" in warning for warning in warnings), warnings)
 
-    def test_reclaim_stale_claim_ignores_unexpired_lease(self) -> None:
+    def test_reclaim_stale_claim_ignores_recent_heartbeat(self) -> None:
         claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
-        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=10, updated_minutes_ago=30)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=10, updated_minutes_ago=1)
 
         reclaimed = issue_queue.reclaimStaleTasks(self.workbook_path, olderThanMinutes=5)
 
@@ -592,10 +642,10 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual(0, exit_code)
         self.assertEqual(str(self.workbook_path.resolve()), payload["workbook"])
         self.assertEqual(5, payload["olderThanMinutes"])
-        self.assertEqual(2, payload["staleCount"])
+        self.assertEqual(1, payload["staleCount"])
         self.assertEqual(1, payload["reclaimableStaleCount"])
-        self.assertEqual({"total": 2, "unexpired": 0, "stale": 2}, payload["activeClaims"])
-        self.assertTrue(payload["reclaimSafety"]["leaseOnly"])
+        self.assertEqual({"total": 2, "unexpired": 1, "stale": 1}, payload["activeClaims"])
+        self.assertTrue(payload["reclaimSafety"]["timingOnly"])
         self.assertTrue(payload["reclaimSafety"]["requiresInspection"])
         self.assertEqual([claim["Issue Name"]], [item["issueName"] for item in payload["stale"]])
         self.assertFalse(payload["stale"][0]["reclaimReady"])
@@ -608,6 +658,38 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual(claim["claimId"], task.values["Claim ID"])
         self.assertEqual(issue_queue.STATUS_IN_PROGRESS, recent_task.status)
         self.assertEqual(recent_claim["claimId"], recent_task.values["Claim ID"])
+
+    def test_reclaim_stale_dry_run_uses_four_hour_default(self) -> None:
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=241)
+        recent_claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-2", leaseMinutes=1)
+        self.set_claim_times(recent_claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=239)
+
+        before = self.workbook_path.read_bytes()
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = issue_queue.main(
+                [
+                    "reclaim-stale",
+                    "--workbook",
+                    str(self.workbook_path),
+                    "--dry-run",
+                ]
+            )
+        payload = json.loads(stdout.getvalue())
+
+        self.assertEqual(0, exit_code)
+        self.assertEqual(240, payload["olderThanMinutes"])
+        self.assertEqual(1, payload["staleCount"])
+        self.assertEqual(1, payload["reclaimableStaleCount"])
+        self.assertEqual([claim["Issue Name"]], [item["issueName"] for item in payload["stale"]])
+        self.assertEqual(before, self.workbook_path.read_bytes())
+        state = issue_queue.loadQueue(self.workbook_path)
+        self.assertEqual(issue_queue.STATUS_IN_PROGRESS, issue_queue.taskByName(state, claim["Issue Name"]).status)
+        self.assertEqual(
+            issue_queue.STATUS_IN_PROGRESS,
+            issue_queue.taskByName(state, recent_claim["Issue Name"]).status,
+        )
 
     def test_list_table_marks_expired_in_progress_lease(self) -> None:
         claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)


### PR DESCRIPTION
What changed

- Changed stale reclaim defaults to a 240-minute heartbeat age threshold.
- Made reclaim-stale report and mutate rows whose Updated At UTC is older than the threshold, even when Lease Until UTC is still in the future.
- Added controllerCapacity reporting to shortlist when --controller-id is provided.
- Documented a four non-stale active issue floor per controller, alongside the existing global active-worker target.
- Updated queue controller docs, goal prompt, and AGENTS.md to require shortlist --controller-id before refill decisions.

Why

Controllers need stale worker detection based on missing heartbeat/update age, and each controller needs a visible deficit-to-floor signal so it keeps at least four of its own issues actively worked when eligible work exists.

Validation

- black -l 120 scripts/issue_queue.py tests/test_issue_queue.py
- python3 -m unittest tests.test_issue_queue
- python3 -m unittest tests.test_issue_queue tests.test_controller_resource_audit
- python3 scripts/issue_queue.py validate
- python3 scripts/issue_queue.py shortlist --seed floor-smoke --controller-id ctrl-smoke --include-rejected --json
- python3 scripts/issue_queue.py reclaim-stale --dry-run
- python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes
- git diff --check

Known limitations

- The queue tool reports capacity deficits; actual claiming is still performed by controller refill loops through serialized workbook-only claim PRs.