### PR TITLE
Preserve Nouraajd class progression defaults

### DIFF
--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -145,6 +145,14 @@ def load(self, context):
     def _grant_quest(player, quest_name):
         ensure_quest(player, quest_name, registry=_player_quest_registry)
 
+    def _set_numeric_property_default(obj, name, value):
+        if not hasattr(obj, name):
+            obj.setNumericProperty(name, value)
+
+    def _set_bool_property_default(obj, name, value):
+        if not hasattr(obj, name):
+            obj.setBoolProperty(name, value)
+
     def _get_quest_system(game_map):
         return QuestSystem(game_map)
 
@@ -389,16 +397,16 @@ def load(self, context):
                 quest_system.reset_all()
                 game_map.setBoolProperty("ASKED_ABOUT_GIRL", False)
                 game_map.setBoolProperty("TALKED_TO_VICTOR", False)
-                player.setNumericProperty("warrior_barricades", 0)
-                player.setNumericProperty("assasin_trails", 0)
-                player.setNumericProperty("inquisitor_clues", 0)
-                player.setNumericProperty("sorcerer_sigils", 0)
-                player.setNumericProperty("wayfarer_routes", 0)
-                player.setBoolProperty("braced_nouraajd_gate", False)
-                player.setBoolProperty("shadowed_robed_men", False)
-                player.setBoolProperty("inspected_stained_glass", False)
-                player.setBoolProperty("decoded_stained_glass_ward", False)
-                player.setBoolProperty("charted_smuggler_route", False)
+                _set_numeric_property_default(player, "warrior_barricades", 0)
+                _set_numeric_property_default(player, "assasin_trails", 0)
+                _set_numeric_property_default(player, "inquisitor_clues", 0)
+                _set_numeric_property_default(player, "sorcerer_sigils", 0)
+                _set_numeric_property_default(player, "wayfarer_routes", 0)
+                _set_bool_property_default(player, "braced_nouraajd_gate", False)
+                _set_bool_property_default(player, "shadowed_robed_men", False)
+                _set_bool_property_default(player, "inspected_stained_glass", False)
+                _set_bool_property_default(player, "decoded_stained_glass_ward", False)
+                _set_bool_property_default(player, "charted_smuggler_route", False)
                 _grant_quest(player, "rolfQuest")
                 player.addItem("letterFromRolf")
 

--- a/test.py
+++ b/test.py
@@ -10469,6 +10469,83 @@ class GameTest(unittest.TestCase):
         return True, json.dumps(results, sort_keys=True)
 
     @game_test
+    def test_nouraajd_start_event_preserves_existing_class_progression(self):
+        game = load_game_module()
+        cases = [
+            {
+                "player_type": "Wayfarer",
+                "counter": "wayfarer_routes",
+                "counter_value": 3,
+                "flag": "charted_smuggler_route",
+                "default_counter": "inquisitor_clues",
+                "default_flag": "inspected_stained_glass",
+            },
+            {
+                "player_type": "Inquisitor",
+                "counter": "inquisitor_clues",
+                "counter_value": 2,
+                "flag": "inspected_stained_glass",
+                "default_counter": "wayfarer_routes",
+                "default_flag": "charted_smuggler_route",
+            },
+        ]
+        results = {}
+        save_names = []
+
+        try:
+            for case in cases:
+                save_name = unique_save_name(f"nouraajd_{case['player_type'].lower()}_class_progression")
+                save_names.append(save_name)
+                cleanup_save_slot(save_name)
+                _g, game_map, player = load_game_map_with_player("nouraajd", case["player_type"])
+                start_events = [
+                    obj
+                    for obj in game_map.getObjects()
+                    if obj.getTypeId() == "StartEvent" or obj.getType() == "StartEvent"
+                ]
+
+                self.assertTrue(start_events, "The Nouraajd map should author StartEvent tiles.")
+                self.assertFalse(hasattr(player, case["default_counter"]))
+                self.assertFalse(hasattr(player, case["default_flag"]))
+
+                player.setNumericProperty(case["counter"], case["counter_value"])
+                player.setBoolProperty(case["flag"], True)
+                game_map.setBoolProperty("ASKED_ABOUT_GIRL", True)
+
+                start_coords = start_events[0].getCoords()
+                player.moveTo(start_coords.x, start_coords.y, start_coords.z)
+                pump_event_loop(5)
+
+                self.assertEqual(case["counter_value"], player.getNumericProperty(case["counter"]))
+                self.assertTrue(player.getBoolProperty(case["flag"]))
+                self.assertTrue(hasattr(player, case["default_counter"]))
+                self.assertTrue(hasattr(player, case["default_flag"]))
+                self.assertEqual(0, player.getNumericProperty(case["default_counter"]))
+                self.assertFalse(player.getBoolProperty(case["default_flag"]))
+                self.assertFalse(game_map.getBoolProperty("ASKED_ABOUT_GIRL"))
+
+                game.CMapLoader.save(game_map, save_name)
+                loaded_game = game.CGameLoader.loadGame()
+                game.CGameLoader.loadSavedGame(loaded_game, save_name)
+                loaded_player = loaded_game.getMap().getPlayer()
+
+                self.assertEqual(case["counter_value"], loaded_player.getNumericProperty(case["counter"]))
+                self.assertTrue(loaded_player.getBoolProperty(case["flag"]))
+
+                results[case["player_type"]] = {
+                    "counter": loaded_player.getNumericProperty(case["counter"]),
+                    "flag": loaded_player.getBoolProperty(case["flag"]),
+                    "default_counter": loaded_player.getNumericProperty(case["default_counter"]),
+                    "default_flag": loaded_player.getBoolProperty(case["default_flag"]),
+                    "asked_about_girl": loaded_game.getMap().getBoolProperty("ASKED_ABOUT_GIRL"),
+                }
+
+            return True, json.dumps(results, sort_keys=True)
+        finally:
+            for save_name in save_names:
+                cleanup_save_slot(save_name)
+
+    @game_test
     def test_nouraajd_main_quest_remains_completable_by_every_class(self):
         class_ids = ("Assasin", "Inquisitor", "Sorcerer", "Warrior", "Wayfarer")
         results = {}


### PR DESCRIPTION
What changed:
- Added default-only property initialization helpers in res/maps/nouraajd/script.py.
- Updated StartEvent so player-scoped class progression counters and flags are preserved on revisit while map-scoped flags still reset.
- Added a regression covering Wayfarer/Inquisitor progression through StartEvent and save/load.

Why:
- StartEvent unconditionally reset player progression such as inquisitor_clues, wayfarer_routes, inspected_stained_glass, and charted_smuggler_route, erasing progression on Nouraajd revisit or transition.

Validation:
- python3 -m py_compile res/maps/nouraajd/script.py test.py
- git diff --check
- GAME_BUILD_DIR=/tmp/fon-progression-test-build-3EyO2B python3 test.py GameTest.test_nouraajd_start_event_preserves_existing_class_progression
- GAME_BUILD_DIR=/tmp/fon-progression-test-build-3EyO2B python3 test.py GameTest.test_nouraajd_class_specific_dialog_routes_unlock_for_type_ids

Known limitations:
- Focused runtime tests used an existing temporary _game build root with this worktree's resources; no local native build, full Python suite, or coverage run was executed. PR CI should provide Linux/full/coverage evidence.
