### PR TITLE
Fix GUI native unit test crashes

### DIFF
--- a/src/core/CProvider.cpp
+++ b/src/core/CProvider.cpp
@@ -526,6 +526,10 @@ std::shared_ptr<CAnimation> CAnimationProvider::getAnimation(const std::shared_p
         // manager
         vstd::logger::warning("Loading empty animation");
     }
+    if (!animation) {
+        vstd::logger::warning("Skipping animation with unregistered animation type:", object->getAnimation());
+        return nullptr;
+    }
     animation->setObject(object);
     return animation;
 }
@@ -533,6 +537,10 @@ std::shared_ptr<CAnimation> CAnimationProvider::getAnimation(const std::shared_p
 std::shared_ptr<CAnimation> CAnimationProvider::getAnimation(const std::shared_ptr<CGame> &game, std::string path,
                                                              bool custom) {
     std::shared_ptr<CGameObject> object = game->createObject<CGameObject>();
+    if (!object) {
+        vstd::logger::warning("Skipping animation path with unregistered CGameObject type:", path);
+        return nullptr;
+    }
     object->setAnimation(std::move(path));
     auto animation = getAnimation(game, object, custom);
     if (animation) {

--- a/src/gui/object/CProxyTargetGraphicsObject.cpp
+++ b/src/gui/object/CProxyTargetGraphicsObject.cpp
@@ -64,8 +64,13 @@ void CProxyTargetGraphicsObject::refresh() {
 }
 
 void CProxyTargetGraphicsObject::addProxyObject(std::shared_ptr<CGui> gui, int &x, int &y) {
+    auto game = gui ? gui->getGame() : nullptr;
+    if (!game) {
+        vstd::logger::warning("Skipping proxy object without game context:", proxyLayout);
+        return;
+    }
     std::shared_ptr<CProxyGraphicsObject> nh = std::make_shared<CProxyGraphicsObject>(x, y);
-    std::shared_ptr<CLayout> layout1 = gui->getGame()->template createObject<CLayout>(proxyLayout);
+    std::shared_ptr<CLayout> layout1 = game->template createObject<CLayout>(proxyLayout);
     if (!layout1) {
         vstd::logger::warning("Skipping proxy object with missing layout:", proxyLayout);
         return;

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -604,17 +604,17 @@ class ContentValidatorTest(unittest.TestCase):
             textwrap.dedent("""
                 class CGameObject {
                     V_META(CGameObject, vstd::meta::empty,
-                           V_PROPERTY(CGameObject, std::string, name, getName, setName))
+                        V_PROPERTY(CGameObject, std::string, name, getName, setName))
                 };
 
                 class CPropertyBase {
                     V_META(CPropertyBase, CGameObject,
-                           V_PROPERTY(CPropertyBase, std::set<std::shared_ptr<CItem>>, loot, getLoot, setLoot))
+                        V_PROPERTY(CPropertyBase, std::set<std::shared_ptr<CItem>>, loot, getLoot, setLoot))
                 };
 
                 class CPropertyDerived {
                     V_META(CPropertyDerived, CPropertyBase,
-                           V_PROPERTY(CPropertyDerived, int, count, getCount, setCount))
+                        V_PROPERTY(CPropertyDerived, int, count, getCount, setCount))
                 };
             """).lstrip(),
             encoding="utf-8",

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -201,7 +201,7 @@ void test_list_view_refreshes_from_generic_property_notifications() {
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
 
     auto gui = std::make_shared<CGui>();
-    create_gui_game(gui);
+    auto game = create_gui_game(gui);
     auto refresh_target = std::make_shared<CGameObject>();
     auto list = std::make_shared<RefreshCountingListView>();
     gui->pushChild(list);
@@ -223,7 +223,7 @@ void test_list_view_refresh_event_compatibility() {
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
 
     auto gui = std::make_shared<CGui>();
-    create_gui_game(gui);
+    auto game = create_gui_game(gui);
     auto refresh_target = std::make_shared<CGameObject>();
     auto list = std::make_shared<RefreshCountingListView>();
     gui->pushChild(list);
@@ -245,7 +245,7 @@ void test_list_view_property_subscriptions_follow_resolved_target_and_null() {
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
 
     auto gui = std::make_shared<CGui>();
-    create_gui_game(gui);
+    auto game = create_gui_game(gui);
     auto first_target = std::make_shared<CGameObject>();
     auto second_target = std::make_shared<CGameObject>();
     auto list = std::make_shared<RefreshCountingListView>();

--- a/tests/unit/test_gui_drag_proxy.cpp
+++ b/tests/unit/test_gui_drag_proxy.cpp
@@ -18,6 +18,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "core/CGame.h"
 #include "core/CSerialization.h"
+#include "core/CTypeRegistration.h"
+#include "core/CTypes.h"
 #include "gui/CGui.h"
 #include "gui/CLayout.h"
 #include "gui/object/CGameGraphicsObject.h"
@@ -111,14 +113,25 @@ std::shared_ptr<CGameObject> drag_payload(const std::shared_ptr<CGame> &game) {
     return payload;
 }
 
+std::shared_ptr<CGame> create_gui_game(const std::shared_ptr<CGui> &gui) {
+    type_registration::registerGuiTypes();
+    type_registration::registerGuiAnimationTypes();
+
+    auto game = std::make_shared<CGame>();
+    game->setGui(gui);
+    gui->setGame(game);
+    for (const auto &[name, builder] : *CTypes::builders()) {
+        game->getObjectHandler()->registerType(name, builder);
+    }
+    return game;
+}
+
 void test_gui_drag_session_serializes_proxy_child_and_removes_it_after_drop_or_cancel() {
     SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
 
-    auto game = std::make_shared<CGame>();
     auto gui = std::make_shared<CGui>();
-    game->setGui(gui);
-    gui->setGame(game);
+    auto game = create_gui_game(gui);
 
     auto source = attach_mouse_recorder(gui);
     auto target = attach_drop_target_recorder(gui);


### PR DESCRIPTION
## Summary
- Keep the GUI unit-test game fixture alive while list-view proxy refreshes run.
- Initialize/register production GUI and animation builders in the drag-proxy unit-test fixture.
- Make proxy-grid and animation creation fail closed when a bare test game lacks game context or animation constructors.
- Normalize indentation in the content-validator fixture string so current main passes `GameTest.test_indentation`.

## Why
- Current main is blocking multiple controller implementation PRs with native segfaults in `for_unit_tests.gui_unit_tests` and `for_unit_tests.gui_drag_proxy_unit_tests` across Linux, coverage, and Windows.
- Local gdb showed `gui_unit_tests` dereferencing an expired `gui->getGame()` during proxy layout creation and `gui_drag_proxy_unit_tests` dereferencing a missing animation after unregistered animation construction.
- The first CI rerun showed those native GUI crashes fixed, then failed later on `GameTest.test_indentation` because an existing tracked fixture line used non-4-space indentation.

## Validation
- `GAME_CONFIGURE_SKIP_APT=1 GAME_CONFIGURE_SKIP_SUBMODULES=1 GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh`
- `cmake --build cmake-build-release --target gui_unit_tests gui_drag_proxy_unit_tests -j$(nproc)`
- before fix: `SDL_VIDEODRIVER=dummy SDL_RENDER_DRIVER=software ./cmake-build-release/gui_unit_tests` exited 139
- before fix: `SDL_VIDEODRIVER=dummy SDL_RENDER_DRIVER=software ./cmake-build-release/gui_drag_proxy_unit_tests` exited 139
- after fix: `SDL_VIDEODRIVER=dummy SDL_RENDER_DRIVER=software ./cmake-build-release/gui_unit_tests` passed
- after fix: `SDL_VIDEODRIVER=dummy SDL_RENDER_DRIVER=software ./cmake-build-release/gui_drag_proxy_unit_tests` passed
- `SDL_VIDEODRIVER=dummy SDL_RENDER_DRIVER=software ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests\.(gui_unit_tests|gui_drag_proxy_unit_tests)` passed
- `cmake --build cmake-build-release --target for_unit_tests -j$(nproc)`
- `SDL_VIDEODRIVER=dummy SDL_RENDER_DRIVER=software ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` initially showed handler/map plugin crashes before `_game` was built
- `cmake --build cmake-build-release --target _game -j$(nproc)`
- rerun `SDL_VIDEODRIVER=dummy SDL_RENDER_DRIVER=software ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` passed: 10/10 tests
- post-rebase: `black -l 120 tests/test_content_validator.py`
- post-rebase: `python3 test.py GameTest.test_indentation` passed
- post-rebase: `python3 -m unittest tests.test_content_validator` passed: 20 tests
- post-rebase: `cmake --build cmake-build-release --target gui_unit_tests gui_drag_proxy_unit_tests -j$(nproc)` passed
- post-rebase: `SDL_VIDEODRIVER=dummy SDL_RENDER_DRIVER=software ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests\.(gui_unit_tests|gui_drag_proxy_unit_tests)` passed: 2/2 tests
- `clang-format -i tests/unit/test_gui.cpp tests/unit/test_gui_drag_proxy.cpp src/gui/object/CProxyTargetGraphicsObject.cpp src/core/CProvider.cpp`
- `git diff --check origin/main...HEAD`

## Known limitations
- Full Python, coverage, and Windows validation were not run locally; GitHub Actions should provide Linux, linux-coverage, and Windows evidence before this repair is merged.