### PR TITLE
[codex] Fix PR audit status semantics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     outputs:
-      coverage-needed: ${{ steps.coverage-needed.outputs.run }}
+      coverage-needed: ${{ steps.change-classification.outputs.coverage-needed }}
+      native-needed: ${{ steps.change-classification.outputs.native-needed }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -47,8 +48,8 @@ jobs:
           python3 -m unittest tests.test_content_validator
       - name: test (python fast)
         run: python3 test.py --suite fast
-      - name: detect coverage need
-        id: coverage-needed
+      - name: classify changed paths
+        id: change-classification
         shell: bash
         run: |
           set -euo pipefail
@@ -70,24 +71,19 @@ jobs:
             fi
           fi
 
-          run_coverage=false
-          while IFS= read -r path; do
-            case "${path}" in
-              test.py|tests/unit/*|scripts/run_coverage.sh|scripts/coverage_report.py|native_plugins/*|src/core/*|src/handler/*|src/object/*)
-                run_coverage=true
-                break
-                ;;
-            esac
-          done < <(git diff --name-only "${base}" "${head}")
-
-          echo "run=${run_coverage}" >> "${GITHUB_OUTPUT}"
-          if [[ "${run_coverage}" == "true" ]]; then
-            echo "Coverage is required for this change."
-          else
-            echo "Coverage is not required for the changed paths."
+          force_native=()
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            force_native=(--force-native)
           fi
 
+          python3 scripts/ci_change_classifier.py \
+            --base "${base}" \
+            --head "${head}" \
+            "${force_native[@]}" \
+            --github-output "${GITHUB_OUTPUT}"
+
   linux:
+    needs: linux-fast
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     env:
@@ -109,7 +105,11 @@ jobs:
         run: python3 -m pip install --upgrade -r requirements-dev.txt
       - name: Smoke test Python deps
         run: python3 -c "from PIL import Image; import black; print('python deps ok')"
+      - name: Skip native validation
+        if: needs.linux-fast.outputs.native-needed != 'true'
+        run: echo "Native validation is not required for these changed paths."
       - name: Install native deps
+        if: needs.linux-fast.outputs.native-needed == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake ninja-build ccache clang-format black \
@@ -118,6 +118,7 @@ jobs:
             libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
             xvfb xauth
       - name: Detect ccache metadata
+        if: needs.linux-fast.outputs.native-needed == 'true'
         id: ccache
         shell: bash
         run: |
@@ -126,6 +127,7 @@ jobs:
           echo "dir=$(ccache --get-config cache_dir)" >> "${GITHUB_OUTPUT}"
           echo "prefix=${{ runner.os }}-ccache-release-${compiler_id}-" >> "${GITHUB_OUTPUT}"
       - name: Restore ccache
+        if: needs.linux-fast.outputs.native-needed == 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ steps.ccache.outputs.dir }}
@@ -134,45 +136,53 @@ jobs:
             ${{ steps.ccache.outputs.prefix }}
             ${{ runner.os }}-ccache-
       - name: Cache Python test timings
+        if: needs.linux-fast.outputs.native-needed == 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ env.GAME_TEST_TIMINGS_FILE }}
           key: ${{ runner.os }}-test-timings-linux-${{ github.run_id }}
           restore-keys: ${{ runner.os }}-test-timings-linux-
       - name: configure
+        if: needs.linux-fast.outputs.native-needed == 'true'
         run: GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh
       - name: build test targets
+        if: needs.linux-fast.outputs.native-needed == 'true'
         run: cmake --build cmake-build-release --target _game for_unit_tests performance_guard_tests -j"$(nproc)"
       - name: Smoke test game imports
+        if: needs.linux-fast.outputs.native-needed == 'true'
         run: PYTHONPATH=cmake-build-release:res python3 -c "import _game; import game; print('game imports ok')"
       - name: ccache stats after build
-        if: always()
+        if: always() && needs.linux-fast.outputs.native-needed == 'true'
         shell: bash
         run: |
           if command -v ccache >/dev/null 2>&1; then
             ccache --show-stats
           fi
       - name: test (c++)
+        if: needs.linux-fast.outputs.native-needed == 'true'
         run: ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests
       - name: performance guard (native)
+        if: needs.linux-fast.outputs.native-needed == 'true'
         run: ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance
       - name: test (python gameplay)
+        if: needs.linux-fast.outputs.native-needed == 'true'
         timeout-minutes: 45
         run: python3 test.py --suite gameplay --jobs "$(nproc)"
       - name: test (python ui)
+        if: needs.linux-fast.outputs.native-needed == 'true'
         timeout-minutes: 45
         run: python3 test.py --suite ui --jobs "$(nproc)"
       - name: package
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && needs.linux-fast.outputs.native-needed == 'true'
         run: cmake --build cmake-build-release --target package -j"$(nproc)"
       - name: publish
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && needs.linux-fast.outputs.native-needed == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: fall-of-nouraajd-linux
           path: cmake-build-release/fall-of-nouraajd-*.tar.gz
       - name: Save ccache
-        if: always()
+        if: always() && needs.linux-fast.outputs.native-needed == 'true'
         continue-on-error: true
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
@@ -261,6 +271,8 @@ jobs:
           key: ${{ steps.ccache.outputs.prefix }}${{ github.run_id }}-${{ github.run_attempt }}
 
   windows-deps:
+    needs: linux-fast
+    if: needs.linux-fast.outputs.native-needed == 'true'
     runs-on: windows-2022
     timeout-minutes: 120
     outputs:
@@ -534,7 +546,10 @@ jobs:
           ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 
   windows:
-    needs: windows-deps
+    needs:
+      - linux-fast
+      - windows-deps
+    if: needs.linux-fast.outputs.native-needed == 'true'
     runs-on: windows-2022
     timeout-minutes: 120
     env: *windows-env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,15 +300,17 @@ python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux --require-step cover
 Run heavy local Linux validation only when the PR workflow cannot cover the required evidence, a focused local
 reproduction is necessary before opening the PR, or GitHub Actions polling is unavailable or blocked. Passing the PR
 `build / linux` check, polled with `python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux`, is sufficient PR
-delivery evidence for Linux compilation, native tests, native performance guards, Python suites, and conditional
-coverage. Coverage is satisfied by CI only when the workflow's path rule runs the `coverage` step somewhere in the
-selected build workflow run, currently in the conditional `linux-coverage` job; the poller auto-adds this step for
-coverage-relevant PR paths. Additional Windows, release, MCP gameplay, manual, or platform-specific validation is needed
-only when the task explicitly targets that surface or the user requests it. Report local commands, skipped or blocked
-local commands, and CI job names/conclusions separately; never imply a skipped local command passed. When CI polling
-supplies the full validation evidence, wait for the selected check(s) to pass before enabling auto-merge. If GitHub
-merges before polling finishes, stop waiting on that Actions run, fetch `origin/main`, verify the merge, and continue
-from the merged state.
+delivery evidence for the validation class selected by `scripts/ci_change_classifier.py`: native/source/content changes
+run Linux compilation, native tests, native performance guards, Python suites, and conditional coverage, while
+workflow-only docs/prompts/tooling changes keep a terminal `linux` check but skip unrelated native-heavy steps after
+focused workflow validation. Coverage is satisfied by CI only when the workflow's path rule runs the `coverage` step
+somewhere in the selected build workflow run, currently in the conditional `linux-coverage` job; the poller auto-adds
+this step for coverage-relevant PR paths. Additional Windows, release, MCP gameplay, manual, or platform-specific
+validation is needed only when the task explicitly targets that surface or the user requests it. Report local commands,
+skipped or blocked local commands, and CI job names/conclusions separately; never imply a skipped local command passed.
+When CI polling supplies the full validation evidence, wait for the selected check(s) to pass before enabling auto-merge.
+If GitHub merges before polling finishes, stop waiting on that Actions run, fetch `origin/main`, verify the merge, and
+continue from the merged state.
 
 Windows Release equivalent:
 

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -357,12 +357,14 @@ python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux --require-step cover
 
 Run heavy local Linux validation only when CI cannot cover the required evidence, a focused local reproduction is
 necessary before opening the PR, or GitHub Actions polling is unavailable or blocked. Report focused local checks
-separately from CI-polled validation. Passing `build / linux` is sufficient PR delivery evidence for Linux compilation,
-native tests, native performance guards, Python suites, and conditional coverage. It proves coverage only when the
-workflow's changed-path rule runs its `coverage` step somewhere in the selected build workflow run, currently in the
-conditional `linux-coverage` job; the poller auto-adds this step for coverage-relevant PR paths. Additional platform,
-release, MCP gameplay, manual, or issue-specific validation is needed only when the task targets that surface or the
-user requests it.
+separately from CI-polled validation. Passing `build / linux` is sufficient PR delivery evidence for the validation class
+selected by `scripts/ci_change_classifier.py`: native/source/content changes run Linux compilation, native tests, native
+performance guards, Python suites, and conditional coverage, while workflow-only docs/prompts/tooling changes keep a
+terminal `linux` check but skip unrelated native-heavy steps after focused workflow validation. It proves coverage only
+when the workflow's changed-path rule runs its `coverage` step somewhere in the selected build workflow run, currently in
+the conditional `linux-coverage` job; the poller auto-adds this step for coverage-relevant PR paths. Additional platform,
+release, MCP gameplay, manual, or issue-specific validation is needed only when the task targets that surface or the user
+requests it.
 Do not enable auto-merge until CI-polled validation passes when it is the only full-validation evidence.
 
 Workbook-only queue-state PRs that update only `planning/fall_of_nouraajd_issue_proposals.xlsx` are different from

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -120,9 +120,11 @@ Recommended required status checks:
 - `windows` (shown in some GitHub branch-protection UI as `build / windows`)
 
 These jobs cover the current PR build, native C++ tests, native performance guards, Python regression suite, dependency
-cache validation, and packaging on Linux and Windows. The workflow also has a conditional `linux-coverage` job that runs
-`./scripts/run_coverage.sh` when changed paths match the coverage rule; because it is path-gated, do not configure it as
-an always-present branch-protection check.
+cache validation, and packaging on Linux and Windows when `scripts/ci_change_classifier.py` marks native validation
+necessary. Workflow-only docs/prompts/tooling PRs still produce terminal `linux` check evidence, but native-heavy Linux
+steps and Windows jobs are skipped after focused workflow validation. The workflow also has a conditional
+`linux-coverage` job that runs `./scripts/run_coverage.sh` when changed paths match the coverage rule; because it is
+path-gated, do not configure it as an always-present branch-protection check.
 
 ## CI-Polled Validation
 For local agents, prefer the PR `linux` job as the default delivery path for heavy Linux validation. Run focused local
@@ -149,11 +151,13 @@ python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux --require-step cover
 
 Run heavy local Linux validation only when CI cannot cover the required evidence, a focused local reproduction is
 necessary before opening the PR, or GitHub Actions polling is unavailable or blocked. Passing `build / linux` is
-sufficient PR delivery evidence for the Release build, native tests, performance guard, gameplay suite, and UI suite. It
-proves coverage only when the workflow's changed-path rule runs the `coverage` step somewhere in the selected build
-workflow run, currently in `linux-coverage`; the poller auto-adds that step for coverage-relevant PR paths. Record the
-polled job name, conclusion, and URL separately from local commands. Do not report skipped local commands as passed, and
-do not enable auto-merge until the selected CI-polled validation has passed when it is the only full-validation evidence.
+sufficient PR delivery evidence for the classifier-selected validation class: native/source/content changes run the
+Release build, native tests, performance guard, gameplay suite, and UI suite, while workflow-only changes keep a terminal
+Linux check and skip unrelated native-heavy steps. It proves coverage only when the workflow's changed-path rule runs the
+`coverage` step somewhere in the selected build workflow run, currently in `linux-coverage`; the poller auto-adds that
+step for coverage-relevant PR paths. Record the polled job name, conclusion, and URL separately from local commands. Do
+not report skipped local commands as passed, and do not enable auto-merge until the selected CI-polled validation has
+passed when it is the only full-validation evidence.
 
 Manual repository settings for `main`:
 - require a pull request before merging

--- a/scripts/ci_change_classifier.py
+++ b/scripts/ci_change_classifier.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Classify changed paths for GitHub Actions validation routing."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+COVERAGE_PATH_PATTERNS = (
+    "test.py",
+    "tests/unit/*",
+    "scripts/run_coverage.sh",
+    "scripts/coverage_report.py",
+    "native_plugins/*",
+    "src/core/*",
+    "src/gui/*",
+    "src/handler/*",
+    "src/object/*",
+)
+
+NATIVE_PATH_PATTERNS = (
+    "CMakeLists.txt",
+    "cmake/*",
+    "configure.bat",
+    "configure.sh",
+    "native_plugins/*",
+    "random-dungeon-generator/*",
+    "res/*",
+    "src/*",
+    "test.py",
+    "tests/fixtures/*",
+    "tests/regression/*",
+    "tests/unit/*",
+    "vcpkg.json",
+    "vstd/*",
+)
+
+LIGHTWEIGHT_PATH_PATTERNS = (
+    ".github/workflows/*",
+    "AGENTS.md",
+    "docs/*",
+    "prompts/*",
+    "scripts/ci_change_classifier.py",
+    "scripts/controller_resource_audit.py",
+    "scripts/issue_queue.py",
+    "scripts/poll_pr_checks.py",
+    "scripts/pr_review_audit.py",
+    "scripts/validate_content.py",
+    "scripts/workflow_observations.py",
+    "tests/security/test_configure_supply_chain.py",
+    "tests/test_ci_change_classifier.py",
+    "tests/test_content_validator.py",
+    "tests/test_controller_resource_audit.py",
+    "tests/test_issue_queue.py",
+    "tests/test_poll_pr_checks.py",
+    "tests/test_pr_review_audit.py",
+    "tests/test_prompt_inventory.py",
+    "tests/test_workflow_observations.py",
+)
+
+
+@dataclass(frozen=True)
+class ChangeClassification:
+    paths: tuple[str, ...]
+    coverageNeeded: bool
+    nativeNeeded: bool
+    nativeReasons: tuple[str, ...]
+
+
+def matchesAny(path: str, patterns: Sequence[str]) -> bool:
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns)
+
+
+def normalizePath(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def uniquePaths(paths: Sequence[str]) -> tuple[str, ...]:
+    return tuple(sorted(dict.fromkeys(path for path in (normalizePath(item) for item in paths) if path)))
+
+
+def classifyPaths(paths: Sequence[str], *, forceNative: bool = False) -> ChangeClassification:
+    changed = uniquePaths(paths)
+    coverageNeeded = any(matchesAny(path, COVERAGE_PATH_PATTERNS) for path in changed)
+    nativeReasons: list[str] = []
+
+    if forceNative:
+        nativeReasons.append("forced")
+    if coverageNeeded:
+        nativeReasons.append("coverage-relevant paths")
+
+    for path in changed:
+        if matchesAny(path, NATIVE_PATH_PATTERNS):
+            nativeReasons.append(path)
+        elif not matchesAny(path, LIGHTWEIGHT_PATH_PATTERNS):
+            nativeReasons.append(f"unclassified:{path}")
+
+    return ChangeClassification(
+        paths=changed,
+        coverageNeeded=coverageNeeded,
+        nativeNeeded=bool(nativeReasons),
+        nativeReasons=tuple(dict.fromkeys(nativeReasons)),
+    )
+
+
+def changedPaths(base: str, head: str) -> tuple[str, ...]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", base, head],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return uniquePaths(result.stdout.splitlines())
+
+
+def writeGithubOutput(path: Path, classification: ChangeClassification) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"coverage-needed={str(classification.coverageNeeded).lower()}\n")
+        handle.write(f"native-needed={str(classification.nativeNeeded).lower()}\n")
+
+
+def parseArgs(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", help="Base Git revision for changed-path detection")
+    parser.add_argument("--head", help="Head Git revision for changed-path detection")
+    parser.add_argument("--path", action="append", default=[], help="Changed path; may be repeated")
+    parser.add_argument("--paths-from-stdin", action="store_true", help="Read changed paths from stdin")
+    parser.add_argument("--force-native", action="store_true", help="Force native validation to be required")
+    parser.add_argument("--github-output", help="Append GitHub Actions output variables to this file")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parseArgs(argv or sys.argv[1:])
+    paths = list(args.path)
+    if args.base or args.head:
+        if not args.base or not args.head:
+            print("ci_change_classifier: --base and --head must be supplied together", file=sys.stderr)
+            return 2
+        try:
+            paths.extend(changedPaths(args.base, args.head))
+        except subprocess.CalledProcessError as exc:
+            print(f"ci_change_classifier: git diff failed: {exc.stderr.strip()}", file=sys.stderr)
+            return 2
+    if args.paths_from_stdin:
+        paths.extend(sys.stdin.read().splitlines())
+
+    classification = classifyPaths(paths, forceNative=args.force_native)
+    if args.github_output:
+        try:
+            writeGithubOutput(Path(args.github_output), classification)
+        except OSError as exc:
+            print(f"ci_change_classifier: {exc}", file=sys.stderr)
+            return 2
+    print(
+        json.dumps(
+            {
+                "coverageNeeded": classification.coverageNeeded,
+                "nativeNeeded": classification.nativeNeeded,
+                "nativeReasons": list(classification.nativeReasons),
+                "paths": list(classification.paths),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/poll_pr_checks.py
+++ b/scripts/poll_pr_checks.py
@@ -12,22 +12,17 @@ import time
 from dataclasses import dataclass
 from typing import Any, Sequence
 
+try:
+    from ci_change_classifier import COVERAGE_PATH_PATTERNS
+except ImportError:  # pragma: no cover - used when imported as scripts.poll_pr_checks
+    from scripts.ci_change_classifier import COVERAGE_PATH_PATTERNS
+
 DEFAULT_JOBS = ("linux",)
 DEFAULT_WORKFLOW = "build.yml"
 DEFAULT_INTERVAL_SECONDS = 30
 DEFAULT_TIMEOUT_SECONDS = 7200
 SUCCESS_CONCLUSION = "SUCCESS"
 COVERAGE_STEP = "coverage"
-COVERAGE_PATH_PATTERNS = (
-    "test.py",
-    "tests/unit/*",
-    "scripts/run_coverage.sh",
-    "scripts/coverage_report.py",
-    "native_plugins/*",
-    "src/core/*",
-    "src/handler/*",
-    "src/object/*",
-)
 
 
 @dataclass(frozen=True)

--- a/scripts/pr_review_audit.py
+++ b/scripts/pr_review_audit.py
@@ -9,6 +9,7 @@ import sys
 from collections import Counter
 from collections.abc import Iterable
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -43,6 +44,16 @@ class CheckSummary:
     failed: tuple[str, ...] = ()
     pending: tuple[str, ...] = ()
     total: int = 0
+
+
+@dataclass(frozen=True)
+class CheckAttempt:
+    identity: tuple[str, str]
+    name: str
+    state: str
+    timestamp: float | None
+    attempt: int | None
+    index: int
 
 
 def normalizeToken(value: Any) -> str:
@@ -112,6 +123,115 @@ def checkName(check: dict[str, Any], fallback: str) -> str:
     return str(firstValue(check, "name", "context", "checkName", "job", default=fallback))
 
 
+def nestedValue(mapping: dict[str, Any], *names: str) -> Any:
+    value: Any = mapping
+    for name in names:
+        if not isinstance(value, dict):
+            return None
+        value = value.get(name)
+    return value
+
+
+def checkWorkflowName(check: dict[str, Any]) -> str:
+    workflow = firstValue(check, "workflowName", "workflow_name", "workflow", default="")
+    if isinstance(workflow, dict):
+        workflow = firstValue(workflow, "name", "workflowName", "workflow_name", default="")
+    return str(workflow or "")
+
+
+def checkIdentity(check: dict[str, Any], fallback: str) -> tuple[str, str]:
+    workflow = normalizeToken(checkWorkflowName(check))
+    name = normalizeToken(checkName(check, fallback))
+    return (workflow, name)
+
+
+def parseTimestamp(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def checkTimestamp(check: dict[str, Any]) -> float | None:
+    timestamps = [
+        parseTimestamp(firstValue(check, name, default=None))
+        for name in (
+            "completedAt",
+            "completed_at",
+            "updatedAt",
+            "updated_at",
+            "startedAt",
+            "started_at",
+            "createdAt",
+            "created_at",
+        )
+    ]
+    timestamps = [timestamp for timestamp in timestamps if timestamp is not None]
+    return max(timestamps) if timestamps else None
+
+
+def parseAttempt(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def checkAttemptNumber(check: dict[str, Any]) -> int | None:
+    values = [
+        firstValue(
+            check,
+            "runAttempt",
+            "run_attempt",
+            "attempt",
+            "attemptNumber",
+            "attempt_number",
+            "checkRunAttempt",
+            "check_run_attempt",
+            default=None,
+        ),
+        nestedValue(check, "checkSuite", "workflowRun", "runAttempt"),
+        nestedValue(check, "check_suite", "workflow_run", "run_attempt"),
+        nestedValue(check, "workflowRun", "runAttempt"),
+        nestedValue(check, "workflow_run", "run_attempt"),
+    ]
+    attempts = [attempt for attempt in (parseAttempt(value) for value in values) if attempt is not None]
+    return max(attempts) if attempts else None
+
+
+def currentCheckAttempt(attempts: Sequence[CheckAttempt]) -> CheckAttempt:
+    if not attempts:
+        raise ValueError("check attempt group cannot be empty")
+    if all(attempt.timestamp is not None for attempt in attempts):
+        return max(
+            attempts,
+            key=lambda attempt: (
+                attempt.timestamp,
+                attempt.attempt if attempt.attempt is not None else -1,
+                attempt.index,
+            ),
+        )
+    if all(attempt.attempt is not None for attempt in attempts):
+        return max(attempts, key=lambda attempt: (attempt.attempt, attempt.index))
+
+    stateRank = {"failure": 3, "pending": 2, "unknown": 1, "success": 0}
+    return max(attempts, key=lambda attempt: (stateRank[attempt.state], attempt.index))
+
+
 def stateFromCheck(check: dict[str, Any]) -> str:
     state = normalizeToken(firstValue(check, "state", "status", default=""))
     conclusion = normalizeToken(firstValue(check, "conclusion", "result", default=""))
@@ -177,19 +297,31 @@ def checkSummary(record: dict[str, Any]) -> CheckSummary:
     if isinstance(rawChecks, str) or not isinstance(rawChecks, Iterable):
         rawChecks = [rawChecks]
 
-    failed: list[str] = []
-    pending: list[str] = []
+    byIdentity: dict[tuple[str, str], list[CheckAttempt]] = {}
     unknown = False
     checks = list(rawChecks or ())
     for index, rawCheck in enumerate(checks, start=1):
         check = rawCheck if isinstance(rawCheck, dict) else {"state": rawCheck}
         name = checkName(check, f"check {index}")
         state = stateFromCheck(check)
-        if state == "failure":
-            failed.append(name)
-        elif state == "pending":
-            pending.append(name)
-        elif state == "unknown":
+        attempt = CheckAttempt(
+            identity=checkIdentity(check, f"check {index}"),
+            name=name,
+            state=state,
+            timestamp=checkTimestamp(check),
+            attempt=checkAttemptNumber(check),
+            index=index,
+        )
+        byIdentity.setdefault(attempt.identity, []).append(attempt)
+
+    failed: list[str] = []
+    pending: list[str] = []
+    for attempt in (currentCheckAttempt(attempts) for attempts in byIdentity.values()):
+        if attempt.state == "failure":
+            failed.append(attempt.name)
+        elif attempt.state == "pending":
+            pending.append(attempt.name)
+        elif attempt.state == "unknown":
             unknown = True
 
     if failed:
@@ -284,7 +416,11 @@ def actionFromSignals(
 ) -> tuple[str, list[str]]:
     buckets: list[str] = [prType]
     state = normalizeToken(firstValue(record, "state", default="open"))
-    merged = truthy(firstValue(record, "merged", "isMerged", default=False))
+    merged = (
+        state == "merged"
+        or truthy(firstValue(record, "merged", "isMerged", default=False))
+        or bool(firstValue(record, "mergedAt", "merged_at", "mergeCommit", "merge_commit", default=None))
+    )
     branchMerged = truthy(firstValue(record, "branchMergedToMain", "branch_merged_to_main", default=False))
     draft = truthy(firstValue(record, "draft", "isDraft", default=False))
     reviewDecision = normalizeToken(firstValue(record, "reviewDecision", "review_decision", default=""))
@@ -332,7 +468,10 @@ def actionFromSignals(
         blockers.append("required check failure: " + ", ".join(checks.failed))
         buckets.append("failing_ci")
     elif checks.state == "pending":
-        buckets.append("poll")
+        if prType == "workbook_only_queue_pr":
+            buckets.append("ci_exempt_pending")
+        else:
+            buckets.append("poll")
     elif checks.state == "unknown":
         blockers.append("check rollup is missing or unrecognized")
         buckets.append("human_review_required")

--- a/tests/security/test_configure_supply_chain.py
+++ b/tests/security/test_configure_supply_chain.py
@@ -97,14 +97,20 @@ class ConfigureSupplyChainTest(unittest.TestCase):
 
     def test_linux_coverage_path_filter_matches_required_policy(self):
         workflow_text = (REPO_ROOT / ".github" / "workflows" / "build.yml").read_text()
-        match = re.search(r"(?ms)- name: detect coverage need\n(?P<body>.*?)(?=^      - name:|\Z)", workflow_text)
-        self.assertIsNotNone(match)
-        detection_body = match.group("body")
+        classifier_text = (REPO_ROOT / "scripts" / "ci_change_classifier.py").read_text()
 
-        self.assertIn("test.py|tests/unit/*|scripts/run_coverage.sh", detection_body)
-        self.assertIn("scripts/coverage_report.py", detection_body)
-        self.assertIn("native_plugins/*|src/core/*|src/handler/*|src/object/*", detection_body)
-        self.assertNotIn("test.py|tests/*|", detection_body)
+        self.assertIn("- name: classify changed paths", workflow_text)
+        self.assertIn("python3 scripts/ci_change_classifier.py", workflow_text)
+        self.assertIn('"test.py"', classifier_text)
+        self.assertIn('"tests/unit/*"', classifier_text)
+        self.assertIn('"scripts/run_coverage.sh"', classifier_text)
+        self.assertIn('"scripts/coverage_report.py"', classifier_text)
+        self.assertIn('"native_plugins/*"', classifier_text)
+        self.assertIn('"src/core/*"', classifier_text)
+        self.assertIn('"src/gui/*"', classifier_text)
+        self.assertIn('"src/handler/*"', classifier_text)
+        self.assertIn('"src/object/*"', classifier_text)
+        self.assertNotIn('"tests/*"', classifier_text)
 
     def test_run_coverage_default_line_gate_is_90_percent(self):
         run_coverage = (REPO_ROOT / "scripts" / "run_coverage.sh").read_text()

--- a/tests/test_ci_change_classifier.py
+++ b/tests/test_ci_change_classifier.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from scripts import ci_change_classifier
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class CiChangeClassifierTest(unittest.TestCase):
+    def classify(self, *paths: str) -> ci_change_classifier.ChangeClassification:
+        return ci_change_classifier.classifyPaths(paths)
+
+    def test_workflow_python_and_docs_do_not_need_native_validation(self) -> None:
+        classification = self.classify(
+            ".github/workflows/build.yml",
+            "scripts/pr_review_audit.py",
+            "tests/test_pr_review_audit.py",
+            "docs/testing.md",
+            "prompts/codex-workflow-optimizer.md",
+        )
+
+        self.assertFalse(classification.nativeNeeded)
+        self.assertFalse(classification.coverageNeeded)
+        self.assertEqual((), classification.nativeReasons)
+        self.assertIn(".github/workflows/build.yml", classification.paths)
+
+    def test_gui_cpp_requires_native_and_coverage_validation(self) -> None:
+        classification = self.classify("src/gui/panel/CListView.cpp")
+
+        self.assertTrue(classification.nativeNeeded)
+        self.assertTrue(classification.coverageNeeded)
+        self.assertIn("coverage-relevant paths", classification.nativeReasons)
+        self.assertIn("src/gui/panel/CListView.cpp", classification.nativeReasons)
+
+    def test_native_core_and_unit_test_paths_require_coverage(self) -> None:
+        for path in ("src/core/CGame.cpp", "src/handler/CFightHandler.cpp", "tests/unit/test_gui.cpp"):
+            with self.subTest(path=path):
+                classification = self.classify(path)
+                self.assertTrue(classification.nativeNeeded)
+                self.assertTrue(classification.coverageNeeded)
+
+    def test_content_and_unknown_paths_fail_closed_to_native_validation(self) -> None:
+        for path in ("res/maps/nouraajd/script.py", "requirements-dev.txt"):
+            with self.subTest(path=path):
+                classification = self.classify(path)
+                self.assertTrue(classification.nativeNeeded)
+                self.assertFalse(classification.coverageNeeded)
+
+        self.assertIn("unclassified:requirements-dev.txt", self.classify("requirements-dev.txt").nativeReasons)
+
+    def test_force_native_preserves_push_validation_policy(self) -> None:
+        classification = ci_change_classifier.classifyPaths(["docs/testing.md"], forceNative=True)
+
+        self.assertTrue(classification.nativeNeeded)
+        self.assertFalse(classification.coverageNeeded)
+        self.assertIn("forced", classification.nativeReasons)
+
+    def test_github_output_writes_booleans(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "github-output"
+            classification = self.classify("src/gui/CListView.cpp")
+
+            ci_change_classifier.writeGithubOutput(output, classification)
+
+            self.assertEqual("coverage-needed=true\nnative-needed=true\n", output.read_text(encoding="utf-8"))
+
+    def test_cli_outputs_json_for_explicit_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "github-output"
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exitCode = ci_change_classifier.main(
+                    ["--path", "scripts/pr_review_audit.py", "--github-output", str(output)]
+                )
+
+            self.assertEqual(0, exitCode)
+            payload = json.loads(stdout.getvalue())
+            self.assertFalse(payload["coverageNeeded"])
+            self.assertFalse(payload["nativeNeeded"])
+            values = dict(line.split("=", 1) for line in output.read_text(encoding="utf-8").splitlines())
+            self.assertEqual({"coverage-needed": "false", "native-needed": "false"}, values)
+
+    def test_build_workflow_uses_classifier_outputs_for_native_routing(self) -> None:
+        workflow = (REPO_ROOT / ".github/workflows/build.yml").read_text(encoding="utf-8")
+
+        self.assertIn("coverage-needed: ${{ steps.change-classification.outputs.coverage-needed }}", workflow)
+        self.assertIn("native-needed: ${{ steps.change-classification.outputs.native-needed }}", workflow)
+        self.assertIn("python3 scripts/ci_change_classifier.py", workflow)
+        self.assertIn("force_native=(--force-native)", workflow)
+        self.assertIn("if: needs.linux-fast.outputs.native-needed != 'true'", workflow)
+        self.assertIn("if: needs.linux-fast.outputs.native-needed == 'true'", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_poll_pr_checks.py
+++ b/tests/test_poll_pr_checks.py
@@ -6,7 +6,7 @@ from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
-from scripts import poll_pr_checks
+from scripts import ci_change_classifier, poll_pr_checks
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -62,14 +62,16 @@ class PollPrChecksTest(unittest.TestCase):
 
     def test_changed_files_require_coverage_for_workflow_paths(self) -> None:
         self.assertTrue(poll_pr_checks.changedFilesRequireCoverage(["src/core/CGame.cpp"]))
+        self.assertTrue(poll_pr_checks.changedFilesRequireCoverage(["src/gui/panel/CListView.cpp"]))
         self.assertTrue(poll_pr_checks.changedFilesRequireCoverage(["src/handler/CFightHandler.cpp"]))
         self.assertTrue(poll_pr_checks.changedFilesRequireCoverage(["tests/unit/test_core.cpp"]))
         self.assertFalse(poll_pr_checks.changedFilesRequireCoverage(["docs/testing.md", "scripts/poll_pr_checks.py"]))
 
     def test_coverage_path_patterns_match_workflow_detector(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/build.yml").read_text(encoding="utf-8")
-        for pattern in poll_pr_checks.COVERAGE_PATH_PATTERNS:
-            self.assertIn(pattern, workflow)
+
+        self.assertEqual(ci_change_classifier.COVERAGE_PATH_PATTERNS, poll_pr_checks.COVERAGE_PATH_PATTERNS)
+        self.assertIn("scripts/ci_change_classifier.py", workflow)
 
     def test_evaluate_run_treats_missing_run_as_pending(self) -> None:
         evaluation = poll_pr_checks.evaluateRun(None, ["linux"], [])
@@ -327,7 +329,7 @@ class PollPrChecksTest(unittest.TestCase):
 
         with (
             patch.object(poll_pr_checks, "runGhPrView", return_value=open_pr),
-            patch.object(poll_pr_checks, "runGhPrFiles", return_value=("src/core/CGame.cpp",)),
+            patch.object(poll_pr_checks, "runGhPrFiles", return_value=("src/gui/panel/CListView.cpp",)),
             patch.object(poll_pr_checks, "runGhRunList", return_value=[{"databaseId": 1, "headSha": "abc123"}]),
             patch.object(poll_pr_checks, "runGhRunView", return_value=completed_run),
         ):

--- a/tests/test_pr_review_audit.py
+++ b/tests/test_pr_review_audit.py
@@ -55,6 +55,42 @@ class PrReviewAuditTest(unittest.TestCase):
         self.assertIn("workbook_only_queue_pr", review["buckets"])
         self.assertIn("confirm XLSX-only diff", review["recommendedActions"][0])
 
+    def test_workbook_only_queue_pr_does_not_poll_pending_ci(self) -> None:
+        review = self.classify(
+            {
+                "number": 121,
+                "title": "Claim queue row",
+                "files": ["planning/fall_of_nouraajd_issue_proposals.xlsx"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [{"name": "build / linux", "status": "in_progress"}],
+            }
+        )
+
+        self.assertEqual("ready_to_merge", review["actionCategory"])
+        self.assertEqual("workbook_only_queue_pr", review["prType"])
+        self.assertEqual("pending", review["checkState"])
+        self.assertEqual(["build / linux"], review["pendingChecks"])
+        self.assertIn("ci_exempt_pending", review["buckets"])
+        self.assertNotIn("poll", review["buckets"])
+        self.assertTrue(review["mergeAllowed"])
+        self.assertIn("confirm XLSX-only diff", review["recommendedActions"][0])
+
+    def test_workbook_only_queue_pr_still_blocks_failed_ci(self) -> None:
+        review = self.classify(
+            {
+                "number": 122,
+                "title": "Claim queue row",
+                "files": ["planning/fall_of_nouraajd_issue_proposals.xlsx"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [{"name": "build / linux", "status": "completed", "conclusion": "failure"}],
+            }
+        )
+
+        self.assertEqual("failing_ci", review["actionCategory"])
+        self.assertEqual("workbook_only_queue_pr", review["prType"])
+        self.assertFalse(review["mergeAllowed"])
+        self.assertIn("required check failure: build / linux", review["blockers"])
+
     def test_dirty_and_failing_pr_requires_update_before_ci_fix(self) -> None:
         review = self.classify(
             {
@@ -158,6 +194,186 @@ class PrReviewAuditTest(unittest.TestCase):
                         "name": "linux-coverage",
                         "status": "COMPLETED",
                         "conclusion": "SKIPPED",
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual("ready_to_merge", review["actionCategory"])
+        self.assertEqual("success", review["checkState"])
+        self.assertEqual([], review["failedChecks"])
+
+    def test_newer_duplicate_check_success_replaces_older_cancelled_attempt(self) -> None:
+        review = self.classify(
+            {
+                "number": 123,
+                "files": ["scripts/pr_review_audit.py"],
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [
+                    {
+                        "__typename": "CheckRun",
+                        "name": "linux",
+                        "workflowName": "build",
+                        "status": "COMPLETED",
+                        "conclusion": "CANCELLED",
+                        "completedAt": "2026-06-20T10:00:00Z",
+                    },
+                    {
+                        "__typename": "CheckRun",
+                        "name": "linux",
+                        "workflowName": "build",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS",
+                        "completedAt": "2026-06-20T10:10:00Z",
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual("ready_to_merge", review["actionCategory"])
+        self.assertEqual("success", review["checkState"])
+        self.assertEqual([], review["failedChecks"])
+
+    def test_newer_duplicate_check_pending_replaces_older_failure(self) -> None:
+        review = self.classify(
+            {
+                "number": 124,
+                "files": ["scripts/pr_review_audit.py"],
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [
+                    {
+                        "__typename": "CheckRun",
+                        "name": "linux",
+                        "workflowName": "build",
+                        "status": "COMPLETED",
+                        "conclusion": "FAILURE",
+                        "completedAt": "2026-06-20T10:00:00Z",
+                    },
+                    {
+                        "__typename": "CheckRun",
+                        "name": "linux",
+                        "workflowName": "build",
+                        "status": "IN_PROGRESS",
+                        "startedAt": "2026-06-20T10:15:00Z",
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual("poll", review["actionCategory"])
+        self.assertEqual("pending", review["checkState"])
+        self.assertEqual([], review["failedChecks"])
+        self.assertEqual(["linux"], review["pendingChecks"])
+
+    def test_newer_duplicate_check_failure_replaces_older_success(self) -> None:
+        review = self.classify(
+            {
+                "number": 125,
+                "files": ["scripts/pr_review_audit.py"],
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [
+                    {
+                        "__typename": "CheckRun",
+                        "name": "linux",
+                        "workflowName": "build",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS",
+                        "completedAt": "2026-06-20T10:00:00Z",
+                    },
+                    {
+                        "__typename": "CheckRun",
+                        "name": "linux",
+                        "workflowName": "build",
+                        "status": "COMPLETED",
+                        "conclusion": "FAILURE",
+                        "completedAt": "2026-06-20T10:15:00Z",
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual("failing_ci", review["actionCategory"])
+        self.assertEqual("failure", review["checkState"])
+        self.assertEqual(["linux"], review["failedChecks"])
+
+    def test_same_label_checks_from_different_workflows_remain_independent(self) -> None:
+        review = self.classify(
+            {
+                "number": 126,
+                "files": ["scripts/pr_review_audit.py"],
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [
+                    {
+                        "__typename": "CheckRun",
+                        "name": "lint",
+                        "workflowName": "fast",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS",
+                        "completedAt": "2026-06-20T10:00:00Z",
+                    },
+                    {
+                        "__typename": "CheckRun",
+                        "name": "lint",
+                        "workflowName": "full",
+                        "status": "COMPLETED",
+                        "conclusion": "FAILURE",
+                        "completedAt": "2026-06-20T10:05:00Z",
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual("failing_ci", review["actionCategory"])
+        self.assertEqual(["lint"], review["failedChecks"])
+
+    def test_missing_duplicate_ordering_uses_conservative_state(self) -> None:
+        review = self.classify(
+            {
+                "number": 127,
+                "files": ["scripts/pr_review_audit.py"],
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [
+                    {
+                        "name": "linux",
+                        "workflowName": "build",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS",
+                    },
+                    {
+                        "name": "linux",
+                        "workflowName": "build",
+                        "status": "COMPLETED",
+                        "conclusion": "FAILURE",
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual("failing_ci", review["actionCategory"])
+        self.assertEqual("failure", review["checkState"])
+        self.assertEqual(["linux"], review["failedChecks"])
+
+    def test_attempt_number_orders_duplicate_checks_without_timestamps(self) -> None:
+        review = self.classify(
+            {
+                "number": 128,
+                "files": ["scripts/pr_review_audit.py"],
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [
+                    {
+                        "__typename": "CheckRun",
+                        "name": "linux",
+                        "workflowName": "build",
+                        "status": "COMPLETED",
+                        "conclusion": "FAILURE",
+                        "checkSuite": {"workflowRun": {"runAttempt": 1}},
+                    },
+                    {
+                        "name": "linux",
+                        "workflowName": "build",
+                        "status": "COMPLETED",
+                        "conclusion": "SUCCESS",
+                        "run_attempt": 2,
                     },
                 ],
             }
@@ -307,6 +523,26 @@ class PrReviewAuditTest(unittest.TestCase):
         self.assertEqual("branch_cleanup_candidate", review["actionCategory"])
         self.assertTrue(review["humanApprovalRequired"])
         self.assertFalse(review["cleanupAllowed"])
+
+    def test_github_merged_state_is_cleanup_candidate_only(self) -> None:
+        review = self.classify(
+            {
+                "number": 129,
+                "state": "MERGED",
+                "mergedAt": "2026-06-20T18:59:01Z",
+                "mergeCommit": {"oid": "25a5a983d2085cd92564fa56a1349648416e8a2b"},
+                "files": ["planning/fall_of_nouraajd_issue_proposals.xlsx"],
+                "mergeStateStatus": "UNKNOWN",
+                "statusCheckRollup": [{"name": "linux", "status": "IN_PROGRESS"}],
+            }
+        )
+
+        self.assertEqual("branch_cleanup_candidate", review["actionCategory"])
+        self.assertEqual("workbook_only_queue_pr", review["prType"])
+        self.assertEqual("pending", review["checkState"])
+        self.assertTrue(review["humanApprovalRequired"])
+        self.assertFalse(review["mergeAllowed"])
+        self.assertNotIn("PR state is merged", review["blockers"])
 
     def test_dirty_local_recovery_state_is_never_touch(self) -> None:
         review = self.classify(


### PR DESCRIPTION
## What changed

- Updated `scripts/pr_review_audit.py` to collapse duplicate status-check attempts by stable workflow/name identity and newest timestamp or attempt evidence.
- Kept failed checks blocking, but allowed workbook-only queue PRs with only pending CI to reach the existing workbook-only merge recommendation.
- Treated GitHub `state: MERGED` / `mergedAt` / `mergeCommit` payloads as merged cleanup evidence instead of human-review debt.
- Added `scripts/ci_change_classifier.py` so the build workflow can distinguish workflow-only docs/prompts/tooling changes from native/source/content changes.
- Wired `build.yml` so workflow-only PRs still get terminal `linux` evidence but skip unrelated native-heavy Linux steps and Windows jobs; native/source/content changes still run native validation.
- Added `src/gui/*` to the shared coverage-relevant path policy used by CI and `scripts/poll_pr_checks.py`.

## Why

Current queue policy says XLSX-only queue-state PRs are CI-exempt after diff review and queue validation, but the PR audit classified any pending check as `poll`. Issue #624 also identified that stale failed/cancelled check attempts could keep a PR classified as failing after a newer successful rerun. A live audit also showed merged PR #634 classified as human-review debt because `gh pr view` reports `state: MERGED` without a separate `merged: true` field.

While validating this PR, the old head failed `linux` on unrelated native GUI C++ segfaults that also affected workbook-only PR #634. Issue #618 calls out this workflow problem: workflow-only PRs should not spend or fail on unrelated native validation, while GUI C++ changes must remain coverage-relevant.

## Validation

- `black -l 120 scripts/ci_change_classifier.py scripts/poll_pr_checks.py scripts/pr_review_audit.py tests/test_ci_change_classifier.py tests/test_poll_pr_checks.py tests/test_pr_review_audit.py tests/security/test_configure_supply_chain.py`
- `python3 -m py_compile scripts/ci_change_classifier.py scripts/poll_pr_checks.py scripts/pr_review_audit.py`
- `python3 -m unittest tests.test_ci_change_classifier tests.test_poll_pr_checks tests.test_pr_review_audit tests.security.test_configure_supply_chain tests.test_issue_queue tests.test_prompt_inventory tests.test_controller_resource_audit tests.test_workflow_observations` (`132` tests)
- `python3 scripts/ci_change_classifier.py --paths-from-stdin < <(git diff --name-only origin/main HEAD)` -> `nativeNeeded=false`, `coverageNeeded=false` for this workflow-only PR
- `python3 scripts/ci_change_classifier.py --path src/gui/panel/CListView.cpp` -> `nativeNeeded=true`, `coverageNeeded=true`
- `python3 scripts/issue_queue.py validate` (passes with existing heartbeat-overdue lease-valid warnings on rows 11, 15, 71, 96, 107, 128, 132)
- `python3 scripts/workflow_observations.py validate`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`
- `python3 scripts/pr_review_audit.py --input /tmp/pr-review-audit-semantics.json --format table`
- `git diff --check origin/main..HEAD`
- `python3 scripts/poll_pr_checks.py 640 --check linux` -> PASS on head `8d034a95c0bd39cdf05cb0f8e509f681354c9bcf`

## Known limitations

- The PR audit remains read-only and advisory; it does not collect PR snapshots or merge/cleanup anything by itself.
- When duplicate check attempts lack timestamps and attempt numbers, the classifier deliberately keeps the most conservative state.
- The CI change classifier is deliberately fail-closed: unclassified paths require native validation until explicitly classified.