### PR TITLE
[codex] Recognize PR status check rollups

### DIFF
--- a/scripts/pr_review_audit.py
+++ b/scripts/pr_review_audit.py
@@ -22,10 +22,12 @@ FAILURE_STATES = {
     "error",
     "failure",
     "failed",
+    "stale",
     "startup_failure",
     "timed_out",
 }
 PENDING_STATES = {"expected", "in_progress", "pending", "queued", "requested", "waiting"}
+NEUTRAL_STATES = {"neutral", "skipped"}
 
 CLEAN_MERGE_STATES = {"clean", "has_hooks"}
 UPDATE_MERGE_STATES = {"behind", "conflicting", "dirty"}
@@ -120,6 +122,8 @@ def stateFromCheck(check: dict[str, Any]) -> str:
             return "failure"
     if state in {"completed", "complete"} and not conclusion:
         return "unknown"
+    if conclusion in NEUTRAL_STATES or state in NEUTRAL_STATES or rollup in NEUTRAL_STATES:
+        return "success"
     if conclusion in SUCCESS_STATES or state in SUCCESS_STATES or rollup in SUCCESS_STATES:
         return "success"
     if state in PENDING_STATES or conclusion in PENDING_STATES or rollup in PENDING_STATES:
@@ -148,6 +152,8 @@ def checkSummary(record: dict[str, Any]) -> CheckSummary:
         "checks",
         "checkRuns",
         "check_runs",
+        "statusCheckRollup",
+        "status_check_rollup",
         "statusChecks",
         "status_checks",
         default=None,

--- a/tests/test_pr_review_audit.py
+++ b/tests/test_pr_review_audit.py
@@ -86,6 +86,87 @@ class PrReviewAuditTest(unittest.TestCase):
         self.assertEqual("workflow_pr", review["prType"])
         self.assertEqual(["build / linux"], review["pendingChecks"])
 
+    def test_status_check_rollup_list_reports_pending_checks(self) -> None:
+        review = self.classify(
+            {
+                "number": 118,
+                "files": ["scripts/pr_review_audit.py"],
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [
+                    {
+                        "__typename": "CheckRun",
+                        "name": "linux-fast",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS",
+                    },
+                    {
+                        "__typename": "CheckRun",
+                        "name": "linux",
+                        "status": "IN_PROGRESS",
+                        "conclusion": "",
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual("poll", review["actionCategory"])
+        self.assertEqual("pending", review["checkState"])
+        self.assertEqual(["linux"], review["pendingChecks"])
+
+    def test_status_check_rollup_list_reports_failures(self) -> None:
+        review = self.classify(
+            {
+                "number": 119,
+                "files": ["scripts/pr_review_audit.py"],
+                "mergeStateStatus": "UNKNOWN",
+                "statusCheckRollup": [
+                    {
+                        "__typename": "CheckRun",
+                        "name": "linux-fast",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS",
+                    },
+                    {
+                        "__typename": "CheckRun",
+                        "name": "linux",
+                        "status": "COMPLETED",
+                        "conclusion": "FAILURE",
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual("failing_ci", review["actionCategory"])
+        self.assertEqual("failure", review["checkState"])
+        self.assertEqual(["linux"], review["failedChecks"])
+
+    def test_skipped_status_check_rollup_entry_is_non_blocking(self) -> None:
+        review = self.classify(
+            {
+                "number": 120,
+                "files": ["scripts/pr_review_audit.py"],
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [
+                    {
+                        "__typename": "CheckRun",
+                        "name": "linux",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS",
+                    },
+                    {
+                        "__typename": "CheckRun",
+                        "name": "linux-coverage",
+                        "status": "COMPLETED",
+                        "conclusion": "SKIPPED",
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual("ready_to_merge", review["actionCategory"])
+        self.assertEqual("success", review["checkState"])
+        self.assertEqual([], review["failedChecks"])
+
     def test_stale_linked_claim_requires_human_review(self) -> None:
         review = self.classify(
             {


### PR DESCRIPTION
## What changed
- Teach `scripts/pr_review_audit.py` to read GitHub CLI `statusCheckRollup` entries as check-run data.
- Preserve pending and failed check names from GitHub-style check nodes.
- Treat neutral/skipped check conclusions as non-blocking so path-skipped jobs do not make an otherwise successful rollup unknown.
- Add regressions for pending, failing, and skipped `statusCheckRollup` entries.

## Why
After PR #601 merged, the documented open-PR snapshot command produced `statusCheckRollup` arrays, but the audit script ignored that field and classified every open PR's check state as `unknown`. The live audit now distinguishes one pending PR from five failing-CI PRs.

## Validation
- `python3 -B -m unittest tests.test_pr_review_audit tests.test_issue_queue tests.test_controller_resource_audit tests.test_poll_pr_checks tests.test_prompt_inventory`
- `python3 scripts/issue_queue.py validate`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`
- `git diff --check origin/main..HEAD`
- `python3 scripts/pr_review_audit.py --input /tmp/pr-review-snapshot.json --format table`

## Known limitations
- This does not yet enrich raw GitHub PR snapshots with workbook/queue linkage, so implementation PRs without explicit queue metadata still classify as `unknown_pr`.