### PR TITLE
Add repository health to controller audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,31 @@ These instructions apply to the entire repository unless a more specific `AGENTS
 
 The default branch is `main`.
 
-Keep changes narrow. Do not modify unrelated files, generated build output, packaged artifacts, dependency lock state, or submodule SHAs unless the task explicitly requires it. Do not rebase or update from `main` unless asked. Pull request squash auto-merge is the default; after opening a pull request, run `gh pr merge <PR_NUMBER> --auto --squash` unless the user explicitly asks not to, GitHub reports that the merge command is unavailable, or the pull request is intentionally using CI-polled validation as the full validation evidence. When CI-polled validation replaces local heavy validation, poll the required GitHub Actions check(s) to success before enabling auto-merge. If a task requires touching `random-dungeon-generator` or `vstd`, state that clearly and rerun the full validation workflow.
+Keep changes narrow. Do not modify unrelated files, generated build output, packaged artifacts, dependency lock state, or submodule SHAs unless the task explicitly requires it. Do not rebase or update from `main` unless asked. If a task requires touching `random-dungeon-generator` or `vstd`, state that clearly and rerun the full validation workflow.
+
+## Pull request merge policy
+
+Never push directly to `main`. Publish reviewable pull requests and use squash merging only.
+
+For ordinary implementation or workflow-optimization PRs, run focused local validation, open the PR, and use GitHub
+Actions polling for heavy Linux validation when the workflow covers the required evidence. If CI polling supplies the
+full validation evidence, run `python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux` to success before enabling
+auto-merge; add `--require-step coverage` for coverage-relevant changes. After the required evidence is present, run
+`gh pr merge <PR_NUMBER> --auto --squash` unless the user explicitly asks not to, GitHub reports that auto-merge is
+unavailable, or branch protection/check state prevents it. If validation or auto-merge is blocked, report the exact
+blocker and leave the PR intact.
+
+For workbook-only queue-state PRs that update only `planning/fall_of_nouraajd_issue_proposals.xlsx`, first confirm the
+diff is XLSX-only and `python3 scripts/issue_queue.py validate` passed. Then merge the claim, terminal-status,
+heartbeat, reclaim, priority, dependency, or other approved queue-state PR immediately with
+`gh pr merge <PR_NUMBER> --squash`; do not wait for GitHub Actions on these CI-exempt controller coordination PRs. If
+repository settings block direct merge, enable auto-merge and continue supervising other safe work, but do not treat the
+queue update as durable until the PR is actually merged.
+
+Do not treat queued auto-merge as merged. If a PR merges while checks are still being polled, stop waiting on that
+Actions run, fetch `origin/main`, verify the merge, and continue from the merged commit. When newer user or system
+instructions say not to merge or not to enable auto-merge, follow those instructions and leave the PR open with the
+validation evidence.
 
 When this file conflicts with the current code, tests, or build scripts, trust the code and update this file as part of the fix.
 
@@ -77,8 +101,8 @@ actually merges, create a fresh implementation worktree from updated `origin/mai
 and pass it the generated issue prompt plus any controller overrides. Workers must inspect source, verify root cause,
 make the smallest backward-compatible change, add regression coverage, run focused and required validation where
 feasible, and report exact commands and outcomes. The controller reviews the diff, commits, pushes, opens the
-implementation PR, polls required CI first when CI supplies full validation evidence, and enables squash auto-merge; do
-not mark the issue `DONE` until that implementation PR actually merges.
+implementation PR, polls required CI first when CI supplies full validation evidence, and enables squash auto-merge
+according to the pull request merge policy; do not mark the issue `DONE` until that implementation PR actually merges.
 
 After every controller loop iteration, claim/PR status check, cleanup audit, and before dispatching new work, print a
 concise live status table. Include controller ID, worker owner, issue key, phase, progress estimate, last action,
@@ -95,11 +119,12 @@ reproduction is necessary or GitHub Actions cannot provide the needed evidence. 
 feedback, then outsource compilation, native tests, performance guards, full Python suites, and coverage to GitHub
 Actions polling. Report the exact local commands used.
 
-For local disk safety, run `python3 scripts/controller_resource_audit.py --json` before dispatch/refill decisions, before
-any necessary local heavy validation, after every controller loop iteration, and after any merged checkpoint cleanup.
-Treat low free disk, high filesystem usage, large accumulated run/worktrees, or prunable worktree metadata as blockers to
-new work until reported or cleaned safely. Remove only completed clean worktrees, use `git worktree prune` only for
-prunable metadata after review, and do not delete branches unless explicitly asked.
+For local repository and disk safety, run `python3 scripts/controller_resource_audit.py --json` before dispatch/refill
+decisions, before any necessary local heavy validation, after every controller loop iteration, and after any merged
+checkpoint cleanup. Treat unreadable Git state, unresolved `HEAD` or `origin/main`, zero-byte loose Git objects,
+zero-byte Git ref files, low free disk, high filesystem usage, large accumulated run/worktrees, or prunable worktree
+metadata as blockers to new work until reported or cleaned safely. Remove only completed clean worktrees, use
+`git worktree prune` only for prunable metadata after review, and do not delete branches unless explicitly asked.
 
 ## Project overview
 
@@ -581,8 +606,16 @@ After finishing a change, always complete the repository delivery workflow:
 3. Commit the change with a clear, specific commit message.
 4. Push the branch to the remote.
 5. Open a pull request targeting `main`.
-6. Run `gh pr merge <PR_NUMBER> --auto --squash` for the pull request by default, unless the user explicitly asks not to, GitHub reports that the merge command is unavailable, or CI polling is supplying the full validation evidence and has not passed yet. Replace `<PR_NUMBER>` with the pull request just opened.
-7. If GitHub queues auto-merge, do not wait for checks to finish unless those checks are the selected CI-polled validation evidence and the PR is still open. If the PR has already merged, stop waiting on its Actions run, fetch `origin/main`, and continue from the merged commit.
+6. For implementation PRs, poll the selected GitHub Actions evidence to success before auto-merge when CI polling is
+   replacing local heavy validation.
+7. Run `gh pr merge <PR_NUMBER> --auto --squash` after required evidence is present unless the user explicitly asks not
+   to, GitHub reports that auto-merge is unavailable, or branch protection/check state blocks it. Replace `<PR_NUMBER>`
+   with the pull request just opened.
+8. For workbook-only queue-state PRs, use the immediate squash-merge rule in the pull request merge policy after
+   confirming the diff is XLSX-only and queue validation passed.
+9. If GitHub queues auto-merge, do not wait for checks to finish unless those checks are the selected CI-polled
+   validation evidence and the PR is still open. If the PR has already merged, stop waiting on its Actions run, fetch
+   `origin/main`, and continue from the merged commit.
 
 Keep one logical change per commit where practical. Do not bundle unrelated cleanup with feature or bug-fix work. Do not bypass failing required checks or unresolved merge conflicts unless the user explicitly instructs that specific bypass. If pushing, opening, merging, or enabling auto-merge is blocked by missing remotes, authentication, permissions, unavailable checks, merge conflicts, or platform failures, report the exact blocker and leave the branch and pull request intact.
 

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -228,10 +228,11 @@ loop, and after merged-checkpoint cleanup:
 python3 scripts/controller_resource_audit.py --json
 ```
 
-The audit reports disk usage, active and prunable worktree registrations, and matching controller run/worktrees such as
-`/tmp/nouraajd-*` and `/tmp/fall-of-nouraajd-codex`. It is report-only by default. Treat audit errors as blockers to new
-heavy work, and treat warnings about prunable worktree metadata or large accumulated run/worktrees as cleanup prompts
-before refilling worker slots.
+The audit reports Git repository health, disk usage, active and prunable worktree registrations, and matching controller
+run/worktrees such as `/tmp/nouraajd-*` and `/tmp/fall-of-nouraajd-codex`. It is report-only by default. Treat audit
+errors such as unreadable Git state, unresolved `HEAD` or `origin/main`, zero-byte loose Git objects, zero-byte Git ref
+files, or disk pressure as blockers to new heavy work, and treat warnings about prunable worktree metadata or large
+accumulated run/worktrees as cleanup prompts before refilling worker slots.
 
 ## Subagent progress protocol
 

--- a/scripts/controller_resource_audit.py
+++ b/scripts/controller_resource_audit.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Read-only disk and worktree resource audit for controller workflows."""
+"""Read-only repository, disk, and worktree resource audit for controller workflows."""
 
 from __future__ import annotations
 
@@ -46,6 +46,18 @@ class WorktreeRecord:
 class RunTreeRecord:
     path: str
     sizeBytes: int
+
+
+@dataclass(frozen=True)
+class GitHealthReport:
+    statusExitCode: int
+    statusStdout: str
+    statusStderr: str
+    head: str | None
+    originMain: str | None
+    gitCommonDir: str | None
+    emptyLooseObjects: tuple[str, ...]
+    emptyRefs: tuple[str, ...]
 
 
 def bytesToGib(value: int) -> float:
@@ -164,6 +176,102 @@ def runGitWorktreeList(repoRoot: Path) -> list[WorktreeRecord]:
     return parseWorktreePorcelain(result.stdout)
 
 
+def runGit(
+    repoRoot: Path,
+    args: Sequence[str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "--no-optional-locks", *args],
+        cwd=repoRoot,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def resolveGitPath(repoRoot: Path, pathText: str | None) -> Path | None:
+    if not pathText:
+        return None
+    path = Path(pathText.strip())
+    if not path.is_absolute():
+        path = repoRoot / path
+    return path.resolve()
+
+
+def findEmptyLooseObjects(gitCommonDir: Path | None) -> tuple[str, ...]:
+    if gitCommonDir is None:
+        return ()
+    objectsDir = gitCommonDir / "objects"
+    if not objectsDir.is_dir():
+        return ()
+
+    emptyObjects: list[str] = []
+    for prefixDir in objectsDir.iterdir():
+        if not prefixDir.is_dir() or len(prefixDir.name) != 2:
+            continue
+        for objectPath in prefixDir.iterdir():
+            try:
+                if objectPath.is_file() and objectPath.stat().st_size == 0:
+                    emptyObjects.append(str(objectPath.relative_to(objectsDir)))
+            except OSError:
+                continue
+    return tuple(sorted(emptyObjects))
+
+
+def findEmptyRefs(gitCommonDir: Path | None) -> tuple[str, ...]:
+    if gitCommonDir is None:
+        return ()
+    refsDir = gitCommonDir / "refs"
+    if not refsDir.is_dir():
+        return ()
+
+    emptyRefs: list[str] = []
+    for refPath in refsDir.rglob("*"):
+        try:
+            if refPath.is_file() and refPath.stat().st_size == 0:
+                emptyRefs.append(str(refPath.relative_to(gitCommonDir)))
+        except OSError:
+            continue
+    return tuple(sorted(emptyRefs))
+
+
+def runGitHealth(repoRoot: Path) -> GitHealthReport:
+    status = runGit(repoRoot, ["status", "--short", "--branch"])
+    head = runGit(repoRoot, ["rev-parse", "--verify", "HEAD"])
+    originMain = runGit(repoRoot, ["rev-parse", "--verify", "refs/remotes/origin/main"])
+    commonDir = runGit(repoRoot, ["rev-parse", "--git-common-dir"])
+    gitCommonDir = resolveGitPath(repoRoot, commonDir.stdout.strip()) if commonDir.returncode == 0 else None
+
+    return GitHealthReport(
+        statusExitCode=status.returncode,
+        statusStdout=status.stdout.strip(),
+        statusStderr=status.stderr.strip(),
+        head=head.stdout.strip() if head.returncode == 0 else None,
+        originMain=originMain.stdout.strip() if originMain.returncode == 0 else None,
+        gitCommonDir=str(gitCommonDir) if gitCommonDir is not None else None,
+        emptyLooseObjects=findEmptyLooseObjects(gitCommonDir),
+        emptyRefs=findEmptyRefs(gitCommonDir),
+    )
+
+
+def evaluateGitHealth(report: GitHealthReport) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    if report.statusExitCode != 0:
+        detail = report.statusStderr or report.statusStdout or "no git status output"
+        errors.append(f"git status failed with exit code {report.statusExitCode}: {detail}")
+    if not report.head:
+        errors.append("HEAD could not be resolved")
+    if not report.originMain:
+        errors.append("refs/remotes/origin/main could not be resolved")
+    if report.emptyLooseObjects:
+        errors.append(f"{len(report.emptyLooseObjects)} zero-byte loose git object(s) found")
+    if report.emptyRefs:
+        errors.append(f"{len(report.emptyRefs)} zero-byte git ref file(s) found")
+    return errors, warnings
+
+
 def directorySize(path: Path) -> int:
     total = 0
     for root, dirs, files in os.walk(path, topdown=True):
@@ -208,6 +316,7 @@ def discoverRunTrees(
 
 def payload(
     repoRoot: Path,
+    gitHealth: GitHealthReport,
     diskReports: Sequence[DiskReport],
     worktrees: Sequence[WorktreeRecord],
     runTrees: Sequence[RunTreeRecord],
@@ -216,6 +325,22 @@ def payload(
 ) -> dict[str, Any]:
     return {
         "repoRoot": str(repoRoot),
+        "git": {
+            "statusExitCode": gitHealth.statusExitCode,
+            "statusStdout": gitHealth.statusStdout,
+            "statusStderr": gitHealth.statusStderr,
+            "head": gitHealth.head,
+            "originMain": gitHealth.originMain,
+            "gitCommonDir": gitHealth.gitCommonDir,
+            "emptyLooseObjects": {
+                "total": len(gitHealth.emptyLooseObjects),
+                "records": list(gitHealth.emptyLooseObjects),
+            },
+            "emptyRefs": {
+                "total": len(gitHealth.emptyRefs),
+                "records": list(gitHealth.emptyRefs),
+            },
+        },
         "disk": [
             {
                 "path": report.path,
@@ -243,6 +368,13 @@ def payload(
 
 def printHuman(report: dict[str, Any]) -> None:
     print(f"Repository: {report['repoRoot']}")
+    git = report["git"]
+    print("Git:")
+    print(f"  status exit code: {git['statusExitCode']}")
+    print(f"  HEAD: {git['head'] or 'unresolved'}")
+    print(f"  origin/main: {git['originMain'] or 'unresolved'}")
+    print(f"  zero-byte loose objects: {git['emptyLooseObjects']['total']}")
+    print(f"  zero-byte refs: {git['emptyRefs']['total']}")
     print("Disk:")
     for item in report["disk"]:
         print(f"  {item['path']}: {item['freeHuman']} free, " f"{item['usedPercent']:.1f}% used")
@@ -300,6 +432,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     runTreePatterns = args.run_tree_pattern or list(DEFAULT_RUN_TREE_PATTERNS)
 
     try:
+        gitHealth = runGitHealth(repoRoot)
         diskReports = [diskReport(path) for path in uniqueDiskPaths]
         worktrees = runGitWorktreeList(repoRoot)
         runTrees = discoverRunTrees(runTreeRoots, runTreePatterns, includeSizes=not args.skip_run_tree_sizes)
@@ -309,10 +442,13 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     minFreeBytes = int(args.min_free_gib * 1024 * 1024 * 1024)
     errors, warnings = evaluateDiskReports(diskReports, minFreeBytes, args.max_used_percent)
+    gitErrors, gitWarnings = evaluateGitHealth(gitHealth)
+    errors.extend(gitErrors)
+    warnings.extend(gitWarnings)
     summary = worktreeSummary(worktrees)
     if summary["prunable"]:
         warnings.append(f"{summary['prunable']} prunable worktree registration(s); review and run git worktree prune")
-    report = payload(repoRoot, diskReports, worktrees, runTrees, errors, warnings)
+    report = payload(repoRoot, gitHealth, diskReports, worktrees, runTrees, errors, warnings)
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:

--- a/tests/test_controller_resource_audit.py
+++ b/tests/test_controller_resource_audit.py
@@ -96,6 +96,55 @@ detached
         self.assertTrue(records[0].path.endswith("fall-of-nouraajd-codex"))
         self.assertEqual(23, records[0].sizeBytes)
 
+    def test_find_empty_loose_objects_reports_relative_object_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            git_common_dir = Path(temp_dir)
+            empty_object = git_common_dir / "objects" / "ab" / "1234"
+            empty_object.parent.mkdir(parents=True)
+            empty_object.touch()
+            non_empty_object = git_common_dir / "objects" / "cd" / "5678"
+            non_empty_object.parent.mkdir(parents=True)
+            non_empty_object.write_text("not empty", encoding="utf-8")
+
+            records = controller_resource_audit.findEmptyLooseObjects(git_common_dir)
+
+        self.assertEqual(("ab/1234",), records)
+
+    def test_find_empty_refs_reports_relative_ref_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            git_common_dir = Path(temp_dir)
+            empty_ref = git_common_dir / "refs" / "remotes" / "origin" / "broken"
+            empty_ref.parent.mkdir(parents=True)
+            empty_ref.touch()
+            non_empty_ref = git_common_dir / "refs" / "heads" / "main"
+            non_empty_ref.parent.mkdir(parents=True)
+            non_empty_ref.write_text("abc123\n", encoding="utf-8")
+
+            records = controller_resource_audit.findEmptyRefs(git_common_dir)
+
+        self.assertEqual(("refs/remotes/origin/broken",), records)
+
+    def test_evaluate_git_health_flags_unreadable_repository_state(self) -> None:
+        report = controller_resource_audit.GitHealthReport(
+            statusExitCode=128,
+            statusStdout="",
+            statusStderr="fatal: bad object HEAD",
+            head=None,
+            originMain=None,
+            gitCommonDir="/repo/.git",
+            emptyLooseObjects=("48/6a2ad72f8ff03edd3bca9ec9ff76cb2c81b612",),
+            emptyRefs=("refs/remotes/origin/broken",),
+        )
+
+        errors, warnings = controller_resource_audit.evaluateGitHealth(report)
+
+        self.assertEqual([], warnings)
+        self.assertTrue(any("git status failed with exit code 128" in error for error in errors), errors)
+        self.assertIn("HEAD could not be resolved", errors)
+        self.assertIn("refs/remotes/origin/main could not be resolved", errors)
+        self.assertIn("1 zero-byte loose git object(s) found", errors)
+        self.assertIn("1 zero-byte git ref file(s) found", errors)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- Added Git repository health reporting to `scripts/controller_resource_audit.py`.
- The audit now reports `git status` failures, unresolved `HEAD`/`origin/main`, zero-byte loose Git objects, and zero-byte Git ref files in JSON and human output.
- Updated `AGENTS.md` to make PR merge policy explicit for:
  - implementation and workflow-optimization PRs,
  - CI-polled validation before auto-merge,
  - workbook-only queue-state PRs that are squash-merged immediately after XLSX-only diff review and queue validation.
- Updated queue-controller docs to describe the repository-health portion of the audit.
- Added focused unit coverage for empty loose-object detection, empty-ref detection, and Git-health error classification.

## Why

The optimizer loop encountered an unsafe checkout where `git status` failed with `fatal: bad object HEAD`, the object store contained zero-byte loose objects, and remote refs contained zero-byte files. The controller resource audit already gates dispatch and validation on local resource state, so surfacing repository health there makes unsafe checkout state visible before claim, dispatch, cleanup, or merge work continues.

## Validation

- `python3 -m unittest tests.test_controller_resource_audit` passed: 7 tests.
- `python3 -m unittest tests.test_issue_queue` passed: 31 tests.
- `python3 scripts/issue_queue.py validate` passed with no errors or warnings.
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes` passed on the clean checkpoint worktree with no errors or warnings.
- `git diff --check` passed.
- Read-only proof against the corrupted checkout:
  - `python3 /tmp/fon-workflow-optimizer-20260620/scripts/controller_resource_audit.py --repo-root /home/andrz/git/fall-of-nouraajd4 --json --skip-run-tree-sizes` exited nonzero as expected and reported `git status` exit 128, 18 zero-byte loose Git objects, 2 zero-byte Git ref files, and 32 prunable worktree registrations.
- GitHub Actions polling:
  - `python3 scripts/poll_pr_checks.py 594 --check linux` passed. The `build / linux` job completed successfully for PR head `0b6afca0c1ecb3bb40a2e6fc4f1440d6b2f37853`.

## Known limitations

- The focused tests cover helper and evaluator behavior. The full corrupt-checkout JSON path was validated manually against the observed damaged checkout rather than by adding an integration fixture that creates a corrupt Git repository.
- Auto-merge is intentionally not enabled for this PR because the active user-provided AGENTS instruction says not to merge pull requests.
