### PR TITLE
[codex] Add read-only PR review audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,23 @@ Actions run, fetch `origin/main`, verify the merge, and continue from the merged
 instructions say not to merge or not to enable auto-merge, follow those instructions and leave the PR open with the
 validation evidence.
 
+Before closing stale PRs, deleting branches, merging old work, or using open PRs as dispatch evidence, classify the PR
+debt with the read-only audit:
+
+```bash
+python3 scripts/pr_review_audit.py --input /tmp/pr-review-snapshot.json --format table
+```
+
+Feed it a normalized JSON snapshot containing changed files, merge state, check rollup, queue linkage, and recovery
+state. The audit separates `actionCategory` from `prType` so workbook-only queue PRs, active-claim implementation PRs,
+workflow PRs, stale linked claims, and cleanup candidates can be reviewed consistently. Its output is advisory and
+read-only: it must never close PRs, delete branches, edit the workbook, or override failed checks. Destructive cleanup,
+obsolete/duplicate PR closure, stale-claim recovery, dirty worktree recovery, and any merge with missing signals require
+explicit human approval. A controller-owned implementation PR marked `failing_ci`, `needs_update_rebase`,
+`human_review_required`, or `never_touch` is controller attention debt; resolve or assign recovery for that PR, but do
+not use source overlap alone to leave the controller below its four live non-stale owned claims when eligible work
+exists.
+
 When this file conflicts with the current code, tests, or build scripts, trust the code and update this file as part of the fix.
 
 ## Queue controller workflow
@@ -113,8 +130,8 @@ according to the pull request merge policy; do not mark the issue `DONE` until t
 After every controller loop iteration, claim/PR status check, cleanup audit, and before dispatching new work, print a
 concise live status table. Include controller ID, worker owner, issue key, phase, progress estimate, last action,
 changed files, running validation command, branch, PR state, resource state, cleanup state, project-manager brief state,
-QA review state, blockers, and next controller action. Use subagent status polling or structured worker updates for
-live status; the workbook is durable queue state, not the live worker-status channel.
+QA review state, open-PR audit summary, blockers, and next controller action. Use subagent status polling or structured
+worker updates for live status; the workbook is durable queue state, not the live worker-status channel.
 
 When a controller loop does not publish any new claim, still fetch and inspect `origin/main` before the next decision.
 Check whether claim, implementation, status, or reclaim PRs merged elsewhere and update live state from the merged

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -10,6 +10,7 @@ concurrent controllers can be distinguished.
 
 - `planning/fall_of_nouraajd_issue_proposals.xlsx` — canonical queue and human-readable backlog.
 - `scripts/issue_queue.py` — atomic claim/progress/completion CLI.
+- `scripts/pr_review_audit.py` — read-only stale/open PR classification helper for merge, cleanup, and dispatch review.
 - `prompts/codex-queue-controller.md` — controller-agent operating prompt.
 - `tests/test_issue_queue.py` — focused queue and concurrency regressions.
 
@@ -120,6 +121,26 @@ the dependency, highest-priority-tier, randomized story/substory, resource, clea
 dependency, status, or scope change must be approved by the user or controller and merged through a serialized
 workbook-only pull request before it affects dispatch.
 
+Before cleanup, stale-PR closure, stale-branch cleanup, or merge decisions, run a read-only open-PR review audit against
+a normalized snapshot that includes changed files, merge state, CI rollup, queue linkage, and any local recovery signals:
+
+```bash
+python3 scripts/pr_review_audit.py --input /tmp/pr-review-snapshot.json --format table
+```
+
+The audit emits an `actionCategory` such as `ready_to_merge`, `poll`, `failing_ci`, `needs_update_rebase`,
+`human_review_required`, `obsolete_duplicate_close`, `branch_cleanup_candidate`, or `never_touch`, plus a separate
+`prType` such as `workbook_only_queue_pr`, `implementation_pr_with_active_workbook_claim`, `workflow_pr`, or
+`unknown_pr`. Treat the result as advisory evidence for the controller and project-manager brief. It does not close PRs,
+delete branches, touch the workbook, or bypass failing checks. Human approval is required before closing obsolete or
+duplicate PRs, deleting local or remote branches, reclaiming recoverable stale claims, touching dirty worktrees, or
+merging any PR with missing classification signals.
+
+Controller-owned implementation PRs classified as `failing_ci`, `needs_update_rebase`, `human_review_required`, or
+`never_touch` require controller attention or explicit recovery assignment before the controller treats their issues as
+resolved. They do not reintroduce source-overlap as a hard claim exclusion: keep the exact four non-stale owned-claim
+target whenever status-and-dependency eligible work exists and no concrete non-source blocker prevents dispatch.
+
 Assign one read-only QA role when subagent capacity permits. QA reviews issue selection risk, diff scope, regression
 coverage, validation commands, GitHub Actions evidence, and merge readiness. QA must not claim issues, edit the
 workbook, or start heavy validation unless the controller explicitly delegates a bounded validation task.
@@ -219,6 +240,8 @@ work, print a live status table containing at least:
 - pull request number or pending PR state;
 - current resource and disk state;
 - cleanup state, including prunable worktree metadata and accumulated run/worktree size when known;
+- open-PR audit summary, including any controller-owned PR requiring update, CI fix, human review, or never-touch
+  recovery;
 - project-manager prioritization brief state or the reason no project-manager subagent is available;
 - QA review state or the reason no QA subagent is available;
 - blockers;

--- a/prompts/codex-workflow-optimizer.md
+++ b/prompts/codex-workflow-optimizer.md
@@ -39,7 +39,7 @@ Relevant optimization areas include:
 - Git worktree lifecycle;
 - branch and PR creation;
 - merge-state detection;
-- stale branch or stale claim recovery;
+- stale branch, stale PR, or stale claim recovery;
 - CI and validation efficiency;
 - resource-aware scheduling;
 - deterministic tests;
@@ -52,7 +52,9 @@ Do not consume or modify normal gameplay backlog items merely to create optimiza
 ## Multiagent operating model
 
 Maintain enough live subagents to support the active workflow target; queue-controller operation uses at least eight
-active implementation issues whenever eight safe, eligible, non-conflicting issues exist.
+active implementation issues whenever eight status-and-dependency eligible issues exist and no concrete non-source
+blocker prevents safe dispatch. Each controller must keep exactly four non-stale owned implementation claims when four
+status-and-dependency eligible issues are available for that controller, and must not claim a fifth.
 
 Use these roles, rotating them when useful:
 
@@ -99,6 +101,7 @@ Print a concise live status table containing:
 - current command or validation;
 - branch and worktree;
 - PR number and merge state;
+- open-PR audit summary;
 - blocker;
 - next controller action.
 
@@ -113,6 +116,8 @@ Repeat the following cycle:
    - Fetch `origin/main`.
    - Inspect open workflow-related PRs, active worktrees, branches, dirty state, disk usage, and accumulated
      run/worktrees.
+   - Classify stale/open PR debt with `scripts/pr_review_audit.py` before cleanup, stale-branch decisions, or merge
+     decisions; treat the result as read-only evidence.
    - Never destroy or overwrite unreviewed work.
 
 2. Establish evidence
@@ -120,6 +125,7 @@ Repeat the following cycle:
      - `python3 scripts/issue_queue.py validate`
      - `python3 -m unittest tests.test_issue_queue`
      - `python3 -m unittest tests.test_controller_resource_audit`
+     - `python3 -m unittest tests.test_pr_review_audit`
      - `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`
    - Collect relevant evidence such as failures, test duration, queue conflicts, stale claims, PR-state errors,
      unnecessary rebuilds, resource pressure, disk pressure, stale run/worktrees, prunable worktree metadata, and

--- a/scripts/pr_review_audit.py
+++ b/scripts/pr_review_audit.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Read-only PR review classifier for controller cleanup and merge decisions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+WORKBOOK_PATH = "planning/fall_of_nouraajd_issue_proposals.xlsx"
+
+SUCCESS_STATES = {"success", "successful", "passed", "pass"}
+FAILURE_STATES = {
+    "action_required",
+    "cancelled",
+    "canceled",
+    "error",
+    "failure",
+    "failed",
+    "startup_failure",
+    "timed_out",
+}
+PENDING_STATES = {"expected", "in_progress", "pending", "queued", "requested", "waiting"}
+
+CLEAN_MERGE_STATES = {"clean", "has_hooks"}
+UPDATE_MERGE_STATES = {"behind", "conflicting", "dirty"}
+HUMAN_MERGE_STATES = {"blocked", "draft", "unknown", "unstable"}
+
+OPEN_STATES = {"open"}
+OBSOLETE_LABELS = {"duplicate", "obsolete", "superseded"}
+
+
+@dataclass(frozen=True)
+class CheckSummary:
+    state: str
+    failed: tuple[str, ...] = ()
+    pending: tuple[str, ...] = ()
+    total: int = 0
+
+
+def normalizeToken(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return value != 0
+    return normalizeToken(value) in {"1", "true", "yes", "y", "on"}
+
+
+def firstValue(mapping: dict[str, Any], *names: str, default: Any = None) -> Any:
+    for name in names:
+        if name in mapping:
+            return mapping[name]
+    return default
+
+
+def normalizeFiles(record: dict[str, Any]) -> tuple[str, ...]:
+    rawFiles = firstValue(record, "files", "changedFiles", "changed_files", "filenames", default=())
+    if isinstance(rawFiles, dict):
+        rawFiles = firstValue(rawFiles, "nodes", "items", "files", default=())
+    if isinstance(rawFiles, str):
+        rawFiles = [rawFiles]
+    elif not isinstance(rawFiles, Iterable):
+        rawFiles = ()
+    files: list[str] = []
+    for item in rawFiles or ():
+        if isinstance(item, dict):
+            item = firstValue(item, "filename", "path", "name", default="")
+        if item:
+            files.append(str(item))
+    return tuple(sorted(dict.fromkeys(files)))
+
+
+def normalizeLabels(record: dict[str, Any]) -> tuple[str, ...]:
+    rawLabels = firstValue(record, "labels", "labelNames", "label_names", default=())
+    if isinstance(rawLabels, dict):
+        rawLabels = firstValue(rawLabels, "nodes", "items", "labels", default=())
+    if isinstance(rawLabels, str):
+        rawLabels = [rawLabels]
+    elif not isinstance(rawLabels, Iterable):
+        rawLabels = ()
+    labels: list[str] = []
+    for item in rawLabels or ():
+        if isinstance(item, dict):
+            item = firstValue(item, "name", "title", default="")
+        token = normalizeToken(item)
+        if token:
+            labels.append(token)
+    return tuple(sorted(dict.fromkeys(labels)))
+
+
+def queuePayload(record: dict[str, Any]) -> dict[str, Any]:
+    payload = firstValue(record, "queue", "workbook", "workbookRow", "linkedQueueRow", default={})
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def checkName(check: dict[str, Any], fallback: str) -> str:
+    return str(firstValue(check, "name", "context", "checkName", "job", default=fallback))
+
+
+def stateFromCheck(check: dict[str, Any]) -> str:
+    state = normalizeToken(firstValue(check, "state", "status", default=""))
+    conclusion = normalizeToken(firstValue(check, "conclusion", "result", default=""))
+    rollup = normalizeToken(firstValue(check, "rollup", "checkRollup", default=""))
+
+    for token in (conclusion, state, rollup):
+        if token in FAILURE_STATES:
+            return "failure"
+    if state in {"completed", "complete"} and not conclusion:
+        return "unknown"
+    if conclusion in SUCCESS_STATES or state in SUCCESS_STATES or rollup in SUCCESS_STATES:
+        return "success"
+    if state in PENDING_STATES or conclusion in PENDING_STATES or rollup in PENDING_STATES:
+        return "pending"
+    return "unknown"
+
+
+def summaryFromRollup(value: Any) -> CheckSummary | None:
+    if isinstance(value, dict):
+        value = firstValue(value, "state", "status", "conclusion", "rollup", default="")
+    token = normalizeToken(value)
+    if not token:
+        return None
+    if token in SUCCESS_STATES:
+        return CheckSummary(state="success", total=1)
+    if token in FAILURE_STATES:
+        return CheckSummary(state="failure", failed=("check rollup",), total=1)
+    if token in PENDING_STATES:
+        return CheckSummary(state="pending", pending=("check rollup",), total=1)
+    return CheckSummary(state="unknown", total=1)
+
+
+def checkSummary(record: dict[str, Any]) -> CheckSummary:
+    rawChecks = firstValue(
+        record,
+        "checks",
+        "checkRuns",
+        "check_runs",
+        "statusChecks",
+        "status_checks",
+        default=None,
+    )
+    if rawChecks is None:
+        rollup = firstValue(
+            record,
+            "checkRollup",
+            "check_rollup",
+            "checksState",
+            "checks_state",
+            "ciState",
+            "ci_state",
+            default=None,
+        )
+        summary = summaryFromRollup(rollup)
+        return summary or CheckSummary(state="unknown")
+
+    if isinstance(rawChecks, dict):
+        rawChecks = firstValue(rawChecks, "nodes", "items", "checks", default=())
+    if isinstance(rawChecks, str) or not isinstance(rawChecks, Iterable):
+        rawChecks = [rawChecks]
+
+    failed: list[str] = []
+    pending: list[str] = []
+    unknown = False
+    checks = list(rawChecks or ())
+    for index, rawCheck in enumerate(checks, start=1):
+        check = rawCheck if isinstance(rawCheck, dict) else {"state": rawCheck}
+        name = checkName(check, f"check {index}")
+        state = stateFromCheck(check)
+        if state == "failure":
+            failed.append(name)
+        elif state == "pending":
+            pending.append(name)
+        elif state == "unknown":
+            unknown = True
+
+    if failed:
+        return CheckSummary(state="failure", failed=tuple(failed), pending=tuple(pending), total=len(checks))
+    if pending:
+        return CheckSummary(state="pending", pending=tuple(pending), total=len(checks))
+    if unknown or not checks:
+        return CheckSummary(state="unknown", total=len(checks))
+    return CheckSummary(state="success", total=len(checks))
+
+
+def mergeState(record: dict[str, Any]) -> str:
+    return normalizeToken(
+        firstValue(record, "mergeStateStatus", "merge_state_status", "mergeableState", "mergeable_state", default="")
+    )
+
+
+def isWorkbookOnly(files: Sequence[str]) -> bool:
+    return tuple(files) == (WORKBOOK_PATH,)
+
+
+def isWorkflowFile(path: str) -> bool:
+    return path == "AGENTS.md" or path.startswith(("docs/", "prompts/", "scripts/", ".github/"))
+
+
+def hasQueueLink(queue: dict[str, Any]) -> bool:
+    return any(
+        firstValue(queue, name, default=None)
+        for name in ("issue", "issueName", "status", "owner", "claimId", "claim_id")
+    )
+
+
+def queueStatus(queue: dict[str, Any]) -> str:
+    return normalizeToken(firstValue(queue, "status", "queueStatus", "rowStatus", default=""))
+
+
+def queueClaimIsStale(queue: dict[str, Any]) -> bool:
+    return any(
+        truthy(firstValue(queue, name, default=False))
+        for name in ("stale", "claimStale", "claim_stale", "leaseExpired", "lease_expired")
+    )
+
+
+def queueOwner(queue: dict[str, Any]) -> str:
+    return str(firstValue(queue, "owner", "assignee", default="") or "")
+
+
+def controllerOwned(queue: dict[str, Any]) -> bool:
+    explicit = firstValue(queue, "controllerOwned", "controller_owned", default=None)
+    if explicit is not None:
+        return truthy(explicit)
+    return queueOwner(queue).startswith("controller/")
+
+
+def classifyPrType(record: dict[str, Any], files: Sequence[str], queue: dict[str, Any]) -> tuple[str, list[str]]:
+    blockers: list[str] = []
+    if isWorkbookOnly(files):
+        return "workbook_only_queue_pr", blockers
+    if queueStatus(queue) == "in_progress" and not queueClaimIsStale(queue):
+        return "implementation_pr_with_active_workbook_claim", blockers
+    if queueStatus(queue) == "in_progress" and queueClaimIsStale(queue):
+        return "implementation_pr_with_stale_workbook_claim", blockers
+    if hasQueueLink(queue) or firstValue(record, "linkedIssue", "issue", "issueName", default=None):
+        return "implementation_pr", blockers
+    if files and all(isWorkflowFile(path) for path in files):
+        return "workflow_pr", blockers
+    blockers.append("missing queue link, changed-file class, or PR type signal")
+    return "unknown_pr", blockers
+
+
+def localSafetyBlockers(record: dict[str, Any]) -> list[str]:
+    local = firstValue(record, "local", "branch", "recovery", default={})
+    if not isinstance(local, dict):
+        local = {}
+    blockers: list[str] = []
+    if truthy(firstValue(local, "dirty", "dirtyWorktree", "worktreeDirty", default=False)):
+        blockers.append("local worktree is dirty")
+    if truthy(firstValue(local, "unpushedCommits", "unpushed", default=False)):
+        blockers.append("branch has unpushed commits")
+    if truthy(firstValue(local, "unreviewedCommits", "unreviewed", default=False)):
+        blockers.append("branch has unreviewed commits")
+    return blockers
+
+
+def actionFromSignals(
+    record: dict[str, Any],
+    prType: str,
+    labels: Sequence[str],
+    merge: str,
+    checks: CheckSummary,
+    blockers: list[str],
+) -> tuple[str, list[str]]:
+    buckets: list[str] = [prType]
+    state = normalizeToken(firstValue(record, "state", default="open"))
+    merged = truthy(firstValue(record, "merged", "isMerged", default=False))
+    branchMerged = truthy(firstValue(record, "branchMergedToMain", "branch_merged_to_main", default=False))
+    draft = truthy(firstValue(record, "draft", "isDraft", default=False))
+    reviewDecision = normalizeToken(firstValue(record, "reviewDecision", "review_decision", default=""))
+
+    localBlockers = localSafetyBlockers(record)
+    if localBlockers:
+        blockers.extend(localBlockers)
+        buckets.append("never_touch")
+        return "never_touch", buckets
+
+    if state not in OPEN_STATES:
+        if merged or branchMerged:
+            buckets.append("branch_cleanup_candidate")
+            return "branch_cleanup_candidate", buckets
+        buckets.append("human_review_required")
+        blockers.append(f"PR state is {state or 'unknown'}")
+        return "human_review_required", buckets
+
+    if any(label in OBSOLETE_LABELS for label in labels) or truthy(
+        firstValue(record, "obsolete", "duplicate", "superseded", default=False)
+    ):
+        buckets.append("obsolete_duplicate_close")
+        return "obsolete_duplicate_close", buckets
+
+    if draft:
+        blockers.append("PR is draft")
+        buckets.append("human_review_required")
+    if reviewDecision in {"changes_requested", "review_required"}:
+        blockers.append(f"review decision is {reviewDecision}")
+        buckets.append("human_review_required")
+    if merge in UPDATE_MERGE_STATES:
+        blockers.append(f"merge state {merge.upper()} requires update/rebase")
+        buckets.append("needs_update_rebase")
+    elif merge in HUMAN_MERGE_STATES:
+        blockers.append(f"merge state {merge.upper()} requires human review")
+        buckets.append("human_review_required")
+    elif not merge:
+        blockers.append("merge state is missing")
+        buckets.append("human_review_required")
+    elif merge not in CLEAN_MERGE_STATES:
+        blockers.append(f"merge state {merge.upper()} is unrecognized")
+        buckets.append("human_review_required")
+
+    if checks.state == "failure":
+        blockers.append("required check failure: " + ", ".join(checks.failed))
+        buckets.append("failing_ci")
+    elif checks.state == "pending":
+        buckets.append("poll")
+    elif checks.state == "unknown":
+        blockers.append("check rollup is missing or unrecognized")
+        buckets.append("human_review_required")
+
+    queue = queuePayload(record)
+    if queueClaimIsStale(queue):
+        blockers.append("linked workbook claim is stale or lease-expired")
+        buckets.append("human_review_required")
+
+    if prType == "unknown_pr":
+        buckets.append("human_review_required")
+
+    if "needs_update_rebase" in buckets:
+        return "needs_update_rebase", buckets
+    if "failing_ci" in buckets:
+        return "failing_ci", buckets
+    if "human_review_required" in buckets:
+        return "human_review_required", buckets
+    if "poll" in buckets:
+        return "poll", buckets
+    buckets.append("ready_to_merge")
+    return "ready_to_merge", buckets
+
+
+def recommendedActions(actionCategory: str, prType: str, blockers: Sequence[str]) -> list[str]:
+    if actionCategory == "ready_to_merge" and prType == "workbook_only_queue_pr":
+        return ["confirm XLSX-only diff and queue validation, then merge according to workbook-only policy"]
+    if actionCategory == "ready_to_merge":
+        return ["confirm required evidence and merge according to pull request policy"]
+    if actionCategory == "poll":
+        return ["poll pending required checks for the exact PR head"]
+    if actionCategory == "failing_ci":
+        return ["fix or re-run failed required checks before merge or cleanup"]
+    if actionCategory == "needs_update_rebase":
+        return ["update or rebase the branch before any merge decision"]
+    if actionCategory == "obsolete_duplicate_close":
+        return ["request explicit human approval before closing obsolete or duplicate work"]
+    if actionCategory == "branch_cleanup_candidate":
+        return ["request explicit human approval before deleting local or remote branches"]
+    if actionCategory == "never_touch":
+        return ["do not merge, close, delete, or overwrite until recoverable work is reviewed"]
+    if blockers:
+        return ["collect missing signals or resolve blockers before cleanup or merge"]
+    return ["inspect manually before taking action"]
+
+
+def classifyPr(record: dict[str, Any]) -> dict[str, Any]:
+    files = normalizeFiles(record)
+    labels = normalizeLabels(record)
+    queue = queuePayload(record)
+    checks = checkSummary(record)
+    blockers: list[str] = []
+    prType, typeBlockers = classifyPrType(record, files, queue)
+    blockers.extend(typeBlockers)
+    actionCategory, buckets = actionFromSignals(record, prType, labels, mergeState(record), checks, blockers)
+    buckets = sorted(dict.fromkeys(buckets))
+    blockerTuple = tuple(dict.fromkeys(blockers))
+    isControllerOwned = controllerOwned(queue)
+    dispatchAttention = (
+        isControllerOwned
+        and prType
+        in {
+            "implementation_pr",
+            "implementation_pr_with_active_workbook_claim",
+            "implementation_pr_with_stale_workbook_claim",
+            "unknown_pr",
+        }
+        and actionCategory
+        in {
+            "failing_ci",
+            "human_review_required",
+            "needs_update_rebase",
+            "never_touch",
+            "obsolete_duplicate_close",
+        }
+    )
+    humanApproval = actionCategory in {
+        "branch_cleanup_candidate",
+        "human_review_required",
+        "never_touch",
+        "obsolete_duplicate_close",
+    }
+    return {
+        "number": firstValue(record, "number", "prNumber", "id", default=None),
+        "title": firstValue(record, "title", default=""),
+        "state": normalizeToken(firstValue(record, "state", default="open")) or "unknown",
+        "actionCategory": actionCategory,
+        "prType": prType,
+        "buckets": buckets,
+        "changedFiles": list(files),
+        "checkState": checks.state,
+        "failedChecks": list(checks.failed),
+        "pendingChecks": list(checks.pending),
+        "mergeState": mergeState(record) or "missing",
+        "controllerOwned": isControllerOwned,
+        "controllerDispatchAttention": dispatchAttention,
+        "mergeAllowed": actionCategory == "ready_to_merge",
+        "cleanupAllowed": False,
+        "humanApprovalRequired": humanApproval,
+        "blockers": list(blockerTuple),
+        "recommendedActions": recommendedActions(actionCategory, prType, blockerTuple),
+    }
+
+
+def loadRecords(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        records = payload
+    elif isinstance(payload, dict):
+        records = firstValue(payload, "pullRequests", "pull_requests", "prs", "items", "nodes", default=None)
+        if records is None:
+            records = [payload]
+    else:
+        raise ValueError("input JSON must be an object or list")
+    if not isinstance(records, list):
+        raise ValueError("pull request records must be a list")
+    normalized: list[dict[str, Any]] = []
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError("each pull request record must be an object")
+        normalized.append(record)
+    return normalized
+
+
+def auditPayload(records: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    reviews = [classifyPr(record) for record in records]
+    actionCounts = Counter(review["actionCategory"] for review in reviews)
+    typeCounts = Counter(review["prType"] for review in reviews)
+    return {
+        "readOnly": True,
+        "summary": {
+            "total": len(reviews),
+            "actions": dict(sorted(actionCounts.items())),
+            "types": dict(sorted(typeCounts.items())),
+            "controllerDispatchAttention": sum(1 for review in reviews if review["controllerDispatchAttention"]),
+            "mergeAllowed": sum(1 for review in reviews if review["mergeAllowed"]),
+            "cleanupAllowed": 0,
+        },
+        "pullRequests": reviews,
+    }
+
+
+def renderTable(payload: dict[str, Any]) -> str:
+    lines = ["PR\tACTION\tTYPE\tCHECKS\tMERGE\tATTENTION\tBLOCKERS"]
+    for review in payload["pullRequests"]:
+        number = review["number"]
+        prNumber = f"#{number}" if number is not None else "-"
+        blockers = "; ".join(review["blockers"]) if review["blockers"] else "-"
+        attention = "yes" if review["controllerDispatchAttention"] else "no"
+        lines.append(
+            "\t".join(
+                [
+                    prNumber,
+                    review["actionCategory"],
+                    review["prType"],
+                    review["checkState"],
+                    review["mergeState"],
+                    attention,
+                    blockers,
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def readInput(path: str | None) -> Any:
+    if path:
+        text = Path(path).read_text(encoding="utf-8")
+    else:
+        text = sys.stdin.read()
+    if not text.strip():
+        raise ValueError("no input JSON provided")
+    return json.loads(text)
+
+
+def parseArgs(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", help="JSON file containing normalized pull request records; defaults to stdin")
+    parser.add_argument("--format", choices=("json", "table"), default="json")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parseArgs(argv or sys.argv[1:])
+    try:
+        payload = auditPayload(loadRecords(readInput(args.input)))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"pr_review_audit: {exc}", file=sys.stderr)
+        return 2
+    if args.format == "table":
+        print(renderTable(payload))
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pr_review_audit.py
+++ b/tests/test_pr_review_audit.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from scripts import pr_review_audit
+
+
+def successCheck() -> dict[str, str]:
+    return {"name": "build / linux", "status": "completed", "conclusion": "success"}
+
+
+class PrReviewAuditTest(unittest.TestCase):
+    def classify(self, payload: dict[str, object]) -> dict[str, object]:
+        return pr_review_audit.classifyPr(payload)
+
+    def test_ready_implementation_pr_keeps_active_claim_type(self) -> None:
+        review = self.classify(
+            {
+                "number": 101,
+                "title": "Fix combat flow",
+                "files": ["src/handler/CFightHandler.cpp"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [successCheck()],
+                "queue": {
+                    "status": "IN_PROGRESS",
+                    "owner": "controller/ctrl-a/subagent-1",
+                    "claimId": "abc123",
+                },
+            }
+        )
+
+        self.assertEqual("ready_to_merge", review["actionCategory"])
+        self.assertEqual("implementation_pr_with_active_workbook_claim", review["prType"])
+        self.assertTrue(review["mergeAllowed"])
+        self.assertFalse(review["controllerDispatchAttention"])
+
+    def test_workbook_only_queue_pr_is_ready_only_after_successful_signals(self) -> None:
+        review = self.classify(
+            {
+                "number": 102,
+                "title": "Claim queue row",
+                "files": ["planning/fall_of_nouraajd_issue_proposals.xlsx"],
+                "mergeable_state": "clean",
+                "checkRollup": "success",
+            }
+        )
+
+        self.assertEqual("ready_to_merge", review["actionCategory"])
+        self.assertEqual("workbook_only_queue_pr", review["prType"])
+        self.assertIn("workbook_only_queue_pr", review["buckets"])
+        self.assertIn("confirm XLSX-only diff", review["recommendedActions"][0])
+
+    def test_dirty_and_failing_pr_requires_update_before_ci_fix(self) -> None:
+        review = self.classify(
+            {
+                "number": 103,
+                "files": ["src/gui/CListView.cpp"],
+                "mergeable_state": "dirty",
+                "checks": [{"name": "coverage", "state": "FAILURE"}],
+                "queue": {"status": "IN_PROGRESS", "owner": "controller/ctrl-a/subagent-2"},
+            }
+        )
+
+        self.assertEqual("needs_update_rebase", review["actionCategory"])
+        self.assertIn("failing_ci", review["buckets"])
+        self.assertTrue(review["controllerDispatchAttention"])
+        self.assertTrue(any("merge state DIRTY" in blocker for blocker in review["blockers"]))
+        self.assertTrue(any("required check failure" in blocker for blocker in review["blockers"]))
+
+    def test_pending_checks_are_pollable(self) -> None:
+        review = self.classify(
+            {
+                "number": 104,
+                "files": ["scripts/issue_queue.py"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [{"name": "build / linux", "status": "in_progress"}],
+            }
+        )
+
+        self.assertEqual("poll", review["actionCategory"])
+        self.assertEqual("workflow_pr", review["prType"])
+        self.assertEqual(["build / linux"], review["pendingChecks"])
+
+    def test_stale_linked_claim_requires_human_review(self) -> None:
+        review = self.classify(
+            {
+                "number": 105,
+                "files": ["res/maps/siege/script.py"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [successCheck()],
+                "queue": {
+                    "status": "IN_PROGRESS",
+                    "owner": "controller/ctrl-a/subagent-3",
+                    "claimId": "stale-claim",
+                    "leaseExpired": True,
+                },
+            }
+        )
+
+        self.assertEqual("human_review_required", review["actionCategory"])
+        self.assertEqual("implementation_pr_with_stale_workbook_claim", review["prType"])
+        self.assertTrue(review["controllerDispatchAttention"])
+        self.assertIn("linked workbook claim is stale or lease-expired", review["blockers"])
+
+    def test_unknown_unlinked_pr_is_not_merge_ready(self) -> None:
+        review = self.classify(
+            {
+                "number": 106,
+                "title": "Mystery branch",
+                "mergeStateStatus": "CLEAN",
+                "checks": [successCheck()],
+            }
+        )
+
+        self.assertEqual("human_review_required", review["actionCategory"])
+        self.assertEqual("unknown_pr", review["prType"])
+        self.assertFalse(review["controllerDispatchAttention"])
+        self.assertFalse(review["mergeAllowed"])
+
+    def test_controller_owned_unknown_pr_counts_as_attention_debt(self) -> None:
+        review = self.classify(
+            {
+                "number": 115,
+                "title": "Controller branch with missing queue signals",
+                "mergeStateStatus": "CLEAN",
+                "checks": [successCheck()],
+                "queue": {"controllerOwned": True},
+            }
+        )
+
+        self.assertEqual("human_review_required", review["actionCategory"])
+        self.assertEqual("unknown_pr", review["prType"])
+        self.assertTrue(review["controllerDispatchAttention"])
+
+    def test_github_changed_file_count_is_missing_signal_not_crash(self) -> None:
+        review = self.classify(
+            {
+                "number": 113,
+                "title": "Raw GitHub PR list item",
+                "changed_files": 3,
+                "mergeable_state": "clean",
+                "checkRollup": "success",
+            }
+        )
+
+        self.assertEqual("human_review_required", review["actionCategory"])
+        self.assertEqual("unknown_pr", review["prType"])
+        self.assertIn("missing queue link", review["blockers"][0])
+
+    def test_non_controller_owned_failing_pr_does_not_count_as_controller_attention(self) -> None:
+        review = self.classify(
+            {
+                "number": 116,
+                "files": ["src/gui/CListView.cpp"],
+                "mergeable_state": "dirty",
+                "checks": [{"name": "coverage", "state": "FAILURE"}],
+                "queue": {"status": "IN_PROGRESS", "owner": "external-worker"},
+            }
+        )
+
+        self.assertEqual("needs_update_rebase", review["actionCategory"])
+        self.assertFalse(review["controllerOwned"])
+        self.assertFalse(review["controllerDispatchAttention"])
+
+    def test_unstable_merge_state_requires_human_review(self) -> None:
+        review = self.classify(
+            {
+                "number": 117,
+                "files": ["scripts/pr_review_audit.py"],
+                "mergeStateStatus": "UNSTABLE",
+                "checks": [successCheck()],
+            }
+        )
+
+        self.assertEqual("human_review_required", review["actionCategory"])
+        self.assertEqual("workflow_pr", review["prType"])
+        self.assertFalse(review["mergeAllowed"])
+        self.assertIn("merge state UNSTABLE requires human review", review["blockers"])
+
+    def test_graphql_nodes_payloads_are_supported(self) -> None:
+        review = self.classify(
+            {
+                "number": 114,
+                "files": {"nodes": [{"path": "scripts/pr_review_audit.py"}]},
+                "labels": {"nodes": [{"name": "workflow"}]},
+                "checks": {"nodes": [{"name": "build / linux", "state": "SUCCESS"}]},
+                "mergeStateStatus": "CLEAN",
+            }
+        )
+
+        self.assertEqual("ready_to_merge", review["actionCategory"])
+        self.assertEqual("workflow_pr", review["prType"])
+
+    def test_obsolete_duplicate_close_requires_human_approval(self) -> None:
+        review = self.classify(
+            {
+                "number": 107,
+                "files": ["docs/old-flow.md"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [successCheck()],
+                "labels": [{"name": "duplicate"}],
+            }
+        )
+
+        self.assertEqual("obsolete_duplicate_close", review["actionCategory"])
+        self.assertTrue(review["humanApprovalRequired"])
+        self.assertFalse(review["cleanupAllowed"])
+
+    def test_closed_merged_branch_is_cleanup_candidate_only(self) -> None:
+        review = self.classify(
+            {
+                "number": 108,
+                "state": "closed",
+                "merged": True,
+                "files": ["scripts/poll_pr_checks.py"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [successCheck()],
+            }
+        )
+
+        self.assertEqual("branch_cleanup_candidate", review["actionCategory"])
+        self.assertTrue(review["humanApprovalRequired"])
+        self.assertFalse(review["cleanupAllowed"])
+
+    def test_dirty_local_recovery_state_is_never_touch(self) -> None:
+        review = self.classify(
+            {
+                "number": 109,
+                "files": ["src/core/CGameContext.cpp"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [successCheck()],
+                "queue": {"status": "IN_PROGRESS", "owner": "controller/ctrl-a/subagent-4"},
+                "local": {"dirtyWorktree": True},
+            }
+        )
+
+        self.assertEqual("never_touch", review["actionCategory"])
+        self.assertIn("local worktree is dirty", review["blockers"])
+        self.assertFalse(review["cleanupAllowed"])
+
+    def test_audit_payload_summarizes_actions_and_attention(self) -> None:
+        payload = pr_review_audit.auditPayload(
+            [
+                {
+                    "number": 110,
+                    "files": ["scripts/issue_queue.py"],
+                    "mergeStateStatus": "CLEAN",
+                    "checks": [successCheck()],
+                },
+                {
+                    "number": 111,
+                    "files": ["src/core/CGameContext.cpp"],
+                    "mergeStateStatus": "DIRTY",
+                    "checks": [successCheck()],
+                    "queue": {"status": "IN_PROGRESS", "owner": "controller/ctrl-a/subagent-4"},
+                },
+            ]
+        )
+
+        self.assertTrue(payload["readOnly"])
+        self.assertEqual(2, payload["summary"]["total"])
+        self.assertEqual(1, payload["summary"]["actions"]["ready_to_merge"])
+        self.assertEqual(1, payload["summary"]["controllerDispatchAttention"])
+
+    def test_cli_outputs_json_and_table_from_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "prs.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "pullRequests": [
+                            {
+                                "number": 112,
+                                "files": ["scripts/pr_review_audit.py"],
+                                "mergeStateStatus": "CLEAN",
+                                "checks": [successCheck()],
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exitCode = pr_review_audit.main(["--input", str(path)])
+            self.assertEqual(0, exitCode)
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(1, payload["summary"]["total"])
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exitCode = pr_review_audit.main(["--input", str(path), "--format", "table"])
+            self.assertEqual(0, exitCode)
+            self.assertIn("PR\tACTION\tTYPE", stdout.getvalue())
+            self.assertIn("#112", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- Added `scripts/pr_review_audit.py`, a read-only classifier for stale/open PR review snapshots.
- Added unit coverage for ready, pending, failing, dirty, stale-claim, unknown, duplicate, branch-cleanup, raw GitHub-count, GraphQL-nodes, non-controller-owned, and `UNSTABLE` merge-state cases.
- Updated `AGENTS.md`, `docs/codex-agent-queue.md`, and `prompts/codex-workflow-optimizer.md` so controllers run the PR audit before cleanup/merge decisions while preserving the exact four non-stale owned-claim target.

## Why
Controllers need a repeatable policy for stale/open PR cleanup or merge decisions without reintroducing source-overlap as a hard blocker or allowing destructive cleanup by default.

## Validation
- `python3 -B -m unittest tests.test_pr_review_audit tests.test_issue_queue tests.test_controller_resource_audit tests.test_poll_pr_checks tests.test_prompt_inventory`
- `python3 scripts/issue_queue.py validate`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`
- `git diff --check origin/main..HEAD`

## Known limitations
- The audit consumes a normalized JSON snapshot; it intentionally does not call GitHub, close PRs, delete branches, mutate the workbook, merge PRs, or override failed checks.
- Destructive cleanup and stale-claim recovery still require explicit human approval.