### PR TITLE
Add save migration registry

### DIFF
--- a/src/core/CSaveFormat.cpp
+++ b/src/core/CSaveFormat.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <algorithm>
 #include <cctype>
+#include <map>
 
 namespace CSaveFormat {
 
@@ -91,6 +92,68 @@ std::optional<std::string> readSnapshotMapName(const std::shared_ptr<json> &snap
     return (*snapshot)["properties"]["mapName"].get<std::string>();
 }
 
+namespace {
+
+constexpr int LEGACY_SCHEMA_VERSION = 0;
+
+struct SourceDocument {
+    int schemaVersion = SCHEMA_VERSION;
+    std::shared_ptr<json> snapshot;
+    std::string mapName;
+    Encoding encoding = Encoding::Versioned;
+};
+
+using Migration = std::expected<std::shared_ptr<json>, std::string> (*)(const SourceDocument &source);
+
+std::expected<std::shared_ptr<json>, std::string> migrateCurrentSchema(const SourceDocument &source) {
+    if (!source.snapshot || !source.snapshot->is_object()) {
+        return std::unexpected("save migration source snapshot is not an object");
+    }
+    return source.snapshot;
+}
+
+std::expected<std::shared_ptr<json>, std::string> migrateLegacySchema(const SourceDocument &source) {
+    if (!source.snapshot || !source.snapshot->is_object()) {
+        return std::unexpected("save migration source snapshot is not an object");
+    }
+    return std::make_shared<json>(*source.snapshot);
+}
+
+const std::map<int, Migration> &migrationRegistry() {
+    static const std::map<int, Migration> registry = {
+        {LEGACY_SCHEMA_VERSION, migrateLegacySchema},
+        {SCHEMA_VERSION, migrateCurrentSchema},
+    };
+    return registry;
+}
+
+std::expected<DecodedDocument, std::string> migrateToCurrentSnapshot(const SourceDocument &source) {
+    if (source.schemaVersion > SCHEMA_VERSION) {
+        return std::unexpected("save schema version is newer than this game build");
+    }
+
+    auto migration = migrationRegistry().find(source.schemaVersion);
+    if (migration == migrationRegistry().end()) {
+        return std::unexpected("unsupported save schema version");
+    }
+
+    auto snapshot = migration->second(source);
+    if (!snapshot) {
+        return std::unexpected(snapshot.error());
+    }
+
+    auto snapshotMapName = readSnapshotMapName(*snapshot);
+    if (!snapshotMapName) {
+        return std::unexpected("save snapshot is missing a valid CMap mapName");
+    }
+    if (*snapshotMapName != source.mapName) {
+        return std::unexpected("save envelope mapName does not match snapshot mapName");
+    }
+    return DecodedDocument{*snapshot, source.mapName, source.encoding};
+}
+
+} // namespace
+
 std::expected<DecodedDocument, std::string> decodeDocument(const std::shared_ptr<json> &document) {
     if (!document || !document->is_object()) {
         return std::unexpected("save root is not a JSON object");
@@ -107,9 +170,6 @@ std::expected<DecodedDocument, std::string> decodeDocument(const std::shared_ptr
         if (schemaVersion > SCHEMA_VERSION) {
             return std::unexpected("save schema version is newer than this game build");
         }
-        if (schemaVersion != SCHEMA_VERSION) {
-            return std::unexpected("unsupported save schema version");
-        }
         if (!document->contains("mapName") || !(*document)["mapName"].is_string()) {
             return std::unexpected("save envelope is missing string mapName");
         }
@@ -121,14 +181,7 @@ std::expected<DecodedDocument, std::string> decodeDocument(const std::shared_ptr
             return std::unexpected("save envelope is missing object snapshot");
         }
         auto snapshot = CJsonUtil::alias(document, (*document)["snapshot"]);
-        auto snapshotMapName = readSnapshotMapName(snapshot);
-        if (!snapshotMapName) {
-            return std::unexpected("save snapshot is missing a valid CMap mapName");
-        }
-        if (*snapshotMapName != mapName) {
-            return std::unexpected("save envelope mapName does not match snapshot mapName");
-        }
-        return DecodedDocument{snapshot, mapName, Encoding::Versioned};
+        return migrateToCurrentSnapshot(SourceDocument{schemaVersion, snapshot, mapName, Encoding::Versioned});
     }
 
     auto legacyMapName = readSnapshotMapName(document);
@@ -138,7 +191,7 @@ std::expected<DecodedDocument, std::string> decodeDocument(const std::shared_ptr
     if (!isValidMapName(*legacyMapName)) {
         return std::unexpected("legacy save contains invalid mapName");
     }
-    return DecodedDocument{document, *legacyMapName, Encoding::Legacy};
+    return migrateToCurrentSnapshot(SourceDocument{LEGACY_SCHEMA_VERSION, document, *legacyMapName, Encoding::Legacy});
 }
 
 std::expected<std::shared_ptr<json>, std::string> buildEnvelope(const std::shared_ptr<json> &snapshot,

--- a/src/core/CSaveFormat.h
+++ b/src/core/CSaveFormat.h
@@ -49,6 +49,8 @@ std::optional<std::string> backupSlotFromFilename(const std::filesystem::path &f
 
 std::optional<std::string> readSnapshotMapName(const std::shared_ptr<json> &snapshot);
 
+// Decodes every supported on-disk save shape through the schema migration registry and returns the
+// current in-memory snapshot shape consumed by strict CSerialization deserialization.
 std::expected<DecodedDocument, std::string> decodeDocument(const std::shared_ptr<json> &document);
 
 std::expected<std::shared_ptr<json>, std::string> buildEnvelope(const std::shared_ptr<json> &snapshot,

--- a/test.py
+++ b/test.py
@@ -7393,6 +7393,46 @@ class GameTest(unittest.TestCase):
             cleanup_save_slot(save_name)
 
     @game_test
+    def test_old_schema_save_envelope_loads_through_migration_registry(self):
+        game = load_game_module()
+
+        save_name = unique_save_name("old_schema_migration")
+        save_path = save_primary_path(save_name)
+        cleanup_save_slot(save_name)
+        save_path.parent.mkdir(exist_ok=True)
+        _source_game, source_map, _player = load_game_map_with_player("test")
+        marker = f"old-schema-marker-{time.time_ns()}"
+        source_map.description = marker
+        old_schema_save = {
+            "format": SAVE_FORMAT,
+            "schemaVersion": 0,
+            "mapName": "test",
+            "snapshot": json.loads(game.jsonify(source_map)),
+        }
+        save_path.write_text(json.dumps(old_schema_save), encoding="utf-8")
+
+        try:
+            loaded_game = game.CGameLoader.loadGame()
+            game.CGameLoader.loadSavedGame(loaded_game, save_name)
+            loaded_map = loaded_game.getMap()
+            self.assertEqual(marker, loaded_map.description)
+
+            game.CMapLoader.save(loaded_map, save_name)
+            saved_json = json.loads(save_path.read_text(encoding="utf-8"))
+            snapshot = assert_save_envelope(self, saved_json, "test")
+            self.assertEqual(marker, snapshot.get("properties", {}).get("description"))
+
+            return True, json.dumps(
+                {
+                    "old_schema_loaded": True,
+                    "resaved_schema": saved_json.get("schemaVersion"),
+                },
+                sort_keys=True,
+            )
+        finally:
+            cleanup_save_slot(save_name)
+
+    @game_test
     def test_legacy_save_rejects_noncanonical_player_name_without_activation(self):
         game = load_game_module()
 
@@ -7863,11 +7903,6 @@ class GameTest(unittest.TestCase):
                 "missing_schema",
                 {"format": SAVE_FORMAT, "mapName": "test", "snapshot": valid_snapshot},
                 "save envelope is missing integer schemaVersion",
-            ),
-            (
-                "old_schema",
-                {"format": SAVE_FORMAT, "schemaVersion": 0, "mapName": "test", "snapshot": valid_snapshot},
-                "unsupported save schema version",
             ),
             (
                 "missing_map_name",

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -1063,6 +1063,13 @@ std::shared_ptr<json> make_save_snapshot(std::string map_name = "test") {
     return snapshot;
 }
 
+bool save_snapshot_has_map(const std::shared_ptr<json> &snapshot, const std::string &map_name) {
+    return snapshot && snapshot->is_object() && snapshot->contains("class") &&
+           (*snapshot)["class"].get<std::string>() == "CMap" && snapshot->contains("properties") &&
+           (*snapshot)["properties"].is_object() && (*snapshot)["properties"].contains("mapName") &&
+           (*snapshot)["properties"]["mapName"].get<std::string>() == map_name;
+}
+
 void test_save_format_codec_validation() {
     auto snapshot = make_save_snapshot();
     auto envelope = CSaveFormat::buildEnvelope(snapshot, "test");
@@ -1073,13 +1080,16 @@ void test_save_format_codec_validation() {
                 "save envelope should use the canonical schema version");
 
     auto decoded = CSaveFormat::decodeDocument(*envelope);
-    expect_true(decoded.has_value() && decoded->mapName == "test" &&
-                    decoded->encoding == CSaveFormat::Encoding::Versioned,
-                "save format should decode versioned envelopes");
+    expect_true(
+        decoded.has_value() && decoded->mapName == "test" && decoded->encoding == CSaveFormat::Encoding::Versioned &&
+            decoded->snapshot.get() == &(*envelope)->at("snapshot") && save_snapshot_has_map(decoded->snapshot, "test"),
+        "save migration registry should no-op current schema envelopes");
 
+    const auto legacy_before = snapshot->dump();
     auto legacy = CSaveFormat::decodeDocument(snapshot);
-    expect_true(legacy.has_value() && legacy->mapName == "test" && legacy->encoding == CSaveFormat::Encoding::Legacy,
-                "save format should decode legacy snapshots");
+    expect_true(legacy.has_value() && legacy->mapName == "test" && legacy->encoding == CSaveFormat::Encoding::Legacy &&
+                    save_snapshot_has_map(legacy->snapshot, "test") && snapshot->dump() == legacy_before,
+                "save migration registry should migrate legacy snapshots without mutating the source");
     expect_true(!CSaveFormat::decodeDocument(make_save_snapshot("../test")).has_value(),
                 "save format should reject legacy snapshots with invalid map names");
 
@@ -1094,12 +1104,20 @@ void test_save_format_codec_validation() {
 
     auto old_schema = std::make_shared<json>(**envelope);
     (*old_schema)["schemaVersion"] = 0;
-    expect_true(!CSaveFormat::decodeDocument(old_schema).has_value(), "save format should reject old schema versions");
+    const auto old_schema_before = old_schema->dump();
+    auto old_schema_decoded = CSaveFormat::decodeDocument(old_schema);
+    expect_true(old_schema_decoded.has_value() && old_schema_decoded->mapName == "test" &&
+                    old_schema_decoded->encoding == CSaveFormat::Encoding::Versioned &&
+                    save_snapshot_has_map(old_schema_decoded->snapshot, "test") &&
+                    old_schema->dump() == old_schema_before,
+                "save migration registry should migrate old schema envelopes without mutating the source");
 
     auto future_schema = std::make_shared<json>(**envelope);
     (*future_schema)["schemaVersion"] = CSaveFormat::SCHEMA_VERSION + 1;
-    expect_true(!CSaveFormat::decodeDocument(future_schema).has_value(),
-                "save format should reject future schema versions");
+    const auto future_schema_before = future_schema->dump();
+    expect_true(!CSaveFormat::decodeDocument(future_schema).has_value() &&
+                    future_schema->dump() == future_schema_before,
+                "save migration registry should reject future schema versions without mutating the source");
 
     auto invalid_map = std::make_shared<json>(**envelope);
     (*invalid_map)["mapName"] = "../test";


### PR DESCRIPTION
## What changed

- Added an internal save migration registry keyed by source schema version in `CSaveFormat`.
- Routed current, legacy, and schema-0 versioned save decoding through that migration path.
- Preserved future-version rejection and source-document immutability guarantees.
- Expanded native save-format unit coverage for current no-op migration, legacy migration, old schema envelope migration, and future-version rejection.

## Why

`[EPIC_03][STORY_05][SUBSTORY_02]Add migration registry` needs one documented decode path for schema evolution before strict `CSerialization` restore consumes the snapshot. Previously, versioned saves with any non-current schema were rejected without a registry-backed normalization point.

## Validation

Local focused checks:
- `clang-format -i src/core/CSaveFormat.h src/core/CSaveFormat.cpp tests/unit/test_core.cpp`
- `clang-format --dry-run --Werror src/core/CSaveFormat.h src/core/CSaveFormat.cpp tests/unit/test_core.cpp`
- `git diff --check`
- `git diff --exit-code -- planning/fall_of_nouraajd_issue_proposals.xlsx`

Skipped locally by controller policy / environment:
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests`: this worktree has no ready native build tree, and the controller is using GitHub Actions for native build/test/coverage evidence.

Required CI evidence:
- `python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux --require-step coverage`

## Known limitations

The initial schema-0 migration is intentionally identity-by-copy because no older field-shape transformation exists yet; future schema changes can register concrete transformations in the same path.