### PR TITLE
Move GUI handler ownership into game context

### DIFF
--- a/src/core/CGame.cpp
+++ b/src/core/CGame.cpp
@@ -38,9 +38,7 @@ std::shared_ptr<CGameContext> CGame::getContext() {
     return context;
 }
 
-std::shared_ptr<CGuiHandler> CGame::getGuiHandler() {
-    return guiHandler.get([this]() { return std::make_shared<CGuiHandler>(this->ptr<CGame>()); });
-}
+std::shared_ptr<CGuiHandler> CGame::getGuiHandler() { return getContext()->getGuiHandler(); }
 
 std::shared_ptr<CScriptHandler> CGame::getScriptHandler() { return getContext()->getScriptHandler(); }
 

--- a/src/core/CGame.h
+++ b/src/core/CGame.h
@@ -82,7 +82,6 @@ class CGame : public CGameObject {
     std::shared_ptr<CSlotConfig> getSlotConfiguration();
 
   private:
-    vstd::lazy<CGuiHandler> guiHandler;
     vstd::lazy<CSlotConfig> slotConfiguration;
 
     std::shared_ptr<CGameContext> context;

--- a/src/core/CGameContext.cpp
+++ b/src/core/CGameContext.cpp
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "core/CGameContext.h"
 #include "core/CGame.h"
+#include "handler/CGuiHandler.h"
 #include "handler/CObjectHandler.h"
 #include "handler/CRngHandler.h"
 #include "handler/CScriptHandler.h"
@@ -31,6 +32,17 @@ std::shared_ptr<CObjectHandler> CGameContext::getObjectHandler() {
         objectHandler = std::make_shared<CObjectHandler>();
     }
     return objectHandler;
+}
+
+std::shared_ptr<CGuiHandler> CGameContext::getGuiHandler() {
+    if (!guiHandler) {
+        auto owner = game.lock();
+        if (!owner) {
+            throw std::runtime_error("Cannot create CGuiHandler without an active CGame.");
+        }
+        guiHandler = std::make_shared<CGuiHandler>(owner);
+    }
+    return guiHandler;
 }
 
 std::shared_ptr<CScriptHandler> CGameContext::getScriptHandler() {

--- a/src/core/CGameContext.h
+++ b/src/core/CGameContext.h
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 
 class CGame;
+class CGuiHandler;
 class CObjectHandler;
 class CRngHandler;
 class CScriptHandler;
@@ -30,12 +31,15 @@ class CGameContext {
 
     std::shared_ptr<CObjectHandler> getObjectHandler();
 
+    std::shared_ptr<CGuiHandler> getGuiHandler();
+
     std::shared_ptr<CScriptHandler> getScriptHandler();
 
     std::shared_ptr<CRngHandler> getRngHandler();
 
   private:
     std::weak_ptr<CGame> game;
+    std::shared_ptr<CGuiHandler> guiHandler;
     std::shared_ptr<CObjectHandler> objectHandler;
     std::shared_ptr<CScriptHandler> scriptHandler;
     std::shared_ptr<CRngHandler> rngHandler;

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -407,6 +407,7 @@ void init_game_module(py::module_ &m) {
     py::class_<CGameContext, std::shared_ptr<CGameContext>>(m, "CGameContext",
                                                             "Runtime service context owned by a game instance.")
         .def("getObjectHandler", &CGameContext::getObjectHandler, "Return the object factory/registry handler.")
+        .def("getGuiHandler", &CGameContext::getGuiHandler, "Return the GUI handler service.")
         .def("getScriptHandler", &CGameContext::getScriptHandler, "Return the Python script execution service.")
         .def("getRngHandler", &CGameContext::getRngHandler, "Return the random encounter/loot handler.");
 

--- a/test.py
+++ b/test.py
@@ -3456,18 +3456,22 @@ class GameTest(unittest.TestCase):
         self.assertIs(context, g.getContext())
 
         object_handler = context.getObjectHandler()
+        gui_handler = context.getGuiHandler()
         script_handler = context.getScriptHandler()
         rng_handler = context.getRngHandler()
 
         self.assertIs(object_handler, context.getObjectHandler())
+        self.assertIs(gui_handler, context.getGuiHandler())
         self.assertIs(script_handler, context.getScriptHandler())
         self.assertIs(rng_handler, context.getRngHandler())
         self.assertIs(object_handler, g.getObjectHandler())
+        self.assertIs(gui_handler, g.getGuiHandler())
         self.assertIs(rng_handler, g.getRngHandler())
 
         other_game = game.CGameLoader.loadGame()
         self.assertIsNot(context, other_game.getContext())
         self.assertIsNot(object_handler, other_game.getObjectHandler())
+        self.assertIsNot(gui_handler, other_game.getGuiHandler())
 
         object_handler.registerConfigJson(
             "contextOwnedProbe",

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "core/CJsonUtil.h"
 #include "core/CGame.h"
+#include "core/CGameContext.h"
 #include "core/CList.h"
 #include "core/CPathFinder.h"
 #include "core/CSaveFormat.h"
@@ -776,6 +777,20 @@ void test_object_clone_batches_property_notifications() {
     expect_true(probe->threat_changed_calls == 0, "clone batches should suppress dynamic field signals");
 }
 
+void test_game_context_owns_distinct_gui_handlers_per_game() {
+    auto first_game = std::make_shared<CGame>();
+    auto second_game = std::make_shared<CGame>();
+
+    auto first_context_handler = first_game->getContext()->getGuiHandler();
+    auto first_game_handler = first_game->getGuiHandler();
+    auto second_game_handler = second_game->getGuiHandler();
+
+    expect_true(first_context_handler == first_game_handler,
+                "CGame::getGuiHandler should return the handler owned by CGameContext");
+    expect_true(first_game_handler != second_game_handler,
+                "separate CGame instances should receive distinct GUI handlers");
+}
+
 void test_delayed_future_handlers_run_through_event_loop() {
     auto loop = vstd::event_loop<>::instance();
     const int previous_fps = loop->getFps();
@@ -1012,6 +1027,7 @@ int main() {
     test_nested_property_notification_batches_emit_one_deterministic_signal();
     test_object_deserialization_batches_property_notifications();
     test_object_clone_batches_property_notifications();
+    test_game_context_owns_distinct_gui_handlers_per_game();
     test_delayed_future_handlers_run_through_event_loop();
     test_script_rejects_executable_expressions();
     test_save_format_codec_validation();

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -791,6 +791,15 @@ void test_game_context_owns_distinct_gui_handlers_per_game() {
                 "separate CGame instances should receive distinct GUI handlers");
 }
 
+void test_game_context_rejects_services_without_owner_game() {
+    auto context = std::make_shared<CGameContext>(std::shared_ptr<CGame>());
+
+    expect_runtime_error([&]() { context->getGuiHandler(); },
+                         "CGuiHandler creation should require an active owning game");
+    expect_runtime_error([&]() { context->getRngHandler(); },
+                         "CRngHandler creation should require an active owning game");
+}
+
 void test_delayed_future_handlers_run_through_event_loop() {
     auto loop = vstd::event_loop<>::instance();
     const int previous_fps = loop->getFps();
@@ -1028,6 +1037,7 @@ int main() {
     test_object_deserialization_batches_property_notifications();
     test_object_clone_batches_property_notifications();
     test_game_context_owns_distinct_gui_handlers_per_game();
+    test_game_context_rejects_services_without_owner_game();
     test_delayed_future_handlers_run_through_event_loop();
     test_script_rejects_executable_expressions();
     test_save_format_codec_validation();


### PR DESCRIPTION
Issue: [EPIC_02][STORY_02][SUBSTORY_01] Move CGuiHandler ownership to context
Claim ID: fd9f18bb-3846-43a1-89a8-9472fe10b0ca
Owner: controller/ctrl-lis-2-9b3984de/subagent-4

## What changed
- Moved the lazy `CGuiHandler` instance out of `CGame` and into `CGameContext`.
- Kept the existing `CGame::getGuiHandler()` public API by delegating to `getContext()->getGuiHandler()`.
- Exposed `CGameContext.getGuiHandler()` through the Python binding.
- Added C++ and Python regression coverage for context-owned GUI handler identity and per-game separation.

## Why
`CGame` still owned the GUI handler directly, while related runtime services had already moved behind `CGameContext`. That kept GUI service lifetime outside the context-scoped ownership model and made it harder to isolate per-game services consistently.

## Validation
- `clang-format -i src/core/CGame.h src/core/CGame.cpp src/core/CGameContext.h src/core/CGameContext.cpp src/core/CModule.cpp tests/unit/test_core.cpp`
- `black -l 120 test.py`
- `python3 -m py_compile test.py`
- `git diff --check`
- `git diff --exit-code -- planning/fall_of_nouraajd_issue_proposals.xlsx`
- Worker focused local validation before controller review:
  - `GAME_CONFIGURE_SKIP_APT=1 GAME_CONFIGURE_SKIP_SUBMODULES=1 GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh`
  - `git submodule update --init --recursive`
  - `CCACHE_DIR=.../.ccache cmake --build cmake-build-release --target core_unit_tests -j$(nproc)`
  - `CCACHE_DIR=.../.ccache ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests.core_unit_tests`

## Skipped or blocked local checks
- Plain `./configure.sh` attempted `sudo apt-get` and could not proceed without a sudo password prompt.
- Heavy local native/full Python/coverage validation was not repeated by the controller; this PR touches `src/core/**`, `test.py`, and unit tests, so Linux CI with the coverage step is the required full validation evidence.

## Manual review notes
- The queue workbook is not modified by this implementation branch.
