### PR TITLE
Recognize queue health fields in PR audit

### DIFF
--- a/scripts/pr_review_audit.py
+++ b/scripts/pr_review_audit.py
@@ -359,10 +359,23 @@ def queueStatus(queue: dict[str, Any]) -> str:
 
 
 def queueClaimIsStale(queue: dict[str, Any]) -> bool:
-    return any(
+    if any(
         truthy(firstValue(queue, name, default=False))
-        for name in ("stale", "claimStale", "claim_stale", "leaseExpired", "lease_expired")
-    )
+        for name in (
+            "stale",
+            "claimStale",
+            "claim_stale",
+            "heartbeatOverdue",
+            "heartbeat_overdue",
+            "leaseExpired",
+            "lease_expired",
+            "reclaimable",
+        )
+    ):
+        return True
+
+    claimHealth = normalizeToken(firstValue(queue, "claimHealth", "claim_health", default=""))
+    return bool(claimHealth and claimHealth != "healthy")
 
 
 def queueOwner(queue: dict[str, Any]) -> str:
@@ -478,7 +491,7 @@ def actionFromSignals(
 
     queue = queuePayload(record)
     if queueClaimIsStale(queue):
-        blockers.append("linked workbook claim is stale or lease-expired")
+        blockers.append("linked workbook claim requires recovery before merge or cleanup")
         buckets.append("human_review_required")
 
     if prType == "unknown_pr":

--- a/tests/test_pr_review_audit.py
+++ b/tests/test_pr_review_audit.py
@@ -402,7 +402,91 @@ class PrReviewAuditTest(unittest.TestCase):
         self.assertEqual("human_review_required", review["actionCategory"])
         self.assertEqual("implementation_pr_with_stale_workbook_claim", review["prType"])
         self.assertTrue(review["controllerDispatchAttention"])
-        self.assertIn("linked workbook claim is stale or lease-expired", review["blockers"])
+        self.assertIn("linked workbook claim requires recovery before merge or cleanup", review["blockers"])
+
+    def test_heartbeat_overdue_linked_claim_requires_human_review(self) -> None:
+        review = self.classify(
+            {
+                "number": 130,
+                "files": ["src/gui/CMap.cpp"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [successCheck()],
+                "queue": {
+                    "status": "IN_PROGRESS",
+                    "owner": "controller/ctrl-a/subagent-5",
+                    "claimId": "heartbeat-overdue-claim",
+                    "heartbeatOverdue": True,
+                    "leaseExpired": False,
+                },
+            }
+        )
+
+        self.assertEqual("human_review_required", review["actionCategory"])
+        self.assertEqual("implementation_pr_with_stale_workbook_claim", review["prType"])
+        self.assertTrue(review["controllerDispatchAttention"])
+
+    def test_reclaimable_linked_claim_requires_human_review(self) -> None:
+        review = self.classify(
+            {
+                "number": 131,
+                "files": ["src/core/CGameContext.cpp"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [successCheck()],
+                "queue": {
+                    "status": "IN_PROGRESS",
+                    "owner": "controller/ctrl-a/subagent-6",
+                    "claimId": "reclaimable-claim",
+                    "reclaimable": True,
+                },
+            }
+        )
+
+        self.assertEqual("human_review_required", review["actionCategory"])
+        self.assertEqual("implementation_pr_with_stale_workbook_claim", review["prType"])
+        self.assertTrue(review["controllerDispatchAttention"])
+
+    def test_unhealthy_claim_health_requires_human_review(self) -> None:
+        review = self.classify(
+            {
+                "number": 132,
+                "files": ["src/handler/CFightHandler.cpp"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [successCheck()],
+                "queue": {
+                    "status": "IN_PROGRESS",
+                    "owner": "controller/ctrl-a/subagent-7",
+                    "claimId": "lease-expired-recent-heartbeat",
+                    "claimHealth": "lease_expired_heartbeat_recent",
+                },
+            }
+        )
+
+        self.assertEqual("human_review_required", review["actionCategory"])
+        self.assertEqual("implementation_pr_with_stale_workbook_claim", review["prType"])
+        self.assertTrue(review["controllerDispatchAttention"])
+
+    def test_healthy_claim_health_keeps_active_claim_type(self) -> None:
+        review = self.classify(
+            {
+                "number": 133,
+                "files": ["src/handler/CFightHandler.cpp"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [successCheck()],
+                "queue": {
+                    "status": "IN_PROGRESS",
+                    "owner": "controller/ctrl-a/subagent-8",
+                    "claimId": "healthy-claim",
+                    "claimHealth": "healthy",
+                    "heartbeatOverdue": False,
+                    "leaseExpired": False,
+                    "reclaimable": False,
+                },
+            }
+        )
+
+        self.assertEqual("ready_to_merge", review["actionCategory"])
+        self.assertEqual("implementation_pr_with_active_workbook_claim", review["prType"])
+        self.assertFalse(review["controllerDispatchAttention"])
 
     def test_unknown_unlinked_pr_is_not_merge_ready(self) -> None:
         review = self.classify(


### PR DESCRIPTION
## What Changed
- Expanded `scripts/pr_review_audit.py` queue recovery detection to recognize the current queue timing fields: `heartbeatOverdue`, `heartbeat_overdue`, `reclaimable`, and `claimHealth` / `claim_health`.
- Updated the recovery blocker wording so it covers heartbeat-overdue, lease-expired, suspect, and reclaimable linked claims.
- Added focused regression coverage for heartbeat-overdue, reclaimable, unhealthy `claimHealth`, and explicitly healthy queue payloads.

## Why
`issue_queue.py` now exposes richer heartbeat/lease health than the older stale/lease-only fields. The PR audit could receive normalized queue linkage for a controller-owned PR and still miss recovery debt when the payload only used the newer fields, under-classifying work that should require controller inspection before merge or cleanup.

## Validation
- `python3 -m py_compile scripts/pr_review_audit.py`
- `python3 -m unittest tests.test_pr_review_audit`
- `python3 -m black --check -l 120 scripts/pr_review_audit.py tests/test_pr_review_audit.py`
- `python3 scripts/issue_queue.py validate`
- `python3 scripts/workflow_observations.py validate`
- `python3 -m unittest tests.test_issue_queue`
- `python3 -m unittest tests.test_prompt_inventory tests.test_controller_resource_audit tests.test_workflow_observations`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`
- `python3 scripts/issue_queue.py reclaim-stale --dry-run`
- `git diff --check`

## Known Limitations
- This does not add automatic GitHub PR snapshot enrichment. Controllers still need normalized queue linkage for the audit to classify implementation PRs precisely.
- This PR intentionally does not change merge policy or branch protection settings.
