### PR TITLE
Add GUI drag session pointer capture

### DIFF
--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -480,6 +480,8 @@ void init_game_module(py::module_ &m) {
 
     py::class_<CGui, CGameGraphicsObject, std::shared_ptr<CGui>>(m, "CGui", "Game GUI root object.")
         .def("getGame", &CGui::getGame, "Return the owning game.")
+        .def("hasDragSession", &CGui::hasDragSession, "Return whether a GUI drag transaction is active.")
+        .def("hasPointerCapture", &CGui::hasPointerCapture, "Return whether a GUI widget owns pointer capture.")
         .def("read_pixels", &read_gui_pixels, "Read the current SDL renderer pixels as RGBA bytes, width, and height.");
 
     py::class_<CAnimation, CGameGraphicsObject, std::shared_ptr<CAnimation>>(m, "CAnimation",

--- a/src/gui/CGui.cpp
+++ b/src/gui/CGui.cpp
@@ -42,8 +42,6 @@ void CGui::render(int i1) {
     SDL_SAFE(SDL_RenderPresent(renderer.get()));
 }
 
-bool CGui::event(SDL_Event *event) { return CGameGraphicsObject::event(this->ptr<CGui>(), event); }
-
 SDL_Renderer *CGui::getRenderer() const { return renderer.get(); }
 
 std::shared_ptr<CTextureCache> CGui::getTextureCache() {
@@ -69,3 +67,138 @@ void CGui::setTileSize(int tileSize) { CGui::tileSize = std::clamp(tileSize, 1, 
 int CGui::getTileCountX() { return width / tileSize + 1; }
 
 int CGui::getTileCountY() { return height / tileSize + 1; }
+
+bool CGui::event(SDL_Event *event) {
+    if (!event) {
+        return false;
+    }
+    if (event->type == SDL_MOUSEMOTION) {
+        updateDragSession(event->motion.x, event->motion.y);
+        if (hasPointerCapture()) {
+            return dispatchPointerCaptureEvent(event);
+        }
+    }
+    if (event->type == SDL_MOUSEBUTTONUP) {
+        updateDragSession(event->button.x, event->button.y);
+        if (!hasDragSession() && !hasPointerCapture()) {
+            return CGameGraphicsObject::event(this->ptr<CGui>(), event);
+        }
+        const auto captured = pointerCapture.lock();
+        const bool releaseInsideCapture = isPointerInside(captured, event->button.x, event->button.y);
+        const bool targetHandled =
+            (hasDragSession() || releaseInsideCapture) ? CGameGraphicsObject::event(this->ptr<CGui>(), event) : false;
+        const bool capturedHandled = releaseInsideCapture ? false : dispatchPointerCaptureEvent(event);
+        if (hasDragSession() && !getDragSession()->acceptedTarget.lock()) {
+            cancelDragSession();
+        }
+        releasePointerCapture();
+        clearDragSession();
+        return targetHandled || capturedHandled;
+    }
+    if (event->type == SDL_WINDOWEVENT && event->window.event == SDL_WINDOWEVENT_LEAVE) {
+        cancelDragSession();
+        releasePointerCapture();
+        clearDragSession();
+    }
+    return CGameGraphicsObject::event(this->ptr<CGui>(), event);
+}
+
+void CGui::capturePointer(std::shared_ptr<CGameGraphicsObject> widget) {
+    if (widget && widget->isAttachedToGui(this->ptr<CGui>())) {
+        pointerCapture = widget;
+    }
+}
+
+void CGui::releasePointerCapture() { pointerCapture.reset(); }
+
+void CGui::releasePointerCaptureFor(const std::shared_ptr<CGameGraphicsObject> &root) {
+    auto captured = pointerCapture.lock();
+    if (ownsGraphicsObject(root, captured)) {
+        releasePointerCapture();
+    }
+}
+
+bool CGui::hasPointerCapture() const { return !pointerCapture.expired(); }
+
+bool CGui::isPointerCapturedBy(const std::shared_ptr<CGameGraphicsObject> &widget) const {
+    return widget && pointerCapture.lock() == widget;
+}
+
+void CGui::startDragSession(std::shared_ptr<CGameGraphicsObject> sourceWidget, std::shared_ptr<CGameObject> payload,
+                            int sourceIndex, int startX, int startY) {
+    if (!sourceWidget || !sourceWidget->isAttachedToGui(this->ptr<CGui>())) {
+        return;
+    }
+    dragSession =
+        DragSession{sourceWidget, std::move(payload), sourceIndex, {startX, startY}, {startX, startY}, {}, false};
+}
+
+void CGui::updateDragSession(int currentX, int currentY) {
+    if (dragSession) {
+        dragSession->current = {currentX, currentY};
+    }
+}
+
+void CGui::acceptDragSession(std::shared_ptr<CGameGraphicsObject> target) {
+    if (dragSession && target && target->isAttachedToGui(this->ptr<CGui>())) {
+        dragSession->acceptedTarget = target;
+        dragSession->canceled = false;
+    }
+}
+
+void CGui::cancelDragSession() {
+    if (dragSession) {
+        dragSession->acceptedTarget.reset();
+        dragSession->canceled = true;
+    }
+}
+
+void CGui::cancelDragSessionFor(const std::shared_ptr<CGameGraphicsObject> &root) {
+    if (!dragSession) {
+        return;
+    }
+    if (ownsGraphicsObject(root, dragSession->sourceWidget.lock()) ||
+        ownsGraphicsObject(root, dragSession->acceptedTarget.lock())) {
+        cancelDragSession();
+        clearDragSession();
+    }
+}
+
+void CGui::clearDragSession() { dragSession.reset(); }
+
+bool CGui::hasDragSession() const { return dragSession.has_value(); }
+
+const CGui::DragSession *CGui::getDragSession() const { return dragSession ? &*dragSession : nullptr; }
+
+CGui::DragSession *CGui::getDragSession() { return dragSession ? &*dragSession : nullptr; }
+
+bool CGui::dispatchPointerCaptureEvent(SDL_Event *event) {
+    auto captured = pointerCapture.lock();
+    if (!captured || !captured->isAttachedToGui(this->ptr<CGui>())) {
+        releasePointerCapture();
+        return false;
+    }
+    auto rect = captured->getRect();
+    if (event->type == SDL_MOUSEMOTION) {
+        return captured->mouseMotionEvent(this->ptr<CGui>(), static_cast<SDL_EventType>(event->type),
+                                          event->motion.x - rect->x, event->motion.y - rect->y, event->motion.xrel,
+                                          event->motion.yrel);
+    }
+    if (event->type == SDL_MOUSEBUTTONUP || event->type == SDL_MOUSEBUTTONDOWN) {
+        return captured->mouseEvent(this->ptr<CGui>(), static_cast<SDL_EventType>(event->type), event->button.button,
+                                    event->button.x - rect->x, event->button.y - rect->y);
+    }
+    return false;
+}
+
+bool CGui::isPointerInside(const std::shared_ptr<CGameGraphicsObject> &object, int x, int y) {
+    if (!object || !object->isAttachedToGui(this->ptr<CGui>())) {
+        return false;
+    }
+    return CUtil::isIn(object->getRect(), x, y);
+}
+
+bool CGui::ownsGraphicsObject(const std::shared_ptr<CGameGraphicsObject> &root,
+                              const std::shared_ptr<CGameGraphicsObject> &object) const {
+    return root && object && (root == object || root->findChild(object) != nullptr);
+}

--- a/src/gui/CGui.cpp
+++ b/src/gui/CGui.cpp
@@ -125,12 +125,18 @@ bool CGui::isPointerCapturedBy(const std::shared_ptr<CGameGraphicsObject> &widge
 }
 
 void CGui::startDragSession(std::shared_ptr<CGameGraphicsObject> sourceWidget, std::shared_ptr<CGameObject> payload,
-                            int sourceIndex, int startX, int startY) {
+                            int sourceIndex, int startX, int startY, bool sourceCallbackDeferred) {
     if (!sourceWidget || !sourceWidget->isAttachedToGui(this->ptr<CGui>())) {
         return;
     }
-    dragSession =
-        DragSession{sourceWidget, std::move(payload), sourceIndex, {startX, startY}, {startX, startY}, {}, false};
+    DragSession session;
+    session.sourceWidget = sourceWidget;
+    session.payload = std::move(payload);
+    session.sourceIndex = sourceIndex;
+    session.start = {startX, startY};
+    session.current = {startX, startY};
+    session.sourceCallbackDeferred = sourceCallbackDeferred;
+    dragSession = std::move(session);
 }
 
 void CGui::updateDragSession(int currentX, int currentY) {

--- a/src/gui/CGui.h
+++ b/src/gui/CGui.h
@@ -44,6 +44,7 @@ class CGui : public CGameGraphicsObject {
         SDL_Point current{0, 0};
         std::weak_ptr<CGameGraphicsObject> acceptedTarget;
         bool canceled = false;
+        bool sourceCallbackDeferred = false;
     };
 
     using CGameGraphicsObject::render;
@@ -91,7 +92,7 @@ class CGui : public CGameGraphicsObject {
     bool isPointerCapturedBy(const std::shared_ptr<CGameGraphicsObject> &widget) const;
 
     void startDragSession(std::shared_ptr<CGameGraphicsObject> sourceWidget, std::shared_ptr<CGameObject> payload,
-                          int sourceIndex, int startX, int startY);
+                          int sourceIndex, int startX, int startY, bool sourceCallbackDeferred = false);
 
     void updateDragSession(int currentX, int currentY);
 

--- a/src/gui/CGui.h
+++ b/src/gui/CGui.h
@@ -23,6 +23,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/object/CGameGraphicsObject.h"
 #include "object/CGameObject.h"
 
+#include <optional>
+
 class CTextureCache;
 
 class CTextManager;
@@ -34,6 +36,16 @@ class CGui : public CGameGraphicsObject {
     fn::sdl::RendererPtr renderer;
 
   public:
+    struct DragSession {
+        std::weak_ptr<CGameGraphicsObject> sourceWidget;
+        std::shared_ptr<CGameObject> payload;
+        int sourceIndex = -1;
+        SDL_Point start{0, 0};
+        SDL_Point current{0, 0};
+        std::weak_ptr<CGameGraphicsObject> acceptedTarget;
+        bool canceled = false;
+    };
+
     using CGameGraphicsObject::render;
 
     SDL_Renderer *getRenderer() const;
@@ -68,6 +80,35 @@ class CGui : public CGameGraphicsObject {
 
     bool event(SDL_Event *event);
 
+    void capturePointer(std::shared_ptr<CGameGraphicsObject> widget);
+
+    void releasePointerCapture();
+
+    void releasePointerCaptureFor(const std::shared_ptr<CGameGraphicsObject> &root);
+
+    bool hasPointerCapture() const;
+
+    bool isPointerCapturedBy(const std::shared_ptr<CGameGraphicsObject> &widget) const;
+
+    void startDragSession(std::shared_ptr<CGameGraphicsObject> sourceWidget, std::shared_ptr<CGameObject> payload,
+                          int sourceIndex, int startX, int startY);
+
+    void updateDragSession(int currentX, int currentY);
+
+    void acceptDragSession(std::shared_ptr<CGameGraphicsObject> target);
+
+    void cancelDragSession();
+
+    void cancelDragSessionFor(const std::shared_ptr<CGameGraphicsObject> &root);
+
+    void clearDragSession();
+
+    bool hasDragSession() const;
+
+    const DragSession *getDragSession() const;
+
+    DragSession *getDragSession();
+
     std::shared_ptr<CTextureCache> getTextureCache();
 
     std::shared_ptr<CTextManager> getTextManager();
@@ -75,4 +116,16 @@ class CGui : public CGameGraphicsObject {
     vstd::lazy<CTextureCache> _textureCache;
 
     vstd::lazy<CTextManager> _textManager;
+
+  private:
+    bool dispatchPointerCaptureEvent(SDL_Event *event);
+
+    bool isPointerInside(const std::shared_ptr<CGameGraphicsObject> &object, int x, int y);
+
+    bool ownsGraphicsObject(const std::shared_ptr<CGameGraphicsObject> &root,
+                            const std::shared_ptr<CGameGraphicsObject> &object) const;
+
+    std::optional<DragSession> dragSession;
+
+    std::weak_ptr<CGameGraphicsObject> pointerCapture;
 };

--- a/src/gui/object/CGameGraphicsObject.cpp
+++ b/src/gui/object/CGameGraphicsObject.cpp
@@ -168,8 +168,13 @@ void CGameGraphicsObject::addChild(const std::shared_ptr<CGameGraphicsObject> &c
 }
 
 void CGameGraphicsObject::removeChild(const std::shared_ptr<CGameGraphicsObject> &child) {
+    auto gui = getGui();
     if (children.erase(child)) {
         child->removeParent();
+        if (gui) {
+            gui->releasePointerCaptureFor(child);
+            gui->cancelDragSessionFor(child);
+        }
     }
 }
 

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -54,6 +54,12 @@ bool CListView::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int bu
         const auto *session = gui->getDragSession();
         const bool sourceIsSelf = session->sourceWidget.lock() == self;
         if (sourceIsSelf) {
+            int index = -1;
+            std::shared_ptr<CGameObject> object;
+            if (session->sourceCallbackDeferred && !session->canceled && !dragMoved(*session) &&
+                tryGetClickedObject(gui, x, y, index, object)) {
+                invokeCallback(gui, index, object);
+            }
             return true;
         }
         int index = -1;
@@ -79,10 +85,12 @@ bool CListView::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int bu
     if (gui) {
         auto rect = getLayout() ? getLayout()->getRect(this->ptr<CGameGraphicsObject>()) : CUtil::rect(0, 0, 0, 0);
         auto self = this->ptr<CListView>();
-        gui->startDragSession(self, object, index, rect->x + x, rect->y + y);
+        gui->startDragSession(self, object, index, rect->x + x, rect->y + y, invokeSelect(gui, index, object));
         gui->capturePointer(self);
     }
-    invokeCallback(gui, index, object);
+    if (!gui || !gui->hasDragSession() || !gui->getDragSession()->sourceCallbackDeferred) {
+        invokeCallback(gui, index, object);
+    }
     return true;
 }
 
@@ -367,12 +375,17 @@ void CListView::addItem(const std::shared_ptr<CGui> &gui, std::list<std::shared_
                 return true;
             }
             if (button == SDL_BUTTON_LEFT) {
+                const bool deferSourceCallback = self->invokeSelect(gui, itemIndex, object);
+                bool dragStarted = false;
                 if (auto source = sourceGraphic.lock()) {
                     auto rect = source->getLayout() ? source->getLayout()->getRect(source) : CUtil::rect(0, 0, 0, 0);
-                    gui->startDragSession(self, object, itemIndex, rect->x + x, rect->y + y);
+                    gui->startDragSession(self, object, itemIndex, rect->x + x, rect->y + y, deferSourceCallback);
                     gui->capturePointer(self);
+                    dragStarted = gui->hasDragSession();
                 }
-                self->invokeCallback(gui, itemIndex, object);
+                if (!deferSourceCallback || !dragStarted) {
+                    self->invokeCallback(gui, itemIndex, object);
+                }
                 return true;
             }
             if (button == SDL_BUTTON_RIGHT) {

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -85,12 +85,10 @@ bool CListView::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int bu
     if (gui) {
         auto rect = getLayout() ? getLayout()->getRect(this->ptr<CGameGraphicsObject>()) : CUtil::rect(0, 0, 0, 0);
         auto self = this->ptr<CListView>();
-        gui->startDragSession(self, object, index, rect->x + x, rect->y + y, invokeSelect(gui, index, object));
+        gui->startDragSession(self, object, index, rect->x + x, rect->y + y);
         gui->capturePointer(self);
     }
-    if (!gui || !gui->hasDragSession() || !gui->getDragSession()->sourceCallbackDeferred) {
-        invokeCallback(gui, index, object);
-    }
+    invokeCallback(gui, index, object);
     return true;
 }
 

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -28,6 +28,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/object/CProxyGraphicsObject.h"
 #include "gui/object/CWidget.h"
 #include "handler/CEventHandler.h"
+#include <cstdlib>
 #include <exception>
 
 namespace {
@@ -39,11 +40,31 @@ std::shared_ptr<CAnimation> createListItemAnimation(const std::shared_ptr<CGui> 
     animation->setLayout(std::make_shared<CParentLayout>());
     return animation;
 }
+
+bool dragMoved(const CGui::DragSession &session) {
+    return std::abs(session.current.x - session.start.x) > 0 || std::abs(session.current.y - session.start.y) > 0;
+}
 } // namespace
 
 void CListView::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> loc, int frameTime) {}
 
 bool CListView::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button, int x, int y) {
+    if (type == SDL_MOUSEBUTTONUP && button == SDL_BUTTON_LEFT && gui && gui->hasDragSession()) {
+        auto self = this->ptr<CListView>();
+        const auto *session = gui->getDragSession();
+        const bool sourceIsSelf = session->sourceWidget.lock() == self;
+        if (sourceIsSelf) {
+            return true;
+        }
+        int index = -1;
+        std::shared_ptr<CGameObject> object;
+        if (!session->canceled && dragMoved(*session) && tryGetClickedObject(gui, x, y, index, object)) {
+            invokeCallback(gui, index, object);
+            gui->acceptDragSession(self);
+            return true;
+        }
+        return false;
+    }
     if (type != SDL_MOUSEBUTTONDOWN || (button != SDL_BUTTON_LEFT && button != SDL_BUTTON_RIGHT)) {
         return true;
     }
@@ -54,6 +75,12 @@ bool CListView::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int bu
     }
     if (button == SDL_BUTTON_RIGHT) {
         return invokeRightClickCallback(gui, index, object);
+    }
+    if (gui) {
+        auto rect = getLayout() ? getLayout()->getRect(this->ptr<CGameGraphicsObject>()) : CUtil::rect(0, 0, 0, 0);
+        auto self = this->ptr<CListView>();
+        gui->startDragSession(self, object, index, rect->x + x, rect->y + y);
+        gui->capturePointer(self);
     }
     invokeCallback(gui, index, object);
     return true;
@@ -328,25 +355,31 @@ void CListView::addItem(const std::shared_ptr<CGui> &gui, std::list<std::shared_
                         int itemIndex) const {
     auto self = const_cast<CListView *>(this)->ptr<CListView>();
     auto object = indexedCollection.find(itemIndex)->second;
+    auto itemAnimation = createListItemAnimation(gui, object);
+    std::weak_ptr<CGameGraphicsObject> sourceGraphic = itemAnimation;
     std::shared_ptr<CGameGraphicsObject> objectGraphic =
-        createListItemAnimation(gui, object)
-            ->withCallback(
-                [self, itemIndex, object](std::shared_ptr<CGui> gui, SDL_EventType type, int button, int, int) {
-                    if (type != SDL_MOUSEBUTTONDOWN) {
-                        return false;
-                    }
-                    if (!self->isAttachedToGui(gui)) {
-                        return true;
-                    }
-                    if (button == SDL_BUTTON_LEFT) {
-                        self->invokeCallback(gui, itemIndex, object);
-                        return true;
-                    }
-                    if (button == SDL_BUTTON_RIGHT) {
-                        return self->invokeRightClickCallback(gui, itemIndex, object);
-                    }
-                    return false;
-                });
+        itemAnimation->withCallback([self, sourceGraphic, itemIndex,
+                                     object](std::shared_ptr<CGui> gui, SDL_EventType type, int button, int x, int y) {
+            if (type != SDL_MOUSEBUTTONDOWN) {
+                return false;
+            }
+            if (!self->isAttachedToGui(gui)) {
+                return true;
+            }
+            if (button == SDL_BUTTON_LEFT) {
+                if (auto source = sourceGraphic.lock()) {
+                    auto rect = source->getLayout() ? source->getLayout()->getRect(source) : CUtil::rect(0, 0, 0, 0);
+                    gui->startDragSession(self, object, itemIndex, rect->x + x, rect->y + y);
+                    gui->capturePointer(self);
+                }
+                self->invokeCallback(gui, itemIndex, object);
+                return true;
+            }
+            if (button == SDL_BUTTON_RIGHT) {
+                return self->invokeRightClickCallback(gui, itemIndex, object);
+            }
+            return false;
+        });
     objectGraphic->setPriority(2);
     return_val.push_back(objectGraphic);
 }

--- a/test.py
+++ b/test.py
@@ -450,6 +450,7 @@ SDL_KEYDOWN = 0x300
 SDL_KEYUP = 0x301
 SDL_QUIT = 0x100
 SDL_INIT_EVENTS = 0x00004000
+SDL_MOUSEMOTION = 0x400
 SDL_MOUSEBUTTONDOWN = 0x401
 SDL_MOUSEBUTTONUP = 0x402
 SDL_PRESSED = 1
@@ -569,6 +570,7 @@ XVFB_GAMEPLAY_CHILD_TESTS = (
     "test_screenshot_inventory_equipped_selection_has_rendered_pixels",
     "test_screenshot_inventory_item_selection_has_rendered_pixels",
     "test_screenshot_inventory_panel_has_rendered_pixels",
+    "test_inventory_drag_release_outside_source_equips_item",
     "test_inventory_equipped_selection_resets_inventory_selection",
     "test_inventory_quest_item_selection_is_ignored",
     "test_fight_quest_item_selection_is_ignored",
@@ -617,6 +619,7 @@ XVFB_GAMEPLAY_CHILD_DURATION_HINTS = {
     "test_screenshot_minimap_has_rendered_pixels": 6,
     "test_screenshot_inventory_equipped_selection_has_rendered_pixels": 6,
     "test_screenshot_inventory_item_selection_has_rendered_pixels": 6,
+    "test_inventory_drag_release_outside_source_equips_item": 6,
     "test_inventory_equipped_selection_resets_inventory_selection": 6,
     "test_inventory_quest_item_selection_is_ignored": 6,
     "test_fight_quest_item_selection_is_ignored": 6,
@@ -845,6 +848,52 @@ def push_sdl_mouse_button_event(x, y, button=SDL_BUTTON_LEFT, event_type=SDL_MOU
     focused_window = focused_sdl_window()
     if focused_window:
         event.button.windowID = sdl.SDL_GetWindowID(focused_window)
+
+    sdl.SDL_PushEvent.argtypes = [ctypes.POINTER(SDL_Event)]
+    sdl.SDL_PushEvent.restype = ctypes.c_int
+    pushed = sdl.SDL_PushEvent(ctypes.byref(event))
+    if pushed != 1:
+        raise AssertionError(f"SDL_PushEvent returned {pushed}.")
+
+
+def push_sdl_mouse_motion_event(x, y, xrel=0, yrel=0):
+    import ctypes
+
+    class SDL_MouseMotionEvent(ctypes.Structure):
+        _fields_ = [
+            ("type", ctypes.c_uint32),
+            ("timestamp", ctypes.c_uint32),
+            ("windowID", ctypes.c_uint32),
+            ("which", ctypes.c_uint32),
+            ("state", ctypes.c_uint32),
+            ("x", ctypes.c_int32),
+            ("y", ctypes.c_int32),
+            ("xrel", ctypes.c_int32),
+            ("yrel", ctypes.c_int32),
+        ]
+
+    class SDL_Event(ctypes.Union):
+        _fields_ = [
+            ("type", ctypes.c_uint32),
+            ("motion", SDL_MouseMotionEvent),
+            ("padding", ctypes.c_uint8 * 56),
+        ]
+
+    sdl = load_sdl_library()
+    event = SDL_Event()
+    event.type = SDL_MOUSEMOTION
+    event.motion.type = SDL_MOUSEMOTION
+    event.motion.state = 1 << (SDL_BUTTON_LEFT - 1)
+    event.motion.x = x
+    event.motion.y = y
+    event.motion.xrel = xrel
+    event.motion.yrel = yrel
+
+    sdl.SDL_GetWindowID.argtypes = [ctypes.c_void_p]
+    sdl.SDL_GetWindowID.restype = ctypes.c_uint32
+    focused_window = focused_sdl_window()
+    if focused_window:
+        event.motion.windowID = sdl.SDL_GetWindowID(focused_window)
 
     sdl.SDL_PushEvent.argtypes = [ctypes.POINTER(SDL_Event)]
     sdl.SDL_PushEvent.restype = ctypes.c_int
@@ -12924,6 +12973,43 @@ class XvfbGameplayProcessTest(unittest.TestCase):
         self.assertEqual(0, selected_after_equip.get("equippedCollection", 0))
         self.assertEqual(0, selected_after_equipped_click.get("inventoryCollection", 0))
         self.assertEqual(1, selected_after_equipped_click.get("equippedCollection", 0))
+
+    def test_inventory_drag_release_outside_source_equips_item(self):
+        _, g, _, player = create_xvfb_gameplay_session(self)
+        player.addItem("ChaosSword")
+        panel = open_panel_for_screenshot(self, g, "inventoryPanel", "CGameInventoryPanel")
+        list_views = collect_gui_children(panel, "CListView")
+        inventory_list = next(
+            list_view for list_view in list_views if list_view.getCollection() == "inventoryCollection"
+        )
+        equipped_list = next(list_view for list_view in list_views if list_view.getCollection() == "equippedCollection")
+        inventory_rect = inventory_list.getResolvedRect()
+        equipped_rect = equipped_list.getResolvedRect()
+        start_x = inventory_rect[0] + 25
+        start_y = inventory_rect[1] + 25
+        outside_source_x = inventory_rect[0] + inventory_rect[2] + 20
+        outside_source_y = start_y
+        target_x = equipped_rect[0] + 25
+        target_y = equipped_rect[1] + 25
+        inventory_before = player.countItems("ChaosSword")
+
+        push_sdl_mouse_button_event(start_x, start_y, SDL_BUTTON_LEFT, SDL_MOUSEBUTTONDOWN)
+        pump_event_loop(3)
+        self.assertTrue(g.getGui().hasDragSession())
+        self.assertTrue(g.getGui().hasPointerCapture())
+
+        push_sdl_mouse_motion_event(outside_source_x, outside_source_y, outside_source_x - start_x, 0)
+        pump_event_loop(3)
+        self.assertTrue(g.getGui().hasDragSession())
+        self.assertTrue(g.getGui().hasPointerCapture())
+
+        push_sdl_mouse_button_event(target_x, target_y, SDL_BUTTON_LEFT, SDL_MOUSEBUTTONUP)
+        pump_event_loop(5)
+
+        self.assertFalse(g.getGui().hasDragSession())
+        self.assertFalse(g.getGui().hasPointerCapture())
+        self.assertEqual(inventory_before - 1, player.countItems("ChaosSword"))
+        self.assertEqual("ChaosSword", player.getWeapon().getTypeId())
 
     def test_inventory_quest_item_selection_is_ignored(self):
         game, g, _, player = create_xvfb_gameplay_session(self, map_name="nouraajd")

--- a/test.py
+++ b/test.py
@@ -571,6 +571,7 @@ XVFB_GAMEPLAY_CHILD_TESTS = (
     "test_screenshot_inventory_item_selection_has_rendered_pixels",
     "test_screenshot_inventory_panel_has_rendered_pixels",
     "test_inventory_drag_release_outside_source_equips_item",
+    "test_inventory_preselected_drag_release_equips_item",
     "test_inventory_equipped_selection_resets_inventory_selection",
     "test_inventory_quest_item_selection_is_ignored",
     "test_fight_quest_item_selection_is_ignored",
@@ -620,6 +621,7 @@ XVFB_GAMEPLAY_CHILD_DURATION_HINTS = {
     "test_screenshot_inventory_equipped_selection_has_rendered_pixels": 6,
     "test_screenshot_inventory_item_selection_has_rendered_pixels": 6,
     "test_inventory_drag_release_outside_source_equips_item": 6,
+    "test_inventory_preselected_drag_release_equips_item": 6,
     "test_inventory_equipped_selection_resets_inventory_selection": 6,
     "test_inventory_quest_item_selection_is_ignored": 6,
     "test_fight_quest_item_selection_is_ignored": 6,
@@ -12993,6 +12995,47 @@ class XvfbGameplayProcessTest(unittest.TestCase):
         target_y = equipped_rect[1] + 25
         inventory_before = player.countItems("ChaosSword")
 
+        push_sdl_mouse_button_event(start_x, start_y, SDL_BUTTON_LEFT, SDL_MOUSEBUTTONDOWN)
+        pump_event_loop(3)
+        self.assertTrue(g.getGui().hasDragSession())
+        self.assertTrue(g.getGui().hasPointerCapture())
+
+        push_sdl_mouse_motion_event(outside_source_x, outside_source_y, outside_source_x - start_x, 0)
+        pump_event_loop(3)
+        self.assertTrue(g.getGui().hasDragSession())
+        self.assertTrue(g.getGui().hasPointerCapture())
+
+        push_sdl_mouse_button_event(target_x, target_y, SDL_BUTTON_LEFT, SDL_MOUSEBUTTONUP)
+        pump_event_loop(5)
+
+        self.assertFalse(g.getGui().hasDragSession())
+        self.assertFalse(g.getGui().hasPointerCapture())
+        self.assertEqual(inventory_before - 1, player.countItems("ChaosSword"))
+        self.assertEqual("ChaosSword", player.getWeapon().getTypeId())
+
+    def test_inventory_preselected_drag_release_equips_item(self):
+        _, g, _, player = create_xvfb_gameplay_session(self)
+        player.addItem("ChaosSword")
+        panel = open_panel_for_screenshot(self, g, "inventoryPanel", "CGameInventoryPanel")
+        list_views = collect_gui_children(panel, "CListView")
+        inventory_list = next(
+            list_view for list_view in list_views if list_view.getCollection() == "inventoryCollection"
+        )
+        equipped_list = next(list_view for list_view in list_views if list_view.getCollection() == "equippedCollection")
+        inventory_rect = inventory_list.getResolvedRect()
+        equipped_rect = equipped_list.getResolvedRect()
+        start_x = inventory_rect[0] + 25
+        start_y = inventory_rect[1] + 25
+        outside_source_x = inventory_rect[0] + inventory_rect[2] + 20
+        outside_source_y = start_y
+        target_x = equipped_rect[0] + 25
+        target_y = equipped_rect[1] + 25
+
+        push_sdl_mouse_click(start_x, start_y)
+        pump_event_loop(5)
+        self.assertEqual(1, get_panel_selection_box_counts_by_collection(panel).get("inventoryCollection", 0))
+
+        inventory_before = player.countItems("ChaosSword")
         push_sdl_mouse_button_event(start_x, start_y, SDL_BUTTON_LEFT, SDL_MOUSEBUTTONDOWN)
         pump_event_loop(3)
         self.assertTrue(g.getGui().hasDragSession())

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -55,6 +55,15 @@ class CountingRenderObject : public CGameGraphicsObject {
 
 class MouseEventRecorder : public CGameGraphicsObject {
   public:
+    bool mouseEvent(std::shared_ptr<CGui>, SDL_EventType type, int button, int x, int y) override {
+        ++button_count;
+        last_type = type;
+        last_button = button;
+        last_x = x;
+        last_y = y;
+        return true;
+    }
+
     bool mouseMotionEvent(std::shared_ptr<CGui>, SDL_EventType type, int x, int y, int xrel, int yrel) override {
         ++motion_count;
         last_type = type;
@@ -81,10 +90,12 @@ class MouseEventRecorder : public CGameGraphicsObject {
         return true;
     }
 
+    int button_count = 0;
     int motion_count = 0;
     int wheel_count = 0;
     int cancel_count = 0;
     SDL_EventType last_type = SDL_FIRSTEVENT;
+    int last_button = 0;
     int last_x = 0;
     int last_y = 0;
     int last_xrel = 0;
@@ -97,6 +108,26 @@ std::shared_ptr<MouseEventRecorder> attach_mouse_recorder(const std::shared_ptr<
     auto recorder = std::make_shared<MouseEventRecorder>();
     auto layout = std::make_shared<CLayout>();
     layout->setRect(10, 20, 100, 80);
+    recorder->setLayout(layout);
+    gui->pushChild(recorder);
+    return recorder;
+}
+
+class DropTargetRecorder : public MouseEventRecorder {
+  public:
+    bool mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button, int x, int y) override {
+        MouseEventRecorder::mouseEvent(gui, type, button, x, y);
+        if (type == SDL_MOUSEBUTTONUP && button == SDL_BUTTON_LEFT && gui && gui->hasDragSession()) {
+            gui->acceptDragSession(this->ptr<CGameGraphicsObject>());
+        }
+        return true;
+    }
+};
+
+std::shared_ptr<DropTargetRecorder> attach_drop_target_recorder(const std::shared_ptr<CGui> &gui) {
+    auto recorder = std::make_shared<DropTargetRecorder>();
+    auto layout = std::make_shared<CLayout>();
+    layout->setRect(200, 20, 100, 80);
     recorder->setLayout(layout);
     gui->pushChild(recorder);
     return recorder;
@@ -211,6 +242,27 @@ void test_gui_routes_mouse_motion_to_target_child() {
                 "mouse motion relative deltas should be preserved");
 }
 
+void test_gui_routes_mouse_button_up_without_drag_to_target_child() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto recorder = attach_mouse_recorder(gui);
+
+    SDL_Event event{};
+    event.type = SDL_MOUSEBUTTONUP;
+    event.button.button = SDL_BUTTON_LEFT;
+    event.button.x = 35;
+    event.button.y = 55;
+
+    expect_true(gui->event(&event), "mouse button up without a drag should use normal hit testing");
+    expect_true(recorder->button_count == 1, "mouse button up should be routed to the target child");
+    expect_true(recorder->last_type == SDL_MOUSEBUTTONUP, "mouse button handler should receive the SDL event type");
+    expect_true(recorder->last_button == SDL_BUTTON_LEFT, "mouse button handler should receive the SDL button");
+    expect_true(recorder->last_x == 25 && recorder->last_y == 35,
+                "mouse button coordinates should be relative to the child layout");
+}
+
 void test_gui_routes_mouse_wheel_to_target_child() {
     SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
@@ -255,6 +307,90 @@ void test_gui_routes_window_leave_as_mouse_cancel() {
     expect_true(recorder->last_type == SDL_WINDOWEVENT, "mouse cancel handler should receive the SDL event type");
 }
 
+void test_gui_pointer_capture_routes_drag_release_and_clears_session() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto source = attach_mouse_recorder(gui);
+    auto target = attach_drop_target_recorder(gui);
+    auto payload = std::make_shared<CGameObject>();
+
+    gui->startDragSession(source, payload, 7, 20, 30);
+    gui->capturePointer(source);
+
+    SDL_Event motion{};
+    motion.type = SDL_MOUSEMOTION;
+    motion.motion.x = 220;
+    motion.motion.y = 55;
+    motion.motion.xrel = 200;
+    motion.motion.yrel = 25;
+
+    expect_true(gui->event(&motion), "captured mouse motion outside the source should be consumed");
+    expect_true(source->motion_count == 1, "captured source should receive motion outside its rectangle");
+    expect_true(target->motion_count == 0, "motion should not be rerouted to the hovered target during capture");
+    expect_true(gui->hasDragSession(), "drag session should remain active during captured motion");
+    expect_true(gui->hasPointerCapture(), "pointer capture should remain active during captured motion");
+
+    SDL_Event button_up{};
+    button_up.type = SDL_MOUSEBUTTONUP;
+    button_up.button.button = SDL_BUTTON_LEFT;
+    button_up.button.x = 220;
+    button_up.button.y = 55;
+
+    expect_true(gui->event(&button_up), "drop over target should be consumed");
+    expect_true(target->button_count == 1, "drop target should receive the release under the pointer");
+    expect_true(source->button_count == 1, "captured source should also receive the release");
+    expect_true(!gui->hasDragSession(), "drop should clear the drag session");
+    expect_true(!gui->hasPointerCapture(), "drop should clear pointer capture");
+}
+
+void test_gui_pointer_capture_does_not_duplicate_same_source_release() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto source = attach_mouse_recorder(gui);
+
+    gui->startDragSession(source, std::make_shared<CGameObject>(), 7, 20, 30);
+    gui->capturePointer(source);
+
+    SDL_Event motion{};
+    motion.type = SDL_MOUSEMOTION;
+    motion.motion.x = 36;
+    motion.motion.y = 56;
+    motion.motion.xrel = 1;
+    motion.motion.yrel = 1;
+
+    expect_true(gui->event(&motion), "same-source jitter motion should be captured");
+
+    SDL_Event button_up{};
+    button_up.type = SDL_MOUSEBUTTONUP;
+    button_up.button.button = SDL_BUTTON_LEFT;
+    button_up.button.x = 36;
+    button_up.button.y = 56;
+
+    expect_true(gui->event(&button_up), "same-source release should be handled");
+    expect_true(source->button_count == 1, "same-source release should not be dispatched twice");
+    expect_true(!gui->hasDragSession(), "same-source release should clear the drag session");
+    expect_true(!gui->hasPointerCapture(), "same-source release should clear pointer capture");
+}
+
+void test_gui_pointer_capture_clears_when_captured_widget_is_removed() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto source = attach_mouse_recorder(gui);
+
+    gui->startDragSession(source, std::make_shared<CGameObject>(), 3, 20, 30);
+    gui->capturePointer(source);
+    gui->removeChild(source);
+
+    expect_true(!gui->hasDragSession(), "removing the captured widget should clear the drag session");
+    expect_true(!gui->hasPointerCapture(), "removing the captured widget should clear pointer capture");
+}
+
 void test_render_traversal_stops_after_detach() {
     SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
@@ -286,8 +422,12 @@ int main() {
     test_inventory_double_select_uses_selected_item_and_clears_selection();
     test_panel_event_callbacks_stop_after_close();
     test_gui_routes_mouse_motion_to_target_child();
+    test_gui_routes_mouse_button_up_without_drag_to_target_child();
     test_gui_routes_mouse_wheel_to_target_child();
     test_gui_routes_window_leave_as_mouse_cancel();
+    test_gui_pointer_capture_routes_drag_release_and_clears_session();
+    test_gui_pointer_capture_does_not_duplicate_same_source_release();
+    test_gui_pointer_capture_clears_when_captured_widget_is_removed();
     test_render_traversal_stops_after_detach();
     test_texture_cache_without_gui_fails_closed();
 


### PR DESCRIPTION
Issue: [EPIC_05][STORY_01][SUBSTORY_02] Add GUI drag session and pointer capture
Claim ID: 6cac35ba-f083-46a0-b009-e8ca03a9b3a7
Owner: controller/ctrl-lis-2-9b3984de/subagent-5

## What changed
- Added a `CGui`-owned drag session with source widget, payload, source index, start/current coordinates, accepted target, and cancellation state.
- Added pointer capture so the drag source receives motion and release events after the pointer leaves its rectangle.
- Clears capture/session on drop, cancel, widget removal, or window leave.
- Updated `CListView` to start generic drag sessions and accept drops without duplicating same-source releases.
- Exposed `CGui.hasDragSession()` and `CGui.hasPointerCapture()` to Python for regression checks.
- Added native GUI regressions for normal button-up dispatch, captured drag release, same-source release deduplication, and capture cleanup after widget removal.
- Added an Xvfb inventory drag regression that verifies the dragged `ChaosSword` is actually equipped.

## Why
`CGui::event()` previously routed mouse events only through ordinary hit-testing. Drag motion/up events were lost when the pointer left the source widget, which made generic drag-and-drop infrastructure impossible.

## Validation
- `clang-format -i src/core/CModule.cpp src/gui/CGui.cpp src/gui/CGui.h src/gui/object/CGameGraphicsObject.cpp src/gui/panel/CListView.cpp tests/unit/test_gui.cpp`
- `black -l 120 test.py`
- `python3 -m py_compile test.py`
- `git diff --check`
- `git diff --exit-code -- planning/fall_of_nouraajd_issue_proposals.xlsx`
- Worker focused local validation:
  - `cmake --build cmake-build-release --target _game for_unit_tests -j8`
  - `ctest --test-dir cmake-build-release --output-on-failure -R gui_unit_tests`

## Skipped or blocked local checks
- `GAME_XVFB_ONLY_CHILD_TESTS=test_inventory_drag_release_outside_source_equips_item GAME_XVFB_ISOLATE=1 python3 test.py XvfbGameplayTest.test_keyboard_gameplay_under_xvfb` skipped locally because SDL x11 is unavailable under Xvfb in this environment: `x11 not available`.
- Heavy local full-suite and coverage validation were not run by the controller. This PR touches `src/core/CModule.cpp`, `test.py`, and unit tests, so Linux CI plus `linux-coverage` is the required full validation evidence.

## Manual review notes
- The queue workbook is not modified by this implementation branch.
