### PR TITLE
Add transition generation counter

### DIFF
--- a/src/core/CGame.cpp
+++ b/src/core/CGame.cpp
@@ -23,7 +23,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 CGame::CGame() {}
 
-CGame::~CGame() {}
+CGame::~CGame() {
+    if (context) {
+        context->advanceTransitionGeneration();
+    }
+}
 
 void CGame::changeMap(std::string file) { CGameLoader::changeMap(this->ptr<CGame>(), std::move(file)); }
 

--- a/src/core/CGameContext.cpp
+++ b/src/core/CGameContext.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "handler/CRngHandler.h"
 #include "handler/CScriptHandler.h"
 
+#include <atomic>
 #include <stdexcept>
 #include <utility>
 
@@ -61,4 +62,20 @@ std::shared_ptr<CRngHandler> CGameContext::getRngHandler() {
         rngHandler = std::make_shared<CRngHandler>(owner);
     }
     return rngHandler;
+}
+
+CGameContext::TransitionGeneration CGameContext::getTransitionGeneration() const {
+    return transitionGeneration.load(std::memory_order_acquire);
+}
+
+CGameContext::TransitionGeneration CGameContext::captureTransitionGeneration() const {
+    return getTransitionGeneration();
+}
+
+bool CGameContext::isTransitionGenerationCurrent(TransitionGeneration expectedGeneration) const {
+    return getTransitionGeneration() == expectedGeneration;
+}
+
+CGameContext::TransitionGeneration CGameContext::advanceTransitionGeneration() {
+    return transitionGeneration.fetch_add(1, std::memory_order_acq_rel) + 1;
 }

--- a/src/core/CGameContext.h
+++ b/src/core/CGameContext.h
@@ -17,6 +17,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 
+#include <atomic>
+#include <cstdint>
 #include <memory>
 
 class CGame;
@@ -27,6 +29,8 @@ class CScriptHandler;
 
 class CGameContext {
   public:
+    using TransitionGeneration = std::uint64_t;
+
     explicit CGameContext(std::shared_ptr<CGame> game);
 
     std::shared_ptr<CObjectHandler> getObjectHandler();
@@ -37,10 +41,19 @@ class CGameContext {
 
     std::shared_ptr<CRngHandler> getRngHandler();
 
+    TransitionGeneration getTransitionGeneration() const;
+
+    TransitionGeneration captureTransitionGeneration() const;
+
+    bool isTransitionGenerationCurrent(TransitionGeneration expectedGeneration) const;
+
+    TransitionGeneration advanceTransitionGeneration();
+
   private:
     std::weak_ptr<CGame> game;
     std::shared_ptr<CGuiHandler> guiHandler;
     std::shared_ptr<CObjectHandler> objectHandler;
     std::shared_ptr<CScriptHandler> scriptHandler;
     std::shared_ptr<CRngHandler> rngHandler;
+    std::atomic<TransitionGeneration> transitionGeneration = 0;
 };

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -424,7 +424,13 @@ void init_game_module(py::module_ &m) {
         .def("getObjectHandler", &CGameContext::getObjectHandler, "Return the object factory/registry handler.")
         .def("getGuiHandler", &CGameContext::getGuiHandler, "Return the GUI handler service.")
         .def("getScriptHandler", &CGameContext::getScriptHandler, "Return the Python script execution service.")
-        .def("getRngHandler", &CGameContext::getRngHandler, "Return the random encounter/loot handler.");
+        .def("getRngHandler", &CGameContext::getRngHandler, "Return the random encounter/loot handler.")
+        .def("getTransitionGeneration", &CGameContext::getTransitionGeneration,
+             "Return the current transition/session generation.")
+        .def("captureTransitionGeneration", &CGameContext::captureTransitionGeneration,
+             "Capture the current transition/session generation for deferred callbacks.")
+        .def("isTransitionGenerationCurrent", &CGameContext::isTransitionGenerationCurrent,
+             "Return whether a captured transition/session generation is still current.");
 
     py::enum_<CSceneManager::TransitionState>(m, "CSceneTransitionState", "Scene transition lifecycle state.")
         .value("Idle", CSceneManager::TransitionState::Idle)

--- a/src/core/CSceneManager.cpp
+++ b/src/core/CSceneManager.cpp
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "core/CSceneManager.h"
 #include "core/CGame.h"
+#include "core/CGameContext.h"
 #include "core/CLoader.h"
 #include "core/CMap.h"
 #include "core/CPlaytestTrace.h"
@@ -61,6 +62,9 @@ bool CSceneManager::requestMapChange(const std::shared_ptr<CGame> &game, MapTran
 
     transitionState = TransitionState::TransitionPending;
     pendingMapName = mapName;
+    auto context = game->getContext();
+    context->advanceTransitionGeneration();
+    const auto expectedGeneration = context->captureTransitionGeneration();
     if (CPlaytestTrace::enabled()) {
         json fields = {
             {"accepted", true},
@@ -72,12 +76,45 @@ bool CSceneManager::requestMapChange(const std::shared_ptr<CGame> &game, MapTran
     }
 
     auto manager = shared_from_this();
-    vstd::call_later([manager, game, mapName]() {
+    std::weak_ptr<CGame> weakGame = game;
+    std::weak_ptr<CGameContext> weakContext = context;
+    vstd::call_later([manager, weakGame, weakContext, expectedGeneration, mapName]() {
+        auto resetIfStillPending = [&manager, &mapName]() {
+            if (manager->transitionState == TransitionState::TransitionPending && manager->pendingMapName == mapName) {
+                manager->resetTransition();
+            }
+        };
+        auto game = weakGame.lock();
+        auto context = weakContext.lock();
+        if (!game || !context || !context->isTransitionGenerationCurrent(expectedGeneration)) {
+            resetIfStillPending();
+            return;
+        }
         if (manager->transitionState != TransitionState::TransitionPending || manager->pendingMapName != mapName) {
             return;
         }
-        vstd::call_when([game]() { return !game->getMap() || !game->getMap()->isMoving(); },
-                        [manager, game, mapName]() { manager->performMapChange(game, mapName); });
+        vstd::call_when(
+            [weakGame, weakContext, expectedGeneration]() {
+                auto game = weakGame.lock();
+                auto context = weakContext.lock();
+                return !game || !context || !context->isTransitionGenerationCurrent(expectedGeneration) ||
+                       !game->getMap() || !game->getMap()->isMoving();
+            },
+            [manager, weakGame, weakContext, expectedGeneration, mapName]() {
+                auto resetIfStillPending = [&manager, &mapName]() {
+                    if (manager->transitionState == TransitionState::TransitionPending &&
+                        manager->pendingMapName == mapName) {
+                        manager->resetTransition();
+                    }
+                };
+                auto game = weakGame.lock();
+                auto context = weakContext.lock();
+                if (!game || !context || !context->isTransitionGenerationCurrent(expectedGeneration)) {
+                    resetIfStillPending();
+                    return;
+                }
+                manager->performMapChange(game, mapName);
+            });
     });
     return true;
 }
@@ -119,6 +156,7 @@ void CSceneManager::performMapChange(const std::shared_ptr<CGame> &game, const s
             }
             game->getMap()->setTurn(oldMap->getTurn());
         }
+        game->getContext()->advanceTransitionGeneration();
         if (CPlaytestTrace::enabled()) {
             CPlaytestTrace::addMapContext(traceFields, game->getMap());
             traceFields["result"] = "completed";

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -20,7 +20,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CGame.h"
 #include "core/CGameContext.h"
 #include "core/CList.h"
+#include "core/CMap.h"
 #include "core/CPathFinder.h"
+#include "core/CPlaytestTrace.h"
 #include "core/CSaveFormat.h"
 #include "core/CSerialization.h"
 #include "core/CScript.h"
@@ -28,7 +30,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CTypes.h"
 #include "core/CUtil.h"
 #include "gui/CSdlResources.h"
+#include "object/CCreature.h"
 #include "object/CGameObject.h"
+#include "object/CItem.h"
 #include "test_harness.h"
 #include "vutil.h"
 
@@ -597,13 +601,27 @@ void test_nested_primitive_wrappers_serialize_direct_values_and_round_trip() {
                                            []() { return std::make_shared<PrimitiveSerializationHolder>(); });
     game->getObjectHandler()->registerType(CListString::static_meta()->name(),
                                            []() { return std::make_shared<CListString>(); });
+    game->getObjectHandler()->registerType(CListInt::static_meta()->name(),
+                                           []() { return std::make_shared<CListInt>(); });
     game->getObjectHandler()->registerType(CMapStringString::static_meta()->name(),
                                            []() { return std::make_shared<CMapStringString>(); });
+    game->getObjectHandler()->registerType(CMapStringInt::static_meta()->name(),
+                                           []() { return std::make_shared<CMapStringInt>(); });
+    game->getObjectHandler()->registerType(CMapIntString::static_meta()->name(),
+                                           []() { return std::make_shared<CMapIntString>(); });
+    game->getObjectHandler()->registerType(CMapIntInt::static_meta()->name(),
+                                           []() { return std::make_shared<CMapIntInt>(); });
 
     auto list_values = std::make_shared<CListString>();
     list_values->setValues({"north", "south"});
     auto map_values = std::make_shared<CMapStringString>();
     map_values->setValues({{"confirm", "enter"}, {"inventory", "i"}});
+    auto int_list_values = std::make_shared<CListInt>();
+    int_list_values->setValues({2, 3, 5});
+    auto int_string_map_values = std::make_shared<CMapIntString>();
+    int_string_map_values->setValues({{7, "seven"}, {11, "eleven"}});
+    auto int_int_map_values = std::make_shared<CMapIntInt>();
+    int_int_map_values->setValues({{13, 169}, {17, 289}});
 
     auto holder = std::make_shared<PrimitiveSerializationHolder>();
     holder->setGame(game);
@@ -677,6 +695,53 @@ void test_nested_primitive_wrappers_serialize_direct_values_and_round_trip() {
                     ref_round_trip->getMapValues()->getValues() ==
                         std::map<std::string, std::string>({{"i", "inventoryPanel"}, {"j", "questPanel"}}),
                 "CMapStringString object refs should resolve to the referenced primitive wrapper");
+
+    auto serialized_int_list =
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::serialize(int_list_values);
+    auto int_list_round_trip = std::dynamic_pointer_cast<CListInt>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game,
+                                                                                              serialized_int_list));
+    expect_true(int_list_round_trip && int_list_round_trip->getValues() == std::set<int>({2, 3, 5}),
+                "CListInt should round-trip integer sets through primitive JSON arrays");
+
+    auto serialized_int_string_map =
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::serialize(int_string_map_values);
+    auto int_string_map_round_trip = std::dynamic_pointer_cast<CMapIntString>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(
+            game, serialized_int_string_map));
+    expect_true(int_string_map_round_trip && int_string_map_round_trip->getValues() ==
+                                                 std::map<int, std::string>({{7, "seven"}, {11, "eleven"}}),
+                "CMapIntString should round-trip integer keys through string-keyed JSON objects");
+
+    auto serialized_int_int_map =
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::serialize(int_int_map_values);
+    auto int_int_map_round_trip = std::dynamic_pointer_cast<CMapIntInt>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game,
+                                                                                              serialized_int_int_map));
+    expect_true(int_int_map_round_trip &&
+                    int_int_map_round_trip->getValues() == std::map<int, int>({{13, 169}, {17, 289}}),
+                "CMapIntInt should round-trip integer keys and values through string-keyed JSON objects");
+
+    auto string_int_map_values = std::make_shared<CMapStringInt>();
+    string_int_map_values->setValues({{"one", 1}, {"two", 2}});
+    auto serialized_string_int_map =
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::serialize(string_int_map_values);
+    auto string_int_map_round_trip = std::dynamic_pointer_cast<CMapStringInt>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(
+            game, serialized_string_int_map));
+    expect_true(string_int_map_round_trip &&
+                    string_int_map_round_trip->getValues() == std::map<std::string, int>({{"one", 1}, {"two", 2}}),
+                "CMapStringInt should round-trip string keys and integer values");
+
+    auto invalid_int_key_config = std::make_shared<json>();
+    (*invalid_int_key_config)["class"] = CMapIntString::static_meta()->name();
+    (*invalid_int_key_config)["properties"]["values"] = {{"", "empty"}, {"bad", "ignored"}, {"23", "kept"}};
+    auto invalid_int_key_round_trip = std::dynamic_pointer_cast<CMapIntString>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game,
+                                                                                              invalid_int_key_config));
+    expect_true(invalid_int_key_round_trip &&
+                    invalid_int_key_round_trip->getValues() == std::map<int, std::string>({{23, "kept"}}),
+                "integer-key maps should skip empty and unparsable JSON object keys");
 }
 
 void test_nested_property_notification_batches_emit_one_deterministic_signal() {
@@ -798,6 +863,92 @@ void test_game_context_rejects_services_without_owner_game() {
                          "CGuiHandler creation should require an active owning game");
     expect_runtime_error([&]() { context->getRngHandler(); },
                          "CRngHandler creation should require an active owning game");
+}
+
+void test_game_context_transition_generation_helpers_and_shutdown() {
+    auto game = std::make_shared<CGame>();
+    auto context = game->getContext();
+
+    auto initial_generation = context->getTransitionGeneration();
+    auto captured_generation = context->captureTransitionGeneration();
+    expect_true(captured_generation == initial_generation,
+                "capturing transition generation should return the current generation");
+    expect_true(context->isTransitionGenerationCurrent(captured_generation),
+                "freshly captured transition generation should be current");
+
+    auto advanced_generation = context->advanceTransitionGeneration();
+    expect_true(advanced_generation == initial_generation + 1,
+                "advancing transition generation should increment monotonically");
+    expect_true(context->getTransitionGeneration() == advanced_generation,
+                "reading transition generation should return the advanced value");
+    expect_true(!context->isTransitionGenerationCurrent(captured_generation),
+                "captured transition generation should become stale after an advance");
+
+    auto shutdown_generation = context->captureTransitionGeneration();
+    game.reset();
+    expect_true(context->getTransitionGeneration() == shutdown_generation + 1,
+                "destroying the owning game should advance transition generation");
+    expect_true(!context->isTransitionGenerationCurrent(shutdown_generation),
+                "shutdown should make previously captured transition generation stale");
+}
+
+void test_playtest_trace_records_and_helper_payloads() {
+    CPlaytestTrace::configure(false);
+    CPlaytestTrace::record("ignored");
+    expect_true(CPlaytestTrace::records().empty(), "disabled playtest trace should ignore records");
+
+    CPlaytestTrace::configure(true, "", 1);
+    CPlaytestTrace::recordJson("trace_payload", R"({"value": 7})");
+    CPlaytestTrace::recordJson("trace_non_object_payload", R"([1, 2])");
+    CPlaytestTrace::recordJson("trace_after_truncation", "");
+
+    auto records = CPlaytestTrace::records();
+    expect_true(records.size() == 2, "trace should retain one record plus one truncation marker");
+    auto first = json::parse(records.front());
+    auto second = json::parse(records.back());
+    expect_true(first["event"].get<std::string>() == "trace_payload" && first["value"].get<int>() == 7,
+                "recordJson should preserve object payload fields");
+    expect_true(second["event"].get<std::string>() == "trace_truncated" && second["truncated"].get<bool>(),
+                "trace should add a single truncation marker after maxRecords");
+
+    auto drained = CPlaytestTrace::drain();
+    expect_true(drained.size() == 2 && CPlaytestTrace::records().empty(),
+                "drain should return and clear buffered trace records");
+
+    CPlaytestTrace::configure(true);
+    CPlaytestTrace::clear();
+    expect_true(CPlaytestTrace::records().empty(), "clear should reset trace records");
+
+    auto object = std::make_shared<CGameObject>();
+    object->setName("traceObject");
+    object->setType("CGameObject");
+    auto ref = CPlaytestTrace::objectRef(object);
+    expect_true(ref["name"].get<std::string>() == "traceObject" && ref["type"].get<std::string>() == "CGameObject",
+                "objectRef should serialize stable object identity");
+
+    auto creature = std::make_shared<CCreature>();
+    creature->setName("traceCreature");
+    auto creature_ref = CPlaytestTrace::objectRef(creature);
+    expect_true(!creature_ref["isPlayer"].get<bool>(), "creature trace refs should include player classification");
+    expect_true(CPlaytestTrace::objectRefs({creature}).size() == 1, "objectRefs should serialize creature lists");
+
+    auto item = std::make_shared<CItem>();
+    item->setName("traceItem");
+    expect_true(CPlaytestTrace::itemRefs({item}).size() == 1, "itemRefs should serialize item sets");
+    expect_true(CPlaytestTrace::objectRef(nullptr).is_null(), "objectRef should preserve null objects");
+
+    json fields = json::object();
+    CPlaytestTrace::addMapContext(fields, nullptr);
+    expect_true(fields.empty(), "addMapContext should ignore null maps");
+
+    auto map = std::make_shared<CMap>();
+    map->setName("traceMapObject");
+    map->setTurn(42);
+    CPlaytestTrace::addMapContext(fields, map);
+    expect_true(fields["map"].get<std::string>() == "traceMapObject" && fields["turn"].get<int>() == 42,
+                "addMapContext should serialize map identity and turn");
+
+    CPlaytestTrace::configure(false);
 }
 
 void test_delayed_future_handlers_run_through_event_loop() {
@@ -1038,6 +1189,8 @@ int main() {
     test_object_clone_batches_property_notifications();
     test_game_context_owns_distinct_gui_handlers_per_game();
     test_game_context_rejects_services_without_owner_game();
+    test_game_context_transition_generation_helpers_and_shutdown();
+    test_playtest_trace_records_and_helper_payloads();
     test_delayed_future_handlers_run_through_event_loop();
     test_script_rejects_executable_expressions();
     test_save_format_codec_validation();

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -18,8 +18,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "core/CController.h"
 #include "core/CGame.h"
+#include "core/CGameContext.h"
 #include "core/CLoader.h"
 #include "core/CMap.h"
+#include "core/CPlaytestTrace.h"
 #include "core/CProvider.h"
 #include "core/CSceneManager.h"
 #include "core/CSerialization.h"
@@ -65,6 +67,37 @@ bool contains_coords(const std::vector<Coords> &coords, Coords target) {
     return std::ranges::find(coords, target) != coords.end();
 }
 
+struct TraceReset {
+    ~TraceReset() { CPlaytestTrace::configure(false); }
+};
+
+std::vector<json> drain_trace_json() {
+    std::vector<json> records;
+    for (const auto &line : CPlaytestTrace::drain()) {
+        records.push_back(json::parse(line));
+    }
+    return records;
+}
+
+bool has_trace_event(const std::vector<json> &records, const std::string &event) {
+    for (const auto &record : records) {
+        if (record.contains("event") && record["event"].get<std::string>() == event) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool has_trace_event_reason(const std::vector<json> &records, const std::string &event, const std::string &reason) {
+    for (const auto &record : records) {
+        if (record.contains("event") && record["event"].get<std::string>() == event && record.contains("reason") &&
+            record["reason"].get<std::string>() == reason) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void test_scene_manager_state_duplicate_and_player_transfer() {
     auto game = CGameLoader::loadGame();
     CGameLoader::startGameWithPlayer(game, "test", "Warrior");
@@ -98,6 +131,91 @@ void test_scene_manager_state_duplicate_and_player_transfer() {
                 "scene manager should return to idle after transition completion");
     expect_true(!manager->isTransitionPending(), "completed scene transition should clear pending state");
     expect_true(manager->getPendingMapName().empty(), "completed scene transition should clear pending map name");
+}
+
+void test_scene_manager_transition_generation_start_and_commit() {
+    auto game = CGameLoader::loadGame();
+    CGameLoader::startGameWithPlayer(game, "test", "Warrior");
+
+    auto context = game->getContext();
+    auto initial_generation = context->captureTransitionGeneration();
+    auto manager = game->getSceneManager();
+
+    expect_true(manager->requestMapChange(game, "ritual"), "scene manager should accept a transition request");
+    auto started_generation = context->getTransitionGeneration();
+    expect_true(started_generation == initial_generation + 1,
+                "accepted scene transition should advance generation when it starts");
+    expect_true(!context->isTransitionGenerationCurrent(initial_generation),
+                "pre-transition generation should be stale after transition start");
+    expect_true(context->isTransitionGenerationCurrent(started_generation),
+                "transition-start generation should remain current before commit");
+
+    pump_event_loop_iterations();
+
+    auto committed_generation = context->getTransitionGeneration();
+    expect_true(committed_generation == started_generation + 1,
+                "completed scene transition should advance generation when it commits");
+    expect_true(!context->isTransitionGenerationCurrent(started_generation),
+                "transition-start generation should be stale after commit");
+    expect_true(context->isTransitionGenerationCurrent(committed_generation),
+                "committed transition generation should be current");
+}
+
+void test_scene_manager_stale_transition_generation_clears_pending_state() {
+    auto game = CGameLoader::loadGame();
+    CGameLoader::startGameWithPlayer(game, "test", "Warrior");
+
+    auto old_map = game->getMap();
+    auto manager = game->getSceneManager();
+    auto context = game->getContext();
+
+    expect_true(manager->requestMapChange(game, "ritual"), "scene manager should accept a transition request");
+    auto started_generation = context->captureTransitionGeneration();
+    context->advanceTransitionGeneration();
+
+    pump_event_loop_iterations();
+
+    expect_true(game->getMap() == old_map, "stale transition generation should not replace the active map");
+    expect_true(!context->isTransitionGenerationCurrent(started_generation),
+                "manually advanced transition generation should make the request stale");
+    expect_true(manager->getTransitionState() == CSceneManager::TransitionState::Idle,
+                "stale transition callback should clear pending state");
+    expect_true(!manager->isTransitionPending(), "stale transition callback should not leave a pending transition");
+    expect_true(manager->getPendingMapName().empty(), "stale transition callback should clear pending map name");
+}
+
+void test_scene_manager_trace_rejections_and_completion() {
+    TraceReset reset;
+    CPlaytestTrace::configure(true);
+
+    auto standalone_manager = std::make_shared<CSceneManager>();
+    expect_true(!standalone_manager->requestMapChange(nullptr, "ritual"),
+                "trace-enabled scene manager should reject null-game requests");
+
+    auto first_game = CGameLoader::loadGame();
+    CGameLoader::startGameWithPlayer(first_game, "test", "Warrior");
+    auto second_game = CGameLoader::loadGame();
+    CGameLoader::startGameWithPlayer(second_game, "test", "Warrior");
+    auto first_manager = first_game->getSceneManager();
+
+    expect_true(!first_manager->requestMapChange(second_game, "ritual"),
+                "trace-enabled scene manager should reject mismatched game requests");
+    expect_true(first_manager->requestMapChange(first_game, "ritual"),
+                "trace-enabled scene manager should accept a valid transition");
+    expect_true(!first_manager->requestMapChange(first_game, "siege"),
+                "trace-enabled scene manager should reject duplicate pending transitions");
+
+    pump_event_loop_iterations();
+
+    auto records = drain_trace_json();
+    expect_true(has_trace_event_reason(records, "map_transition_rejected", "missing_game"),
+                "trace should record missing-game rejection");
+    expect_true(has_trace_event_reason(records, "map_transition_rejected", "mismatched_scene_manager"),
+                "trace should record mismatched-manager rejection");
+    expect_true(has_trace_event_reason(records, "map_transition_rejected", "transition_pending"),
+                "trace should record duplicate pending transition rejection");
+    expect_true(has_trace_event(records, "map_transition_requested"), "trace should record accepted transitions");
+    expect_true(has_trace_event(records, "map_transition_completed"), "trace should record completed transitions");
 }
 
 void test_scene_manager_repeated_transitions_and_controller_usability() {
@@ -866,6 +984,9 @@ int main() {
     pybind11::scoped_interpreter guard{};
 
     test_scene_manager_state_duplicate_and_player_transfer();
+    test_scene_manager_transition_generation_start_and_commit();
+    test_scene_manager_stale_transition_generation_clears_pending_state();
+    test_scene_manager_trace_rejections_and_completion();
     test_scene_manager_repeated_transitions_and_controller_usability();
     test_scene_manager_null_and_legacy_missing_target_behavior();
     test_scene_manager_rejects_cross_game_requests();


### PR DESCRIPTION
## What changed

- Added a monotonic transition/session generation value on `CGameContext`.
- Advanced the generation when map transitions start, when they commit, and when the owning game shuts down.
- Guarded deferred scene-transition callbacks with a captured generation so stale callbacks can be detected.
- Cleared pending scene-transition state when a deferred callback discovers its captured generation is stale.
- Exposed read/capture/compare helpers to Python bindings.
- Added focused native unit coverage for generation helpers, stale deferred callbacks, scene-transition start/commit behavior, trace payload helpers, and primitive wrapper serialization helpers used by the coverage-safe core path.

## Why

Deferred scene-transition work previously relied on pending scene-manager state and map names only. There was no context-scoped generation value that later callbacks or tests could use to distinguish current lifecycle work from stale work.

Queue identity:
- Issue: `[EPIC_02][STORY_04][SUBSTORY_01]Add transition generation counter`
- Claim ID: `3ddf9cdc-ab7f-48c3-8a42-01b212f4989e`
- Owner: `controller/ctrl-lis-2-b17e29a3/subagent-1`

## Validation

Local:
- `clang-format -i src/core/CGame.cpp src/core/CGameContext.cpp src/core/CGameContext.h src/core/CModule.cpp src/core/CSceneManager.cpp tests/unit/test_core.cpp tests/unit/test_map.cpp`
- `git diff --check`
- `find . -maxdepth 3 -type f \( -name core_unit_tests -o -name map_unit_tests \) -print` showed no prebuilt focused native test executables.
- First CI poll: `build / linux` passed, `linux-coverage` failed at `89.37% (8825/9875)` against the `90.00%` gate. The follow-up commit adds coverage for the changed transition/trace surface and nearby reviewed core serializer helpers.

Deferred to CI:
- Native build and unit tests
- Python suite
- Coverage
- `build / linux` will be polled with required coverage because this touches `src/core/**` and `tests/unit/**`.

## Known limitations / follow-up

- `CLoader.cpp` was inspected, but the implementation lives in `CSceneManager` because `CGameLoader::changeMap` delegates there.
- Local native tests were not run because the focused executables were not already built and controller policy avoids local native-heavy validation when CI can provide it.