### PR TITLE
Defer siege gate blocking until clear

### DIFF
--- a/res/maps/siege/script.py
+++ b/res/maps/siege/script.py
@@ -75,22 +75,16 @@ def load(self, context):
             self.setBoolProperty("pendingSeal", False)
 
         def hasCreatureAtGate(self):
-            gate_coords = self.getCoords()
-            occupied = False
-
-            def checkObject(ob):
-                nonlocal occupied
-                coords = ob.getCoords()
-                if (
-                    isinstance(ob, CCreature)
-                    and coords.x == gate_coords.x
-                    and coords.y == gate_coords.y
-                    and coords.z == gate_coords.z
-                ):
-                    occupied = True
-
-            self.getMap().forObjects(checkObject, lambda ob: not occupied)
-            return occupied
+            game_map = self.getMap()
+            for ob in game_map.getObjectsAtCoords(self.getCoords()):
+                if not isinstance(ob, CCreature):
+                    continue
+                if not ob.isAlive():
+                    continue
+                if game_map.getObjectByName(ob.getName()) is None:
+                    continue
+                return True
+            return False
 
         def completePendingSeal(self):
             if self.hasCreatureAtGate():

--- a/test.py
+++ b/test.py
@@ -11740,6 +11740,59 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_siege_spawn_point_ignores_dead_gate_creatures_when_completing_seal(self):
+        class FakeEvent:
+            def __init__(self, cause):
+                self.cause = cause
+
+            def getCause(self):
+                return self.cause
+
+        game = load_game_module()
+        original_show_question = game.CGuiHandler.showQuestion
+
+        try:
+            game.CGuiHandler.showQuestion = lambda self, message: True
+            g, game_map, player = load_game_map_with_player("siege")
+            spawn_point = find_runtime_object(game_map, "spawnPoint1")
+            spawn_coords = spawn_point.getCoords()
+            player.moveTo(spawn_coords.x, spawn_coords.y, spawn_coords.z)
+
+            defeated_creature = g.createObject("siegePritz")
+            defeated_creature.name = "defeatedGateOccupant"
+            game_map.addObject(defeated_creature)
+            defeated_creature.relocateWithoutMoveHooks(spawn_coords)
+            defeated_creature.setHp(0)
+
+            player.addItem("magicWand")
+            spawn_point.setBoolProperty("enabled", True)
+            spawn_point.setBoolProperty("canStep", True)
+            spawn_point.onEnter(FakeEvent(player))
+
+            self.assertTrue(spawn_point.getBoolProperty("destroyed"))
+            self.assertTrue(spawn_point.getBoolProperty("pendingSeal"))
+            self.assertFalse(defeated_creature.isAlive())
+
+            exit_coords = find_adjacent_walkable_tile(game_map, spawn_coords)
+            player.moveTo(exit_coords.x, exit_coords.y, exit_coords.z)
+            spawn_point.onTurn(None)
+
+            self.assertFalse(spawn_point.getBoolProperty("pendingSeal"))
+            self.assertFalse(spawn_point.getBoolProperty("canStep"))
+        finally:
+            game.CGuiHandler.showQuestion = original_show_question
+
+        return True, json.dumps(
+            {
+                "canStep": spawn_point.getBoolProperty("canStep"),
+                "defeated_creature_alive": defeated_creature.isAlive(),
+                "destroyed": spawn_point.getBoolProperty("destroyed"),
+                "pendingSeal": spawn_point.getBoolProperty("pendingSeal"),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_siege_spawn_point_seal_consumes_one_wand_once_while_pending(self):
         class FakeEvent:
             def __init__(self, cause):


### PR DESCRIPTION
## Summary
- Make siege gate pending-seal occupancy checks use `getObjectsAtCoords()` for the gate tile.
- Ignore dead or unregistered creatures when deciding whether a sealed gate is still occupied.
- Add a regression GameTest that seals a gate with the player and a defeated creature on the tile, moves the player away, and verifies the gate finishes sealing.

## Why
The pending-seal helper treated any creature at the gate as an occupant. Dead creatures could therefore keep `pendingSeal=True` and leave the gate walkable after the player stepped away.

## Validation
- `black -l 120 res/maps/siege/script.py test.py`
- `python3 -m py_compile res/maps/siege/script.py test.py`
- inline Python stub harness for live/dead/empty gate occupancy
- `git diff --check`
- Post-rebase `git diff --check origin/main...HEAD`
- Post-rebase `python3 -m py_compile res/maps/siege/script.py test.py`

## Blocked Local Runtime Check
- `python3 test.py GameTest.test_siege_spawn_point_defers_blocking_sealed_occupied_gate GameTest.test_siege_spawn_point_ignores_dead_gate_creatures_when_completing_seal GameTest.test_siege_spawn_point_seal_consumes_one_wand_once_while_pending`
- Blocked before assertions because this worktree has no compiled `_game` module: `ModuleNotFoundError: No module named '_game'`.

## Queue
- Issue: `[EPIC_01][STORY_04][SUBSTORY_03]Defer blocking until cell is empty`
- Claim ID: `dd81399f-bcdb-425d-9830-e79969d809cb`
- Owner: `controller/ctrl-lis-2-36d0fa13/subagent-2`

## Notes
- Heavy Linux build, Python runtime tests, and coverage are expected from GitHub Actions `build / linux`; this PR touches `test.py`, so the controller will require the CI coverage step before auto-merge.
- The queue requested an MCP scenario; local MCP/runtime execution was unavailable without `_game`, so CI runtime evidence is required before completion.
