### PR TITLE
Report map and player property hygiene

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -26,6 +26,7 @@ SCRIPT_MAP_CALLS = {"changeMap"}
 SCRIPT_OBJECT_NAME_CALLS = {"getObjectByName", "removeObjectByName"}
 SCRIPT_PROPERTY_READ_CALLS = {"getBoolProperty", "getNumericProperty", "getStringProperty"}
 SCRIPT_PROPERTY_WRITE_CALLS = {"setBoolProperty", "setNumericProperty", "setStringProperty", "incProperty"}
+SCRIPT_BOOL_PROPERTY_METHODS = {"getBoolProperty", "setBoolProperty"}
 SCRIPT_PROPERTY_DEFAULT_WRITE_CALLS = {
     "_set_bool_property_default": "setBoolProperty",
     "_set_numeric_property_default": "setNumericProperty",
@@ -160,6 +161,11 @@ class ScriptLegacyBoolFlag:
     lineno: int
     context: str
 
+    @property
+    def location(self) -> str:
+        call = f'LegacyBoolFlag("{self.name}")'
+        return f"{self.context}:{self.lineno} {call}" if self.context else f"line {self.lineno} {call}"
+
 
 @dataclass(frozen=True)
 class ScriptPropertyAccess:
@@ -174,6 +180,60 @@ class ScriptPropertyAccess:
     def location(self) -> str:
         call = f'{self.method}("{self.name}")'
         return f"{self.context}:{self.lineno} {call}" if self.context else f"line {self.lineno} {call}"
+
+
+@dataclass(frozen=True)
+class ScriptPropertyHygieneAllowance:
+    path: str
+    owner: str
+    name: str
+    reason: str
+
+
+SCRIPT_PROPERTY_HYGIENE_ALLOWLIST = (
+    ScriptPropertyHygieneAllowance(
+        path="res/maps/nouraajd/script.py",
+        owner="player",
+        name="CAN_CRAFT_SCROLLS",
+        reason="Crafting recipes read this player compatibility flag through unlockFlag configuration.",
+    ),
+    ScriptPropertyHygieneAllowance(
+        path="res/maps/nouraajd/script.py",
+        owner="player",
+        name="CAN_BREW_GREATER_POTIONS",
+        reason="Crafting recipes read this player compatibility flag through unlockFlag configuration.",
+    ),
+    ScriptPropertyHygieneAllowance(
+        path="res/maps/multilevel/script.py",
+        owner="map",
+        name="used_stairs_up",
+        reason="Walkthrough and MCP validation read this map telemetry flag outside map script source.",
+    ),
+    ScriptPropertyHygieneAllowance(
+        path="res/maps/multilevel/script.py",
+        owner="map",
+        name="used_stairs_down",
+        reason="Walkthrough and MCP validation read this map telemetry flag outside map script source.",
+    ),
+    ScriptPropertyHygieneAllowance(
+        path="res/maps/multilevel/script.py",
+        owner="map",
+        name="visited_multilevel_start",
+        reason="Map entry marker is intentionally externally observable instead of read by map script source.",
+    ),
+    ScriptPropertyHygieneAllowance(
+        path="res/maps/ritual/script.py",
+        owner="map",
+        name="ritual_started",
+        reason="Walkthrough and MCP validation read this progression flag outside map script source.",
+    ),
+    ScriptPropertyHygieneAllowance(
+        path="res/maps/siege/script.py",
+        owner="map",
+        name="campaign_completed",
+        reason="Campaign completion marker is intentionally externally observable after quest completion.",
+    ),
+)
 
 
 @dataclass
@@ -510,7 +570,10 @@ class ScriptAnalyzer(ast.NodeVisitor):
 
     @property
     def _context(self) -> str:
-        return ".".join([*self._class_stack, *self._function_stack])
+        function_stack = self._function_stack
+        if self._class_stack and function_stack and function_stack[0] == "load":
+            function_stack = function_stack[1:]
+        return ".".join([*self._class_stack, *function_stack])
 
 
 def call_name(func: ast.AST) -> str | None:
@@ -607,7 +670,11 @@ class TriggerAnalyzer(ast.NodeVisitor):
 
 
 class ContentValidator:
-    def __init__(self, repo_root: Path) -> None:
+    def __init__(
+        self,
+        repo_root: Path,
+        property_hygiene_allowlist: tuple[ScriptPropertyHygieneAllowance, ...] | None = None,
+    ) -> None:
         self.repo_root = repo_root.resolve()
         self.issues: list[ValidationIssue] = []
         self.global_entries: dict[str, ConfigEntry] = {}
@@ -624,6 +691,9 @@ class ContentValidator:
         self.native_plugin_declared_class_sources: dict[str, set[str]] = {}
         self.python_registered_classes: set[str] = set()
         self.registration_exclusions: dict[str, RegistrationExclusion] = {}
+        self.property_hygiene_allowlist = (
+            SCRIPT_PROPERTY_HYGIENE_ALLOWLIST if property_hygiene_allowlist is None else property_hygiene_allowlist
+        )
 
     def validate(self) -> list[ValidationIssue]:
         self._collect_engine_classes()
@@ -923,6 +993,7 @@ class ContentValidator:
         self._validate_map_json(context, visible, known_classes)
         self._validate_dialogs(context, visible)
         self._validate_script_refs(context, visible, known_classes)
+        self._validate_script_property_hygiene(context)
 
     def _visible_entries(self, context: MapContext) -> dict[str, ConfigEntry]:
         visible = dict(self.global_entries)
@@ -1408,6 +1479,107 @@ class ContentValidator:
                     self._issue(context.script_info.path, trigger.location, f'unknown trigger event "{trigger.value}"')
             elif trigger.name == "trigger target" and trigger.value not in object_names:
                 self._issue(context.script_info.path, trigger.location, f'unknown trigger target "{trigger.value}"')
+
+    def _validate_script_property_hygiene(self, context: MapContext) -> None:
+        info = context.script_info
+        if not info:
+            return
+
+        valid_legacy_flags = self._validate_legacy_bool_flags(info)
+        accesses_by_key: dict[tuple[str, str], dict[str, list[ScriptPropertyAccess]]] = {}
+        owners_by_property: dict[str, set[str]] = {}
+        unknown_accesses: list[ScriptPropertyAccess] = []
+
+        for legacy_flag in valid_legacy_flags:
+            owners_by_property.setdefault(legacy_flag, set()).add("map")
+
+        for access in info.property_reads + info.property_writes:
+            if access.method not in SCRIPT_BOOL_PROPERTY_METHODS:
+                continue
+            if access.owner in {"map", "player"}:
+                owners_by_property.setdefault(access.name, set()).add(access.owner)
+                by_access = accesses_by_key.setdefault((access.owner, access.name), {"read": [], "write": []})
+                by_access[access.access].append(access)
+            elif access.owner == "unknown":
+                unknown_accesses.append(access)
+
+        for property_name, owners in sorted(owners_by_property.items()):
+            if len(owners) <= 1:
+                continue
+            first_access = self._first_property_access(info, property_name)
+            location = first_access.location if first_access else f'property "{property_name}"'
+            owner_list = ", ".join(sorted(owners))
+            self._issue(
+                info.path, location, f'bool property "{property_name}" is used on multiple owners: {owner_list}'
+            )
+
+        for (owner, property_name), accesses in sorted(accesses_by_key.items()):
+            if owner == "map" and property_name in valid_legacy_flags:
+                continue
+            if self._property_hygiene_allowance_reason(info.path, owner, property_name):
+                continue
+
+            reads = accesses["read"]
+            writes = accesses["write"]
+            if reads and not writes:
+                self._issue(
+                    info.path,
+                    reads[0].location,
+                    f'{owner} bool property "{property_name}" is read without a write/default, legacy sync, '
+                    "or allowlist",
+                )
+            elif writes and not reads:
+                self._issue(
+                    info.path,
+                    writes[0].location,
+                    f'write-only {owner} bool property "{property_name}" has no read, legacy sync, or allowlist',
+                )
+
+        reviewed_names = set(owners_by_property)
+        for allowance in self.property_hygiene_allowlist:
+            if allowance.path == self._rel(info.path):
+                reviewed_names.add(allowance.name)
+        for access in unknown_accesses:
+            if access.name not in reviewed_names:
+                continue
+            if self._property_hygiene_allowance_reason(info.path, "unknown", access.name):
+                continue
+            self._issue(
+                info.path,
+                access.location,
+                f'bool property "{access.name}" has unknown receiver; manual review required to classify ownership',
+            )
+
+    def _validate_legacy_bool_flags(self, info: ScriptInfo) -> set[str]:
+        valid_flags: set[str] = set()
+        for flag in info.legacy_bool_flags:
+            usage = info.quest_states.get(flag.quest)
+            if usage is None or not usage.storage_key:
+                self._issue(
+                    info.path,
+                    flag.location,
+                    f'legacy bool flag "{flag.name}" references unknown quest key "{flag.quest}"',
+                )
+                continue
+            valid_flags.add(flag.name)
+        return valid_flags
+
+    def _first_property_access(self, info: ScriptInfo, property_name: str) -> ScriptPropertyAccess | None:
+        accesses = [
+            access
+            for access in info.property_reads + info.property_writes
+            if access.name == property_name and access.owner in {"map", "player"}
+        ]
+        if not accesses:
+            return None
+        return min(accesses, key=lambda access: access.lineno)
+
+    def _property_hygiene_allowance_reason(self, path: Path, owner: str, property_name: str) -> str | None:
+        relative_path = self._rel(path)
+        for allowance in self.property_hygiene_allowlist:
+            if allowance.path == relative_path and allowance.owner == owner and allowance.name == property_name:
+                return allowance.reason
+        return None
 
     def _entry_is_quest(self, entry: ConfigEntry, visible: dict[str, ConfigEntry]) -> bool:
         resolved = self._resolve_entry(entry, visible)

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -24,7 +24,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.validate_content import ContentValidator, validate_repo
+from scripts.validate_content import ContentValidator, ScriptPropertyHygieneAllowance, validate_repo
 
 
 class ContentValidatorTest(unittest.TestCase):
@@ -262,6 +262,203 @@ class ContentValidatorTest(unittest.TestCase):
         self.assertIn(("map", "MAIN_DONE", "setBoolProperty"), property_writes)
         self.assertIn(("map", "MAIN_TURN", "setNumericProperty"), property_writes)
         self.assertIn(("player", "skill_flag", "setBoolProperty"), property_writes)
+
+    def test_given_player_bool_read_without_default_when_validating_then_reports_uninitialized_property(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            @register(context)
+            class StartEvent(CEvent):
+                def onEnter(self, event):
+                    player = self.getMap().getPlayer()
+                    if player.getBoolProperty("has_relic"):
+                        player.addGold(1)
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            "StartEvent.onEnter",
+            'getBoolProperty("has_relic")',
+            'player bool property "has_relic" is read without a write/default',
+        )
+
+    def test_given_stale_map_bool_write_when_validating_then_reports_write_only_property(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            @register(context)
+            class StartEvent(CEvent):
+                def onEnter(self, event):
+                    game_map = self.getMap()
+                    game_map.setBoolProperty("STALE_FLAG", True)
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            "StartEvent.onEnter",
+            'setBoolProperty("STALE_FLAG")',
+            'write-only map bool property "STALE_FLAG"',
+        )
+
+    def test_given_stale_player_bool_write_when_validating_then_reports_write_only_property(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            @register(context)
+            class StartEvent(CEvent):
+                def onEnter(self, event):
+                    player = self.getMap().getPlayer()
+                    player.setBoolProperty("STALE_PLAYER_FLAG", True)
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            "StartEvent.onEnter",
+            'setBoolProperty("STALE_PLAYER_FLAG")',
+            'write-only player bool property "STALE_PLAYER_FLAG"',
+        )
+
+    def test_given_map_and_player_bool_name_collision_when_validating_then_reports_owner_collision(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            @register(context)
+            class StartEvent(CEvent):
+                def onEnter(self, event):
+                    game_map = self.getMap()
+                    player = game_map.getPlayer()
+                    game_map.setBoolProperty("shared_flag", True)
+                    game_map.getBoolProperty("shared_flag")
+                    player.setBoolProperty("shared_flag", True)
+                    player.getBoolProperty("shared_flag")
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'bool property "shared_flag" is used on multiple owners: map, player',
+        )
+
+    def test_given_unknown_receiver_for_reviewed_bool_when_validating_then_reports_manual_review(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            @register(context)
+            class StartEvent(CEvent):
+                def onEnter(self, event):
+                    game_map = self.getMap()
+                    game_map.setBoolProperty("reviewed_flag", True)
+                    game_map.getBoolProperty("reviewed_flag")
+                    if holder.getBoolProperty("reviewed_flag"):
+                        game_map.getPlayer().addGold(1)
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'getBoolProperty("reviewed_flag")',
+            'bool property "reviewed_flag" has unknown receiver; manual review required',
+        )
+
+    def test_given_unknown_legacy_bool_quest_key_when_validating_then_reports_missing_mapping(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            class QuestSystem(QuestStateStore):
+                QUEST_KEYS = {"main": "quest_state_main"}
+                LEGACY_BOOL_FLAGS = (
+                    LegacyBoolFlag("BROKEN_LEGACY_FLAG", "missing", states=("done",)),
+                )
+
+            @register(context)
+            class StartEvent(CEvent):
+                pass
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'LegacyBoolFlag("BROKEN_LEGACY_FLAG")',
+            'legacy bool flag "BROKEN_LEGACY_FLAG" references unknown quest key "missing"',
+        )
+
+    def test_given_valid_legacy_bool_sync_when_validating_then_accepts_map_flag_read(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            class QuestSystem(QuestStateStore):
+                QUEST_KEYS = {"main": "quest_state_main"}
+                QUEST_DEFAULTS = {"main": "locked"}
+                LEGACY_BOOL_FLAGS = (
+                    LegacyBoolFlag("MAIN_DONE", "main", states=("done",)),
+                )
+
+                def complete(self):
+                    self._set_state("main", "done")
+
+            @register(context)
+            class StartEvent(CEvent):
+                def onEnter(self, event):
+                    game_map = self.getMap()
+                    if game_map.getBoolProperty("MAIN_DONE"):
+                        game_map.getPlayer().addGold(1)
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
+    def test_given_allowlisted_compatibility_flag_when_validating_then_suppresses_write_only_diagnostic(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            @register(context)
+            class StartEvent(CEvent):
+                def onEnter(self, event):
+                    game_map = self.getMap()
+                    game_map.setBoolProperty("STALE_FLAG", True)
+            """,
+        )
+        allowance = ScriptPropertyHygieneAllowance(
+            path="res/maps/broken/script.py",
+            owner="map",
+            name="STALE_FLAG",
+            reason="Regression fixture for an externally read compatibility flag.",
+        )
+
+        issues = ContentValidator(root, property_hygiene_allowlist=(allowance,)).validate()
+
+        self.assertEqual([], [str(issue) for issue in issues])
 
     def test_invalid_transition_targets_report_map_name(self):
         root = self.make_fixture(script_map="missingMap")
@@ -784,6 +981,36 @@ def write_script(path, script_quest, script_map):
             """).lstrip(),
         encoding="utf-8",
     )
+
+
+def write_property_hygiene_script(path, body):
+    header = textwrap.dedent("""
+        def load(self, context):
+            from game import CDialog
+            from game import CEvent
+            from game import CQuest
+            from game import LegacyBoolFlag
+            from game import QuestStateStore
+            from game import register
+        """).lstrip()
+    script_body = textwrap.indent(textwrap.dedent(body).strip(), "    ")
+    trailer = textwrap.indent(
+        textwrap.dedent("""
+            @register(context)
+            class GoodQuest(CQuest):
+                pass
+
+            @register(context)
+            class BrokenDialog(CDialog):
+                def valid_action(self):
+                    pass
+
+                def valid_condition(self):
+                    return True
+            """).strip(),
+        "    ",
+    )
+    path.write_text(f"{header}\n{script_body}\n\n{trailer}\n", encoding="utf-8")
 
 
 def read_json(path):


### PR DESCRIPTION
## Summary
- Add bool map/player property hygiene validation using the script analyzer property metadata.
- Report read-without-default, write-only, owner-collision, unknown-receiver, and invalid legacy bool flag mappings with source locations.
- Add focused content-validator regressions and allowlist documented compatibility flags that are read outside the map script source.

## Why
- Row 129 / [EPIC_07][STORY_01][SUBSTORY_03] needs the validator to report stale or ambiguous map/player property usage before quest validation is integrated more broadly.

## Validation
- `black -l 120 scripts/validate_content.py tests/test_content_validator.py`
- `python3 -m unittest tests.test_content_validator`
- `python3 scripts/validate_content.py --repo-root .`
- `python3 -m py_compile scripts/validate_content.py tests/test_content_validator.py`
- `git diff --check origin/main...HEAD`

## Known limitations
- Heavy native validation was not run locally per controller policy; the PR workflow is expected to provide Linux validation evidence.