### PR TITLE
Align validate stale warnings with reclaim policy

### DIFF
--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -357,8 +357,9 @@ that reclaim PR actually merges. The mutating command reclaims rows whose last u
 even if their lease is still in the future. Reclaimed rows return to `NOT_STARTED`, retain the incremented `Attempt`,
 and receive an audit note describing the previous owner and claim.
 
-`validate` warns about expired `IN_PROGRESS` leases without failing the workbook, and `list --status IN_PROGRESS --json`
-includes derived lease-expiration fields for read-only controller status checks.
+`validate` warns about `IN_PROGRESS` claims only after they meet the current reclaim age threshold without failing the
+workbook, and `list --status IN_PROGRESS --json` includes derived lease-expiration fields for read-only controller
+status checks.
 
 ## Inspection commands
 

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -444,9 +444,9 @@ workbook. The default reclaim age threshold is 240 minutes; pass `--older-than-m
 controller has an explicit reason to override it. The dry-run output includes `activeClaims`, `staleCount`, and
 `reclaimableStaleCount`; use those fields to distinguish active claims from rows eligible under the current
 heartbeat-age threshold. Dry-run rows are queue-timing candidates only and include `reclaimReady: false`; use mutating
-`reclaim-stale` only when the claim is genuinely stale and no recoverable work remains. Treat `validate` warnings about
-expired `IN_PROGRESS` leases and derived `list --status IN_PROGRESS --json` lease-expiration fields as read-only
-recovery signals, not permission to reclaim without inspection.
+`reclaim-stale` only when the claim is genuinely stale and no recoverable work remains. Treat `validate` stale-claim
+warnings and derived `list --status IN_PROGRESS --json` lease-expiration fields as read-only recovery signals, not
+permission to reclaim without inspection.
 
 ## Resource-aware validation
 

--- a/scripts/issue_queue.py
+++ b/scripts/issue_queue.py
@@ -1060,9 +1060,11 @@ def validateQueueState(state: QueueState) -> tuple[list[str], list[str]]:
                 errors.append(f"Row {task.row}: IN_PROGRESS requires valid Updated At UTC")
             if leaseUntil is None:
                 errors.append(f"Row {task.row}: IN_PROGRESS requires valid Lease Until UTC")
-            elif leaseUntil <= now:
+            if stale := staleClaimPayload(task, now):
                 warnings.append(
-                    f"Row {task.row}: IN_PROGRESS lease expired at {formatUtc(leaseUntil)}; "
+                    f"Row {task.row}: IN_PROGRESS stale claim ({stale['staleReason']}; "
+                    f"last update {stale['updatedAtUtc'] or 'missing'} meets "
+                    f"{stale['staleThresholdMinutes']}-minute reclaim threshold); "
                     "inspect the worker and run reclaim-stale --dry-run before reclaiming"
                 )
             if attempt < 1:

--- a/tests/test_issue_queue.py
+++ b/tests/test_issue_queue.py
@@ -554,15 +554,20 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual(issue_queue.STATUS_IN_PROGRESS, task.status)
         self.assertEqual(claim["claimId"], task.values["Claim ID"])
 
-    def test_validate_warns_about_expired_in_progress_lease(self) -> None:
-        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
-        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=-10)
+    def test_validate_warns_only_for_claims_at_reclaim_threshold(self) -> None:
+        recent_claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
+        self.set_claim_times(recent_claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=239)
+        old_claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-2", leaseMinutes=1)
+        self.set_claim_times(old_claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=241)
 
         state = issue_queue.loadQueue(self.workbook_path)
         errors, warnings = issue_queue.validateQueueState(state)
 
         self.assertEqual([], errors)
-        self.assertTrue(any("IN_PROGRESS lease expired" in warning for warning in warnings), warnings)
+        self.assertEqual(1, len(warnings), warnings)
+        self.assertIn("IN_PROGRESS stale claim", warnings[0])
+        self.assertIn("240-minute reclaim threshold", warnings[0])
+        self.assertIn("reclaim-stale --dry-run", warnings[0])
 
     def test_reclaim_stale_claim_ignores_recent_heartbeat(self) -> None:
         claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)


### PR DESCRIPTION
## What changed

- Aligned `issue_queue.py validate` stale-claim warnings with the same 240-minute reclaim policy used by `reclaim-stale`.
- Kept raw lease-expiration fields in `list --status IN_PROGRESS --json` for read-only status visibility.
- Updated queue docs and controller prompt to distinguish stale-claim warnings from raw lease-expiration fields.
- Updated the queue regression test so a recently updated expired lease does not produce a validate warning, while an old claim does.

## Why

After the 4-hour reclaim policy landed, the current workbook had row 53 with an expired 2-hour lease but a recent heartbeat age below 240 minutes. `validate` warned about that row, while `reclaim-stale --dry-run` correctly reported `staleCount=0`. That mismatch made ordinary validation look actionable even when the row was not reclaimable under the current policy.

## Validation

- `black -l 120 scripts/issue_queue.py tests/test_issue_queue.py`
- `python3 -m unittest tests.test_issue_queue`
- `python3 scripts/issue_queue.py validate`
- `python3 scripts/issue_queue.py reclaim-stale --dry-run`
- `python3 -m unittest tests.test_issue_queue tests.test_controller_resource_audit`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`
- `git diff --check`

## Notes

- No local native build, CTest, full Python suite, or coverage run was used; this is queue-controller tooling and documentation only.
- New subagent review/PM capacity is unavailable in this session due the subagent usage limit, so this checkpoint used deterministic local review and focused tests.
