### PR TITLE
Notify observers from direct state setters

### DIFF
--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -263,7 +263,10 @@ void performance_guard::disableMapCoordinateLookupProbe() {
     mapCoordinateLookupProbeEnabled.store(false, std::memory_order_relaxed);
 }
 
-void CMap::bumpNavigationRevision() { navigationRevision++; }
+void CMap::bumpNavigationRevision() {
+    navigationRevision++;
+    recordDirectPropertyChanged("navigationRevision");
+}
 
 void CMap::moveTile(std::shared_ptr<CTile> tile, int x, int y, int z) {
     Coords coords = normalizeCoords(tile->getCoords());
@@ -274,6 +277,7 @@ void CMap::moveTile(std::shared_ptr<CTile> tile, int x, int y, int z) {
     }
     tiles.insert(std::make_pair(target, tile));
     bumpNavigationRevision();
+    recordDirectPropertyChanged("tiles");
     signal("tileChanged", target);
 }
 
@@ -290,6 +294,7 @@ bool CMap::addTile(std::shared_ptr<CTile> tile, int x, int y, int z) {
     tile->setPosz(coords.z);
     tiles.insert(std::make_pair(coords, tile));
     bumpNavigationRevision();
+    recordDirectPropertyChanged("tiles");
     signal("tileChanged", coords);
     return true;
 }
@@ -301,6 +306,7 @@ void CMap::removeTile(int x, int y, int z) {
         this->tiles.erase(it);
     }
     bumpNavigationRevision();
+    recordDirectPropertyChanged("tiles");
     signal("tileChanged", coords);
 }
 
@@ -392,6 +398,7 @@ void CMap::addObject(const std::shared_ptr<CMapObject> &mapObject) {
     mapObjects.insert(std::make_pair(mapObject->getName(), mapObject));
     mapObjectsCache.insert(std::make_pair(normalizeCoords(mapObject->getCoords()), mapObject->getName()));
     bumpNavigationRevision();
+    recordDirectPropertyChanged("objects");
     getEventHandler()->gameEvent(mapObject, std::make_shared<CGameEvent>(CGameEvent::CType::onCreate));
     signal("objectChanged", mapObject->getCoords());
 }
@@ -409,6 +416,7 @@ void CMap::removeObject(const std::shared_ptr<CMapObject> &mapObject) {
     mapObjects.erase(map_object_it);
     vstd::erase_if(mapObjectsCache, [mapObject](auto it) { return it.second == mapObject->getName(); });
     bumpNavigationRevision();
+    recordDirectPropertyChanged("objects");
     getEventHandler()->gameEvent(mapObject, std::make_shared<CGameEvent>(CGameEvent::CType::onDestroy));
     signal("objectChanged", mapObject->getCoords());
 }
@@ -575,12 +583,16 @@ void CMap::move() {
 
     map->moving = false;
     map->turn++;
+    map->recordDirectPropertyChanged("turn");
     map->signal("turnPassed");
 }
 
 int CMap::getTurn() { return turn; }
 
-void CMap::setTurn(int turn) { this->turn = turn; }
+void CMap::setTurn(int turn) {
+    this->turn = turn;
+    recordDirectPropertyChanged("turn");
+}
 
 void CMap::setTiles(std::set<std::shared_ptr<CTile>> objects) {
     tiles.clear();
@@ -591,6 +603,7 @@ void CMap::setTiles(std::set<std::shared_ptr<CTile>> objects) {
         tiles[normalizeCoords(ob->getCoords())] = ob;
     }
     bumpNavigationRevision();
+    recordDirectPropertyChanged("tiles");
 }
 
 std::set<std::shared_ptr<CTile>> CMap::getTiles() {
@@ -627,6 +640,7 @@ void CMap::setObjects(std::set<std::shared_ptr<CMapObject>> objects) {
         mapObjectsCache.insert(std::make_pair(normalizeCoords(ob->getCoords()), ob->getName()));
     }
     bumpNavigationRevision();
+    recordDirectPropertyChanged("objects");
 }
 
 std::set<std::shared_ptr<CMapObject>> CMap::getObjects() {
@@ -702,6 +716,7 @@ void CMap::objectMoved(const std::shared_ptr<CMapObject> &object, Coords _old, C
 
     mapObjectsCache.insert(std::make_pair(_new, object->getName()));
     bumpNavigationRevision();
+    recordDirectPropertyChanged("objects");
 
     // TODO: check if it`s correct
     signal("objectChanged", _old);

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -130,6 +130,7 @@ void CCreature::removeItem(std::shared_ptr<CItem> item, bool quest) {
                 CPlaytestTrace::addMapContext(fields, getMap());
                 CPlaytestTrace::record("inventory_removed", fields);
             }
+            recordDirectPropertyChanged("items");
             signal("inventoryChanged");
         }
     }
@@ -152,6 +153,7 @@ CItemMap CCreature::getEquipped() { return equipped; }
 
 void CCreature::setEquipped(CItemMap value) {
     equipped = value; // TODO: rethink equipped changed here
+    recordDirectPropertyChanged("equipped");
 }
 
 void CCreature::addItems(std::set<std::shared_ptr<CItem>> items) {
@@ -169,6 +171,7 @@ void CCreature::addItems(std::set<std::shared_ptr<CItem>> items) {
             CPlaytestTrace::addMapContext(fields, getMap());
             CPlaytestTrace::record("inventory_added", fields);
         }
+        recordDirectPropertyChanged("items");
         signal("inventoryChanged");
     }
 }
@@ -178,6 +181,7 @@ void CCreature::addItem(std::string item) { addItem(getGame()->createObject<CIte
 void CCreature::heal(int i) {
     vstd::fail_if(i < 0, "Tried to heal negative value!");
     auto hpMax = getHpMax();
+    const int before = hp;
     if (hp > hpMax) {
         return;
     }
@@ -188,6 +192,9 @@ void CCreature::heal(int i) {
     }
     if (hp > hpMax) {
         hp = hpMax;
+    }
+    if (hp != before) {
+        recordDirectPropertyChanged("hp");
     }
 }
 
@@ -222,7 +229,11 @@ void CCreature::takeDamage(int rawDamage) {
     int blockDice = rand() % 100;
     if (blockDice >= stats->getBlock()) {
         vstd::logger::debug(to_string(), "armor saved from", rawDamage - damageAfterArmor, "damage");
+        const int before = hp;
         hp -= damageAfterArmor;
+        if (hp != before) {
+            recordDirectPropertyChanged("hp");
+        }
     } else {
         vstd::logger::debug(getName(), "blocked", rawDamage, "damage");
     }
@@ -233,7 +244,9 @@ CInteractionMap CCreature::getLevelling() { return levelling; }
 void CCreature::setLevelling(CInteractionMap value) { levelling = value; }
 
 void CCreature::setItems(std::set<std::shared_ptr<CItem>> value) {
+    CGameObject::PropertyNotificationBatch notificationBatch(*this);
     items.clear(); // TODO: rethink inventory changed here
+    recordDirectPropertyChanged("items");
     addItems(value);
 }
 
@@ -293,17 +306,22 @@ void CCreature::addEffect(std::shared_ptr<CEffect> effect) {
     } else {
         vstd::logger::debug(effect->to_string(), "starts for", this->to_string());
         effects.insert(effect);
+        recordDirectPropertyChanged("effects");
         signal("effectsChanged");
     }
 }
 
 int CCreature::getMana() { return mana; }
 
-void CCreature::setMana(int mana) { this->mana = mana; }
+void CCreature::setMana(int mana) {
+    this->mana = mana;
+    recordDirectPropertyChanged("mana");
+}
 
 void CCreature::addMana(int i) {
     vstd::fail_if(i < 0, "Tried to add negative mana!");
     auto manaMax = getManaMax();
+    const int before = mana;
     if (mana > manaMax) {
         return;
     }
@@ -315,6 +333,9 @@ void CCreature::addMana(int i) {
     if (mana > manaMax) {
         mana = manaMax;
     }
+    if (mana != before) {
+        recordDirectPropertyChanged("mana");
+    }
 }
 
 void CCreature::addManaProc(float i) {
@@ -325,7 +346,11 @@ void CCreature::addManaProc(float i) {
 
 void CCreature::takeMana(int i) {
     vstd::fail_if(i < 0, "Tried to take negative mana value!");
+    const int before = mana;
     mana = std::max(0, mana - i);
+    if (mana != before) {
+        recordDirectPropertyChanged("mana");
+    }
 }
 
 bool CCreature::isPlayer() {
@@ -395,15 +420,25 @@ void CCreature::equipItem(std::string i, std::shared_ptr<CItem> newItem) {
             newItem, std::make_shared<CGameEventCaused>(CGameEvent::CType::onEquip, this->ptr<CCreature>()));
         removeItem(newItem);
         equipped[i] = newItem;
+        recordDirectPropertyChanged("equipped");
         signal("equippedChanged");
     } else {
         if (equipped.erase(i)) {
+            recordDirectPropertyChanged("equipped");
             signal("equippedChanged");
         }
     }
 
+    const int previousHp = hp;
+    const int previousMana = mana;
     hp = std::min(hp, getHpMax());
     mana = std::min(mana, getManaMax());
+    if (hp != previousHp) {
+        recordDirectPropertyChanged("hp");
+    }
+    if (mana != previousMana) {
+        recordDirectPropertyChanged("mana");
+    }
 }
 
 bool CCreature::hasInInventory(std::shared_ptr<CItem> item) { return vstd::ctn(items, item); }
@@ -497,7 +532,10 @@ std::string CCreature::getSlotWithItem(std::shared_ptr<CItem> item) {
     return "-1";
 }
 
-void CCreature::setHp(int value) { hp = value; }
+void CCreature::setHp(int value) {
+    hp = value;
+    recordDirectPropertyChanged("hp");
+}
 
 int CCreature::getManaRegRate() { return getStats()->getMainValue() / 10 + 1; }
 
@@ -516,6 +554,7 @@ void CCreature::setGold(int value) {
         CPlaytestTrace::addMapContext(fields, getMap());
         CPlaytestTrace::record("gold_changed", fields);
     }
+    recordDirectPropertyChanged("gold");
 }
 
 void CCreature::beforeMove() {
@@ -597,10 +636,17 @@ void CCreature::onEnter(std::shared_ptr<CGameEvent>) {}
 
 void CCreature::onLeave(std::shared_ptr<CGameEvent>) {}
 
-void CCreature::onDestroy(std::shared_ptr<CGameEvent>) { effects.clear(); }
+void CCreature::onDestroy(std::shared_ptr<CGameEvent>) {
+    if (!effects.empty()) {
+        effects.clear();
+        recordDirectPropertyChanged("effects");
+    }
+}
 
 void CCreature::setEffects(const std::set<std::shared_ptr<CEffect>> &value) {
+    CGameObject::PropertyNotificationBatch notificationBatch(*this);
     effects.clear();
+    recordDirectPropertyChanged("effects");
     for (const auto &effect : value) {
         addEffect(effect);
     }
@@ -640,7 +686,9 @@ void CCreature::useAction(std::shared_ptr<CInteraction> action, std::shared_ptr<
 }
 
 void CCreature::removeEffect(std::shared_ptr<CEffect> effect) {
-    effects.erase(effect);
+    if (effects.erase(effect)) {
+        recordDirectPropertyChanged("effects");
+    }
     signal("effectsChanged");
 }
 

--- a/src/object/CGameObject.cpp
+++ b/src/object/CGameObject.cpp
@@ -128,6 +128,7 @@ void CGameObject::setAnimation(std::string animation) {
     // TODO: implement this in AOP way
     graphicsObject.clear();
     this->animation = animation;
+    recordDirectPropertyChanged("animation");
 }
 
 std::string CGameObject::getLabel() { return label; }
@@ -211,6 +212,15 @@ void CGameObject::recordPropertyChanged(const std::string &name) {
         return;
     }
     notifyPropertyChanged(name);
+}
+
+void CGameObject::recordDirectPropertyChanged(const std::string &name) {
+    for (const auto &suppressedName : directPropertyNotificationSuppressedNames) {
+        if (suppressedName == name) {
+            return;
+        }
+    }
+    recordPropertyChanged(name);
 }
 
 bool CGameObject::hasProperty(std::string name) { return this->meta()->has_property<CGameObject>(name, this->ptr()); }

--- a/src/object/CGameObject.h
+++ b/src/object/CGameObject.h
@@ -23,6 +23,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CUtil.h"
 
 #include <set>
+#include <vector>
 
 class CGameEvent;
 
@@ -76,11 +77,18 @@ class CGameObject : public vstd::stringable, public std::enable_shared_from_this
 
     template <typename T> void setProperty(std::string name, T property) {
         auto object = this->ptr();
-        if (this->meta()->has_property(name, object)) {
-            this->meta()->set_property<CGameObject, T>(name, object, property);
-        } else {
-            this->meta()->set_dynamic_property<CGameObject, T>(name, object, property);
+        directPropertyNotificationSuppressedNames.push_back(name);
+        try {
+            if (this->meta()->has_property(name, object)) {
+                this->meta()->set_property<CGameObject, T>(name, object, property);
+            } else {
+                this->meta()->set_dynamic_property<CGameObject, T>(name, object, property);
+            }
+        } catch (...) {
+            directPropertyNotificationSuppressedNames.pop_back();
+            throw;
         }
+        directPropertyNotificationSuppressedNames.pop_back();
         recordPropertyChanged(name);
     }
 
@@ -191,6 +199,9 @@ class CGameObject : public vstd::stringable, public std::enable_shared_from_this
         }
     }
 
+  protected:
+    void recordDirectPropertyChanged(const std::string &name);
+
   private:
     std::list<std::tuple<std::string, std::weak_ptr<CGameObject>, std::string>> connections;
 
@@ -216,6 +227,7 @@ class CGameObject : public vstd::stringable, public std::enable_shared_from_this
     std::weak_ptr<CGame> game;
 
     int propertyNotificationBatchDepth = 0;
+    std::vector<std::string> directPropertyNotificationSuppressedNames;
     std::set<std::string> batchedPropertyNotifications;
 };
 

--- a/src/object/CPlayer.cpp
+++ b/src/object/CPlayer.cpp
@@ -51,6 +51,8 @@ void CPlayer::checkQuests() {
             quest->onComplete();
             quests.erase(quests.find(quest));
             completedQuests.insert(quest);
+            recordDirectPropertyChanged("quests");
+            recordDirectPropertyChanged("completedQuests");
         }
     }
 }
@@ -77,6 +79,7 @@ void CPlayer::addQuest(std::string questName) {
             CPlaytestTrace::addMapContext(fields, getMap());
             CPlaytestTrace::record("quest_added", fields);
         }
+        recordDirectPropertyChanged("quests");
     }
 }
 
@@ -85,6 +88,7 @@ std::set<std::shared_ptr<CQuest>> CPlayer::getQuests() { return quests; }
 void CPlayer::setQuests(std::set<std::shared_ptr<CQuest>> _quests) {
     std::erase_if(_quests, [](const auto &quest) { return quest == nullptr; });
     this->quests = std::move(_quests);
+    recordDirectPropertyChanged("quests");
 }
 
 std::set<std::shared_ptr<CQuest>> CPlayer::getCompletedQuests() { return completedQuests; }
@@ -92,6 +96,7 @@ std::set<std::shared_ptr<CQuest>> CPlayer::getCompletedQuests() { return complet
 void CPlayer::setCompletedQuests(std::set<std::shared_ptr<CQuest>> _completedQuests) {
     std::erase_if(_completedQuests, [](const auto &quest) { return quest == nullptr; });
     completedQuests = std::move(_completedQuests);
+    recordDirectPropertyChanged("completedQuests");
 }
 
 void CPlayer::incTurn() { turn++; }

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -17,18 +17,47 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "core/CStats.h"
+#include "core/CMap.h"
+#include "core/CTypes.h"
 #include "object/CCreature.h"
+#include "object/CEffect.h"
+#include "object/CGameObject.h"
 #include "object/CItem.h"
+#include "object/CMapObject.h"
 #include "object/CMarket.h"
 #include "object/CPlayer.h"
 #include "object/CQuest.h"
+#include "object/CTile.h"
 #include "test_harness.h"
+#include "vutil.h"
 
 #include <limits>
 #include <memory>
 #include <set>
+#include <utility>
 
 namespace {
+
+class PropertyChangeProbe : public CGameObject {
+    V_META(PropertyChangeProbe, CGameObject, V_METHOD(PropertyChangeProbe, onPropertyChanged, void, std::string),
+           V_METHOD(PropertyChangeProbe, onPropertiesChanged, void, std::set<std::string>))
+
+  public:
+    void onPropertyChanged(std::string property_name) { changedProperties.insert(std::move(property_name)); }
+
+    void onPropertiesChanged(std::set<std::string> property_names) {
+        changedProperties.insert(property_names.begin(), property_names.end());
+    }
+
+    std::set<std::string> changedProperties;
+};
+
+void drain_event_loop() {
+    auto loop = vstd::event_loop<>::instance();
+    for (int i = 0; i < 5; ++i) {
+        loop->run();
+    }
+}
 
 std::shared_ptr<CStats> stats_with_main(int stamina, int intelligence, int armor = 0) {
     auto stats = std::make_shared<CStats>();
@@ -169,6 +198,86 @@ void test_player_quest_setters_filter_nulls_and_skip_duplicates() {
     expect_true(player->getCompletedQuests().size() == 1, "completed duplicate quest should remain completed only");
 }
 
+void test_creature_direct_setters_notify_property_observers() {
+    CTypes::register_type_metadata<PropertyChangeProbe, CGameObject>();
+
+    auto creature = std::make_shared<CCreature>();
+    auto probe = std::make_shared<PropertyChangeProbe>();
+    auto effect = std::make_shared<CEffect>();
+    auto inventory_item = std::make_shared<CItem>();
+    auto equipped_item = std::make_shared<CItem>();
+
+    creature->connect("propertyChanged", probe, "onPropertyChanged");
+    creature->connect("propertiesChanged", probe, "onPropertiesChanged");
+
+    creature->setAnimation("images/misc/marker");
+    creature->setGold(5);
+    creature->setHp(12);
+    creature->setMana(7);
+    creature->setEffects({effect});
+    creature->setItems({inventory_item});
+    creature->setEquipped({{"0", equipped_item}});
+
+    drain_event_loop();
+
+    expect_true(probe->changedProperties.contains("animation"),
+                "direct animation setter should notify property observers");
+    expect_true(probe->changedProperties.contains("gold"), "direct gold setter should notify property observers");
+    expect_true(probe->changedProperties.contains("hp"), "direct hp setter should notify property observers");
+    expect_true(probe->changedProperties.contains("mana"), "direct mana setter should notify property observers");
+    expect_true(probe->changedProperties.contains("effects"), "direct effects setter should notify property observers");
+    expect_true(probe->changedProperties.contains("items"), "direct inventory setter should notify property observers");
+    expect_true(probe->changedProperties.contains("equipped"),
+                "direct equipment setter should notify property observers");
+}
+
+void test_player_quest_setters_notify_property_observers() {
+    CTypes::register_type_metadata<PropertyChangeProbe, CGameObject>();
+
+    auto player = std::make_shared<CPlayer>();
+    auto probe = std::make_shared<PropertyChangeProbe>();
+    auto active = std::make_shared<CQuest>();
+    auto completed = std::make_shared<CQuest>();
+
+    player->connect("propertyChanged", probe, "onPropertyChanged");
+    player->connect("propertiesChanged", probe, "onPropertiesChanged");
+
+    player->setQuests({active});
+    player->setCompletedQuests({completed});
+
+    drain_event_loop();
+
+    expect_true(probe->changedProperties.contains("quests"),
+                "direct active quest setter should notify property observers");
+    expect_true(probe->changedProperties.contains("completedQuests"),
+                "direct completed quest setter should notify property observers");
+}
+
+void test_map_direct_state_setters_notify_property_observers() {
+    CTypes::register_type_metadata<PropertyChangeProbe, CGameObject>();
+
+    auto map = std::make_shared<CMap>();
+    auto probe = std::make_shared<PropertyChangeProbe>();
+    auto tile = std::make_shared<CTile>();
+    auto object = std::make_shared<CMapObject>();
+    object->setName("observedObject");
+
+    map->connect("propertyChanged", probe, "onPropertyChanged");
+    map->connect("propertiesChanged", probe, "onPropertiesChanged");
+
+    map->setTurn(3);
+    map->setTiles({tile});
+    map->setObjects({object});
+
+    drain_event_loop();
+
+    expect_true(probe->changedProperties.contains("turn"), "direct map turn setter should notify property observers");
+    expect_true(probe->changedProperties.contains("tiles"), "direct tile setter should notify property observers");
+    expect_true(probe->changedProperties.contains("objects"), "direct object setter should notify property observers");
+    expect_true(probe->changedProperties.contains("navigationRevision"),
+                "map navigation revision changes should notify property observers");
+}
+
 void test_creature_inventory_equipment_and_ratio_helpers() {
     auto creature = std::make_shared<CCreature>();
     creature->setBaseStats(stats_with_main(10, 10, 200));
@@ -225,6 +334,9 @@ int main() {
     test_market_guard_paths_and_item_transfers();
     test_market_prices_are_bounded_and_non_exploitable();
     test_player_quest_setters_filter_nulls_and_skip_duplicates();
+    test_creature_direct_setters_notify_property_observers();
+    test_player_quest_setters_notify_property_observers();
+    test_map_direct_state_setters_notify_property_observers();
     test_creature_inventory_equipment_and_ratio_helpers();
 
     return finish_tests();


### PR DESCRIPTION
## Summary
- Add guarded direct property notifications for high-value object, creature, player, and map state changes.
- Preserve existing domain-specific signals such as `inventoryChanged`, `equippedChanged`, `effectsChanged`, `tileChanged`, `objectChanged`, and `turnPassed`.
- Add native object tests covering direct setter notifications for creature state, player quest state, and map state.

## Why
Typed setters and direct mutators bypassed `setProperty(...)`, so property observers missed updates for state such as hp, mana, inventory, equipment, quests, map turn, tiles, objects, and navigation revision.

## Validation
- `clang-format -i src/object/CGameObject.h src/object/CGameObject.cpp src/object/CCreature.cpp src/object/CPlayer.cpp src/core/CMap.cpp tests/unit/test_object.cpp`
- `git diff --check`
- Post-rebase `git diff --check origin/main...HEAD`

## Local Validation Not Run
- Focused native `object_unit_tests` was not run locally because this worktree has no configured build tree.
- Full native builds, full CTest, Python suites, coverage, Xvfb, and MCP are intentionally left to GitHub Actions per controller workflow.

## Queue
- Issue: `[EPIC_02][STORY_05][SUBSTORY_03]Update direct setters to notify`
- Claim ID: `2533a7be-7ea1-49be-aad6-82cbec094bb4`
- Owner: `controller/ctrl-lis-2-36d0fa13/subagent-4`

## Notes
- Heavy Linux compilation, native unit tests, Python suite, and coverage are expected from GitHub Actions `build / linux`; this PR touches `src/core/**`, `src/object/**`, and `tests/unit/**`, so the controller will require the CI coverage step before auto-merge.
