### PR TITLE
Use catacombs image for Nouraajd catacombs

### DIFF
--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -387,6 +387,7 @@
   "catacombs": {
     "ref": "Cave",
     "properties": {
+      "animation": "images/buildings/catacombs",
       "message": "Dust-choked catacombs crumble as you wrench the sacred relic free.",
       "chance": "10",
       "monster": {

--- a/test.py
+++ b/test.py
@@ -10112,6 +10112,8 @@ class GameTest(unittest.TestCase):
                 and "already sacrificed" not in courtyard_state.get("properties", {}).get("text", "").lower()
                 and "Victor drinks a vial of poison" not in courtyard_state.get("properties", {}).get("text", "")
             ),
+            "catacombs_uses_catacombs_image": config["catacombs"]["properties"].get("animation")
+            == "images/buildings/catacombs",
         }
 
         failed = sorted([name for name, ok in checks.items() if not ok])


### PR DESCRIPTION
## What changed
- Set the Nouraajd `catacombs` object animation to `images/buildings/catacombs`.
- Added a focused Nouraajd integrity assertion so the object does not fall back to the generic cave image again.

## Why
- The provided `catacombs.png` already matches the tracked `res/images/buildings/catacombs.png` byte-for-byte.
- The missing link was config: the Nouraajd catacombs object inherited `Cave`, whose default animation is `images/buildings/cave`.

## Validation performed
- `python3 -m json.tool res/maps/nouraajd/config.json >/tmp/nouraajd-config.json`
- `python3 -m py_compile test.py`
- `python3 -m black --check -l 120 test.py`
- `python3 test.py GameTest.test_nouraajd_quest_integrity_regression GameTest.test_resource_paths`
- `git diff --check`

## Known limitations / follow-up
- No native build was run; this is a JSON resource reference plus static Python coverage.
