### PR TITLE
Lower coverage gate to 90 percent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,7 +375,7 @@ instrumented/generated lines differently in this repo and can fail the gate even
 The script builds and runs the native `performance_guard_tests` CTest entry as part of coverage validation.
 Coverage line exclusions are not supported; every instrumented line in scope is part of the line gate.
 
-The default eligible-line coverage threshold is 95%. Do not finish coverage-relevant work below that threshold without
+The default eligible-line coverage threshold is 90%. Do not finish coverage-relevant work below that threshold without
 explicitly reporting it.
 
 Coverage reports are generated under `coverage/`.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ steps.
 Also run `./scripts/run_coverage.sh` when a change touches tests (for example
 `test.py` or `tests/unit/**`), `src/core/**`, `src/handler/**`, `src/object/**`,
 `native_plugins/**`, or the coverage tooling. The default coverage run uses the Python reporter without line exclusions,
-runs the bounded `coverage-safe` Python suite, and enforces a 95% eligible-line gate; see `docs/testing.md` for details,
+runs the bounded `coverage-safe` Python suite, and enforces a 90% eligible-line gate; see `docs/testing.md` for details,
 including recommended branch-protection checks.
 Content JSON validation and its focused fixture tests run without needing the
 compiled `_game` module, but other tests require it to be built.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -186,7 +186,7 @@ The script:
 - generates reports in `coverage/coverage.txt` and `coverage/coverage.html`
 - uses the repo-local Python reporter by default; set `COVERAGE_REPORTER=gcovr` only for diagnostic comparison
 - rejects line-exclusion controls; every instrumented line in scope is part of the gate
-- fails if eligible line coverage is below the default `MIN_COVERAGE=95` gate
+- fails if eligible line coverage is below the default `MIN_COVERAGE=90` gate
 
 Optional coverage speed controls:
 - `COVERAGE_CXX_COMPILER_LAUNCHER=<launcher>` overrides the compiler launcher for the coverage build

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${BUILD_DIR:-cmake-build-coverage}"
-MIN_COVERAGE="${MIN_COVERAGE:-95}"
+MIN_COVERAGE="${MIN_COVERAGE:-90}"
 REPORT_DIR="${ROOT_DIR}/coverage"
 COVERAGE_INCLUDE_PREFIXES="${COVERAGE_INCLUDE_PREFIXES:-src native_plugins}"
 COVERAGE_JOBS="${COVERAGE_JOBS:-$(nproc)}"

--- a/test.py
+++ b/test.py
@@ -14189,7 +14189,7 @@ class CoverageReportTest(unittest.TestCase):
             "--report-dir",
             "coverage",
             "--min-line",
-            "95",
+            "90",
         ]
         original_argv = sys.argv[:]
         try:

--- a/tests/security/test_configure_supply_chain.py
+++ b/tests/security/test_configure_supply_chain.py
@@ -106,6 +106,12 @@ class ConfigureSupplyChainTest(unittest.TestCase):
         self.assertIn("native_plugins/*|src/core/*|src/handler/*|src/object/*", detection_body)
         self.assertNotIn("test.py|tests/*|", detection_body)
 
+    def test_run_coverage_default_line_gate_is_90_percent(self):
+        run_coverage = (REPO_ROOT / "scripts" / "run_coverage.sh").read_text()
+
+        self.assertIn('MIN_COVERAGE="${MIN_COVERAGE:-90}"', run_coverage)
+        self.assertNotIn('MIN_COVERAGE="${MIN_COVERAGE:-95}"', run_coverage)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- Lowered the default `MIN_COVERAGE` gate in `scripts/run_coverage.sh` from 95 to 90.
- Updated README, testing docs, and AGENTS coverage policy text to say the default gate is 90%.
- Updated the coverage reporter test fixture to use the new default value.
- Added a focused test that asserts `scripts/run_coverage.sh` defaults to 90%.

## Why

The current coverage gate is blocking controller implementation PRs after coverage exclusions were removed. The user requested the gate be set to 90%.

## Validation

- `black -l 120 --check test.py tests/security/test_configure_supply_chain.py`
- `python3 test.py CoverageReportTest`
- `python3 -m unittest tests.security.test_configure_supply_chain tests.test_issue_queue tests.test_controller_resource_audit`
- `bash -n scripts/run_coverage.sh`
- `rg -n "95%|MIN_COVERAGE=95|MIN_COVERAGE=\"\\$\\{MIN_COVERAGE:-95\\}\"|--min-line[^\\n]*95|\"95\"" AGENTS.md README.md docs prompts scripts test.py tests .github --glob '!coverage/**'` returned no matches
- `git diff --check origin/main...HEAD`
- `python3 scripts/issue_queue.py validate` returned no errors; it reported seven current stale-claim warnings from the workbook
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`

## Notes

- No local native build, full Python suite, or local coverage run was performed; this is coverage tooling, so GitHub Actions coverage should provide the heavy evidence unless explicitly bypassed.
