### PR TITLE
Serialize nested primitive wrapper values

### DIFF
--- a/scripts/coverage_exclusions.json
+++ b/scripts/coverage_exclusions.json
@@ -243,18 +243,18 @@
       "path": "src/core/CSerialization.cpp",
       "reason": "Reviewed legacy uncovered branch baseline; unreviewed coverage changes remain visible in the 95% scoped line gate.",
       "ranges": [
-        "149",
-        "181-182",
-        "231",
-        "275",
-        "301",
-        "317",
-        "339",
-        "345",
-        "353",
-        "365",
+        "239",
+        "271-272",
+        "321",
         "371",
-        "388"
+        "398",
+        "414",
+        "435",
+        "442",
+        "450",
+        "461",
+        "468",
+        "485"
       ]
     },
     {

--- a/src/core/CSerialization.cpp
+++ b/src/core/CSerialization.cpp
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CSerialization.h"
 #include "core/CGame.h"
 #include "core/CJsonUtil.h"
+#include "core/CList.h"
 #include "core/CTypes.h"
 
 #include <stdexcept>
@@ -45,6 +46,87 @@ class CScopedArrayDeserializeContext {
 bool shouldSkipInvalidArrayEntryInStrictMode() {
     return array_deserialize_context.find("property 'quests'") != std::string::npos ||
            array_deserialize_context.find("property 'completedQuests'") != std::string::npos;
+}
+
+std::shared_ptr<json> primitiveValuesConfig(const std::shared_ptr<CGameObject> &object) {
+    if (!object || !CTypes::isPrimitiveType(std::type_index(typeid(*object))) ||
+        !object->meta()->has_property("values", object)) {
+        return nullptr;
+    }
+
+    auto values = std::make_shared<json>();
+    CSerialization::setProperty(values, "values", object->getProperty<std::any>("values"));
+    if (!values->contains("values")) {
+        return nullptr;
+    }
+    return CJsonUtil::clone(&(*values)["values"]);
+}
+
+template <typename T> bool isPrimitiveMapWrapper() {
+    const auto type = std::type_index(typeid(T));
+    return type == std::type_index(typeid(CMapStringString)) || type == std::type_index(typeid(CMapStringInt)) ||
+           type == std::type_index(typeid(CMapIntString)) || type == std::type_index(typeid(CMapIntInt));
+}
+
+template <typename T>
+bool isCompatiblePrimitiveObjectConfig(const std::shared_ptr<CGame> &game, const std::shared_ptr<json> &value) {
+    std::string class_name;
+    if (CJsonUtil::isRef(value)) {
+        if (!game || !game->getObjectHandler()) {
+            return false;
+        }
+        class_name = game->getObjectHandler()->getClass((*value)["ref"].get<std::string>());
+    } else if (CJsonUtil::isType(value)) {
+        class_name = (*value)["class"].get<std::string>();
+    }
+    if (class_name.empty()) {
+        return false;
+    }
+    auto type = game && game->getObjectHandler() ? game->getObjectHandler()->getType(class_name) : nullptr;
+    return type && type->meta()->inherits(T::static_meta()->name());
+}
+
+template <typename T>
+bool shouldKeepPrimitiveObjectConfig(const std::shared_ptr<CGame> &game, const std::shared_ptr<json> &value) {
+    if (!CJsonUtil::isObject(value)) {
+        return false;
+    }
+    return !isPrimitiveMapWrapper<T>() || value->contains("properties") ||
+           isCompatiblePrimitiveObjectConfig<T>(game, value);
+}
+
+template <typename T>
+std::shared_ptr<json> primitiveObjectConfig(const std::shared_ptr<CGame> &game, std::type_index property,
+                                            const std::shared_ptr<json> &value) {
+    if (property != std::type_index(typeid(std::shared_ptr<T>)) || !CTypes::isPrimitiveType<T>() ||
+        shouldKeepPrimitiveObjectConfig<T>(game, value)) {
+        return nullptr;
+    }
+
+    auto config = std::make_shared<json>();
+    (*config)["class"] = T::static_meta()->name();
+    (*config)["properties"]["values"] = *value;
+    return config;
+}
+
+std::shared_ptr<json> primitiveObjectConfig(const std::shared_ptr<CGame> &game, std::type_index property,
+                                            const std::shared_ptr<json> &value) {
+    if (auto config = primitiveObjectConfig<CListString>(game, property, value)) {
+        return config;
+    }
+    if (auto config = primitiveObjectConfig<CListInt>(game, property, value)) {
+        return config;
+    }
+    if (auto config = primitiveObjectConfig<CMapStringString>(game, property, value)) {
+        return config;
+    }
+    if (auto config = primitiveObjectConfig<CMapStringInt>(game, property, value)) {
+        return config;
+    }
+    if (auto config = primitiveObjectConfig<CMapIntString>(game, property, value)) {
+        return config;
+    }
+    return primitiveObjectConfig<CMapIntInt>(game, property, value);
 }
 
 class CGameObjectPointerSerializer : public CSerializerBase {
@@ -124,6 +206,10 @@ std::type_index CSerialization::getProperty(const std::shared_ptr<CGameObject> &
 
 void CSerialization::setArrayProperty(const std::shared_ptr<CGameObject> &object, std::type_index property,
                                       const std::string &key, std::shared_ptr<json> value) {
+    if (auto config = primitiveObjectConfig(object->getGame(), property, value)) {
+        setOtherProperty(std::type_index(typeid(std::shared_ptr<json>)), property, object, key, std::any(config));
+        return;
+    }
     setOtherProperty(std::type_index(typeid(std::shared_ptr<json>)),
                      property != V_VOID ? property : std::type_index(typeid(std::set<std::shared_ptr<CGameObject>>)),
                      object, key, std::any(value));
@@ -131,6 +217,10 @@ void CSerialization::setArrayProperty(const std::shared_ptr<CGameObject> &object
 
 void CSerialization::setObjectProperty(const std::shared_ptr<CGameObject> &object, std::type_index property,
                                        const std::string &key, std::shared_ptr<json> value) {
+    if (auto config = primitiveObjectConfig(object->getGame(), property, value)) {
+        setOtherProperty(std::type_index(typeid(std::shared_ptr<json>)), property, object, key, std::any(config));
+        return;
+    }
     setOtherProperty(std::type_index(typeid(std::shared_ptr<json>)),
                      property != V_VOID ? property : getGenericPropertyType(value), object, key, std::any(value));
 }
@@ -242,6 +332,13 @@ void CSerialization::setProperty(const std::shared_ptr<json> &conf, const std::s
     } else if (propertyType == std::type_index(typeid(bool))) {
         add_member(conf, propertyName, vstd::any_cast<bool>(propertyValue));
     } else {
+        if (CTypes::is_pointer_type(propertyType)) {
+            auto primitiveValues = primitiveValuesConfig(vstd::any_cast<std::shared_ptr<CGameObject>>(propertyValue));
+            if (primitiveValues) {
+                add_member(conf, propertyName, primitiveValues);
+                return;
+            }
+        }
         std::shared_ptr<CSerializerBase> serializer;
         for (const auto &entry : *CTypes::serializers()) {
             auto types = entry.first;

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -105,6 +105,27 @@ class PropertyChangeProbe : public CGameObject {
     int threat_changed_calls = 0;
 };
 
+class PrimitiveSerializationHolder : public CGameObject {
+    V_META(PrimitiveSerializationHolder, CGameObject,
+           V_PROPERTY(PrimitiveSerializationHolder, std::shared_ptr<CListString>, listValues, getListValues,
+                      setListValues),
+           V_PROPERTY(PrimitiveSerializationHolder, std::shared_ptr<CMapStringString>, mapValues, getMapValues,
+                      setMapValues))
+
+  public:
+    std::shared_ptr<CListString> getListValues() { return listValues; }
+
+    void setListValues(std::shared_ptr<CListString> value) { listValues = value; }
+
+    std::shared_ptr<CMapStringString> getMapValues() { return mapValues; }
+
+    void setMapValues(std::shared_ptr<CMapStringString> value) { mapValues = value; }
+
+  private:
+    std::shared_ptr<CListString> listValues;
+    std::shared_ptr<CMapStringString> mapValues;
+};
+
 void drain_event_loop() {
     auto loop = vstd::event_loop<>::instance();
     for (int i = 0; i < 5; ++i) {
@@ -567,6 +588,96 @@ void test_reviewed_value_wrappers_have_explicit_primitive_metadata() {
     expect_true(!CTypes::isPrimitiveType<CStats>(), "multi-property value-like objects should not be primitive");
 }
 
+void test_nested_primitive_wrappers_serialize_direct_values_and_round_trip() {
+    CTypes::register_type_metadata<PrimitiveSerializationHolder, CGameObject>();
+
+    auto game = std::make_shared<CGame>();
+    game->getObjectHandler()->registerType(PrimitiveSerializationHolder::static_meta()->name(),
+                                           []() { return std::make_shared<PrimitiveSerializationHolder>(); });
+    game->getObjectHandler()->registerType(CListString::static_meta()->name(),
+                                           []() { return std::make_shared<CListString>(); });
+    game->getObjectHandler()->registerType(CMapStringString::static_meta()->name(),
+                                           []() { return std::make_shared<CMapStringString>(); });
+
+    auto list_values = std::make_shared<CListString>();
+    list_values->setValues({"north", "south"});
+    auto map_values = std::make_shared<CMapStringString>();
+    map_values->setValues({{"confirm", "enter"}, {"inventory", "i"}});
+
+    auto holder = std::make_shared<PrimitiveSerializationHolder>();
+    holder->setGame(game);
+    holder->setListValues(list_values);
+    holder->setMapValues(map_values);
+
+    auto serialized = CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::serialize(holder);
+    auto properties = &(*serialized)["properties"];
+    auto serialized_list =
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::serialize(list_values);
+
+    expect_true((*properties)["listValues"].is_array(),
+                "nested CListString properties should serialize as their direct JSON array values");
+    expect_true((*properties)["listValues"].size() == 2,
+                "nested CListString direct values should preserve all entries");
+    expect_true((*properties)["mapValues"].is_object() && !CJsonUtil::isObject(&(*properties)["mapValues"]),
+                "nested CMapStringString properties should serialize as their direct JSON object values");
+    expect_true((*properties)["mapValues"]["inventory"].get<std::string>() == "i",
+                "nested CMapStringString direct values should preserve key-value entries");
+    expect_true((*serialized_list)["class"].get<std::string>() == CListString::static_meta()->name() &&
+                    (*serialized_list)["properties"].contains("values"),
+                "top-level primitive wrappers should keep their object identity");
+
+    auto round_trip = std::dynamic_pointer_cast<PrimitiveSerializationHolder>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game, serialized));
+
+    expect_true(round_trip && round_trip->getListValues(),
+                "direct CListString JSON values should deserialize back into the primitive wrapper property");
+    expect_true(round_trip && round_trip->getMapValues(),
+                "direct CMapStringString JSON values should deserialize back into the primitive wrapper property");
+    expect_true(round_trip->getListValues()->getValues() == std::set<std::string>({"north", "south"}),
+                "CListString primitive wrapper values should round-trip through direct nested JSON");
+    expect_true(round_trip->getMapValues()->getValues() ==
+                    std::map<std::string, std::string>({{"confirm", "enter"}, {"inventory", "i"}}),
+                "CMapStringString primitive wrapper values should round-trip through direct nested JSON");
+
+    auto reserved_key_map_values = std::make_shared<CMapStringString>();
+    reserved_key_map_values->setValues({{"ref", "north"}});
+    holder->setMapValues(reserved_key_map_values);
+
+    auto serialized_reserved_map =
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::serialize(holder);
+    auto reserved_map_properties = &(*serialized_reserved_map)["properties"];
+
+    expect_true(CJsonUtil::isObject(&(*reserved_map_properties)["mapValues"]),
+                "single-entry flattened maps can have object-config-shaped keys");
+
+    auto reserved_map_round_trip = std::dynamic_pointer_cast<PrimitiveSerializationHolder>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game,
+                                                                                              serialized_reserved_map));
+
+    expect_true(reserved_map_round_trip && reserved_map_round_trip->getMapValues() &&
+                    reserved_map_round_trip->getMapValues()->getValues() ==
+                        std::map<std::string, std::string>({{"ref", "north"}}),
+                "CMapStringString flattened values named ref should deserialize as primitive map entries");
+
+    auto panel_keys_config = std::make_shared<json>();
+    (*panel_keys_config)["class"] = CMapStringString::static_meta()->name();
+    (*panel_keys_config)["properties"]["values"] = {{"i", "inventoryPanel"}, {"j", "questPanel"}};
+    game->getObjectHandler()->registerConfig("panelKeys", panel_keys_config);
+
+    auto holder_with_ref_config = std::make_shared<json>();
+    (*holder_with_ref_config)["class"] = PrimitiveSerializationHolder::static_meta()->name();
+    (*holder_with_ref_config)["properties"]["mapValues"]["ref"] = "panelKeys";
+
+    auto ref_round_trip = std::dynamic_pointer_cast<PrimitiveSerializationHolder>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game,
+                                                                                              holder_with_ref_config));
+
+    expect_true(ref_round_trip && ref_round_trip->getMapValues() &&
+                    ref_round_trip->getMapValues()->getValues() ==
+                        std::map<std::string, std::string>({{"i", "inventoryPanel"}, {"j", "questPanel"}}),
+                "CMapStringString object refs should resolve to the referenced primitive wrapper");
+}
+
 void test_nested_property_notification_batches_emit_one_deterministic_signal() {
     CTypes::register_type_metadata<PropertyChangeProbe, CGameObject>();
 
@@ -897,6 +1008,7 @@ int main() {
     test_tag_mutation_iteration_and_range_helpers();
     test_property_setters_emit_change_signals();
     test_reviewed_value_wrappers_have_explicit_primitive_metadata();
+    test_nested_primitive_wrappers_serialize_direct_values_and_round_trip();
     test_nested_property_notification_batches_emit_one_deterministic_signal();
     test_object_deserialization_batches_property_notifications();
     test_object_clone_batches_property_notifications();


### PR DESCRIPTION
## Summary
- flatten nested primitive wrapper properties by serializing registered primitive wrappers through their `values` payload
- inflate direct JSON array/object values back into typed primitive wrapper properties during deserialization
- preserve flattened `CMapStringString` entries named `ref` or `class` instead of misreading them as object refs/classes
- keep compatible primitive-wrapper object refs/classes, including sidebar `panelKeys`, resolving as object configs instead of direct map values
- add focused native regressions for nested `CListString`, `CMapStringString`, top-level primitive identity, object-shaped map keys, and referenced primitive map configs
- update the reviewed `CSerialization.cpp` coverage exclusion line numbers after the serializer helper insertion

## Why
Nested primitive wrapper values were still emitted as full `{class, properties}` object configs even though the primitive registration metadata identifies their underlying value payloads. This blocked the planned save-format flattening path. Single-key map values such as `{"ref":"north"}` still need to round-trip as primitive map data, while real object refs such as `{"ref":"panelKeys"}` must continue resolving through the object handler.

## Validation
- `clang-format -i src/core/CSerialization.cpp tests/unit/test_core.cpp`
- `clang-format --dry-run --Werror src/core/CSerialization.cpp tests/unit/test_core.cpp`
- `python3 -m json.tool scripts/coverage_exclusions.json > /tmp/pr551-coverage-exclusions-normalized-review-fix.json`
- `python3 -m unittest test.CoverageReportTest`
- `git diff --check`
- Native/full validation not run locally per queue-controller policy; this touches `src/core/**` and `tests/unit/**`, so PR delivery requires `build / linux` with coverage evidence.

## Queue
- Issue: `[EPIC_03][STORY_04][SUBSTORY_02]Serialize primitive values directly`
- Claim ID: `6c8c9801-7af6-4ff9-a97f-6a374e463a46`
- Owner: `controller/ctrl-lis-2-05df2af9/subagent-6`
