### PR TITLE
Add CListView property refresh subscriptions

### DIFF
--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -425,22 +425,30 @@ void CListView::setSelect(std::string select) { CListView::select = select; }
 
 std::shared_ptr<CScript> CListView::getRefreshObject() { return refreshObject; }
 
-void CListView::setRefreshObject(std::shared_ptr<CScript> refreshObject) { CListView::refreshObject = refreshObject; }
+void CListView::setRefreshObject(std::shared_ptr<CScript> refreshObject) {
+    CListView::refreshObject = refreshObject;
+    refreshSubscriptions();
+}
 
 std::string CListView::getRefreshEvent() { return refreshEvent; }
 
-void CListView::setRefreshEvent(std::string refreshEvent) { CListView::refreshEvent = refreshEvent; }
+void CListView::setRefreshEvent(std::string refreshEvent) {
+    CListView::refreshEvent = refreshEvent;
+    refreshSubscriptions();
+}
 
 bool CListView::getRefreshOnPropertyChanged() { return refreshOnPropertyChanged; }
 
 void CListView::setRefreshOnPropertyChanged(bool refreshOnPropertyChanged) {
     CListView::refreshOnPropertyChanged = refreshOnPropertyChanged;
+    refreshSubscriptions();
 }
 
 std::set<std::string> CListView::getRefreshProperties() { return refreshProperties; }
 
 void CListView::setRefreshProperties(std::set<std::string> refreshProperties) {
     CListView::refreshProperties = std::move(refreshProperties);
+    refreshSubscriptions();
 }
 
 void CListView::initialize() {

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -30,6 +30,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "handler/CEventHandler.h"
 #include <cstdlib>
 #include <exception>
+#include <utility>
 
 namespace {
 std::shared_ptr<CAnimation> createListItemAnimation(const std::shared_ptr<CGui> &gui,
@@ -430,6 +431,18 @@ std::string CListView::getRefreshEvent() { return refreshEvent; }
 
 void CListView::setRefreshEvent(std::string refreshEvent) { CListView::refreshEvent = refreshEvent; }
 
+bool CListView::getRefreshOnPropertyChanged() { return refreshOnPropertyChanged; }
+
+void CListView::setRefreshOnPropertyChanged(bool refreshOnPropertyChanged) {
+    CListView::refreshOnPropertyChanged = refreshOnPropertyChanged;
+}
+
+std::set<std::string> CListView::getRefreshProperties() { return refreshProperties; }
+
+void CListView::setRefreshProperties(std::set<std::string> refreshProperties) {
+    CListView::refreshProperties = std::move(refreshProperties);
+}
+
 void CListView::initialize() {
     auto self = this->ptr<CListView>();
     vstd::call_when(
@@ -438,15 +451,121 @@ void CListView::initialize() {
                    self->getGui()->getGame()->getMap() != nullptr;
         },
         [self]() {
-            if (self->refreshObject) {
-                auto refreshTarget = self->refreshObject->invoke(self->getGui()->getGame(), self);
-                if (refreshTarget) {
-                    refreshTarget->connect(self->refreshEvent, self, "refresh");
-                    refreshTarget->connect(self->refreshEvent, self, "refreshAll");
-                }
-            }
+            self->refreshSubscriptions();
             self->refresh();
         });
+}
+
+void CListView::refreshFromRefreshEvent() { refreshFromSubscription(); }
+
+void CListView::refreshFromPropertyChanged(std::string propertyName) {
+    refreshSubscriptions();
+    if (shouldRefreshForProperty(propertyName)) {
+        refreshFromSubscription();
+    }
+}
+
+void CListView::refreshFromPropertiesChanged(std::set<std::string> propertyNames) {
+    refreshSubscriptions();
+    bool shouldRefresh = refreshOnPropertyChanged;
+    for (const auto &propertyName : propertyNames) {
+        shouldRefresh = shouldRefresh || shouldRefreshForProperty(propertyName);
+    }
+    if (shouldRefresh) {
+        refreshFromSubscription();
+    }
+}
+
+void CListView::refreshFromPropertySpecificChanged() {
+    refreshSubscriptions();
+    refreshFromSubscription();
+}
+
+std::shared_ptr<CGameObject> CListView::resolveRefreshTarget() {
+    if (!refreshObject) {
+        return nullptr;
+    }
+    auto gui = getGui();
+    if (!gui || !gui->getGame()) {
+        return nullptr;
+    }
+    return refreshObject->invoke(gui->getGame(), this->ptr<CListView>());
+}
+
+void CListView::refreshSubscriptions() {
+    auto refreshTarget = resolveRefreshTarget();
+    auto subscribedTarget = refreshSubscriptionTarget.lock();
+    if (subscribedTarget == refreshTarget && subscribedRefreshEvent == refreshEvent &&
+        subscribedRefreshOnPropertyChanged == refreshOnPropertyChanged &&
+        subscribedRefreshProperties == refreshProperties) {
+        return;
+    }
+
+    disconnectRefreshSubscriptions();
+    refreshSubscriptionTarget = refreshTarget;
+    subscribedRefreshEvent = refreshEvent;
+    subscribedRefreshOnPropertyChanged = refreshOnPropertyChanged;
+    subscribedRefreshProperties = refreshProperties;
+    connectRefreshSubscriptions(refreshTarget);
+}
+
+void CListView::disconnectRefreshSubscriptions() {
+    auto refreshTarget = refreshSubscriptionTarget.lock();
+    if (!refreshTarget) {
+        return;
+    }
+
+    auto self = this->ptr<CListView>();
+    if (!subscribedRefreshEvent.empty()) {
+        refreshTarget->disconnect(subscribedRefreshEvent, self, "refreshFromRefreshEvent");
+    }
+    if (subscribedRefreshOnPropertyChanged) {
+        refreshTarget->disconnect("propertyChanged", self, "refreshFromPropertyChanged");
+    }
+    if (subscribedRefreshOnPropertyChanged || !subscribedRefreshProperties.empty()) {
+        refreshTarget->disconnect("propertiesChanged", self, "refreshFromPropertiesChanged");
+    }
+    if (!subscribedRefreshOnPropertyChanged) {
+        for (const auto &propertyName : subscribedRefreshProperties) {
+            if (!propertyName.empty()) {
+                refreshTarget->disconnect(propertyName + "Changed", self, "refreshFromPropertySpecificChanged");
+            }
+        }
+    }
+}
+
+void CListView::connectRefreshSubscriptions(const std::shared_ptr<CGameObject> &refreshTarget) {
+    if (!refreshTarget) {
+        return;
+    }
+
+    auto self = this->ptr<CListView>();
+    if (!refreshEvent.empty()) {
+        refreshTarget->connect(refreshEvent, self, "refreshFromRefreshEvent");
+    }
+    if (refreshOnPropertyChanged) {
+        refreshTarget->connect("propertyChanged", self, "refreshFromPropertyChanged");
+    }
+    if (refreshOnPropertyChanged || !refreshProperties.empty()) {
+        refreshTarget->connect("propertiesChanged", self, "refreshFromPropertiesChanged");
+    }
+    if (!refreshOnPropertyChanged) {
+        for (const auto &propertyName : refreshProperties) {
+            if (!propertyName.empty()) {
+                refreshTarget->connect(propertyName + "Changed", self, "refreshFromPropertySpecificChanged");
+            }
+        }
+    }
+}
+
+void CListView::refreshFromSubscription() {
+    refreshSubscriptions();
+    refresh();
+    refreshAll();
+}
+
+bool CListView::shouldRefreshForProperty(const std::string &propertyName) const {
+    return refreshOnPropertyChanged || refreshProperties.contains(propertyName);
 }
 
 int CListView::getXPrefferedSize() const { return xPrefferedSize; }

--- a/src/gui/panel/CListView.h
+++ b/src/gui/panel/CListView.h
@@ -31,12 +31,19 @@ class CListView : public CProxyTargetGraphicsObject {
            V_PROPERTY(CListView, std::string, rightClickCallback, getRightClickCallback, setRightClickCallback),
            V_PROPERTY(CListView, std::shared_ptr<CScript>, refreshObject, getRefreshObject, setRefreshObject),
            V_PROPERTY(CListView, std::string, refreshEvent, getRefreshEvent, setRefreshEvent),
+           V_PROPERTY(CListView, bool, refreshOnPropertyChanged, getRefreshOnPropertyChanged,
+                      setRefreshOnPropertyChanged),
+           V_PROPERTY(CListView, std::set<std::string>, refreshProperties, getRefreshProperties, setRefreshProperties),
            V_PROPERTY(CListView, int, xPrefferedSize, getXPrefferedSize, setXPrefferedSize),
            V_PROPERTY(CListView, int, yPrefferedSize, getYPrefferedSize, setYPrefferedSize),
            V_PROPERTY(CListView, int, tileSize, getTileSize, setTileSize),
            V_PROPERTY(CListView, bool, allowOversize, getAllowOversize, setAllowOversize),
            V_PROPERTY(CListView, bool, showEmpty, getShowEmpty, setShowEmpty),
-           V_PROPERTY(CListView, bool, grouping, getGrouping, setGrouping), V_METHOD(CListView, initialize))
+           V_PROPERTY(CListView, bool, grouping, getGrouping, setGrouping), V_METHOD(CListView, initialize),
+           V_METHOD(CListView, refreshFromRefreshEvent),
+           V_METHOD(CListView, refreshFromPropertyChanged, void, std::string),
+           V_METHOD(CListView, refreshFromPropertiesChanged, void, std::set<std::string>),
+           V_METHOD(CListView, refreshFromPropertySpecificChanged))
 
     std::string collection;
 
@@ -63,10 +70,38 @@ class CListView : public CProxyTargetGraphicsObject {
 
     void setRefreshEvent(std::string refreshEvent);
 
+    bool getRefreshOnPropertyChanged();
+
+    void setRefreshOnPropertyChanged(bool refreshOnPropertyChanged);
+
+    std::set<std::string> getRefreshProperties();
+
+    void setRefreshProperties(std::set<std::string> refreshProperties);
+
     void initialize();
+
+    void refreshFromRefreshEvent();
+
+    void refreshFromPropertyChanged(std::string propertyName);
+
+    void refreshFromPropertiesChanged(std::set<std::string> propertyNames);
+
+    void refreshFromPropertySpecificChanged();
 
   private:
     std::string refreshEvent;
+
+    bool refreshOnPropertyChanged = false;
+
+    std::set<std::string> refreshProperties;
+
+    std::weak_ptr<CGameObject> refreshSubscriptionTarget;
+
+    std::string subscribedRefreshEvent;
+
+    bool subscribedRefreshOnPropertyChanged = false;
+
+    std::set<std::string> subscribedRefreshProperties;
 
     bool allowOversize = true;
 
@@ -196,4 +231,18 @@ class CListView : public CProxyTargetGraphicsObject {
                      std::list<std::shared_ptr<CGameGraphicsObject>> &return_val) const;
 
     int getItemTypesCount(const std::shared_ptr<CGui> &gui);
+
+  protected:
+    virtual std::shared_ptr<CGameObject> resolveRefreshTarget();
+
+  private:
+    void refreshSubscriptions();
+
+    void disconnectRefreshSubscriptions();
+
+    void connectRefreshSubscriptions(const std::shared_ptr<CGameObject> &refreshTarget);
+
+    void refreshFromSubscription();
+
+    bool shouldRefreshForProperty(const std::string &propertyName) const;
 };

--- a/src/object/CGameObject.cpp
+++ b/src/object/CGameObject.cpp
@@ -165,6 +165,20 @@ void CGameObject::connect(std::string signal, std::shared_ptr<CGameObject> objec
     connections.emplace_back(signal, object, slot);
 }
 
+void CGameObject::disconnect(const std::string &signal, const std::shared_ptr<CGameObject> &object,
+                             const std::string &slot) {
+    auto it = connections.begin();
+    while (it != connections.end()) {
+        auto &[connectedSignal, connectedObject, connectedSlot] = *it;
+        auto target = connectedObject.lock();
+        if (!target || (connectedSignal == signal && target == object && connectedSlot == slot)) {
+            it = connections.erase(it);
+            continue;
+        }
+        ++it;
+    }
+}
+
 void CGameObject::notifyPropertyChanged(const std::string &name) {
     signal("propertyChanged", name);
     signal(name + "Changed");

--- a/src/object/CGameObject.h
+++ b/src/object/CGameObject.h
@@ -162,6 +162,8 @@ class CGameObject : public vstd::stringable, public std::enable_shared_from_this
 
     void connect(std::string signal, std::shared_ptr<CGameObject> object, std::string slot);
 
+    void disconnect(const std::string &signal, const std::shared_ptr<CGameObject> &object, const std::string &slot);
+
     void notifyPropertyChanged(const std::string &name);
 
     void notifyPropertiesChanged(const std::set<std::string> &names);

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -26,11 +26,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/object/CWidget.h"
 #include "gui/panel/CGameInventoryPanel.h"
 #include "gui/panel/CGamePanel.h"
+#include "gui/panel/CListView.h"
 #include "object/CItem.h"
 #include "object/CPlayer.h"
 #include "test_harness.h"
 
 #include <pybind11/embed.h>
+
+#include <utility>
 
 namespace {
 
@@ -104,6 +107,37 @@ class MouseEventRecorder : public CGameGraphicsObject {
     int last_wheel_y = 0;
 };
 
+class RefreshCountingListView : public CListView {
+  public:
+    int getSizeX(std::shared_ptr<CGui>) override { return 1; }
+
+    int getSizeY(std::shared_ptr<CGui>) override { return 1; }
+
+    std::list<std::shared_ptr<CGameGraphicsObject>> getProxiedObjects(std::shared_ptr<CGui>, int, int) override {
+        ++refresh_count;
+        return {};
+    }
+
+    void setResolvedRefreshTarget(std::shared_ptr<CGameObject> refresh_target) {
+        resolvedRefreshTarget = std::move(refresh_target);
+    }
+
+    int refresh_count = 0;
+
+  protected:
+    std::shared_ptr<CGameObject> resolveRefreshTarget() override { return resolvedRefreshTarget; }
+
+  private:
+    std::shared_ptr<CGameObject> resolvedRefreshTarget;
+};
+
+void drain_event_loop() {
+    auto loop = vstd::event_loop<>::instance();
+    for (int i = 0; i < 5; ++i) {
+        loop->run();
+    }
+}
+
 std::shared_ptr<MouseEventRecorder> attach_mouse_recorder(const std::shared_ptr<CGui> &gui) {
     auto recorder = std::make_shared<MouseEventRecorder>();
     auto layout = std::make_shared<CLayout>();
@@ -133,11 +167,122 @@ std::shared_ptr<DropTargetRecorder> attach_drop_target_recorder(const std::share
     return recorder;
 }
 
+std::shared_ptr<CGame> create_gui_game(const std::shared_ptr<CGui> &gui) {
+    auto game = std::make_shared<CGame>();
+    auto map = std::make_shared<CMap>();
+    game->setMap(map);
+    game->setGui(gui);
+    map->setGame(game);
+    gui->setGame(game);
+    return game;
+}
+
 void test_widget_ignores_unarmed_non_left_clicks() {
     auto widget = std::make_shared<CWidget>();
 
     expect_true(!widget->mouseEvent(nullptr, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_RIGHT, 0, 0),
                 "plain widget should ignore right clicks when no click callback is armed");
+}
+
+void test_list_view_refreshes_from_generic_property_notifications() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    create_gui_game(gui);
+    auto refresh_target = std::make_shared<CGameObject>();
+    auto list = std::make_shared<RefreshCountingListView>();
+    list->setResolvedRefreshTarget(refresh_target);
+    list->setRefreshOnPropertyChanged(true);
+    gui->pushChild(list);
+
+    list->initialize();
+    drain_event_loop();
+    const int after_initial_refresh = list->refresh_count;
+
+    refresh_target->setNumericProperty("threat", 1);
+    drain_event_loop();
+
+    expect_true(list->refresh_count == after_initial_refresh + 1,
+                "generic propertyChanged subscription should refresh the list for any changed property");
+}
+
+void test_list_view_refresh_event_compatibility() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    create_gui_game(gui);
+    auto refresh_target = std::make_shared<CGameObject>();
+    auto list = std::make_shared<RefreshCountingListView>();
+    list->setResolvedRefreshTarget(refresh_target);
+    list->setRefreshEvent("legacyRefresh");
+    gui->pushChild(list);
+
+    list->initialize();
+    drain_event_loop();
+    const int after_initial_refresh = list->refresh_count;
+
+    refresh_target->signal("legacyRefresh");
+    drain_event_loop();
+
+    expect_true(list->refresh_count == after_initial_refresh + 1,
+                "legacy no-argument refreshEvent subscription should still refresh the list");
+}
+
+void test_list_view_property_subscriptions_follow_resolved_target_and_null() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    create_gui_game(gui);
+    auto first_target = std::make_shared<CGameObject>();
+    auto second_target = std::make_shared<CGameObject>();
+    auto list = std::make_shared<RefreshCountingListView>();
+    list->setResolvedRefreshTarget(first_target);
+    list->setRefreshProperties({"label"});
+    gui->pushChild(list);
+
+    list->initialize();
+    drain_event_loop();
+    const int after_initial_refresh = list->refresh_count;
+
+    first_target->setStringProperty("label", "first");
+    drain_event_loop();
+    expect_true(list->refresh_count == after_initial_refresh + 1,
+                "property-specific subscription should refresh for the selected property");
+
+    first_target->setNumericProperty("threat", 1);
+    drain_event_loop();
+    expect_true(list->refresh_count == after_initial_refresh + 1,
+                "property-specific subscription should ignore unrelated property notifications");
+
+    list->setResolvedRefreshTarget(second_target);
+    first_target->setStringProperty("label", "handoff");
+    drain_event_loop();
+    expect_true(list->refresh_count == after_initial_refresh + 2,
+                "subscription refresh should reconnect when the resolved refresh target changes");
+
+    first_target->setStringProperty("label", "stale");
+    drain_event_loop();
+    expect_true(list->refresh_count == after_initial_refresh + 2,
+                "old refresh target should be disconnected after reconnecting to a new target");
+
+    second_target->setStringProperty("label", "second");
+    drain_event_loop();
+    expect_true(list->refresh_count == after_initial_refresh + 3,
+                "new refresh target should drive later property-specific refreshes");
+
+    list->setResolvedRefreshTarget(nullptr);
+    second_target->setStringProperty("label", "to-null");
+    drain_event_loop();
+    expect_true(list->refresh_count == after_initial_refresh + 4,
+                "subscription refresh should handle the refresh script resolving to null");
+
+    second_target->setStringProperty("label", "after-null");
+    drain_event_loop();
+    expect_true(list->refresh_count == after_initial_refresh + 4,
+                "previous refresh target should be disconnected when the refresh script resolves to null");
 }
 
 std::shared_ptr<CStats> player_stats() {
@@ -419,6 +564,9 @@ int main() {
     pybind11::scoped_interpreter guard{};
 
     test_widget_ignores_unarmed_non_left_clicks();
+    test_list_view_refreshes_from_generic_property_notifications();
+    test_list_view_refresh_event_compatibility();
+    test_list_view_property_subscriptions_follow_resolved_target_and_null();
     test_inventory_double_select_uses_selected_item_and_clears_selection();
     test_panel_event_callbacks_stop_after_close();
     test_gui_routes_mouse_motion_to_target_child();

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -108,6 +108,8 @@ class MouseEventRecorder : public CGameGraphicsObject {
 };
 
 class RefreshCountingListView : public CListView {
+    V_META(RefreshCountingListView, CListView, vstd::meta::empty())
+
   public:
     int getSizeX(std::shared_ptr<CGui>) override { return 1; }
 

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -19,6 +19,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CGame.h"
 #include "core/CMap.h"
 #include "core/CStats.h"
+#include "core/CTypeRegistration.h"
+#include "core/CTypes.h"
 #include "gui/CGui.h"
 #include "gui/CLayout.h"
 #include "gui/CTextureCache.h"
@@ -171,6 +173,11 @@ std::shared_ptr<DropTargetRecorder> attach_drop_target_recorder(const std::share
 }
 
 std::shared_ptr<CGame> create_gui_game(const std::shared_ptr<CGui> &gui) {
+    type_registration::registerGuiTypes();
+    type_registration::registerGuiPanelTypes();
+    CTypes::register_type_metadata<RefreshCountingListView, CListView, CProxyTargetGraphicsObject, CGameGraphicsObject,
+                                   CGameObject>();
+
     auto game = std::make_shared<CGame>();
     auto map = std::make_shared<CMap>();
     game->setMap(map);

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -27,6 +27,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/panel/CGameInventoryPanel.h"
 #include "gui/panel/CGamePanel.h"
 #include "gui/panel/CListView.h"
+#include "handler/CObjectHandler.h"
 #include "object/CItem.h"
 #include "object/CPlayer.h"
 #include "test_harness.h"
@@ -176,6 +177,8 @@ std::shared_ptr<CGame> create_gui_game(const std::shared_ptr<CGui> &gui) {
     game->setGui(gui);
     map->setGame(game);
     gui->setGame(game);
+    game->getObjectHandler()->registerType(CProxyGraphicsLayout::static_meta()->name(),
+                                           []() { return std::make_shared<CProxyGraphicsLayout>(); });
     return game;
 }
 

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -197,12 +197,11 @@ void test_list_view_refreshes_from_generic_property_notifications() {
     create_gui_game(gui);
     auto refresh_target = std::make_shared<CGameObject>();
     auto list = std::make_shared<RefreshCountingListView>();
+    gui->pushChild(list);
     list->setResolvedRefreshTarget(refresh_target);
     list->setRefreshOnPropertyChanged(true);
-    gui->pushChild(list);
 
-    list->initialize();
-    drain_event_loop();
+    list->refresh();
     const int after_initial_refresh = list->refresh_count;
 
     refresh_target->setNumericProperty("threat", 1);
@@ -220,12 +219,11 @@ void test_list_view_refresh_event_compatibility() {
     create_gui_game(gui);
     auto refresh_target = std::make_shared<CGameObject>();
     auto list = std::make_shared<RefreshCountingListView>();
+    gui->pushChild(list);
     list->setResolvedRefreshTarget(refresh_target);
     list->setRefreshEvent("legacyRefresh");
-    gui->pushChild(list);
 
-    list->initialize();
-    drain_event_loop();
+    list->refresh();
     const int after_initial_refresh = list->refresh_count;
 
     refresh_target->signal("legacyRefresh");
@@ -244,12 +242,11 @@ void test_list_view_property_subscriptions_follow_resolved_target_and_null() {
     auto first_target = std::make_shared<CGameObject>();
     auto second_target = std::make_shared<CGameObject>();
     auto list = std::make_shared<RefreshCountingListView>();
+    gui->pushChild(list);
     list->setResolvedRefreshTarget(first_target);
     list->setRefreshProperties({"label"});
-    gui->pushChild(list);
 
-    list->initialize();
-    drain_event_loop();
+    list->refresh();
     const int after_initial_refresh = list->refresh_count;
 
     first_target->setStringProperty("label", "first");


### PR DESCRIPTION
## Summary
- add CListView refresh subscriptions for generic propertyChanged/propertiesChanged and configured property-specific notifications
- preserve refreshEvent compatibility through a wrapper that refreshes the list and proxied children
- add CGameObject::disconnect for exact signal/slot cleanup and focused GUI unit coverage for target changes and null targets

## Why
Row 107 requires ListView to refresh from property notifications without panel-specific refresh calls, while safely reconnecting when the resolved refresh object changes.

## Validation
- git diff --check origin/main...HEAD
- git diff --exit-code -- planning/fall_of_nouraajd_issue_proposals.xlsx
- clang-format --dry-run --Werror src/gui/panel/CListView.cpp src/gui/panel/CListView.h src/object/CGameObject.cpp src/object/CGameObject.h tests/unit/test_gui.cpp

## Notes
- Local native builds, ctest, full Python suite, and local coverage were skipped per queue-controller policy.
- This PR touches src/object and tests/unit, so CI linux polling must require the coverage step before merge.