### PR TITLE
Auto-require coverage polling for coverage paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,23 +215,25 @@ locally:
 python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux
 ```
 
-For coverage-relevant changes, require the CI `coverage` step explicitly:
+For coverage-relevant changes, the poller auto-requires the CI `coverage` step when changed paths match the workflow
+coverage rule. Passing `--require-step coverage` explicitly is still valid when the caller wants to force that check:
 
 ```sh
 python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux --require-step coverage
 ```
 
 Run heavy local Linux validation only when the PR workflow cannot cover the required evidence, a focused local
-reproduction is necessary before opening the PR, or GitHub Actions polling is unavailable or blocked. Passing the PR `build / linux`
-check, polled with `python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux`, is sufficient PR delivery evidence for
-Linux compilation, native tests, native performance guards, Python suites, and conditional coverage. Coverage is
-satisfied by CI only when the workflow's path rule runs the `coverage` step inside `linux`; use `--require-step coverage`
-for coverage-relevant changes. Additional Windows, release, MCP gameplay, manual, or platform-specific validation is
-needed only when the task explicitly targets that surface or the user requests it. Report local commands, skipped or
-blocked local commands, and CI job names/conclusions separately; never imply a skipped local command passed. When CI
-polling supplies the full validation evidence, wait for the selected check(s) to pass before enabling auto-merge. If
-GitHub merges before polling finishes, stop waiting on that Actions run, fetch `origin/main`, verify the merge, and
-continue from the merged state.
+reproduction is necessary before opening the PR, or GitHub Actions polling is unavailable or blocked. Passing the PR
+`build / linux` check, polled with `python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux`, is sufficient PR
+delivery evidence for Linux compilation, native tests, native performance guards, Python suites, and conditional
+coverage. Coverage is satisfied by CI only when the workflow's path rule runs the `coverage` step somewhere in the
+selected build workflow run, currently in the conditional `linux-coverage` job; the poller auto-adds this step for
+coverage-relevant PR paths. Additional Windows, release, MCP gameplay, manual, or platform-specific validation is needed
+only when the task explicitly targets that surface or the user requests it. Report local commands, skipped or blocked
+local commands, and CI job names/conclusions separately; never imply a skipped local command passed. When CI polling
+supplies the full validation evidence, wait for the selected check(s) to pass before enabling auto-merge. If GitHub
+merges before polling finishes, stop waiting on that Actions run, fetch `origin/main`, verify the merge, and continue
+from the merged state.
 
 Windows Release equivalent:
 

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -278,7 +278,9 @@ full Python suite, and coverage by polling GitHub Actions instead of duplicating
 python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux
 ```
 
-For coverage-relevant changes, require the conditional coverage step explicitly:
+For coverage-relevant changes, the poller auto-requires the conditional coverage step when changed paths match the
+workflow coverage rule. Passing `--require-step coverage` explicitly is still valid when the caller wants to force that
+check:
 
 ```bash
 python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux --require-step coverage
@@ -286,12 +288,13 @@ python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux --require-step cover
 
 Run heavy local Linux validation only when CI cannot cover the required evidence, a focused local reproduction is
 necessary before opening the PR, or GitHub Actions polling is unavailable or blocked. Report focused local checks
-separately from CI-polled validation. Passing `build / linux` is sufficient PR delivery evidence for Linux compilation, native tests,
-native performance guards, Python suites, and conditional coverage. It proves coverage only when the workflow's
-changed-path rule runs its `coverage` step; use `--require-step coverage` for coverage-relevant changes. Additional
-platform, release, MCP gameplay, manual, or issue-specific validation is needed only when the task targets that surface
-or the user requests it. Do not enable auto-merge until CI-polled validation passes when it is the only full-validation
-evidence.
+separately from CI-polled validation. Passing `build / linux` is sufficient PR delivery evidence for Linux compilation,
+native tests, native performance guards, Python suites, and conditional coverage. It proves coverage only when the
+workflow's changed-path rule runs its `coverage` step somewhere in the selected build workflow run, currently in the
+conditional `linux-coverage` job; the poller auto-adds this step for coverage-relevant PR paths. Additional platform,
+release, MCP gameplay, manual, or issue-specific validation is needed only when the task targets that surface or the
+user requests it.
+Do not enable auto-merge until CI-polled validation passes when it is the only full-validation evidence.
 
 Workbook-only queue-state PRs that update only `planning/fall_of_nouraajd_issue_proposals.xlsx` are different from
 implementation PRs. After reviewing that the diff is XLSX-only and running `python3 scripts/issue_queue.py validate`,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -120,9 +120,9 @@ Recommended required status checks:
 - `windows` (shown in some GitHub branch-protection UI as `build / windows`)
 
 These jobs cover the current PR build, native C++ tests, native performance guards, Python regression suite, dependency
-cache validation, and packaging on Linux and Windows. The Linux job also runs `./scripts/run_coverage.sh` when the
-changed paths match the workflow coverage rule, so coverage is conditional inside `linux` rather than a separate
-always-present check.
+cache validation, and packaging on Linux and Windows. The workflow also has a conditional `linux-coverage` job that runs
+`./scripts/run_coverage.sh` when changed paths match the coverage rule; because it is path-gated, do not configure it as
+an always-present branch-protection check.
 
 ## CI-Polled Validation
 For local agents, prefer the PR `linux` job as the default delivery path for heavy Linux validation. Run focused local
@@ -139,19 +139,21 @@ Use `--check` more than once only when the task explicitly needs additional plat
 python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux --check windows-deps --check windows
 ```
 
-For coverage-relevant changes, require the conditional coverage step explicitly:
+For coverage-relevant changes, the poller auto-requires the conditional coverage step when changed paths match the
+workflow coverage rule. Passing `--require-step coverage` explicitly is still valid when the caller wants to force that
+check:
 
 ```bash
 python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux --require-step coverage
 ```
 
 Run heavy local Linux validation only when CI cannot cover the required evidence, a focused local reproduction is
-necessary before opening the PR, or GitHub Actions polling is unavailable or blocked. Passing `build / linux` is sufficient PR
-delivery evidence for the Release build, native tests, performance guard, gameplay suite, UI suite, and conditional
-coverage. It proves coverage only when the workflow's changed-path rule runs the `coverage` step; use
-`--require-step coverage` for coverage-relevant changes. Record the polled job name, conclusion, and URL separately from
-local commands. Do not report skipped local commands as passed, and do not enable auto-merge until the selected
-CI-polled validation has passed when it is the only full-validation evidence.
+necessary before opening the PR, or GitHub Actions polling is unavailable or blocked. Passing `build / linux` is
+sufficient PR delivery evidence for the Release build, native tests, performance guard, gameplay suite, and UI suite. It
+proves coverage only when the workflow's changed-path rule runs the `coverage` step somewhere in the selected build
+workflow run, currently in `linux-coverage`; the poller auto-adds that step for coverage-relevant PR paths. Record the
+polled job name, conclusion, and URL separately from local commands. Do not report skipped local commands as passed, and
+do not enable auto-merge until the selected CI-polled validation has passed when it is the only full-validation evidence.
 
 Manual repository settings for `main`:
 - require a pull request before merging
@@ -164,9 +166,10 @@ If future work splits fast, gameplay, UI/Xvfb, or coverage runs into separate PR
 protection only after they finish deterministically in CI.
 
 ## Coverage Workflow
-For PR delivery, satisfy coverage through the PR `linux` job when its coverage step runs and passes. Run local coverage
-only when CI cannot cover the required evidence, polling is unavailable, or a focused local coverage reproduction is
-necessary. Coverage is required when a change touches tests (for example
+For PR delivery, satisfy coverage by polling the selected build workflow run; the `coverage` step currently runs in the
+conditional `linux-coverage` job. Run local coverage only when CI cannot cover the required evidence, polling is
+unavailable, or a focused local coverage reproduction is necessary. Coverage is required when a change touches tests,
+for example
 `test.py` or `tests/unit/**`), `src/core/**`, `src/handler/**`,
 `src/object/**`, `native_plugins/**`, or the coverage tooling:
 

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -480,20 +480,23 @@ the implementation PR and polling GitHub Actions instead of duplicating those he
 python3 scripts/poll_pr_checks.py "$PR_NUMBER" --check linux
 ```
 
-For coverage-relevant changes, require the conditional coverage step explicitly:
+For coverage-relevant changes, the poller auto-requires the conditional coverage step when changed paths match the
+workflow coverage rule. Passing `--require-step coverage` explicitly is still valid when the caller wants to force that
+check:
 
 ```bash
 python3 scripts/poll_pr_checks.py "$PR_NUMBER" --check linux --require-step coverage
 ```
 
 Run heavy local Linux validation only when CI cannot cover the required evidence, a focused local reproduction is
-necessary before opening the PR, or GitHub Actions polling is unavailable or blocked. Passing `build / linux` is sufficient PR
-delivery evidence for Linux compilation, native tests, native performance guards, Python suites, and conditional
-coverage. It proves coverage only when the workflow's changed-path rule runs its `coverage` step; use
-`--require-step coverage` for coverage-relevant changes. Additional platform, release, MCP gameplay, manual, or
-issue-specific validation is needed only when the task targets that surface or the user requests it. Record focused local
-checks, skipped local heavy commands, CI job names, conclusions, URLs, and the exact PR head separately. If CI polling
-supplies the full validation evidence, do not enable auto-merge until the selected check(s) have passed.
+necessary before opening the PR, or GitHub Actions polling is unavailable or blocked. Passing `build / linux` is
+sufficient PR delivery evidence for Linux compilation, native tests, native performance guards, Python suites, and
+conditional coverage. It proves coverage only when the workflow's changed-path rule runs its `coverage` step somewhere
+in the selected build workflow run, currently in the conditional `linux-coverage` job; the poller auto-adds this step
+for coverage-relevant PR paths. Additional platform, release, MCP gameplay, manual, or issue-specific validation is
+needed only when the task targets that surface or the user requests it. Record focused local checks, skipped local heavy
+commands, CI job names, conclusions, URLs, and the exact PR head separately. If CI polling supplies the full validation
+evidence, do not enable auto-merge until the selected check(s) have passed.
 
 Workers and standby subagents may perform lightweight source inspection and prepare summaries while heavy validation runs.
 Do not dispatch additional implementation work when doing so would leave active workers unpollable. Empty implementation
@@ -518,8 +521,8 @@ Before committing:
    tests, full Python suites, and coverage evidence when the PR workflow covers those checks.
 6. For gameplay changes, confirm required MCP validation; for GUI changes, confirm required Xvfb validation; for
    performance-sensitive changes, confirm deterministic performance guards and evidence from CI or local runs; for
-   coverage-relevant changes, verify that the CI-polled `linux` job ran coverage successfully or record why local
-   coverage was required instead.
+   coverage-relevant changes, verify that the selected build workflow run included a successful `coverage` step,
+   currently in `linux-coverage`, or record why local coverage was required instead.
 
 Then commit and push only intended implementation files:
 

--- a/scripts/poll_pr_checks.py
+++ b/scripts/poll_pr_checks.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import subprocess
 import sys
@@ -16,6 +17,18 @@ DEFAULT_WORKFLOW = "build.yml"
 DEFAULT_INTERVAL_SECONDS = 30
 DEFAULT_TIMEOUT_SECONDS = 7200
 SUCCESS_CONCLUSION = "SUCCESS"
+COVERAGE_STEP = "coverage"
+COVERAGE_PATH_PATTERNS = (
+    "test.py",
+    "tests/unit/*",
+    "scripts/run_coverage.sh",
+    "scripts/coverage_report.py",
+    "scripts/coverage_exclusions.json",
+    "native_plugins/*",
+    "src/core/*",
+    "src/handler/*",
+    "src/object/*",
+)
 
 
 @dataclass(frozen=True)
@@ -98,6 +111,21 @@ def selectRunForHead(runs: Sequence[dict[str, Any]], headSha: str) -> dict[str, 
 def appendUniqueJob(jobs: list[JobRun], job: JobRun) -> None:
     if not any(existing.name == job.name for existing in jobs):
         jobs.append(job)
+
+
+def changedPathRequiresCoverage(path: str) -> bool:
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in COVERAGE_PATH_PATTERNS)
+
+
+def changedFilesRequireCoverage(paths: Sequence[str]) -> bool:
+    return any(changedPathRequiresCoverage(path) for path in paths)
+
+
+def appendUniqueStep(steps: Sequence[str], step: str) -> tuple[str, ...]:
+    normalized = tuple(steps)
+    if step in normalized:
+        return normalized
+    return (*normalized, step)
 
 
 def evaluateRun(
@@ -285,6 +313,20 @@ def runGhPrView(pr: str, repo: str | None) -> dict[str, Any]:
     return payload
 
 
+def runGhPrFiles(pr: str, repo: str | None) -> tuple[str, ...]:
+    command = ghCommandWithRepo(["gh", "pr", "diff", pr, "--name-only"], repo)
+    result = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise PollError(result.stderr.strip() or result.stdout.strip() or f"{' '.join(command)} failed")
+    return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
 def runGhRunList(headSha: str, workflow: str, repo: str | None) -> list[dict[str, Any]]:
     command = ghCommandWithRepo(
         [
@@ -366,6 +408,7 @@ def pollChecks(
     requiredSteps: Sequence[str],
     intervalSeconds: int,
     timeoutSeconds: int,
+    autoRequireCoverage: bool = True,
 ) -> CheckEvaluation:
     started = time.monotonic()
     pr_payload = runGhPrView(pr, repo)
@@ -374,13 +417,18 @@ def pollChecks(
         printEvaluation(pr_payload, None, pr_state_evaluation, requiredSteps)
         return pr_state_evaluation
     head_sha = str(pr_payload["headRefOid"])
+    effective_steps = tuple(requiredSteps)
+    if autoRequireCoverage and COVERAGE_STEP not in effective_steps:
+        changed_files = runGhPrFiles(pr, repo)
+        if changedFilesRequireCoverage(changed_files):
+            effective_steps = appendUniqueStep(effective_steps, COVERAGE_STEP)
 
     while True:
         runs = runGhRunList(head_sha, workflow, repo)
         run_summary = selectRunForHead(runs, head_sha)
         run_payload = runGhRunView(run_summary["databaseId"], repo) if run_summary else None
-        evaluation = evaluateRun(run_payload, requiredJobs, requiredSteps)
-        printEvaluation(pr_payload, run_payload, evaluation, requiredSteps)
+        evaluation = evaluateRun(run_payload, requiredJobs, effective_steps)
+        printEvaluation(pr_payload, run_payload, evaluation, effective_steps)
         if evaluation.succeeded or evaluation.failed:
             return evaluation
         if time.monotonic() - started >= timeoutSeconds:
@@ -395,7 +443,7 @@ def pollChecks(
         latest_pr_payload = runGhPrView(pr, repo)
         pr_state_evaluation = evaluatePrState(latest_pr_payload)
         if pr_state_evaluation is not None:
-            printEvaluation(latest_pr_payload, None, pr_state_evaluation, requiredSteps)
+            printEvaluation(latest_pr_payload, None, pr_state_evaluation, effective_steps)
             return pr_state_evaluation
 
 
@@ -426,7 +474,15 @@ def parseArgs(argv: Sequence[str]) -> argparse.Namespace:
         action="append",
         dest="steps",
         default=[],
-        help="Required step name that must pass somewhere in the selected workflow run. May be repeated.",
+        help=(
+            "Required step name that must pass somewhere in the selected workflow run. May be repeated. "
+            "Coverage is auto-required when PR paths match the build workflow coverage rule."
+        ),
+    )
+    parser.add_argument(
+        "--no-auto-require-coverage",
+        action="store_true",
+        help="Do not auto-require the coverage step when PR paths match the workflow coverage rule.",
     )
     parser.add_argument(
         "--interval-seconds",
@@ -456,6 +512,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             requiredSteps=steps,
             intervalSeconds=args.interval_seconds,
             timeoutSeconds=args.timeout_seconds,
+            autoRequireCoverage=not args.no_auto_require_coverage,
         )
     except PollError as exc:
         print(f"poll_pr_checks: {exc}", file=sys.stderr)

--- a/tests/test_poll_pr_checks.py
+++ b/tests/test_poll_pr_checks.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import io
 import unittest
 from contextlib import redirect_stdout
+from pathlib import Path
 from unittest.mock import patch
 
 from scripts import poll_pr_checks
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class PollPrChecksTest(unittest.TestCase):
@@ -56,6 +59,18 @@ class PollPrChecksTest(unittest.TestCase):
         self.assertTrue(evaluation.succeeded)
         self.assertEqual("success", evaluation.state)
         self.assertEqual("linux", evaluation.jobs[0].name)
+
+    def test_changed_files_require_coverage_for_workflow_paths(self) -> None:
+        self.assertTrue(poll_pr_checks.changedFilesRequireCoverage(["src/core/CGame.cpp"]))
+        self.assertTrue(poll_pr_checks.changedFilesRequireCoverage(["src/handler/CFightHandler.cpp"]))
+        self.assertTrue(poll_pr_checks.changedFilesRequireCoverage(["tests/unit/test_core.cpp"]))
+        self.assertTrue(poll_pr_checks.changedFilesRequireCoverage(["scripts/coverage_exclusions.json"]))
+        self.assertFalse(poll_pr_checks.changedFilesRequireCoverage(["docs/testing.md", "scripts/poll_pr_checks.py"]))
+
+    def test_coverage_path_patterns_match_workflow_detector(self) -> None:
+        workflow = (REPO_ROOT / ".github/workflows/build.yml").read_text(encoding="utf-8")
+        for pattern in poll_pr_checks.COVERAGE_PATH_PATTERNS:
+            self.assertIn(pattern, workflow)
 
     def test_evaluate_run_treats_missing_run_as_pending(self) -> None:
         evaluation = poll_pr_checks.evaluateRun(None, ["linux"], [])
@@ -295,6 +310,98 @@ class PollPrChecksTest(unittest.TestCase):
         self.assertTrue(evaluation.succeeded)
         run_list.assert_not_called()
 
+    def test_poll_checks_auto_requires_coverage_for_coverage_relevant_paths(self) -> None:
+        open_pr = {
+            "headRefOid": "abc123",
+            "url": "https://github.com/example/repo/pull/1",
+            "state": "OPEN",
+        }
+        completed_run = self.runPayload(
+            [
+                self.jobPayload(name="linux"),
+                self.jobPayload(
+                    name="linux-coverage",
+                    steps=[{"name": "coverage", "status": "completed", "conclusion": "failure"}],
+                ),
+            ]
+        )
+
+        with (
+            patch.object(poll_pr_checks, "runGhPrView", return_value=open_pr),
+            patch.object(poll_pr_checks, "runGhPrFiles", return_value=("src/core/CGame.cpp",)),
+            patch.object(poll_pr_checks, "runGhRunList", return_value=[{"databaseId": 1, "headSha": "abc123"}]),
+            patch.object(poll_pr_checks, "runGhRunView", return_value=completed_run),
+        ):
+            with redirect_stdout(io.StringIO()):
+                evaluation = poll_pr_checks.pollChecks(
+                    pr="1",
+                    repo=None,
+                    workflow="build.yml",
+                    requiredJobs=["linux"],
+                    requiredSteps=[],
+                    intervalSeconds=1,
+                    timeoutSeconds=1,
+                )
+
+        self.assertTrue(evaluation.failed)
+        self.assertIn("linux-coverage/coverage=FAILURE", evaluation.message)
+
+    def test_poll_checks_does_not_auto_require_coverage_for_unmatched_paths(self) -> None:
+        open_pr = {
+            "headRefOid": "abc123",
+            "url": "https://github.com/example/repo/pull/1",
+            "state": "OPEN",
+        }
+        completed_run = self.runPayload([self.jobPayload(name="linux")])
+
+        with (
+            patch.object(poll_pr_checks, "runGhPrView", return_value=open_pr),
+            patch.object(poll_pr_checks, "runGhPrFiles", return_value=("docs/testing.md",)),
+            patch.object(poll_pr_checks, "runGhRunList", return_value=[{"databaseId": 1, "headSha": "abc123"}]),
+            patch.object(poll_pr_checks, "runGhRunView", return_value=completed_run),
+        ):
+            with redirect_stdout(io.StringIO()):
+                evaluation = poll_pr_checks.pollChecks(
+                    pr="1",
+                    repo=None,
+                    workflow="build.yml",
+                    requiredJobs=["linux"],
+                    requiredSteps=[],
+                    intervalSeconds=1,
+                    timeoutSeconds=1,
+                )
+
+        self.assertTrue(evaluation.succeeded)
+
+    def test_poll_checks_can_disable_auto_coverage_requirement(self) -> None:
+        open_pr = {
+            "headRefOid": "abc123",
+            "url": "https://github.com/example/repo/pull/1",
+            "state": "OPEN",
+        }
+        completed_run = self.runPayload([self.jobPayload(name="linux")])
+
+        with (
+            patch.object(poll_pr_checks, "runGhPrView", return_value=open_pr),
+            patch.object(poll_pr_checks, "runGhPrFiles") as files,
+            patch.object(poll_pr_checks, "runGhRunList", return_value=[{"databaseId": 1, "headSha": "abc123"}]),
+            patch.object(poll_pr_checks, "runGhRunView", return_value=completed_run),
+        ):
+            with redirect_stdout(io.StringIO()):
+                evaluation = poll_pr_checks.pollChecks(
+                    pr="1",
+                    repo=None,
+                    workflow="build.yml",
+                    requiredJobs=["linux"],
+                    requiredSteps=[],
+                    intervalSeconds=1,
+                    timeoutSeconds=1,
+                    autoRequireCoverage=False,
+                )
+
+        self.assertTrue(evaluation.succeeded)
+        files.assert_not_called()
+
     def test_poll_checks_stops_if_pr_merges_while_job_is_pending(self) -> None:
         open_pr = {
             "headRefOid": "abc123",
@@ -312,6 +419,7 @@ class PollPrChecksTest(unittest.TestCase):
 
         with (
             patch.object(poll_pr_checks, "runGhPrView", side_effect=[open_pr, merged_pr]),
+            patch.object(poll_pr_checks, "runGhPrFiles", return_value=()),
             patch.object(
                 poll_pr_checks, "runGhRunList", return_value=[{"databaseId": 1, "headSha": "abc123"}]
             ) as run_list,


### PR DESCRIPTION
## What changed

- Auto-detect coverage-relevant pull requests in `scripts/poll_pr_checks.py` using `gh pr diff --name-only`.
- Require a successful `coverage` step automatically when changed paths match the build workflow's coverage path rule.
- Added an explicit `--no-auto-require-coverage` escape hatch.
- Added unit coverage for the new path matching and polling behavior.
- Updated queue/testing docs and prompts to describe the conditional `linux-coverage` job instead of implying coverage runs inside `linux`.

## Why

After the workflow split, `--check linux` can pass while the conditional coverage job fails. This makes the poller enforce the coverage step automatically for the same path classes the workflow uses.

## Validation

- `black -l 120 --check scripts/poll_pr_checks.py tests/test_poll_pr_checks.py`
- `python3 -m unittest tests.test_poll_pr_checks tests.test_issue_queue tests.test_controller_resource_audit`
- `python3 scripts/poll_pr_checks.py --help`
- `rg -n 'coverage step inside|conditional inside \`linux\`|inside linux|inside \`linux\`|linux job ran coverage|when its coverage step runs|require the .*coverage step explicitly' AGENTS.md docs/testing.md docs/codex-agent-queue.md prompts/codex-queue-controller.md prompts/codex-workflow-optimizer.md` returned no matches
- `git diff --check origin/main...HEAD`
- `python3 scripts/issue_queue.py validate` returned no errors; it reported eight current stale-claim warnings from the workbook
- `python3 scripts/issue_queue.py reclaim-stale --dry-run`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`

## Notes

- No local native builds, full Python suite, or coverage run were performed; this change is workflow tooling and docs, with heavy validation delegated to GitHub Actions.
- The coverage path patterns intentionally mirror `.github/workflows/build.yml`; the unit test guards that each pattern is represented in the workflow.
