### PR TITLE
Add immutable save compatibility fixtures

### DIFF
--- a/test.py
+++ b/test.py
@@ -127,6 +127,7 @@ FAST_TEST_PREFIXES = (
     "CoverageReportTest.",
     "PlayBootstrapTest.",
     "QuestStateHelperTest.",
+    "SaveFixtureTest.",
     "TestRunnerSuiteTest.",
 )
 FAST_TEST_NAMES = {
@@ -228,6 +229,7 @@ def unique_save_name(prefix):
 
 SAVE_FORMAT = "fall-of-nouraajd-save"
 SAVE_SCHEMA_VERSION = 1
+SAVE_FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "save_compatibility"
 
 
 def save_primary_path(slot_name):
@@ -273,6 +275,316 @@ def assert_save_envelope(test_case, saved_document, map_name):
     test_case.assertEqual("CMap", snapshot.get("class"))
     test_case.assertEqual(map_name, snapshot.get("properties", {}).get("mapName"))
     return snapshot
+
+
+IMMUTABLE_SAVE_FIXTURE_EXPECTATIONS = {
+    "legacy_unversioned_test_map": {
+        "primary": "legacy_unversioned_test_map.json",
+        "summary": {
+            "encoding": "legacy",
+            "map": "test",
+            "turn": 11,
+            "description": "immutable legacy unversioned fixture",
+            "player": {
+                "class": "CPlayer",
+                "name": "player",
+                "typeId": "Warrior",
+                "coords": [1, 2, 0],
+                "activeQuests": [],
+                "completedQuests": [],
+                "items": [],
+            },
+            "questStates": {},
+            "trueFlags": [],
+            "numericProperties": {},
+            "objects": [],
+        },
+    },
+    "schema_v1_test_map": {
+        "primary": "schema_v1_test_map.json",
+        "summary": {
+            "encoding": "versioned",
+            "schemaVersion": 1,
+            "map": "test",
+            "turn": 12,
+            "description": "immutable schema v1 fixture",
+            "player": {
+                "class": "CPlayer",
+                "name": "player",
+                "typeId": "Warrior",
+                "coords": [2, 3, 0],
+                "activeQuests": [],
+                "completedQuests": [],
+                "items": [],
+            },
+            "questStates": {},
+            "trueFlags": [],
+            "numericProperties": {},
+            "objects": [],
+        },
+    },
+    "invalid_primary_valid_backup": {
+        "primary": "invalid_primary_valid_backup.json",
+        "backup": "invalid_primary_valid_backup.json.bak",
+        "primaryInvalidJson": True,
+        "summary": {
+            "encoding": "versioned",
+            "schemaVersion": 1,
+            "map": "test",
+            "turn": 13,
+            "description": "immutable backup recovery fixture",
+            "player": {
+                "class": "CPlayer",
+                "name": "player",
+                "typeId": "Warrior",
+                "coords": [3, 4, 0],
+                "activeQuests": [],
+                "completedQuests": [],
+                "items": [],
+            },
+            "questStates": {},
+            "trueFlags": [],
+            "numericProperties": {},
+            "objects": [],
+        },
+    },
+    "nouraajd_active_quests_v1": {
+        "primary": "nouraajd_active_quests_v1.json",
+        "summary": {
+            "encoding": "versioned",
+            "schemaVersion": 1,
+            "map": "nouraajd",
+            "turn": 77,
+            "description": "immutable Nouraajd active quest fixture",
+            "player": {
+                "class": "CPlayer",
+                "name": "player",
+                "typeId": "Warrior",
+                "coords": [43, 99, 0],
+                "activeQuests": ["rolfQuest", "victorQuest"],
+                "completedQuests": [],
+                "items": [],
+            },
+            "questStates": {
+                "amulet": "not_started",
+                "beren_chain": "letter_pending",
+                "main": "locked",
+                "octobogz_contract": "not_started",
+                "rolf": "awaiting_skull",
+                "victor": "met_victor",
+            },
+            "trueFlags": [],
+            "numericProperties": {},
+            "objects": [],
+        },
+    },
+    "nouraajd_runtime_spawned_quest_actors_v1": {
+        "primary": "nouraajd_runtime_spawned_quest_actors_v1.json",
+        "summary": {
+            "encoding": "versioned",
+            "schemaVersion": 1,
+            "map": "nouraajd",
+            "turn": 104,
+            "description": "immutable Nouraajd runtime quest actor fixture",
+            "player": {
+                "class": "CPlayer",
+                "name": "player",
+                "typeId": "Warrior",
+                "coords": [45, 100, 0],
+                "activeQuests": ["amuletQuest", "victorQuest"],
+                "completedQuests": [],
+                "items": [],
+            },
+            "questStates": {
+                "amulet": "active",
+                "beren_chain": "letter_pending",
+                "main": "locked",
+                "octobogz_contract": "not_started",
+                "rolf": "awaiting_skull",
+                "victor": "encounter_active",
+            },
+            "trueFlags": ["VICTOR_COURTYARD_FOUND", "VICTOR_CULTISTS_SPAWNED"],
+            "numericProperties": {"VICTOR_COURTYARD_TURN": 100},
+            "objects": [
+                {"name": "amuletGoblin", "typeId": "goblinThief"},
+                {"name": "cultLeaderQuest", "typeId": "CultLeader"},
+                {"name": "victorCultist1", "typeId": "Cultist"},
+            ],
+        },
+    },
+    "ritual_progression_v1": {
+        "primary": "ritual_progression_v1.json",
+        "summary": {
+            "encoding": "versioned",
+            "schemaVersion": 1,
+            "map": "ritual",
+            "turn": 39,
+            "description": "immutable ritual progression fixture",
+            "player": {
+                "class": "CPlayer",
+                "name": "player",
+                "typeId": "Warrior",
+                "coords": [3, 22, 0],
+                "activeQuests": [
+                    "destroyAnchorsQuest",
+                    "finalResolutionQuest",
+                    "rescueCaptiveQuest",
+                    "ritualQuest",
+                ],
+                "completedQuests": [],
+                "items": [],
+            },
+            "questStates": {},
+            "trueFlags": ["anchors_destroyed", "leader_spawned", "ritual_initialized", "ritual_started"],
+            "numericProperties": {"anchors_destroyed_count": 3, "ritual_countdown": 62},
+            "objects": [{"name": "ritualLeader", "typeId": "ritualLeaderTemplate"}],
+        },
+    },
+    "siege_progression_v1": {
+        "primary": "siege_progression_v1.json",
+        "summary": {
+            "encoding": "versioned",
+            "schemaVersion": 1,
+            "map": "siege",
+            "turn": 51,
+            "description": "immutable siege progression fixture",
+            "player": {
+                "class": "CPlayer",
+                "name": "player",
+                "typeId": "Warrior",
+                "coords": [12, 8, 0],
+                "activeQuests": ["defendSiegeQuest"],
+                "completedQuests": [],
+                "items": ["magicWand"],
+            },
+            "questStates": {},
+            "trueFlags": ["siege_initialized"],
+            "numericProperties": {},
+            "objects": [{"name": "spawnPoint1", "typeId": "SiegeSpawnPoint"}],
+        },
+    },
+}
+
+
+def fixture_document_snapshot(document):
+    if document.get("format") == SAVE_FORMAT:
+        return "versioned", document.get("snapshot", {})
+    return "legacy", document
+
+
+def fixture_object_type_id(obj):
+    properties = obj.get("properties", {}) if isinstance(obj, dict) else {}
+    return properties.get("typeId") or obj.get("ref") or obj.get("class")
+
+
+def fixture_named_objects(snapshot):
+    objects = []
+    for obj in snapshot.get("properties", {}).get("objects", []):
+        properties = obj.get("properties", {}) if isinstance(obj, dict) else {}
+        name = properties.get("name")
+        if name and name != "player":
+            objects.append({"name": name, "typeId": fixture_object_type_id(obj)})
+    return sorted(objects, key=lambda item: item["name"])
+
+
+def fixture_player_summary(snapshot):
+    for obj in snapshot.get("properties", {}).get("objects", []):
+        properties = obj.get("properties", {}) if isinstance(obj, dict) else {}
+        if obj.get("class") == "CPlayer" or properties.get("name") == "player":
+            return {
+                "class": obj.get("class") or obj.get("ref"),
+                "name": properties.get("name"),
+                "typeId": properties.get("typeId"),
+                "coords": [properties.get("posx", 0), properties.get("posy", 0), properties.get("posz", 0)],
+                "activeQuests": fixture_quest_ids(properties.get("quests", [])),
+                "completedQuests": fixture_quest_ids(properties.get("completedQuests", [])),
+                "items": fixture_item_ids(properties.get("items", [])),
+            }
+    raise AssertionError("Save fixture snapshot does not contain a canonical player object.")
+
+
+def fixture_quest_ids(quests):
+    quest_ids = []
+    for quest in quests:
+        if not isinstance(quest, dict):
+            continue
+        properties = quest.get("properties", {})
+        quest_ids.append(properties.get("typeId") or properties.get("name") or quest.get("ref") or quest.get("class"))
+    return sorted(quest_id for quest_id in quest_ids if quest_id)
+
+
+def fixture_item_ids(items):
+    item_ids = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        properties = item.get("properties", {})
+        item_ids.append(properties.get("typeId") or properties.get("name") or item.get("ref") or item.get("class"))
+    return sorted(item_id for item_id in item_ids if item_id)
+
+
+def save_fixture_summary(document):
+    encoding, snapshot = fixture_document_snapshot(document)
+    properties = snapshot.get("properties", {})
+    summary = {
+        "encoding": encoding,
+        "map": properties.get("mapName"),
+        "turn": properties.get("turn", 0),
+        "description": properties.get("description", ""),
+        "player": fixture_player_summary(snapshot),
+        "questStates": {
+            key.removeprefix("quest_state_"): value
+            for key, value in sorted(properties.items())
+            if key.startswith("quest_state_")
+        },
+        "trueFlags": sorted(
+            key for key, value in properties.items() if isinstance(value, bool) and value and key != "canStep"
+        ),
+        "numericProperties": {
+            key: value
+            for key, value in sorted(properties.items())
+            if key
+            in {
+                "VICTOR_COURTYARD_TURN",
+                "anchors_destroyed_count",
+                "ritual_countdown",
+            }
+        },
+        "objects": fixture_named_objects(snapshot),
+    }
+    if encoding == "versioned":
+        summary["schemaVersion"] = document.get("schemaVersion")
+    return summary
+
+
+class SaveFixtureTest(unittest.TestCase):
+    maxDiff = None
+
+    def test_immutable_save_fixture_summaries_match_expected(self):
+        self.assertTrue(SAVE_FIXTURE_DIR.is_dir(), f"Missing fixture directory: {SAVE_FIXTURE_DIR}")
+        expected_files = set()
+        for expected in IMMUTABLE_SAVE_FIXTURE_EXPECTATIONS.values():
+            expected_files.add(expected["primary"])
+            if expected.get("backup"):
+                expected_files.add(expected["backup"])
+
+        actual_files = {path.name for path in SAVE_FIXTURE_DIR.iterdir() if path.is_file()}
+        self.assertEqual(expected_files, actual_files)
+
+        for fixture_name, expected in IMMUTABLE_SAVE_FIXTURE_EXPECTATIONS.items():
+            primary = SAVE_FIXTURE_DIR / expected["primary"]
+            self.assertTrue(primary.is_file(), fixture_name)
+            if expected.get("primaryInvalidJson"):
+                with self.assertRaises(json.JSONDecodeError, msg=fixture_name):
+                    json.loads(primary.read_text(encoding="utf-8"))
+                document_path = SAVE_FIXTURE_DIR / expected["backup"]
+            else:
+                document_path = primary
+
+            document = json.loads(document_path.read_text(encoding="utf-8"))
+            if document.get("format") == SAVE_FORMAT:
+                assert_save_envelope(self, document, expected["summary"]["map"])
+            self.assertEqual(expected["summary"], save_fixture_summary(document), fixture_name)
 
 
 class ProgressTextTestResult(unittest.TextTestResult):

--- a/tests/fixtures/save_compatibility/invalid_primary_valid_backup.json
+++ b/tests/fixtures/save_compatibility/invalid_primary_valid_backup.json
@@ -1,0 +1,1 @@
+{"snapshot":

--- a/tests/fixtures/save_compatibility/invalid_primary_valid_backup.json.bak
+++ b/tests/fixtures/save_compatibility/invalid_primary_valid_backup.json.bak
@@ -1,0 +1,30 @@
+{
+  "format": "fall-of-nouraajd-save",
+  "mapName": "test",
+  "schemaVersion": 1,
+  "snapshot": {
+    "class": "CMap",
+    "properties": {
+      "description": "immutable backup recovery fixture",
+      "mapName": "test",
+      "objects": [
+        {
+          "class": "CPlayer",
+          "properties": {
+            "completedQuests": [],
+            "items": [],
+            "name": "player",
+            "posx": 3,
+            "posy": 4,
+            "posz": 0,
+            "quests": [],
+            "typeId": "Warrior"
+          }
+        }
+      ],
+      "tiles": [],
+      "triggers": [],
+      "turn": 13
+    }
+  }
+}

--- a/tests/fixtures/save_compatibility/legacy_unversioned_test_map.json
+++ b/tests/fixtures/save_compatibility/legacy_unversioned_test_map.json
@@ -1,0 +1,25 @@
+{
+  "class": "CMap",
+  "properties": {
+    "description": "immutable legacy unversioned fixture",
+    "mapName": "test",
+    "objects": [
+      {
+        "class": "CPlayer",
+        "properties": {
+          "completedQuests": [],
+          "items": [],
+          "name": "player",
+          "posx": 1,
+          "posy": 2,
+          "posz": 0,
+          "quests": [],
+          "typeId": "Warrior"
+        }
+      }
+    ],
+    "tiles": [],
+    "triggers": [],
+    "turn": 11
+  }
+}

--- a/tests/fixtures/save_compatibility/nouraajd_active_quests_v1.json
+++ b/tests/fixtures/save_compatibility/nouraajd_active_quests_v1.json
@@ -1,0 +1,51 @@
+{
+  "format": "fall-of-nouraajd-save",
+  "mapName": "nouraajd",
+  "schemaVersion": 1,
+  "snapshot": {
+    "class": "CMap",
+    "properties": {
+      "description": "immutable Nouraajd active quest fixture",
+      "mapName": "nouraajd",
+      "objects": [
+        {
+          "class": "CPlayer",
+          "properties": {
+            "completedQuests": [],
+            "items": [],
+            "name": "player",
+            "posx": 43,
+            "posy": 99,
+            "posz": 0,
+            "quests": [
+              {
+                "class": "RolfQuest",
+                "properties": {
+                  "name": "rolfQuest",
+                  "typeId": "rolfQuest"
+                }
+              },
+              {
+                "class": "VictorQuest",
+                "properties": {
+                  "name": "victorQuest",
+                  "typeId": "victorQuest"
+                }
+              }
+            ],
+            "typeId": "Warrior"
+          }
+        }
+      ],
+      "quest_state_amulet": "not_started",
+      "quest_state_beren_chain": "letter_pending",
+      "quest_state_main": "locked",
+      "quest_state_octobogz_contract": "not_started",
+      "quest_state_rolf": "awaiting_skull",
+      "quest_state_victor": "met_victor",
+      "tiles": [],
+      "triggers": [],
+      "turn": 77
+    }
+  }
+}

--- a/tests/fixtures/save_compatibility/nouraajd_runtime_spawned_quest_actors_v1.json
+++ b/tests/fixtures/save_compatibility/nouraajd_runtime_spawned_quest_actors_v1.json
@@ -1,0 +1,84 @@
+{
+  "format": "fall-of-nouraajd-save",
+  "mapName": "nouraajd",
+  "schemaVersion": 1,
+  "snapshot": {
+    "class": "CMap",
+    "properties": {
+      "VICTOR_COURTYARD_FOUND": true,
+      "VICTOR_COURTYARD_TURN": 100,
+      "VICTOR_CULTISTS_SPAWNED": true,
+      "description": "immutable Nouraajd runtime quest actor fixture",
+      "mapName": "nouraajd",
+      "objects": [
+        {
+          "class": "CPlayer",
+          "properties": {
+            "completedQuests": [],
+            "items": [],
+            "name": "player",
+            "posx": 45,
+            "posy": 100,
+            "posz": 0,
+            "quests": [
+              {
+                "class": "AmuletQuest",
+                "properties": {
+                  "name": "amuletQuest",
+                  "typeId": "amuletQuest"
+                }
+              },
+              {
+                "class": "VictorQuest",
+                "properties": {
+                  "name": "victorQuest",
+                  "typeId": "victorQuest"
+                }
+              }
+            ],
+            "typeId": "Warrior"
+          }
+        },
+        {
+          "class": "CCreature",
+          "properties": {
+            "name": "cultLeaderQuest",
+            "posx": 44,
+            "posy": 100,
+            "posz": 0,
+            "typeId": "CultLeader"
+          }
+        },
+        {
+          "class": "CCreature",
+          "properties": {
+            "name": "victorCultist1",
+            "posx": 46,
+            "posy": 100,
+            "posz": 0,
+            "typeId": "Cultist"
+          }
+        },
+        {
+          "class": "CCreature",
+          "properties": {
+            "name": "amuletGoblin",
+            "posx": 195,
+            "posy": 8,
+            "posz": 0,
+            "typeId": "goblinThief"
+          }
+        }
+      ],
+      "quest_state_amulet": "active",
+      "quest_state_beren_chain": "letter_pending",
+      "quest_state_main": "locked",
+      "quest_state_octobogz_contract": "not_started",
+      "quest_state_rolf": "awaiting_skull",
+      "quest_state_victor": "encounter_active",
+      "tiles": [],
+      "triggers": [],
+      "turn": 104
+    }
+  }
+}

--- a/tests/fixtures/save_compatibility/ritual_progression_v1.json
+++ b/tests/fixtures/save_compatibility/ritual_progression_v1.json
@@ -1,0 +1,75 @@
+{
+  "format": "fall-of-nouraajd-save",
+  "mapName": "ritual",
+  "schemaVersion": 1,
+  "snapshot": {
+    "class": "CMap",
+    "properties": {
+      "anchors_destroyed": true,
+      "anchors_destroyed_count": 3,
+      "description": "immutable ritual progression fixture",
+      "leader_spawned": true,
+      "mapName": "ritual",
+      "objects": [
+        {
+          "class": "CPlayer",
+          "properties": {
+            "completedQuests": [],
+            "items": [],
+            "name": "player",
+            "posx": 3,
+            "posy": 22,
+            "posz": 0,
+            "quests": [
+              {
+                "class": "DestroyAnchorsQuest",
+                "properties": {
+                  "name": "destroyAnchorsQuest",
+                  "typeId": "destroyAnchorsQuest"
+                }
+              },
+              {
+                "class": "FinalResolutionQuest",
+                "properties": {
+                  "name": "finalResolutionQuest",
+                  "typeId": "finalResolutionQuest"
+                }
+              },
+              {
+                "class": "RescueCaptiveQuest",
+                "properties": {
+                  "name": "rescueCaptiveQuest",
+                  "typeId": "rescueCaptiveQuest"
+                }
+              },
+              {
+                "class": "RitualQuest",
+                "properties": {
+                  "name": "ritualQuest",
+                  "typeId": "ritualQuest"
+                }
+              }
+            ],
+            "typeId": "Warrior"
+          }
+        },
+        {
+          "class": "CCreature",
+          "properties": {
+            "name": "ritualLeader",
+            "posx": 13,
+            "posy": 7,
+            "posz": 0,
+            "typeId": "ritualLeaderTemplate"
+          }
+        }
+      ],
+      "ritual_countdown": 62,
+      "ritual_initialized": true,
+      "ritual_started": true,
+      "tiles": [],
+      "triggers": [],
+      "turn": 39
+    }
+  }
+}

--- a/tests/fixtures/save_compatibility/schema_v1_test_map.json
+++ b/tests/fixtures/save_compatibility/schema_v1_test_map.json
@@ -1,0 +1,30 @@
+{
+  "format": "fall-of-nouraajd-save",
+  "mapName": "test",
+  "schemaVersion": 1,
+  "snapshot": {
+    "class": "CMap",
+    "properties": {
+      "description": "immutable schema v1 fixture",
+      "mapName": "test",
+      "objects": [
+        {
+          "class": "CPlayer",
+          "properties": {
+            "completedQuests": [],
+            "items": [],
+            "name": "player",
+            "posx": 2,
+            "posy": 3,
+            "posz": 0,
+            "quests": [],
+            "typeId": "Warrior"
+          }
+        }
+      ],
+      "tiles": [],
+      "triggers": [],
+      "turn": 12
+    }
+  }
+}

--- a/tests/fixtures/save_compatibility/siege_progression_v1.json
+++ b/tests/fixtures/save_compatibility/siege_progression_v1.json
@@ -1,0 +1,54 @@
+{
+  "format": "fall-of-nouraajd-save",
+  "mapName": "siege",
+  "schemaVersion": 1,
+  "snapshot": {
+    "class": "CMap",
+    "properties": {
+      "description": "immutable siege progression fixture",
+      "mapName": "siege",
+      "objects": [
+        {
+          "class": "CPlayer",
+          "properties": {
+            "completedQuests": [],
+            "items": [
+              {
+                "ref": "magicWand"
+              }
+            ],
+            "name": "player",
+            "posx": 12,
+            "posy": 8,
+            "posz": 0,
+            "quests": [
+              {
+                "class": "DefendSiegeQuest",
+                "properties": {
+                  "name": "defendSiegeQuest",
+                  "typeId": "defendSiegeQuest"
+                }
+              }
+            ],
+            "typeId": "Warrior"
+          }
+        },
+        {
+          "class": "CEvent",
+          "properties": {
+            "enabled": true,
+            "name": "spawnPoint1",
+            "posx": 14,
+            "posy": 9,
+            "posz": 0,
+            "typeId": "SiegeSpawnPoint"
+          }
+        }
+      ],
+      "siege_initialized": true,
+      "tiles": [],
+      "triggers": [],
+      "turn": 51
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- Added immutable save compatibility fixtures under `tests/fixtures/save_compatibility/` for legacy unversioned saves, schema v1 saves, backup recovery, campaign quest state, runtime quest actors, ritual progression, and siege progression.
- Added `SaveFixtureTest` to pin the fixture inventory and expected summaries, and included it in the fast Python suite.

## Why

`[EPIC_03][STORY_05][SUBSTORY_01]Add immutable save fixtures` needs stable repository fixtures so future save-format and migration work has durable examples to validate against instead of relying only on generated transient save data.

## Validation

- `GAME_TEST_OUTPUT_DIR=/tmp/fon-save-fixture-controller-review GAME_TEST_TIMINGS_FILE=/tmp/fon-save-fixture-controller-review/test-timings.json python3 test.py --suite fast SaveFixtureTest.test_immutable_save_fixture_summaries_match_expected`
- `GAME_TEST_OUTPUT_DIR=/tmp/fon-save-fixture-controller-review-postrebase GAME_TEST_TIMINGS_FILE=/tmp/fon-save-fixture-controller-review-postrebase/test-timings.json python3 test.py --suite fast SaveFixtureTest.test_immutable_save_fixture_summaries_match_expected`
- `black -l 120 --check test.py`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- Valid fixture JSON was parsed with `json.loads`; the intentionally invalid primary backup fixture was excluded from that parser check.

## Known limitations

- Native save/load acceptance was not run locally because this worker worktree does not have an importable compiled `game` module. GitHub Actions is expected to provide the heavy Linux validation evidence for the PR.
