### PR TITLE
Fix queue lease recovery accounting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,13 +50,16 @@ randomly select one story with equal probability, then randomly select one eligi
 back to spreadsheet order and do not include ineligible rows in the random choice. Use
 `python3 scripts/issue_queue.py shortlist --seed "$CONTROLLER_ID-<utc-cycle-id>" --controller-id "$CONTROLLER_ID" --include-rejected --json`
 as the read-only mechanical selector before each claim; it reports eligible highest-priority story groups, stale claims,
-`activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`, `controllerCapacity`, target-file overlap advisories,
-rejection summaries, and a seeded recommendation without mutating the workbook. Use the unexpired count, not raw
+`activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`, `activeClaims.leaseExpired`,
+`activeClaims.inactive`, `controllerCapacity`, target-file overlap advisories, rejection summaries, and a seeded
+recommendation without mutating the workbook. `activeClaims.unexpired` means live/pollable rows that are neither
+reclaimable-stale nor lease-expired. Use the unexpired count, not raw
 `activeCount`, when deciding whether the global active-worker floor is genuinely satisfied. Use
-`controllerCapacity.deficitToFloor` and `controllerCapacity.fillableDeficit` to decide whether this controller must keep
-claiming to satisfy its four-owned-issue floor. The controller and project manager must still inspect target-file overlap
-advisories and exclude source-backed active-scope conflicts, then claim the final exact issue with `claim --issue` so
-eligibility is rechecked under the workbook lock.
+`controllerCapacity.activeNonStale`, `controllerCapacity.leaseExpiredOwned`,
+`controllerCapacity.deficitToFloor`, and `controllerCapacity.fillableDeficit` to decide whether this controller must
+keep claiming to satisfy its four-owned-issue floor. The controller and project manager must still inspect target-file
+overlap advisories and exclude source-backed active-scope conflicts, then claim the final exact issue with `claim
+--issue` so eligibility is rechecked under the workbook lock.
 
 Assign a read-only project manager role whenever subagent capacity permits. Before dispatch/refill decisions, the
 project manager should summarize the highest available priority tier, candidate story groups, dependency unlocks, stale

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -81,12 +81,14 @@ python3 scripts/issue_queue.py shortlist \
 The shortlist command does not mutate the workbook. It filters queue status, dependencies, and optional CLI filters,
 keeps only the highest currently eligible priority tier for `storyGroups`, and emits a seeded recommended
 `selected.issue.issueName`. It also reports `activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`,
-`staleClaimCount`, `staleClaims`, `advisoryTargetFileOverlapCount`, `advisoryTargetFileOverlaps`, and per-issue
-`activeFileOverlaps` so stale claims and exact target-file overlaps can inform dispatch decisions without becoming
-automatic blockers. When `--controller-id` is provided, it also reports `controllerCapacity`: the current controller's
-non-stale active issues, stale owned issues, deficit to the four-issue controller floor, and fillable deficit from the
-current eligible set. Treat that output as mechanical evidence for the controller and project-manager brief, not as an
-automatic claim. The controller and PM must still inspect source-backed active-scope conflicts, including:
+`activeClaims.leaseExpired`, `activeClaims.inactive`, `staleClaimCount`, `staleClaims`,
+`advisoryTargetFileOverlapCount`, `advisoryTargetFileOverlaps`, and per-issue `activeFileOverlaps` so stale claims,
+expired leases, and exact target-file overlaps can inform dispatch decisions without becoming automatic blockers.
+`activeClaims.unexpired` means live/pollable rows that are neither reclaimable-stale nor lease-expired. When
+`--controller-id` is provided, it also reports `controllerCapacity`: the current controller's live active issues,
+stale owned issues, lease-expired owned issues, deficit to the four-issue controller floor, and fillable deficit from
+the current eligible set. Treat that output as mechanical evidence for the controller and project-manager brief, not as
+an automatic claim. The controller and PM must still inspect source-backed active-scope conflicts, including:
 
 - rows whose status is not `NOT_STARTED`;
 - rows with unfinished dependencies;
@@ -245,10 +247,12 @@ python3 scripts/issue_queue.py heartbeat \
   --claim-id "$CLAIM_ID" \
   --owner "$OWNER" \
   --progress 20 \
-  --note 'Root cause verified in CFightHandler.cpp and CCreature.cpp'
+  --note 'Root cause verified in CFightHandler.cpp and CCreature.cpp' \
+  --lease-minutes 1440
 ```
 
-Every heartbeat extends the lease. Recommended checkpoints are 5%, 20%, 70%, and 90%.
+Every heartbeat preserves an existing later lease and extends the lease only when the requested renewal would move it
+farther into the future. Recommended checkpoints are 5%, 20%, 70%, and 90%.
 
 Complete only after the implementation pull request has actually merged and validation results have been reviewed:
 
@@ -360,9 +364,9 @@ that reclaim PR actually merges. The mutating command reclaims rows whose last u
 even if their lease is still in the future. Reclaimed rows return to `NOT_STARTED`, retain the incremented `Attempt`,
 and receive an audit note describing the previous owner and claim.
 
-`validate` warns about `IN_PROGRESS` claims only after they meet the current reclaim age threshold without failing the
-workbook, and `list --status IN_PROGRESS --json` includes derived lease-expiration fields for read-only controller
-status checks.
+`validate` warns about expired `IN_PROGRESS` leases before they meet the reclaim age threshold, and warns about stale
+claims after they meet the threshold, without failing the workbook. `list --status IN_PROGRESS --json` includes derived
+lease-expiration fields for read-only controller status checks.
 
 ## Inspection commands
 

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -128,9 +128,9 @@ Maintain at least eight live subagents and keep at least eight implementation is
 implementation issues can safely run, assign the excess subagents only lightweight standby roles such as status polling,
 eligibility summaries, or review preparation, and print the exact blocker preventing eight active issues. Standby
 subagents must not claim issues, edit files, start builds, run tests, or touch the workbook.
-Each controller must also keep at least four of its own non-stale workbook claims active when four eligible issues can
-be safely claimed. Use `controllerCapacity` from `shortlist --controller-id "$CONTROLLER_ID"` to measure the current
-controller's floor; stale owned claims do not count. Continue claim/refill iterations until
+Each controller must also keep at least four of its own live workbook claims active when four eligible issues can be
+safely claimed. Use `controllerCapacity` from `shortlist --controller-id "$CONTROLLER_ID"` to measure the current
+controller's floor; stale owned claims and lease-expired owned claims do not count. Continue claim/refill iterations until
 `controllerCapacity.deficitToFloor` is zero, `controllerCapacity.fillableDeficit` is zero, or a concrete eligibility,
 resource, repository-safety, or worker-status blocker is printed.
 
@@ -211,9 +211,11 @@ pause for a priority/status update, or report a blocker. Do not use the brief as
 Use
 `python3 scripts/issue_queue.py shortlist --seed "$CONTROLLER_ID-<utc-cycle-id>" --controller-id "$CONTROLLER_ID" --include-rejected --json`
 as the read-only mechanical selector before each claim. The command reports eligible highest-priority story groups,
-stale claims, `activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`, rejection summaries, and a seeded
-recommended issue without mutating the workbook. Use the unexpired count, not raw `activeCount`, when deciding whether
-the global active-worker floor is genuinely satisfied. Use `controllerCapacity.activeNonStale`,
+stale claims, `activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`,
+`activeClaims.leaseExpired`, `activeClaims.inactive`, rejection summaries, and a seeded recommended issue without
+mutating the workbook. `activeClaims.unexpired` means live/pollable rows that are neither reclaimable-stale nor
+lease-expired. Use the unexpired count, not raw `activeCount`, when deciding whether the global active-worker floor is
+genuinely satisfied. Use `controllerCapacity.activeNonStale`, `controllerCapacity.leaseExpiredOwned`,
 `controllerCapacity.deficitToFloor`, and `controllerCapacity.fillableDeficit` to enforce this controller's four-issue
 owned-claim floor before stopping a refill loop. It also reports target-file overlap advisories through
 `advisoryTargetFileOverlapCount`, `advisoryTargetFileOverlaps`, and per-issue `activeFileOverlaps`. Treat the
@@ -433,29 +435,31 @@ python3 scripts/issue_queue.py heartbeat \
   --claim-id "$CLAIM_ID" \
   --owner "$OWNER" \
   --progress "$PROGRESS" \
-  --note "$NOTE"
+  --note "$NOTE" \
+  --lease-minutes 1440
 ```
 
-Commit and merge that workbook-only change using the same status-PR process as claim publication.
+Commit and merge that workbook-only change using the same status-PR process as claim publication. A heartbeat preserves
+an existing later lease and extends the lease only when the requested renewal would move it farther into the future.
 
 If a worker disappears, do not overwrite the active claim. Inspect its worktree and branch, then run
 `python3 scripts/issue_queue.py reclaim-stale --dry-run` to list stale `IN_PROGRESS` claims without mutating the
 workbook. The default reclaim age threshold is 240 minutes; pass `--older-than-minutes <minutes>` only when the
 controller has an explicit reason to override it. The dry-run output includes `activeClaims`, `staleCount`, and
-`reclaimableStaleCount`; use those fields to distinguish active claims from rows eligible under the current
+`reclaimableStaleCount`; use those fields to distinguish live claims from inactive rows eligible under the current
 heartbeat-age threshold. Dry-run rows are queue-timing candidates only and include `reclaimReady: false`; use mutating
 `reclaim-stale` only when the claim is genuinely stale and no recoverable work remains. Treat `validate` stale-claim
-warnings and derived `list --status IN_PROGRESS --json` lease-expiration fields as read-only recovery signals, not
-permission to reclaim without inspection.
+warnings, expired-lease warnings, and derived `list --status IN_PROGRESS --json` lease-expiration fields as read-only
+recovery signals, not permission to reclaim without inspection.
 
 ## Resource-aware validation
 
 The controller keeps resource pressure in mind without enforcing a fixed RAM gate or mandatory serial builds. For PR
 delivery, do not run local native builds, `ctest`, full Python suites, or coverage unless a focused local reproduction is
 necessary or GitHub Actions cannot provide the needed evidence. Before any necessary local heavy command, note current
-available RAM, disk pressure, running heavy jobs, and worker status. Treat eight active issue workers as the minimum
-target whenever safe eligible work exists; record the concrete blocker if actual resource pressure prevents eight active
-issues. Also treat four non-stale owned claims as this controller's minimum active target whenever
+available RAM, disk pressure, running heavy jobs, and worker status. Treat eight live issue workers as the minimum
+target whenever safe eligible work exists; record the concrete blocker if actual resource pressure prevents eight live
+issues. Also treat four live owned claims as this controller's minimum active target whenever
 `controllerCapacity.fillableDeficit` is greater than zero; record the concrete blocker if the controller cannot close
 that deficit.
 

--- a/scripts/issue_queue.py
+++ b/scripts/issue_queue.py
@@ -701,18 +701,40 @@ def statusByIssue(state: QueueState) -> dict[str, str]:
     return {task.issueName: task.status for task in state.tasks}
 
 
-def activeTargetFiles(state: QueueState, excludeIssueName: str | None = None) -> set[str]:
+def inactiveClaimIssueNames(
+    state: QueueState,
+    stale: Sequence[dict[str, Any]] | None = None,
+    now: datetime | None = None,
+) -> set[str]:
+    now = now or utcNow()
+    staleIssues = {record["issueName"] for record in (stale if stale is not None else staleClaims(state, now=now))}
+    leaseExpiredIssues = {
+        task.issueName
+        for task in state.tasks
+        if task.status == STATUS_IN_PROGRESS and bool(taskLeasePayload(task, now).get("leaseExpired"))
+    }
+    return staleIssues | leaseExpiredIssues
+
+
+def activeTargetFiles(
+    state: QueueState,
+    excludeIssueName: str | None = None,
+    stale: Sequence[dict[str, Any]] | None = None,
+    now: datetime | None = None,
+    includeInactive: bool = False,
+) -> set[str]:
+    inactiveIssues = set() if includeInactive else inactiveClaimIssueNames(state, stale=stale, now=now)
     files: set[str] = set()
     for task in state.tasks:
         if excludeIssueName is not None and task.issueName == excludeIssueName:
             continue
-        if task.status == STATUS_IN_PROGRESS:
+        if task.status == STATUS_IN_PROGRESS and (includeInactive or task.issueName not in inactiveIssues):
             files.update(task.targetFiles)
     return files
 
 
-def taskActiveFileOverlaps(state: QueueState, task: TaskRecord) -> list[str]:
-    return sorted(task.targetFiles & activeTargetFiles(state, excludeIssueName=task.issueName))
+def taskActiveFileOverlaps(state: QueueState, task: TaskRecord, now: datetime | None = None) -> list[str]:
+    return sorted(task.targetFiles & activeTargetFiles(state, excludeIssueName=task.issueName, now=now))
 
 
 def taskSortKey(task: TaskRecord) -> tuple[Any, ...]:
@@ -762,8 +784,13 @@ def eligibleTasks(
     return eligible, rejected
 
 
-def targetFileOverlapAdvisories(state: QueueState, tasks: Iterable[TaskRecord] | None = None) -> dict[str, list[str]]:
-    activeFiles = activeTargetFiles(state)
+def targetFileOverlapAdvisories(
+    state: QueueState,
+    tasks: Iterable[TaskRecord] | None = None,
+    stale: Sequence[dict[str, Any]] | None = None,
+    now: datetime | None = None,
+) -> dict[str, list[str]]:
+    activeFiles = activeTargetFiles(state, stale=stale, now=now)
     advisories: dict[str, list[str]] = {}
     for task in tasks if tasks is not None else state.tasks:
         if task.status != STATUS_NOT_STARTED:
@@ -794,13 +821,25 @@ def statusCounts(state: QueueState) -> dict[str, int]:
     return dict(sorted(counts.items()))
 
 
-def activeClaimSummary(state: QueueState, stale: Sequence[dict[str, Any]]) -> dict[str, int]:
-    activeCount = statusCounts(state).get(STATUS_IN_PROGRESS, 0)
-    staleCount = len(stale)
+def activeClaimSummary(
+    state: QueueState,
+    stale: Sequence[dict[str, Any]],
+    now: datetime | None = None,
+) -> dict[str, int]:
+    now = now or utcNow()
+    activeTasks = [task for task in state.tasks if task.status == STATUS_IN_PROGRESS]
+    staleIssues = {record["issueName"] for record in stale}
+    leaseExpiredIssues = {
+        task.issueName for task in activeTasks if bool(taskLeasePayload(task, now).get("leaseExpired"))
+    }
+    inactiveIssues = staleIssues | leaseExpiredIssues
+    liveCount = sum(1 for task in activeTasks if task.issueName not in inactiveIssues)
     return {
-        "total": activeCount,
-        "unexpired": max(0, activeCount - staleCount),
-        "stale": staleCount,
+        "total": len(activeTasks),
+        "unexpired": liveCount,
+        "stale": len(stale),
+        "leaseExpired": len(leaseExpiredIssues),
+        "inactive": len(activeTasks) - liveCount,
     }
 
 
@@ -824,6 +863,11 @@ def controllerCapacityPayload(
     ownerPrefix = controllerOwnerPrefix(controllerId)
     stale = staleClaims(state, now=now)
     staleIssues = {record["issueName"] for record in stale}
+    leaseExpiredIssues = {
+        task.issueName
+        for task in state.tasks
+        if task.status == STATUS_IN_PROGRESS and bool(taskLeasePayload(task, now).get("leaseExpired"))
+    }
     activeTasks = [
         task
         for task in state.tasks
@@ -831,7 +875,10 @@ def controllerCapacityPayload(
         and ownerMatchesPrefix(str(task.values.get("Owner") or "").strip(), ownerPrefix)
     ]
     staleTasks = [task for task in activeTasks if task.issueName in staleIssues]
-    liveTasks = [task for task in activeTasks if task.issueName not in staleIssues]
+    leaseExpiredTasks = [task for task in activeTasks if task.issueName in leaseExpiredIssues]
+    liveTasks = [
+        task for task in activeTasks if task.issueName not in staleIssues and task.issueName not in leaseExpiredIssues
+    ]
     deficit = max(0, activeFloor - len(liveTasks))
     fillable = min(deficit, eligibleCount) if eligibleCount is not None else deficit
     return {
@@ -841,12 +888,15 @@ def controllerCapacityPayload(
         "activeTotal": len(activeTasks),
         "activeNonStale": len(liveTasks),
         "staleOwned": len(staleTasks),
+        "leaseExpiredOwned": len(leaseExpiredTasks),
+        "inactiveOwned": len(activeTasks) - len(liveTasks),
         "deficitToFloor": deficit,
         "eligibleCount": eligibleCount,
         "fillableDeficit": fillable,
         "needsRefill": fillable > 0,
         "activeIssues": [task.issueName for task in sorted(liveTasks, key=taskSortKey)],
         "staleIssues": [task.issueName for task in sorted(staleTasks, key=taskSortKey)],
+        "leaseExpiredIssues": [task.issueName for task in sorted(leaseExpiredTasks, key=taskSortKey)],
     }
 
 
@@ -910,11 +960,12 @@ def shortlistTasks(
         component=component,
         allowFileOverlap=allowFileOverlap,
     )
+    now = utcNow()
     counts = statusCounts(state)
-    stale = staleClaims(state)
-    activeClaims = activeClaimSummary(state, stale)
-    activeFiles = activeTargetFiles(state)
-    advisoryOverlaps = targetFileOverlapAdvisories(state)
+    stale = staleClaims(state, now=now)
+    activeClaims = activeClaimSummary(state, stale, now=now)
+    activeFiles = activeTargetFiles(state, stale=stale, now=now)
+    advisoryOverlaps = targetFileOverlapAdvisories(state, stale=stale, now=now)
     selectionSeed = seed or uuid.uuid4().hex
     payload: dict[str, Any] = {
         "eligible": bool(eligible),
@@ -947,6 +998,7 @@ def shortlistTasks(
             controllerId=controllerId,
             activeFloor=controllerActiveFloor,
             eligibleCount=len(eligible),
+            now=now,
         )
     if includeRejected:
         payload["rejected"] = rejected
@@ -1067,6 +1119,13 @@ def validateQueueState(state: QueueState) -> tuple[list[str], list[str]]:
                     f"{stale['staleThresholdMinutes']}-minute reclaim threshold); "
                     "inspect the worker and run reclaim-stale --dry-run before reclaiming"
                 )
+            elif leaseUntil is not None and bool(taskLeasePayload(task, now).get("leaseExpired")):
+                warnings.append(
+                    f"Row {task.row}: IN_PROGRESS lease expired but last update "
+                    f"{formatUtc(updatedAt) if updatedAt else 'missing'} has not met "
+                    f"{DEFAULT_RECLAIM_AGE_MINUTES}-minute reclaim threshold; inspect worker status before refresh "
+                    "or later reclaim-stale --dry-run"
+                )
             if attempt < 1:
                 errors.append(f"Row {task.row}: IN_PROGRESS requires Attempt >= 1")
             if progress >= 100:
@@ -1125,15 +1184,16 @@ def validateQueueState(state: QueueState) -> tuple[list[str], list[str]]:
     return errors, warnings
 
 
-def taskPayload(task: TaskRecord, state: QueueState | None = None) -> dict[str, Any]:
+def taskPayload(task: TaskRecord, state: QueueState | None = None, now: datetime | None = None) -> dict[str, Any]:
+    now = now or utcNow()
     payload = {key: value for key, value in task.values.items()}
     payload["Row"] = task.row
     payload["Status"] = task.status
     payload["Dependencies Parsed"] = task.dependencies
     payload["Target Files Parsed"] = sorted(task.targetFiles)
     payload["Target File Overlap Policy"] = "advisory"
-    payload["Active File Overlaps"] = taskActiveFileOverlaps(state, task) if state is not None else []
-    payload.update(taskLeasePayload(task, utcNow()))
+    payload["Active File Overlaps"] = taskActiveFileOverlaps(state, task, now=now) if state is not None else []
+    payload.update(taskLeasePayload(task, now))
     return payload
 
 
@@ -1331,7 +1391,10 @@ def heartbeatTask(
             if note.strip():
                 setValue(state, task.row, "Last Note", note.strip())
             setValue(state, task.row, "Updated At UTC", formatUtc(now))
-            setValue(state, task.row, "Lease Until UTC", formatUtc(now + timedelta(minutes=leaseMinutes)))
+            requestedLeaseUntil = now + timedelta(minutes=leaseMinutes)
+            currentLeaseUntil = parseUtc(task.values.get("Lease Until UTC"))
+            leaseUntil = max(currentLeaseUntil, requestedLeaseUntil) if currentLeaseUntil else requestedLeaseUntil
+            setValue(state, task.row, "Lease Until UTC", formatUtc(leaseUntil))
             atomicSave(state, workbookPath)
             state = refreshTasks(state)
             return taskPayload(taskByName(state, issueName), state=state)
@@ -1925,7 +1988,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                             },
                             "reclaimableStaleCount": len(stale),
                             "staleCount": len(stale),
-                            "activeClaims": activeClaimSummary(state, stale),
+                            "activeClaims": activeClaimSummary(state, stale, now=now),
                             "stale": markStaleClaimsForInspection(stale),
                         }
                     )

--- a/tests/test_issue_queue.py
+++ b/tests/test_issue_queue.py
@@ -248,6 +248,17 @@ class IssueQueueTest(unittest.TestCase):
         self.assertIn("dependencies-not-done", rejected[self.issue_c][0])
         self.assertNotIn("active-file-overlap", issue_queue.rejectionSummary(rejected))
 
+    def test_target_file_overlap_advisory_ignores_reclaimable_stale_claim(self) -> None:
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=30)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=30, updated_minutes_ago=241)
+
+        state = issue_queue.loadQueue(self.workbook_path)
+        payload = issue_queue.shortlistTasks(state, seed="stale-overlap", includeRejected=True)
+
+        self.assertEqual({}, issue_queue.targetFileOverlapAdvisories(state))
+        self.assertEqual(0, payload["advisoryTargetFileOverlapCount"])
+        self.assertEqual({}, payload["advisoryTargetFileOverlaps"])
+
     def test_shortlist_groups_highest_priority_and_selects_seeded_issue(self) -> None:
         first_story = "[EPIC_01][STORY_01][SUBSTORY_01]First high priority story"
         second_story = "[EPIC_01][STORY_02][SUBSTORY_01]Second high priority story"
@@ -348,7 +359,10 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual(0, payload["activeCount"])
         self.assertEqual(0, payload["unexpiredActiveCount"])
         self.assertEqual(0, payload["staleClaimCount"])
-        self.assertEqual({"total": 0, "unexpired": 0, "stale": 0}, payload["activeClaims"])
+        self.assertEqual(
+            {"total": 0, "unexpired": 0, "stale": 0, "leaseExpired": 0, "inactive": 0},
+            payload["activeClaims"],
+        )
         self.assertEqual(4, payload["controllerCapacity"]["activeFloor"])
         self.assertEqual(0, payload["controllerCapacity"]["activeNonStale"])
         self.assertEqual(4, payload["controllerCapacity"]["deficitToFloor"])
@@ -372,9 +386,92 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual(2, payload["activeCount"])
         self.assertEqual(1, payload["unexpiredActiveCount"])
         self.assertEqual(1, payload["staleClaimCount"])
-        self.assertEqual({"total": 2, "unexpired": 1, "stale": 1}, payload["activeClaims"])
+        self.assertEqual(
+            {"total": 2, "unexpired": 1, "stale": 1, "leaseExpired": 1, "inactive": 1},
+            payload["activeClaims"],
+        )
         self.assertEqual([expired["Issue Name"]], [item["issueName"] for item in payload["staleClaims"]])
         self.assertNotIn(unexpired["Issue Name"], [item["issueName"] for item in payload["staleClaims"]])
+
+    def test_shortlist_does_not_count_expired_recent_lease_as_live_capacity(self) -> None:
+        expired_recent = issue_queue.claimTask(
+            self.workbook_path,
+            owner="controller/ctrl-demo/subagent-1",
+            leaseMinutes=1,
+        )
+        self.set_claim_times(expired_recent["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=1)
+        state = issue_queue.loadQueue(self.workbook_path)
+
+        payload = issue_queue.shortlistTasks(
+            state,
+            seed="expired-capacity",
+            controllerId="ctrl-demo",
+            controllerActiveFloor=4,
+            includeRejected=True,
+        )
+
+        self.assertEqual(1, payload["activeCount"])
+        self.assertEqual(0, payload["unexpiredActiveCount"])
+        self.assertEqual(0, payload["staleClaimCount"])
+        self.assertEqual(set(), issue_queue.activeTargetFiles(state))
+        self.assertEqual({}, issue_queue.targetFileOverlapAdvisories(state))
+        self.assertEqual(0, payload["advisoryTargetFileOverlapCount"])
+        self.assertEqual({}, payload["advisoryTargetFileOverlaps"])
+        self.assertEqual(
+            {"total": 1, "unexpired": 0, "stale": 0, "leaseExpired": 1, "inactive": 1},
+            payload["activeClaims"],
+        )
+        self.assertEqual([], payload["staleClaims"])
+        capacity = payload["controllerCapacity"]
+        self.assertEqual(1, capacity["activeTotal"])
+        self.assertEqual(0, capacity["activeNonStale"])
+        self.assertEqual(0, capacity["staleOwned"])
+        self.assertEqual(1, capacity["leaseExpiredOwned"])
+        self.assertEqual(1, capacity["inactiveOwned"])
+        self.assertEqual(4, capacity["deficitToFloor"])
+        self.assertTrue(capacity["needsRefill"])
+        self.assertEqual([], capacity["activeIssues"])
+        self.assertEqual([expired_recent["Issue Name"]], capacity["leaseExpiredIssues"])
+
+    def test_controller_capacity_refills_when_raw_active_count_meets_floor_but_leases_expired(self) -> None:
+        issues = [f"[EPIC_01][STORY_02][SUBSTORY_{index:02d}]Capacity issue {index}" for index in range(1, 7)]
+        self.create_workbook(
+            [self.task_row(issue, "P0", None, f"src/capacity_{index}.cpp") for index, issue in enumerate(issues)]
+        )
+        claims = [
+            issue_queue.claimTask(
+                self.workbook_path,
+                owner=f"controller/ctrl-demo/subagent-{index}",
+                leaseMinutes=1,
+            )
+            for index in range(1, 5)
+        ]
+        for claim in claims:
+            self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=1)
+        state = issue_queue.loadQueue(self.workbook_path)
+
+        payload = issue_queue.shortlistTasks(
+            state,
+            seed="expired-floor",
+            controllerId="ctrl-demo",
+            controllerActiveFloor=4,
+        )
+
+        self.assertEqual(4, payload["activeCount"])
+        self.assertEqual(0, payload["unexpiredActiveCount"])
+        self.assertEqual(
+            {"total": 4, "unexpired": 0, "stale": 0, "leaseExpired": 4, "inactive": 4},
+            payload["activeClaims"],
+        )
+        capacity = payload["controllerCapacity"]
+        self.assertEqual(4, capacity["activeTotal"])
+        self.assertEqual(0, capacity["activeNonStale"])
+        self.assertEqual(4, capacity["leaseExpiredOwned"])
+        self.assertEqual(4, capacity["inactiveOwned"])
+        self.assertEqual(4, capacity["deficitToFloor"])
+        self.assertEqual(2, capacity["eligibleCount"])
+        self.assertEqual(2, capacity["fillableDeficit"])
+        self.assertTrue(capacity["needsRefill"])
 
     def test_shortlist_reports_controller_capacity_floor(self) -> None:
         live = issue_queue.claimTask(self.workbook_path, owner="controller/ctrl-demo/subagent-1", leaseMinutes=30)
@@ -396,12 +493,15 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual(2, capacity["activeTotal"])
         self.assertEqual(1, capacity["activeNonStale"])
         self.assertEqual(1, capacity["staleOwned"])
+        self.assertEqual(0, capacity["leaseExpiredOwned"])
+        self.assertEqual(1, capacity["inactiveOwned"])
         self.assertEqual(3, capacity["deficitToFloor"])
         self.assertEqual(payload["eligibleCount"], capacity["eligibleCount"])
         self.assertEqual(min(3, payload["eligibleCount"]), capacity["fillableDeficit"])
         self.assertTrue(capacity["needsRefill"])
         self.assertEqual([live["Issue Name"]], capacity["activeIssues"])
         self.assertEqual([stale["Issue Name"]], capacity["staleIssues"])
+        self.assertEqual([], capacity["leaseExpiredIssues"])
 
     def test_controller_id_generates_unique_owner_prefix(self) -> None:
         first = issue_queue.generateControllerId(hostname="Build Host.local", pid=1234, unique="ABCDEF12")
@@ -449,6 +549,50 @@ class IssueQueueTest(unittest.TestCase):
                 progress=20,
                 note="should fail",
             )
+
+    def test_heartbeat_preserves_longer_existing_lease(self) -> None:
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1440)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=1440, updated_minutes_ago=30)
+        state = issue_queue.loadQueue(self.workbook_path)
+        before_task = issue_queue.taskByName(state, claim["Issue Name"])
+        before_lease = issue_queue.parseUtc(before_task.values["Lease Until UTC"])
+
+        issue_queue.heartbeatTask(
+            self.workbook_path,
+            issueName=claim["Issue Name"],
+            claimId=claim["claimId"],
+            owner="controller/subagent-1",
+            progress=20,
+            note="root cause found",
+            leaseMinutes=120,
+        )
+
+        state = issue_queue.loadQueue(self.workbook_path)
+        after_task = issue_queue.taskByName(state, claim["Issue Name"])
+        self.assertEqual(before_lease, issue_queue.parseUtc(after_task.values["Lease Until UTC"]))
+        self.assertEqual(20, after_task.values["Progress %"])
+        self.assertEqual("root cause found", after_task.values["Last Note"])
+
+    def test_heartbeat_refreshes_stale_claim_out_of_stale_report(self) -> None:
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
+        self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=241)
+        state = issue_queue.loadQueue(self.workbook_path)
+        self.assertEqual([claim["Issue Name"]], [item["issueName"] for item in issue_queue.staleClaims(state)])
+
+        issue_queue.heartbeatTask(
+            self.workbook_path,
+            issueName=claim["Issue Name"],
+            claimId=claim["claimId"],
+            owner="controller/subagent-1",
+            progress=20,
+            note="worker is alive",
+            leaseMinutes=60,
+        )
+
+        state = issue_queue.loadQueue(self.workbook_path)
+        self.assertEqual([], issue_queue.staleClaims(state))
+        active = issue_queue.activeClaimSummary(state, [], now=issue_queue.utcNow())
+        self.assertEqual({"total": 1, "unexpired": 1, "stale": 0, "leaseExpired": 0, "inactive": 0}, active)
 
     def test_complete_satisfies_dependency(self) -> None:
         claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1")
@@ -554,7 +698,7 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual(issue_queue.STATUS_IN_PROGRESS, task.status)
         self.assertEqual(claim["claimId"], task.values["Claim ID"])
 
-    def test_validate_warns_only_for_claims_at_reclaim_threshold(self) -> None:
+    def test_validate_warns_for_expired_leases_before_and_after_reclaim_threshold(self) -> None:
         recent_claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
         self.set_claim_times(recent_claim["Issue Name"], lease_minutes_from_now=-10, updated_minutes_ago=239)
         old_claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-2", leaseMinutes=1)
@@ -564,10 +708,11 @@ class IssueQueueTest(unittest.TestCase):
         errors, warnings = issue_queue.validateQueueState(state)
 
         self.assertEqual([], errors)
-        self.assertEqual(1, len(warnings), warnings)
-        self.assertIn("IN_PROGRESS stale claim", warnings[0])
-        self.assertIn("240-minute reclaim threshold", warnings[0])
-        self.assertIn("reclaim-stale --dry-run", warnings[0])
+        self.assertEqual(2, len(warnings), warnings)
+        self.assertTrue(any("IN_PROGRESS lease expired" in warning for warning in warnings), warnings)
+        self.assertTrue(any("has not met 240-minute reclaim threshold" in warning for warning in warnings), warnings)
+        self.assertTrue(any("IN_PROGRESS stale claim" in warning for warning in warnings), warnings)
+        self.assertTrue(any("reclaim-stale --dry-run" in warning for warning in warnings), warnings)
 
     def test_reclaim_stale_claim_ignores_recent_heartbeat(self) -> None:
         claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=1)
@@ -649,7 +794,10 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual(5, payload["olderThanMinutes"])
         self.assertEqual(1, payload["staleCount"])
         self.assertEqual(1, payload["reclaimableStaleCount"])
-        self.assertEqual({"total": 2, "unexpired": 1, "stale": 1}, payload["activeClaims"])
+        self.assertEqual(
+            {"total": 2, "unexpired": 0, "stale": 1, "leaseExpired": 2, "inactive": 2},
+            payload["activeClaims"],
+        )
         self.assertTrue(payload["reclaimSafety"]["timingOnly"])
         self.assertTrue(payload["reclaimSafety"]["requiresInspection"])
         self.assertEqual([claim["Issue Name"]], [item["issueName"] for item in payload["stale"]])
@@ -687,6 +835,10 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual(240, payload["olderThanMinutes"])
         self.assertEqual(1, payload["staleCount"])
         self.assertEqual(1, payload["reclaimableStaleCount"])
+        self.assertEqual(
+            {"total": 2, "unexpired": 0, "stale": 1, "leaseExpired": 2, "inactive": 2},
+            payload["activeClaims"],
+        )
         self.assertEqual([claim["Issue Name"]], [item["issueName"] for item in payload["stale"]])
         self.assertEqual(before, self.workbook_path.read_bytes())
         state = issue_queue.loadQueue(self.workbook_path)


### PR DESCRIPTION
## What changed
- Treat `IN_PROGRESS` claims as live only when they are not reclaimable-stale and their lease has not expired.
- Expose lease-expired and inactive counts in shortlist/controller-capacity payloads.
- Keep expired or reclaimable-stale claims out of active target-file overlap advisories.
- Make heartbeat renewals preserve an existing later lease instead of shortening it.
- Document the updated live-claim semantics and heartbeat lease behavior.

## Why
Expired-but-recent leases could still satisfy controller active-worker floors, and stale rows could keep influencing conflict guidance. That made controllers appear full even when work was no longer live.

## Validation
- `python3 -m unittest tests.test_issue_queue tests.test_controller_resource_audit`
- `python3 scripts/issue_queue.py validate`
- `python3 scripts/controller_resource_audit.py --json`
- `git diff --check`

## Known limitations
- This does not add batch heartbeat PR creation or broader multi-controller dispatch policy changes; those remain separate workflow optimizations.