### PR TITLE
Loosen queue source-overlap dispatch policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,28 +50,33 @@ workbook-only pull requests. Each claim or terminal status PR should mark exactl
 workflow explicitly permits batching and all selected issues are proven independent.
 
 Keep at least eight live subagents attached to the controller whenever the subagent interface is available. Keep at least
-eight implementation issues active whenever eight safe, eligible, non-conflicting issues exist. Treat eight active issues as
-the minimum operating target, not a best-effort aspiration. Before filling any implementation slot, note current RAM,
+eight implementation issues active whenever eight status-and-dependency eligible implementation issues exist. Treat eight
+active issues as the minimum operating target, not a best-effort aspiration. Before filling any implementation slot, note current RAM,
 free disk space, existing run/worktree usage, and running heavy jobs so the controller avoids obvious resource pressure,
 but do not impose a fixed RAM cap or rewrite build parallelism solely by workflow policy. Dispatch work whenever issue
 eligibility, live worker status, and repository safety allow it. Use standby subagents only when fewer than eight
-implementation issues can safely run; they may do lightweight status, eligibility, or review-prep tasks, but must not
-claim issues, edit files, or run heavy validation. Each controller instance must also keep at least four non-stale
-implementation claims under its own `controller/<controller-id>` owner prefix whenever four eligible issues can safely
-be claimed by that controller. Stale owned claims do not count toward this floor. Before filling each free worker slot,
-fetch the latest `origin/main`, recalculate the full eligible set from the merged workbook, and exclude:
+implementation issues are safe for non-source reasons; they may do lightweight status, eligibility, or review-prep tasks,
+but must not claim issues, edit files, or run heavy validation. Each controller instance must keep exactly four non-stale
+implementation claims under its own `controller/<controller-id>` owner prefix whenever at least four status-and-dependency
+eligible issues are available for that controller. Stale owned claims do not count toward this target, and a controller
+must not claim a fifth live implementation issue. Before filling each free worker slot, fetch the latest `origin/main`,
+recalculate the full eligible set from the merged workbook, and exclude:
 
 - rows whose status is not `NOT_STARTED`;
-- rows with dependencies that are not `DONE`;
-- active-scope conflicts, including source-backed direct or indirect conflicts through shared headers, bindings, tests,
-  CMake, map scripts, dialog/config files, serialization, generated resources, or shared runtime systems.
+- rows with dependencies that are not `DONE`.
 
-Treat exact `Target Files / Modules` overlap with active work as advisory scope evidence, not as an automatic exclusion.
-Use it to prioritize review and decide whether a source-backed active-scope conflict exists.
+Treat exact `Target Files / Modules` overlap, shared source areas, open implementation PRs, shared headers, bindings,
+tests, CMake, map scripts, dialog/config files, serialization, generated resources, and shared runtime systems as
+advisory coordination evidence, not automatic claim exclusions. Use these signals to shape worker prompts, expected
+merge/rebase risk, review order, and validation focus. Do not leave an implementation slot empty solely because the next
+status-and-dependency eligible issue overlaps active work; claim it and manage the overlap unless a non-source blocker
+such as missing live worker status, repository safety, resource pressure, authentication, queue validation failure, or an
+unmerged workbook-state PR prevents safe dispatch.
 
 After exclusions, keep only the highest currently available priority tier. Group candidates by `(Epic #, Story #)`,
 randomly select one story with equal probability, then randomly select one eligible substory in that story. Do not fall
-back to spreadsheet order and do not include ineligible rows in the random choice. Use
+back to spreadsheet order, do not include status/dependency-ineligible rows in the random choice, and do not fall back to
+a lower priority tier merely to avoid source overlap. Use
 `python3 scripts/issue_queue.py shortlist --seed "$CONTROLLER_ID-<utc-cycle-id>" --controller-id "$CONTROLLER_ID" --include-rejected --json`
 as the read-only mechanical selector before each claim; it reports eligible highest-priority story groups, stale claims,
 `activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stale`, `activeClaims.leaseExpired`,
@@ -80,16 +85,17 @@ recommendation without mutating the workbook. `activeClaims.unexpired` means liv
 reclaimable-stale nor lease-expired. Use the unexpired count, not raw
 `activeCount`, when deciding whether the global active-worker floor is genuinely satisfied. Use
 `controllerCapacity.activeNonStale`, `controllerCapacity.leaseExpiredOwned`,
-`controllerCapacity.deficitToFloor`, and `controllerCapacity.fillableDeficit` to decide whether this controller must
-keep claiming to satisfy its four-owned-issue floor. The controller and project manager must still inspect target-file
-overlap advisories and exclude source-backed active-scope conflicts, then claim the final exact issue with `claim
---issue` so eligibility is rechecked under the workbook lock.
+`controllerCapacity.deficitToFloor`, `controllerCapacity.fillableDeficit`, `controllerCapacity.activeLimit`,
+`controllerCapacity.availableSlots`, `controllerCapacity.overLimitBy`, and `controllerCapacity.overCapacity` to decide
+whether this controller must refill to four, stop at four, or report over-capacity. The controller and project manager
+must still inspect and record target-file/source-overlap advisories, then claim the final exact issue with
+`claim --issue` so status and dependency eligibility is rechecked under the workbook lock.
 
 Assign a read-only project manager role whenever subagent capacity permits. Before dispatch/refill decisions, the
 project manager should summarize the highest available priority tier, candidate story groups, dependency unlocks, stale
-or blocked work, validation and resource cost, scope conflicts, and any source-backed priority-change recommendations.
+or blocked work, validation and resource cost, scope-overlap advisories, and any source-backed priority-change recommendations.
 The role is advisory: it must not claim work, edit files, touch the workbook, start validation, or override dependency,
-conflict, priority-tier, randomized selection, resource, cleanup, or PR requirements. Priority, dependency, status, or scope
+priority-tier, randomized selection, resource, cleanup, or PR requirements. Priority, dependency, status, or scope
 changes affect dispatch only after an approved workbook-only pull request merges into `main`.
 
 Assign one read-only QA subagent whenever subagent capacity permits. The QA role reviews diffs, regression coverage,

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -25,9 +25,10 @@ The queue uses two different mechanisms:
 Each active row has both an `Owner` and a random `Claim ID`. Heartbeat, completion, block, failure, cancellation, and release operations require both values. A subagent cannot update a task merely by knowing its issue title.
 
 The queue lock prevents duplicate task claims. It does **not** prevent two subagents from editing the same source file.
-Exact `Target Files / Modules` overlap is advisory evidence, not an automatic claim blocker. The controller must inspect
-scopes and serialize work when source-backed direct or indirect conflicts exist through shared headers, bindings, tests,
-CMake, map scripts, dialog/config files, serialization, generated resources, or shared runtime systems.
+Exact `Target Files / Modules` overlap, open implementation PRs, and shared source areas are advisory coordination
+evidence, not automatic claim blockers. The controller must inspect these signals and use them to shape worker prompts,
+review order, expected rebase/merge risk, and validation focus, but a controller should not leave a worker slot empty
+solely because status-and-dependency eligible work overlaps active source scope.
 
 ## Setup
 
@@ -86,21 +87,23 @@ keeps only the highest currently eligible priority tier for `storyGroups`, and e
 expired leases, and exact target-file overlaps can inform dispatch decisions without becoming automatic blockers.
 `activeClaims.unexpired` means live/pollable rows that are neither reclaimable-stale nor lease-expired. When
 `--controller-id` is provided, it also reports `controllerCapacity`: the current controller's live active issues,
-stale owned issues, lease-expired owned issues, deficit to the four-issue controller floor, and fillable deficit from
-the current eligible set. Treat that output as mechanical evidence for the controller and project-manager brief, not as
-an automatic claim. The controller and PM must still inspect source-backed active-scope conflicts, including:
+stale owned issues, lease-expired owned issues, deficit to the four-issue controller target, active limit, available
+slots, over-limit count, over-capacity flag, and fillable deficit from the current eligible set. Treat that output as
+mechanical evidence for the controller and project-manager brief, not as
+an automatic claim. The controller and PM must still inspect coordination advisories, including:
 
 - rows whose status is not `NOT_STARTED`;
 - rows with unfinished dependencies;
-- active-scope conflicts;
-- target-file overlaps with active work that source inspection confirms are real conflicts;
-- indirect conflicts through shared headers, bindings, tests, CMake, map scripts, dialog/config files, serialization,
+- active target-file overlaps;
+- open implementation PRs in nearby source areas;
+- indirect shared scope through headers, bindings, tests, CMake, map scripts, dialog/config files, serialization,
   generated resources, or shared runtime systems.
 
 Keep only the highest currently available priority tier. Group remaining candidates by `(Epic #, Story #)`, randomly
 select one story with equal probability, then randomly select one eligible substory inside it. Never default to workbook
-order and never randomize ineligible rows. After final review, claim the exact selected issue with `claim --issue`; the
-claim command revalidates eligibility under the workbook lock.
+order, never randomize status/dependency-ineligible rows, and never fall back to a lower priority tier merely to avoid
+source overlap. After final review, claim the exact selected issue with `claim --issue`; the claim command revalidates
+status and dependency eligibility under the workbook lock.
 
 Before dispatch/refill decisions, assign a read-only project manager role when subagent capacity permits. The project
 manager reviews the merged workbook, active work, stale claims, blockers, dependency chains, validation cost, resource
@@ -109,11 +112,11 @@ state, disk cleanup needs, and open PR state, then reports:
 - the highest available priority tier and candidate `(Epic #, Story #)` groups;
 - issues likely to unblock other work;
 - stale, blocked, failed, or repeatedly deferred rows needing controller attention;
-- scope, validation, resource, and sequencing risks;
+- scope-overlap, validation, resource, and sequencing risks;
 - source-backed recommendations for priority changes, issue splits, deferrals, or blocker publications.
 
 The project manager is advisory. It must not claim issues, edit files, touch the workbook, start validation, or override
-the dependency, conflict, highest-priority-tier, randomized story/substory, resource, cleanup, or PR requirements. Any priority,
+the dependency, highest-priority-tier, randomized story/substory, resource, cleanup, or PR requirements. Any priority,
 dependency, status, or scope change must be approved by the user or controller and merged through a serialized
 workbook-only pull request before it affects dispatch.
 
@@ -171,25 +174,28 @@ Alternatively use `claim --format prompt`.
 ## Live worker status
 
 Keep at least eight live subagents attached to the controller whenever the subagent interface is available. Keep at least
-eight implementation issues active whenever eight safe, eligible, non-conflicting issues exist. Before dispatching or
-refilling implementation workers, note current RAM, free disk, accumulated run/worktrees, prunable worktree metadata,
-and running heavy build/test/coverage/Xvfb/MCP jobs so the controller avoids obvious resource pressure without imposing
-a fixed RAM cap. If the controller cannot keep eight issue workers active, report the concrete eligibility, conflict,
-status, resource, disk, cleanup, or repository-safety blocker.
+eight implementation issues active whenever eight status-and-dependency eligible implementation issues exist. Before
+dispatching or refilling implementation workers, note current RAM, free disk, accumulated run/worktrees, prunable
+worktree metadata, and running heavy build/test/coverage/Xvfb/MCP jobs so the controller avoids obvious resource
+pressure without imposing a fixed RAM cap. If the controller cannot keep eight issue workers active, report the concrete
+status, dependency, live-worker-status, resource, disk, cleanup, authentication, queue-validation, workbook-PR, or
+repository-safety blocker.
 
-Each controller instance must also keep at least four of its own non-stale workbook claims active whenever four eligible
-issues are available for that controller to claim safely. Stale owned claims do not count toward that per-controller
-floor; run `shortlist --controller-id "$CONTROLLER_ID"` before every refill and keep claiming until
-`controllerCapacity.deficitToFloor` is zero, `controllerCapacity.fillableDeficit` is zero, or a concrete blocker is
-reported.
+Each controller instance must keep exactly four of its own non-stale workbook claims active whenever four
+status-and-dependency eligible issues are available for that controller. Stale owned claims do not count toward that
+per-controller target, and a controller must not claim a fifth live implementation issue. Run
+`shortlist --controller-id "$CONTROLLER_ID"` before every refill and keep claiming until
+`controllerCapacity.deficitToFloor` is zero, `controllerCapacity.fillableDeficit` is zero, or a concrete non-source
+blocker is reported. If `controllerCapacity.overCapacity` is true, stop claiming and report
+`controllerCapacity.overLimitBy`.
 
 Standby subagents may help with lightweight status polling, eligibility summaries, or review preparation only when fewer
-than eight implementation issues can safely run. They must not claim issues, edit files, touch the workbook, start builds,
-run tests, or launch coverage/Xvfb/MCP validation.
+than eight implementation issues are safe for non-source reasons. They must not claim issues, edit files, touch the
+workbook, start builds, run tests, or launch coverage/Xvfb/MCP validation.
 
-When eight implementation workers are not safe, prefer assigning one standby subagent as the project manager so the next
-refill decision has a current prioritization brief. When eight safe implementation issues exist, the project manager
-should run as extra read-only capacity rather than displacing an implementation worker.
+When eight implementation workers are not safe for non-source reasons, prefer assigning one standby subagent as the project manager so the next
+refill decision has a current prioritization brief. When eight status-and-dependency eligible implementation issues
+exist, the project manager should run as extra read-only capacity rather than displacing an implementation worker.
 
 Assign one standby or extra read-only subagent as QA whenever capacity permits. QA reviews selection risk, diffs,
 tests, GitHub Actions evidence, and merge readiness; it must not claim issues, edit the workbook, or start heavy
@@ -391,8 +397,9 @@ python3 scripts/issue_queue.py show --issue "$ISSUE_NAME"
 - Do not run local native builds, `ctest`, full Python suites, or coverage for PR delivery unless a focused local
   reproduction is necessary or GitHub Actions cannot provide the needed evidence.
 - Prefer CI polling for Linux full validation instead of duplicating heavy local build, test, and coverage work.
-- Keep at least eight live subagents and at least eight active implementation issues whenever eight issues are safe and
-  eligible, using standby roles only when fewer than eight implementation workers are safe.
+- Keep at least eight live subagents and at least eight active implementation issues whenever eight issues are
+  status-and-dependency eligible, using standby roles only when fewer than eight implementation workers are safe for
+  non-source reasons.
 - Check resource pressure before dispatch/refill and before starting local heavy validation, but do not impose a fixed
   RAM cap. If missing worker status or actual resource pressure prevents safe dispatch, stop filling worker slots until
   the blocker clears.

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -17,18 +17,20 @@ Explicitly spawn worker subagents for implementation tasks. Do not merely descri
 7. Never use `git reset --hard`, `git clean`, force-push, or destructive checkout operations against a worktree containing unreviewed user changes.
 8. Use a separate Git worktree and branch for every claim publication, implementation task, and terminal queue update.
 9. Keep at least eight live subagents attached to the controller whenever the subagent interface is available.
-10. Keep at least eight implementation issues active whenever eight safe, eligible, non-conflicting issues exist. Treat
-   eight active issues as the minimum operating target, not a best-effort aspiration.
-11. Keep at least four non-stale implementation issues active under this controller's own owner prefix whenever four
-   eligible issues can safely be claimed by this controller. Stale owned claims do not count toward that floor.
+10. Keep at least eight implementation issues active whenever eight status-and-dependency eligible implementation issues
+   exist. Treat eight active issues as the minimum operating target, not a best-effort aspiration.
+11. Keep exactly four non-stale implementation issues active under this controller's own owner prefix whenever four
+   status-and-dependency eligible issues are available for this controller. Stale owned claims and lease-expired claims
+   do not count toward that target, and a controller must not claim a fifth live implementation issue.
 12. Serialize all workbook pull requests. The XLSX file is binary and must never be modified concurrently on multiple branches intended to merge.
 13. Claim and terminal-status pull requests normally update exactly one issue. Do not batch workbook edits unless this workflow explicitly permits it and all selected issues are proven independent.
 14. Preserve public identifiers and backward compatibility unless source evidence proves they are broken.
 15. Do not run local native builds, `ctest`, full Python suites, or coverage for PR delivery unless a focused local
    reproduction is necessary or GitHub Actions cannot provide the needed evidence. Outsource heavy validation to GitHub
    Actions polling.
-16. If fewer than eight issue workers are active or this controller has fewer than four non-stale owned claims, document
-   the concrete eligibility, conflict, status, resource, or repository safety blocker that prevents filling the slot.
+16. If fewer than eight issue workers are active, this controller has fewer than four non-stale owned claims, or this
+   controller has more than four non-stale owned claims, document the concrete status, dependency, live-worker-status,
+   resource, authentication, queue-validation, workbook-PR, repository-safety, or over-capacity blocker.
 17. Run the controller resource audit before dispatch/refill decisions, before heavy validation, after each controller
    loop, and after merged-checkpoint cleanup. Treat low free disk or stale run/worktree pressure as blockers to new work
    until safely reported or cleaned.
@@ -124,19 +126,22 @@ Use lowercase ASCII, hyphens, and repository-approved naming. Do not reuse a bra
 
 ## Live status reporting
 
-Maintain at least eight live subagents and keep at least eight implementation issues active whenever safe. If fewer than eight
-implementation issues can safely run, assign the excess subagents only lightweight standby roles such as status polling,
-eligibility summaries, or review preparation, and print the exact blocker preventing eight active issues. Standby
-subagents must not claim issues, edit files, start builds, run tests, or touch the workbook.
-Each controller must also keep at least four of its own live workbook claims active when four eligible issues can be
-safely claimed. Use `controllerCapacity` from `shortlist --controller-id "$CONTROLLER_ID"` to measure the current
-controller's floor; stale owned claims and lease-expired owned claims do not count. Continue claim/refill iterations until
-`controllerCapacity.deficitToFloor` is zero, `controllerCapacity.fillableDeficit` is zero, or a concrete eligibility,
-resource, repository-safety, or worker-status blocker is printed.
+Maintain at least eight live subagents and keep at least eight implementation issues active whenever status-and-dependency
+eligible issues exist. If fewer than eight implementation issues can safely run for non-source reasons, assign the excess
+subagents only lightweight standby roles such as status polling, eligibility summaries, or review preparation, and print
+the exact blocker preventing eight active issues. Standby subagents must not claim issues, edit files, start builds, run
+tests, or touch the workbook.
+Each controller must also keep exactly four of its own live workbook claims active when four status-and-dependency
+eligible issues are available. Use `controllerCapacity` from `shortlist --controller-id "$CONTROLLER_ID"` to measure the
+current controller's capacity; stale owned claims and lease-expired owned claims do not count. Continue claim/refill
+iterations until `controllerCapacity.deficitToFloor` is zero, `controllerCapacity.fillableDeficit` is zero, or a concrete
+status, dependency, resource, repository-safety, queue-validation, workbook-PR, authentication, or worker-status blocker
+is printed. If `controllerCapacity.overCapacity` is true, stop claiming and report `controllerCapacity.overLimitBy`.
 
 When subagent capacity permits, keep one read-only project manager attached to the controller. The project manager may
 be an extra subagent beyond active implementation workers, or a standby role when fewer than eight implementation issues
-are safe. It must not reduce the floor of eight active implementation issues when eight safe issues exist.
+are safe for non-source reasons. It must not reduce the floor of eight active implementation issues when eight
+status-and-dependency eligible issues exist.
 
 When subagent capacity permits, keep one read-only QA subagent attached to the controller. QA reviews selected issue
 risk, diffs, tests, CI evidence, and merge readiness. QA must not claim issues, edit files, touch the workbook, or run
@@ -176,11 +181,11 @@ subagent is available, the controller must perform this checklist directly and s
 
 The project manager produces a concise prioritization brief containing:
 
-- the highest available priority tier after dependency, status, conflict, resource, and disk review;
+- the highest available priority tier after dependency, status, resource, and disk review;
 - candidate `(Epic #, Story #)` groups in that tier;
 - work likely to unblock dependent issues;
 - stale, blocked, failed, or repeatedly deferred work that needs controller attention;
-- scope conflicts, validation cost, resource risk, and sequencing risk;
+- scope-overlap advisories, validation cost, resource risk, and sequencing risk;
 - recommended priority changes, issue splits, deferrals, or blocker publications with source-backed evidence.
 
 Project-manager recommendations do not bypass the queue rules. The controller must still keep only the highest
@@ -199,9 +204,9 @@ python3 scripts/controller_resource_audit.py --json
 
 Use the audit plus current available memory, active worker status, disk pressure, accumulated run/worktree usage,
 prunable worktree metadata, and running heavy build/test/coverage/Xvfb/MCP jobs as scheduling context. These checks
-inform dispatch, but they do not impose a fixed RAM cap. If actual resource pressure, missing worker status, or
-repository state prevents safe implementation work, keep the extra subagents in standby and record the blocker rather
-than assigning unsafe implementation issues.
+inform dispatch, but they do not impose a fixed RAM cap. If actual resource pressure, missing worker status,
+authentication, queue validation, an unmerged workbook-state PR, or repository state prevents safe implementation work,
+keep the extra subagents in standby and record the blocker rather than assigning unsafe implementation issues.
 
 For each free slot, fetch the latest merged queue state from `origin/main` and calculate the complete
 eligible set yourself. The `claim` command is deterministic by workbook order, so use it only after selecting the exact
@@ -216,8 +221,11 @@ stale claims, `activeClaims.total`, `activeClaims.unexpired`, `activeClaims.stal
 mutating the workbook. `activeClaims.unexpired` means live/pollable rows that are neither reclaimable-stale nor
 lease-expired. Use the unexpired count, not raw `activeCount`, when deciding whether the global active-worker floor is
 genuinely satisfied. Use `controllerCapacity.activeNonStale`, `controllerCapacity.leaseExpiredOwned`,
-`controllerCapacity.deficitToFloor`, and `controllerCapacity.fillableDeficit` to enforce this controller's four-issue
-owned-claim floor before stopping a refill loop. It also reports target-file overlap advisories through
+`controllerCapacity.deficitToFloor`, `controllerCapacity.fillableDeficit`, `controllerCapacity.activeLimit`,
+`controllerCapacity.availableSlots`, `controllerCapacity.overLimitBy`, and `controllerCapacity.overCapacity` to enforce
+this controller's exactly-four owned-claim target before stopping a refill loop. A controller must refill below four
+non-stale owned implementation claims and must not claim a fifth live implementation issue. It also reports target-file
+overlap advisories through
 `advisoryTargetFileOverlapCount`, `advisoryTargetFileOverlaps`, and per-issue `activeFileOverlaps`. Treat the
 recommendation and overlap advisories as evidence for the project-manager brief and final controller review; do not
 exclude a task solely because its exact `Target Files / Modules` overlap active work.
@@ -226,13 +234,13 @@ Claim only after final review with `claim --issue`, which revalidates under the 
 Exclude every row that has:
 
 - a status other than `NOT_STARTED`;
-- any dependency that is not `DONE`;
-- a source-backed active-scope conflict;
-- an indirect conflict through shared headers, bindings, tests, CMake, map scripts, dialog/config files, serialization,
-  generated resources, or shared runtime systems.
+- any dependency that is not `DONE`.
 
-Use exact target-file overlap with active work as an advisory guide for source inspection and sequencing decisions. If
-inspection confirms that the overlap is a real active-scope conflict, exclude or defer it on that basis.
+Use exact target-file overlap, open implementation PRs, and indirect shared scope through headers, bindings, tests, CMake,
+map scripts, dialog/config files, serialization, generated resources, or runtime systems as advisory coordination
+signals. They should shape worker prompts, review order, expected rebase/merge risk, and validation focus. Do not
+exclude, defer, or stop solely because a status-and-dependency eligible issue overlaps active work; claim it and manage
+the overlap unless a non-source blocker prevents safe dispatch.
 
 After exclusions:
 
@@ -241,7 +249,8 @@ After exclusions:
 3. Randomly select one story with equal probability.
 4. Randomly select one eligible substory within the chosen story.
 
-Never default to spreadsheet order, and never randomize an ineligible issue into consideration.
+Never default to spreadsheet order, never randomize a status/dependency-ineligible issue into consideration, and never
+fall back to a lower priority tier merely to avoid source overlap.
 
 ## Dispatch loop
 
@@ -260,9 +269,10 @@ For each free subagent slot:
 
 Do not bypass dependencies to keep workers occupied.
 
-Do not start additional workers when live worker status is missing, when the next candidate conflicts with active work,
-or when actual resource or disk pressure requires waiting for validation or cleanup to finish. Keep at least eight
-subagents alive by assigning standby-only work when fewer than eight implementation slots are safe.
+Do not start additional workers when live worker status is missing or when actual resource, disk, authentication,
+queue-validation, repository-state, or workbook-PR pressure requires waiting for validation or cleanup to finish. Source
+overlap with active work is not, by itself, a reason to leave a worker slot empty. Keep at least eight subagents alive by
+assigning standby-only work when fewer than eight implementation slots are safe for non-source reasons.
 
 If a dispatch/refill loop does not publish a new claim, still fetch and inspect `origin/main` before deciding the next
 action. Another claim, implementation, terminal-status, or reclaim PR may have merged while the controller was polling
@@ -458,10 +468,10 @@ The controller keeps resource pressure in mind without enforcing a fixed RAM gat
 delivery, do not run local native builds, `ctest`, full Python suites, or coverage unless a focused local reproduction is
 necessary or GitHub Actions cannot provide the needed evidence. Before any necessary local heavy command, note current
 available RAM, disk pressure, running heavy jobs, and worker status. Treat eight live issue workers as the minimum
-target whenever safe eligible work exists; record the concrete blocker if actual resource pressure prevents eight live
-issues. Also treat four live owned claims as this controller's minimum active target whenever
-`controllerCapacity.fillableDeficit` is greater than zero; record the concrete blocker if the controller cannot close
-that deficit.
+target whenever status-and-dependency eligible work exists; record the concrete blocker if actual resource pressure
+prevents eight live issues. Also treat four live owned claims as this controller's exact active target: refill whenever
+`controllerCapacity.fillableDeficit` is greater than zero, do not claim when `controllerCapacity.availableSlots` is zero,
+and report `controllerCapacity.overLimitBy` when the controller is over capacity.
 
 Repository instructions may show local build examples such as `-j$(nproc)`. Treat them as local equivalents, not the
 default PR delivery path. Record the reason and exact command in worker reports and PR bodies whenever local heavy
@@ -504,9 +514,11 @@ evidence, do not enable auto-merge until the selected check(s) have passed.
 
 Workers and standby subagents may perform lightweight source inspection and prepare summaries while heavy validation runs.
 Do not dispatch additional implementation work when doing so would leave active workers unpollable. Empty implementation
-slots should be filled until at least eight issues are active unless the eligibility set, conflicts, missing status,
-actual resource pressure, or repository safety prevents it. The subagent floor is satisfied by standby subagents only
-when eight active implementation issues are not safe.
+slots should be filled until at least eight issues are active unless status/dependency eligibility, missing worker
+status, actual resource pressure, queue validation, workbook-PR serialization, authentication, or repository safety
+prevents it. Source overlap and open implementation PR overlap are scheduling risks, not empty-slot reasons. The
+subagent floor is satisfied by standby subagents only when eight active implementation issues are not safe for those
+non-source reasons.
 
 ## Phase 3: review and publish implementation
 
@@ -658,7 +670,6 @@ Stop dispatching new tasks when:
 - GitHub authentication or repository identity cannot be verified;
 - no eligible `NOT_STARTED` task remains;
 - all remaining work is blocked by dependencies;
-- every safe task conflicts with active work;
 - available subagent capacity is exhausted;
 - live worker status cannot be polled or recovered safely;
 - actual resource pressure requires waiting before more work can start;

--- a/scripts/issue_queue.py
+++ b/scripts/issue_queue.py
@@ -101,6 +101,7 @@ ISSUE_NAME_PATTERN = re.compile(r"^\[EPIC_\d{2}\]\[STORY_\d{2}\]\[SUBSTORY_\d{2}
 PRIORITY_ORDER = {"P0": 0, "P1": 1, "P2": 2}
 DEFAULT_RECLAIM_AGE_MINUTES = 240
 DEFAULT_CONTROLLER_ACTIVE_ISSUE_FLOOR = 4
+DEFAULT_CONTROLLER_ACTIVE_ISSUE_LIMIT = 4
 
 
 class QueueError(RuntimeError):
@@ -851,11 +852,16 @@ def controllerCapacityPayload(
     state: QueueState,
     controllerId: str,
     activeFloor: int = DEFAULT_CONTROLLER_ACTIVE_ISSUE_FLOOR,
+    activeLimit: int = DEFAULT_CONTROLLER_ACTIVE_ISSUE_LIMIT,
     eligibleCount: int | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     if activeFloor < 0:
         raise QueueError("--controller-active-floor must be non-negative")
+    if activeLimit < 0:
+        raise QueueError("--controller-active-limit must be non-negative")
+    if activeLimit < activeFloor:
+        raise QueueError("--controller-active-limit must be greater than or equal to --controller-active-floor")
     controllerId = controllerId.strip()
     if not controllerId:
         raise QueueError("--controller-id must be non-empty")
@@ -879,18 +885,25 @@ def controllerCapacityPayload(
     liveTasks = [
         task for task in activeTasks if task.issueName not in staleIssues and task.issueName not in leaseExpiredIssues
     ]
-    deficit = max(0, activeFloor - len(liveTasks))
-    fillable = min(deficit, eligibleCount) if eligibleCount is not None else deficit
+    activeNonStale = len(liveTasks)
+    deficit = max(0, activeFloor - activeNonStale)
+    availableSlots = max(0, activeLimit - activeNonStale)
+    overLimitBy = max(0, activeNonStale - activeLimit)
+    fillable = min(deficit, availableSlots, eligibleCount) if eligibleCount is not None else min(deficit, availableSlots)
     return {
         "controllerId": controllerId,
         "ownerPrefix": ownerPrefix,
         "activeFloor": activeFloor,
+        "activeLimit": activeLimit,
         "activeTotal": len(activeTasks),
-        "activeNonStale": len(liveTasks),
+        "activeNonStale": activeNonStale,
         "staleOwned": len(staleTasks),
         "leaseExpiredOwned": len(leaseExpiredTasks),
-        "inactiveOwned": len(activeTasks) - len(liveTasks),
+        "inactiveOwned": len(activeTasks) - activeNonStale,
         "deficitToFloor": deficit,
+        "availableSlots": availableSlots,
+        "overLimitBy": overLimitBy,
+        "overCapacity": overLimitBy > 0,
         "eligibleCount": eligibleCount,
         "fillableDeficit": fillable,
         "needsRefill": fillable > 0,
@@ -952,6 +965,7 @@ def shortlistTasks(
     includeRejected: bool = False,
     controllerId: str | None = None,
     controllerActiveFloor: int = DEFAULT_CONTROLLER_ACTIVE_ISSUE_FLOOR,
+    controllerActiveLimit: int = DEFAULT_CONTROLLER_ACTIVE_ISSUE_LIMIT,
 ) -> dict[str, Any]:
     eligible, rejected = eligibleTasks(
         state,
@@ -997,6 +1011,7 @@ def shortlistTasks(
             state,
             controllerId=controllerId,
             activeFloor=controllerActiveFloor,
+            activeLimit=controllerActiveLimit,
             eligibleCount=len(eligible),
             now=now,
         )
@@ -1708,7 +1723,7 @@ def buildParser() -> argparse.ArgumentParser:
     shortlistParser.add_argument("--seed", help="Stable seed for reproducible story and substory selection")
     shortlistParser.add_argument("--include-rejected", action="store_true", help="Include per-issue rejection reasons")
     shortlistParser.add_argument("--json", action="store_true", help="Output JSON (default)")
-    shortlistParser.add_argument("--controller-id", help="Include active-worker floor status for this controller")
+    shortlistParser.add_argument("--controller-id", help="Include active-worker capacity status for this controller")
     shortlistParser.add_argument(
         "--controller-active-floor",
         type=int,
@@ -1716,6 +1731,15 @@ def buildParser() -> argparse.ArgumentParser:
         help=(
             "Minimum non-stale active issues this controller should keep when eligible work exists "
             f"(default: {DEFAULT_CONTROLLER_ACTIVE_ISSUE_FLOOR})"
+        ),
+    )
+    shortlistParser.add_argument(
+        "--controller-active-limit",
+        type=int,
+        default=DEFAULT_CONTROLLER_ACTIVE_ISSUE_LIMIT,
+        help=(
+            "Maximum non-stale active issues this controller should own at once "
+            f"(default: {DEFAULT_CONTROLLER_ACTIVE_ISSUE_LIMIT})"
         ),
     )
 
@@ -1872,6 +1896,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                             includeRejected=args.include_rejected,
                             controllerId=args.controller_id,
                             controllerActiveFloor=args.controller_active_floor,
+                            controllerActiveLimit=args.controller_active_limit,
                         )
                     )
                     return 0

--- a/tests/test_issue_queue.py
+++ b/tests/test_issue_queue.py
@@ -364,8 +364,12 @@ class IssueQueueTest(unittest.TestCase):
             payload["activeClaims"],
         )
         self.assertEqual(4, payload["controllerCapacity"]["activeFloor"])
+        self.assertEqual(4, payload["controllerCapacity"]["activeLimit"])
         self.assertEqual(0, payload["controllerCapacity"]["activeNonStale"])
         self.assertEqual(4, payload["controllerCapacity"]["deficitToFloor"])
+        self.assertEqual(4, payload["controllerCapacity"]["availableSlots"])
+        self.assertEqual(0, payload["controllerCapacity"]["overLimitBy"])
+        self.assertFalse(payload["controllerCapacity"]["overCapacity"])
         self.assertEqual(3, payload["controllerCapacity"]["fillableDeficit"])
         self.assertEqual(0, payload["advisoryTargetFileOverlapCount"])
         self.assertIn(
@@ -407,6 +411,7 @@ class IssueQueueTest(unittest.TestCase):
             seed="expired-capacity",
             controllerId="ctrl-demo",
             controllerActiveFloor=4,
+            controllerActiveLimit=4,
             includeRejected=True,
         )
 
@@ -429,6 +434,10 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual(1, capacity["leaseExpiredOwned"])
         self.assertEqual(1, capacity["inactiveOwned"])
         self.assertEqual(4, capacity["deficitToFloor"])
+        self.assertEqual(4, capacity["activeLimit"])
+        self.assertEqual(4, capacity["availableSlots"])
+        self.assertEqual(0, capacity["overLimitBy"])
+        self.assertFalse(capacity["overCapacity"])
         self.assertTrue(capacity["needsRefill"])
         self.assertEqual([], capacity["activeIssues"])
         self.assertEqual([expired_recent["Issue Name"]], capacity["leaseExpiredIssues"])
@@ -455,6 +464,7 @@ class IssueQueueTest(unittest.TestCase):
             seed="expired-floor",
             controllerId="ctrl-demo",
             controllerActiveFloor=4,
+            controllerActiveLimit=4,
         )
 
         self.assertEqual(4, payload["activeCount"])
@@ -469,11 +479,15 @@ class IssueQueueTest(unittest.TestCase):
         self.assertEqual(4, capacity["leaseExpiredOwned"])
         self.assertEqual(4, capacity["inactiveOwned"])
         self.assertEqual(4, capacity["deficitToFloor"])
+        self.assertEqual(4, capacity["activeLimit"])
+        self.assertEqual(4, capacity["availableSlots"])
+        self.assertEqual(0, capacity["overLimitBy"])
+        self.assertFalse(capacity["overCapacity"])
         self.assertEqual(2, capacity["eligibleCount"])
         self.assertEqual(2, capacity["fillableDeficit"])
         self.assertTrue(capacity["needsRefill"])
 
-    def test_shortlist_reports_controller_capacity_floor(self) -> None:
+    def test_shortlist_reports_controller_capacity_target(self) -> None:
         live = issue_queue.claimTask(self.workbook_path, owner="controller/ctrl-demo/subagent-1", leaseMinutes=30)
         stale = issue_queue.claimTask(self.workbook_path, owner="controller/ctrl-demo/subagent-2", leaseMinutes=30)
         self.set_claim_times(stale["Issue Name"], lease_minutes_from_now=30, updated_minutes_ago=241)
@@ -484,24 +498,79 @@ class IssueQueueTest(unittest.TestCase):
             seed="capacity",
             controllerId="ctrl-demo",
             controllerActiveFloor=4,
+            controllerActiveLimit=4,
         )
 
         capacity = payload["controllerCapacity"]
         self.assertEqual("ctrl-demo", capacity["controllerId"])
         self.assertEqual("controller/ctrl-demo", capacity["ownerPrefix"])
         self.assertEqual(4, capacity["activeFloor"])
+        self.assertEqual(4, capacity["activeLimit"])
         self.assertEqual(2, capacity["activeTotal"])
         self.assertEqual(1, capacity["activeNonStale"])
         self.assertEqual(1, capacity["staleOwned"])
         self.assertEqual(0, capacity["leaseExpiredOwned"])
         self.assertEqual(1, capacity["inactiveOwned"])
         self.assertEqual(3, capacity["deficitToFloor"])
+        self.assertEqual(3, capacity["availableSlots"])
+        self.assertEqual(0, capacity["overLimitBy"])
+        self.assertFalse(capacity["overCapacity"])
         self.assertEqual(payload["eligibleCount"], capacity["eligibleCount"])
         self.assertEqual(min(3, payload["eligibleCount"]), capacity["fillableDeficit"])
         self.assertTrue(capacity["needsRefill"])
         self.assertEqual([live["Issue Name"]], capacity["activeIssues"])
         self.assertEqual([stale["Issue Name"]], capacity["staleIssues"])
         self.assertEqual([], capacity["leaseExpiredIssues"])
+
+    def test_shortlist_reports_controller_capacity_limit(self) -> None:
+        issues = [f"[EPIC_01][STORY_03][SUBSTORY_{index:02d}]Limit issue {index}" for index in range(1, 7)]
+        self.create_workbook(
+            [self.task_row(issue, "P0", None, f"src/limit_{index}.cpp") for index, issue in enumerate(issues)]
+        )
+        claims = [
+            issue_queue.claimTask(
+                self.workbook_path,
+                owner=f"controller/ctrl-demo/subagent-{index}",
+                leaseMinutes=30,
+            )
+            for index in range(1, 6)
+        ]
+        state = issue_queue.loadQueue(self.workbook_path)
+
+        payload = issue_queue.shortlistTasks(
+            state,
+            seed="capacity-limit",
+            controllerId="ctrl-demo",
+            controllerActiveFloor=4,
+            controllerActiveLimit=4,
+        )
+
+        capacity = payload["controllerCapacity"]
+        self.assertEqual(5, payload["activeCount"])
+        self.assertEqual(5, capacity["activeTotal"])
+        self.assertEqual(5, capacity["activeNonStale"])
+        self.assertEqual(4, capacity["activeFloor"])
+        self.assertEqual(4, capacity["activeLimit"])
+        self.assertEqual(0, capacity["deficitToFloor"])
+        self.assertEqual(0, capacity["availableSlots"])
+        self.assertEqual(1, capacity["overLimitBy"])
+        self.assertTrue(capacity["overCapacity"])
+        self.assertEqual(1, capacity["eligibleCount"])
+        self.assertEqual(0, capacity["fillableDeficit"])
+        self.assertFalse(capacity["needsRefill"])
+        self.assertEqual([claim["Issue Name"] for claim in claims], capacity["activeIssues"])
+
+    def test_controller_capacity_rejects_limit_below_floor(self) -> None:
+        state = issue_queue.loadQueue(self.workbook_path)
+
+        with self.assertRaises(issue_queue.QueueError):
+            issue_queue.shortlistTasks(
+                state,
+                seed="bad-capacity",
+                controllerId="ctrl-demo",
+                controllerActiveFloor=4,
+                controllerActiveLimit=3,
+            )
 
     def test_controller_id_generates_unique_owner_prefix(self) -> None:
         first = issue_queue.generateControllerId(hostname="Build Host.local", pid=1234, unique="ABCDEF12")


### PR DESCRIPTION
## What changed

- Changed queue-controller policy so source overlaps, open implementation PRs, and shared source areas are advisory coordination signals instead of automatic claim exclusions.
- Kept hard eligibility exclusions limited to non-`NOT_STARTED` status and dependencies that are not `DONE`.
- Added controller capacity reporting for an exact four-issue owned target: `activeLimit`, `availableSlots`, `overLimitBy`, and `overCapacity`.
- Updated queue docs, controller prompt, AGENTS instructions, and queue tests to reflect the new policy.

## Why

The controller stopped even though the queue CLI reported eligible work. The stop was caused by treating source/open-PR overlap as a hard blocker. The intended behavior is that controllers keep dispatching status-and-dependency eligible work and manage source overlap through prompts, review ordering, rebases, and validation.

The user also clarified that each controller should work on at least four and at most four issues at once.

## Validation

- `python3 -m unittest tests.test_issue_queue`
- `python3 -m unittest tests.test_prompt_inventory`
- `python3 scripts/issue_queue.py validate`
- `python3 scripts/issue_queue.py shortlist --seed ctrl-lis-2-00b6627d-20260620Tpolicy --controller-id ctrl-lis-2-00b6627d --include-rejected --json`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`
- `git diff --check origin/main..HEAD`

## Known limitations

- This PR does not claim new queue work.
- A separate stale/open PR cleanup-or-merge policy will be handled in follow-up work.
