### PR TITLE
Route controllers through navigation neighbors

### DIFF
--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -46,6 +46,51 @@ struct TargetFlowField {
 std::mutex targetFlowMutex;
 std::vector<std::shared_ptr<TargetFlowField>> targetFlowCache;
 
+bool contains_navigation_neighbor(const std::shared_ptr<CMap> &map, Coords from, Coords to) {
+    if (!map) {
+        return false;
+    }
+    to = map->normalizeCoords(to);
+    auto neighbors = map->getNavigationNeighbors(from);
+    return std::ranges::find(neighbors, to) != neighbors.end();
+}
+
+void add_unique_candidate(const std::shared_ptr<CMap> &map, std::vector<Coords> &candidates, Coords candidate) {
+    candidate = map->normalizeCoords(candidate);
+    if (std::ranges::find(candidates, candidate) == candidates.end()) {
+        candidates.push_back(candidate);
+    }
+}
+
+std::vector<Coords> get_reverse_navigation_neighbors(const std::shared_ptr<CMap> &map, Coords coords) {
+    coords = map->normalizeCoords(coords);
+    auto candidates = map->getNavigationNeighbors(coords);
+    if (map->getNavigationEdges().empty()) {
+        return candidates;
+    }
+
+    for (const auto &edge : map->getNavigationEdges()) {
+        if (!edge.enabled) {
+            continue;
+        }
+        if (edge.target == coords) {
+            add_unique_candidate(map, candidates, edge.source);
+        }
+        if (edge.bidirectional && edge.source == coords) {
+            add_unique_candidate(map, candidates, edge.target);
+        }
+    }
+
+    std::vector<Coords> reachable;
+    for (auto candidate : candidates) {
+        candidate = map->normalizeCoords(candidate);
+        if (candidate != coords && contains_navigation_neighbor(map, candidate, coords)) {
+            add_unique_candidate(map, reachable, candidate);
+        }
+    }
+    return reachable;
+}
+
 bool creature_can_follow_step(const std::shared_ptr<CCreature> &creature, const Coords &step) {
     if (!creature || !creature->getMap()) {
         return false;
@@ -53,7 +98,7 @@ bool creature_can_follow_step(const std::shared_ptr<CCreature> &creature, const 
     auto map = creature->getMap();
     auto current = map->normalizeCoords(creature->getCoords());
     auto target = map->normalizeCoords(step);
-    return target != current && map->canStep(target);
+    return target != current && map->canStep(target) && contains_navigation_neighbor(map, current, target);
 }
 
 std::shared_ptr<TargetFlowField> build_target_flow_field(const std::shared_ptr<CMap> &map, const Coords &goal,
@@ -85,7 +130,7 @@ std::shared_ptr<TargetFlowField> build_target_flow_field(const std::shared_ptr<C
             continue;
         }
 
-        for (auto previous : map->getAdjacentCoords(current.coords)) {
+        for (auto previous : get_reverse_navigation_neighbors(map, current.coords)) {
             if (previous != goal && !map->canStep(previous)) {
                 continue;
             }
@@ -231,7 +276,7 @@ std::shared_ptr<vstd::future<Coords, void>> CNpcRandomController::control(std::s
                         creature->getCoords(), candidate,
                         [creature](const Coords &c) { return creature->getMap()->canStep(c); },
                         [](auto) -> std::optional<Coords> { return std::nullopt; },
-                        [creature](const Coords &coords) { return creature->getMap()->getAdjacentCoords(coords); },
+                        [creature](const Coords &coords) { return creature->getMap()->getNavigationNeighbors(coords); },
                         [creature](const Coords &from, const Coords &to) {
                             return creature->getMap()->getDistance(from, to);
                         });
@@ -457,7 +502,8 @@ bool CPlayerController::hasPendingPath(std::shared_ptr<CPlayer> player) {
         return false;
     }
     auto next = map->normalizeCoords(it->second);
-    return next != player->getCoords() && map->canStep(next);
+    return next != player->getCoords() && map->canStep(next) &&
+           contains_navigation_neighbor(map, player->getCoords(), next);
 }
 
 bool CPlayerController::canContinue(std::shared_ptr<CPlayer> player) { return hasPendingPath(player); }
@@ -465,16 +511,8 @@ bool CPlayerController::canContinue(std::shared_ptr<CPlayer> player) { return ha
 std::vector<Coords> CPlayerController::calculatePath(std::shared_ptr<CPlayer> player) {
     return CPathFinder::findPath(
         player->getCoords(), *target, [player](Coords coords) { return player->getMap()->canStep(coords); },
-        [player](auto coords) -> std::optional<Coords> {
-            for (auto ob : player->getMap()->getObjectsAtCoords(coords)) {
-                if (ob->getBoolProperty("waypoint")) {
-                    return Coords(ob->getNumericProperty("x"), ob->getNumericProperty("y"),
-                                  ob->getNumericProperty("z"));
-                }
-            }
-            return std::nullopt;
-        },
-        [player](const Coords &coords) { return player->getMap()->getAdjacentCoords(coords); },
+        [](auto) -> std::optional<Coords> { return std::nullopt; },
+        [player](const Coords &coords) { return player->getMap()->getNavigationNeighbors(coords); },
         [player](const Coords &from, const Coords &to) { return player->getMap()->getDistance(from, to); });
 }
 

--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -645,15 +645,7 @@ void CMap::dumpPaths(std::string path) {
     }
     CPathFinder::saveMap(
         currentPlayer->getCoords(), [this](auto coords) { return this->canStep(coords); }, path,
-        [this](auto coords) -> std::optional<Coords> {
-            for (auto ob : getObjectsAtCoords(coords)) {
-                if (ob->getBoolProperty("waypoint")) {
-                    return Coords(ob->getNumericProperty("x"), ob->getNumericProperty("y"),
-                                  ob->getNumericProperty("z"));
-                }
-            }
-            return std::nullopt;
-        },
+        [](auto) -> std::optional<Coords> { return std::nullopt; },
         [this](auto coords) { return this->getNavigationNeighbors(coords); },
         [this](auto from, auto to) { return this->getDistance(from, to); });
 }

--- a/tests/unit/test_controller.cpp
+++ b/tests/unit/test_controller.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CStats.h"
 #include "object/CCreature.h"
 #include "object/CItem.h"
+#include "object/CMapObject.h"
 #include "object/CPlayer.h"
 #include "object/CTile.h"
 #include "test_harness.h"
@@ -29,6 +30,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <pybind11/embed.h>
 
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -63,18 +65,43 @@ std::shared_ptr<CTile> tile(bool can_step) {
     return result;
 }
 
-std::shared_ptr<CMap> open_tile_map(const std::shared_ptr<CGame> &game, int width, int height) {
+std::shared_ptr<CMap> open_tile_map(const std::shared_ptr<CGame> &game, int width, int height, int levels = 1) {
     auto map = std::make_shared<CMap>();
     game->setMap(map);
     map->setGame(game);
-    map->setXBounds({{0, width - 1}});
-    map->setYBounds({{0, height - 1}});
-    for (int y = 0; y < height; ++y) {
-        for (int x = 0; x < width; ++x) {
-            map->addTile(tile(true), x, y, 0);
+    std::map<int, int> x_bounds;
+    std::map<int, int> y_bounds;
+    for (int z = 0; z < levels; ++z) {
+        x_bounds[z] = width - 1;
+        y_bounds[z] = height - 1;
+    }
+    map->setXBounds(x_bounds);
+    map->setYBounds(y_bounds);
+    for (int z = 0; z < levels; ++z) {
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
+                map->addTile(tile(true), x, y, z);
+            }
         }
     }
     return map;
+}
+
+std::shared_ptr<CPlayer> player_at(const std::shared_ptr<CGame> &game, Coords coords) {
+    auto player = std::make_shared<CPlayer>();
+    player->setGame(game);
+    player->setName("player");
+    player->setCoords(coords);
+    return player;
+}
+
+void add_navigation_edge(const std::shared_ptr<CMap> &map, Coords source, Coords target, bool bidirectional = false) {
+    CNavigationEdge edge;
+    edge.source = source;
+    edge.target = target;
+    edge.enabled = true;
+    edge.bidirectional = bidirectional;
+    map->registerNavigationEdge(edge);
 }
 
 void test_movement_controller_null_and_no_map_paths() {
@@ -188,6 +215,59 @@ void test_npc_random_controller_clears_stale_blocked_path() {
                 "NPC random controller should either stay put or replan to a passable step");
 }
 
+void test_player_controller_uses_navigation_neighbors_for_cross_level_route() {
+    auto game = std::make_shared<CGame>();
+    auto map = open_tile_map(game, 3, 1, 2);
+    auto player = player_at(game, Coords(0, 0, 0));
+    auto controller = std::make_shared<CPlayerController>();
+    player->setController(controller);
+
+    add_navigation_edge(map, Coords(1, 0, 0), Coords(1, 0, 1));
+    controller->setTarget(player, Coords(2, 0, 1));
+
+    auto first = resolve_coords(controller->control(player));
+    expect_true(first == Coords(1, 0, 0), "player navigation route should first approach the authored edge");
+    player->moveTo(first);
+    controller->onStepCommitted(player, first);
+
+    auto second = resolve_coords(controller->control(player));
+    expect_true(second == Coords(1, 0, 1), "player navigation route should cross the authored z-level edge");
+    player->moveTo(second);
+    controller->onStepCommitted(player, second);
+
+    auto third = resolve_coords(controller->control(player));
+    expect_true(third == Coords(2, 0, 1), "player navigation route should finish on the target level");
+}
+
+void test_target_controller_flow_field_uses_navigation_neighbors_for_cross_level_pursuit() {
+    auto game = std::make_shared<CGame>();
+    auto map = open_tile_map(game, 3, 1, 2);
+    add_navigation_edge(map, Coords(1, 0, 0), Coords(1, 0, 1));
+
+    auto target = std::make_shared<CMapObject>();
+    target->setGame(game);
+    target->setName("unitTargetAcrossLevels");
+    target->setCoords(Coords(2, 0, 1));
+    map->addObject(target);
+
+    auto chaser = creature_at(0, 0, 0);
+    chaser->setGame(game);
+    chaser->setName("unitChaserAcrossLevels");
+    chaser->setHp(1);
+    auto controller = std::make_shared<CTargetController>();
+    controller->setTarget("unitTargetAcrossLevels");
+    chaser->setController(controller);
+    map->addObject(chaser);
+
+    performance_guard::clearTargetFlowCache();
+    auto first = resolve_coords(controller->control(chaser));
+    expect_true(first == Coords(1, 0, 0), "target flow field should approach an authored z-level edge");
+    chaser->moveTo(first);
+
+    auto second = resolve_coords(controller->control(chaser));
+    expect_true(second == Coords(1, 0, 1), "target flow field should cross the authored z-level edge");
+}
+
 void test_fight_controller_guard_paths_and_fallbacks() {
     auto attacker = creature_at(0, 0, 0);
     auto opponent = creature_at(1, 0, 0);
@@ -264,6 +344,8 @@ int main() {
     test_movement_controller_null_and_no_map_paths();
     test_npc_random_controller_clears_current_tile_path();
     test_npc_random_controller_clears_stale_blocked_path();
+    test_player_controller_uses_navigation_neighbors_for_cross_level_route();
+    test_target_controller_flow_field_uses_navigation_neighbors_for_cross_level_pursuit();
     test_fight_controller_guard_paths_and_fallbacks();
     test_monster_fight_controller_uses_mana_item_when_mana_is_low();
 

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -39,9 +39,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <pybind11/embed.h>
 
 #include <algorithm>
+#include <array>
+#include <filesystem>
+#include <fstream>
 #include <memory>
 #include <set>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -65,6 +69,19 @@ Coords first_adjacent_walkable(const std::shared_ptr<CMap> &map, Coords origin) 
 
 bool contains_coords(const std::vector<Coords> &coords, Coords target) {
     return std::ranges::find(coords, target) != coords.end();
+}
+
+std::pair<int, int> read_png_dimensions(const std::filesystem::path &path) {
+    std::ifstream input(path, std::ios::binary);
+    std::array<unsigned char, 24> header{};
+    input.read(reinterpret_cast<char *>(header.data()), static_cast<std::streamsize>(header.size()));
+
+    auto read_big_endian = [](const unsigned char *bytes) {
+        return (static_cast<int>(bytes[0]) << 24) | (static_cast<int>(bytes[1]) << 16) |
+               (static_cast<int>(bytes[2]) << 8) | static_cast<int>(bytes[3]);
+    };
+
+    return {read_big_endian(&header[16]), read_big_endian(&header[20])};
 }
 
 struct TraceReset {
@@ -708,6 +725,49 @@ void test_map_navigation_neighbors_include_registered_edges() {
                 "unregistering a missing object name should not bump navigation revision");
 }
 
+void test_map_dump_paths_uses_navigation_neighbors() {
+    auto game = CGameLoader::loadGame();
+    auto map = std::make_shared<CMap>();
+    game->setMap(map);
+    map->setGame(game);
+    map->setXBounds({{0, 10}});
+    map->setYBounds({{0, 0}});
+
+    for (int x = 0; x <= 10; ++x) {
+        auto blocked = std::make_shared<CTile>();
+        blocked->setCanStep(false);
+        expect_true(map->addTile(blocked, x, 0, 0), "blocked dump-path fixture tile should be added");
+    }
+
+    for (int x : {0, 10}) {
+        map->removeTile(x, 0, 0);
+        auto open = std::make_shared<CTile>();
+        open->setCanStep(true);
+        expect_true(map->addTile(open, x, 0, 0), "open dump-path fixture tile should be added");
+    }
+
+    CNavigationEdge edge;
+    edge.source = Coords(0, 0, 0);
+    edge.target = Coords(10, 0, 0);
+    edge.enabled = true;
+    map->registerNavigationEdge(edge);
+
+    auto player = std::make_shared<CPlayer>();
+    player->setBaseStats(creature_stats());
+    map->setPlayer(player);
+
+    const auto output_path = std::filesystem::temp_directory_path() / "navigation-neighbor-path-dump.png";
+    std::filesystem::remove(output_path);
+    map->dumpPaths(output_path.string());
+
+    expect_true(std::filesystem::exists(output_path), "navigation-neighbor path dump should create a PNG");
+    expect_true(std::filesystem::file_size(output_path) > 0, "navigation-neighbor path dump should be non-empty");
+    auto [width, height] = read_png_dimensions(output_path);
+    expect_true(width == 44 && height == 4,
+                "navigation-neighbor path dump should include the authored edge target in its bounds");
+    std::filesystem::remove(output_path);
+}
+
 void test_map_defensive_branches_and_strict_validation() {
     auto map = std::make_shared<CMap>();
     map->setXBounds({{0, -1}});
@@ -1049,6 +1109,7 @@ int main() {
     test_map_tiles_bounds_wrapping_and_object_cache();
     test_map_navigation_edges_update_revision();
     test_map_navigation_neighbors_include_registered_edges();
+    test_map_dump_paths_uses_navigation_neighbors();
     test_map_defensive_branches_and_strict_validation();
     test_map_move_interrupts_invalid_planned_steps();
     test_creature_tracks_pending_move_origin_only_during_after_move();


### PR DESCRIPTION
## Summary
- Route player pathing, NPC random movement, target flow fields, and path dumps through `CMap::getNavigationNeighbors()`.
- Remove controller/path-dump direct waypoint scanning now that navigation edges provide the topology contract.
- Add native regressions for cross-level player routing, cross-level target pursuit, and path dumping through authored navigation edges.

## Why
Queue row 79 requires controllers to use the same map navigation topology, including authored edges such as multilevel/stairs links, instead of mixing direct waypoint inspection with adjacent-tile traversal.

## Validation
- `clang-format -i src/core/CController.cpp src/core/CMap.cpp tests/unit/test_controller.cpp tests/unit/test_map.cpp`
- `git diff --check`
- post-rebase `git diff --check origin/main...HEAD`

## Deferred validation
- Local native build/ctest were skipped per controller policy; GitHub Actions `build / linux` will provide compilation and native test evidence.

## Queue
- Issue: [EPIC_04][STORY_01][SUBSTORY_04]Migrate controllers to navigation neighbors
- Claim ID: cb682a74-4b2b-4ce0-abac-2f790a32a42c
- Owner: controller/ctrl-lis-2-b175230b/subagent-2

## Known limitations
- Current repository CI has an unrelated native GUI segfault on recent main/workbook-only runs; this PR may need re-run or mainline repair before merge evidence is available.