### PR TITLE
Document movement-cost route selection semantics

### DIFF
--- a/TODO_WORKLOG.md
+++ b/TODO_WORKLOG.md
@@ -533,3 +533,24 @@
   - Historical pre-95% coverage-gate evidence: `./scripts/run_coverage.sh` passed report generation with
     `lines: 90.17% (9493 out of 10528)` before the current threshold was enforced.
 - Blockers if unresolved: None.
+
+## Batch 28
+- Location: `docs/navigation.md`, `TODO_WORKLOG.md`
+- Original TODO or summary: Row 82 asked to record the movement-cost decision before expanding the navigation contract.
+- Status: documented
+- What was changed: Added a navigation architecture note that keeps phase-1 movement cost scoped to route selection and
+  explicitly excludes turn-budget or extra turn-consumption semantics unless future source evidence and regression
+  coverage justify that contract expansion.
+- Why the change is correct: Source verification shows `CPathFinder` can consume weighted step costs, but current map
+  controllers do not pass a map step-cost callback, `CMap::getMovementCost(...)` still returns `1`, registered
+  navigation-edge costs are stored but not applied by `getNavigationNeighbors(...)`, target flow fields add unit cost
+  per step, and `CMap::move()` commits one selected step per active creature before incrementing the map turn once.
+- Validation performed:
+  - source verification of `docs/`, `src/core/CMap.cpp`, `src/core/CMap.h`, `src/core/CPathFinder.cpp`,
+    `src/core/CPathFinder.h`, `src/core/CController.cpp`, `src/core/CModule.cpp`, `tests/unit/test_map.cpp`, `test.py`,
+    `todo.txt`, and `TODO_WORKLOG.md`
+  - `git diff --check`
+  - `git diff --no-index --check /dev/null docs/navigation.md` -> no whitespace diagnostics; exited `1` because the
+    file is new
+- Blockers if unresolved: Manual review should confirm that future implementation issues treat this as a route-selection
+  decision only and do not infer movement-point or turn-budget behavior from the stored `movementCost` field.

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,20 @@
+# Navigation
+
+## Movement-cost decision
+
+Movement cost is a route-selection contract for phase 1. It is not a turn-budget or extra turn-consumption contract.
+
+Current source state:
+
+- `CPathFinder` supports weighted route selection through its `StepCost` callback.
+- `CMap::getMovementCost(...)` normalizes coordinates, materializes a missing default tile through `getTile(...)`, and
+  currently returns `1`.
+- `CNavigationEdge::movementCost` is stored and exposed, but `CMap::getNavigationNeighbors(...)` returns only neighbor
+  coordinates, so the edge cost is not applied by map-owned navigation yet.
+- Player and NPC map controllers currently call `CPathFinder` with map neighbors and map distance, but without a
+  map-provided step-cost callback. Target-controller flow fields also add `1` per step.
+- `CMap::move()` commits at most one controller-selected step per active creature and increments the map turn once after
+  the simulation cycle; it does not consume turns or movement budget based on movement cost.
+
+Future movement-cost implementation should first wire movement cost into route selection only. Any turn-budget or
+multi-step-per-turn behavior needs separate source evidence, design, and regression coverage.


### PR DESCRIPTION
## Summary
- Add `docs/navigation.md` to record the movement-cost architecture decision.
- Append Batch 28 to `TODO_WORKLOG.md` with source verification and validation notes.

## Why
Queue row 82 requires movement-cost semantics to be explicit before implementation expands the navigation contract. Current source supports weighted pathfinding primitives, but map controllers and navigation edges do not yet apply map-owned movement cost, and map turns are not budgeted by movement cost.

## Verified Behavior
- `CPathFinder` supports weighted route selection through `StepCost`.
- `CMap::getMovementCost(...)` currently returns `1`.
- `CNavigationEdge::movementCost` is stored/exposed but not applied by `CMap::getNavigationNeighbors(...)`.
- Current map controllers do not pass a map step-cost callback.
- `CMap::move()` commits one selected step per active creature and increments the map turn once.

## Validation
- `git diff --check`
- post-rebase `git diff --check origin/main...HEAD`
- `git diff --no-index --check /dev/null docs/navigation.md` produced no whitespace diagnostics and exited `1` because the file is new.

## Queue
- Issue: [EPIC_04][STORY_02][SUBSTORY_01]Record movement-cost decision
- Claim ID: 140d3022-619d-4721-99a0-7cdd8db20cc2
- Owner: controller/ctrl-lis-2-b175230b/subagent-3

## Known limitations
- Manual review should confirm future movement-cost issues treat this as route-selection-only and do not infer turn-budget semantics from the stored `movementCost` field.