### PR TITLE
Validate JSON property value shapes

### DIFF
--- a/res/config/graphics.json
+++ b/res/config/graphics.json
@@ -5,7 +5,7 @@
       "layout": {
         "class": "CLayout",
         "properties": {
-          "h": 30,
+          "h": "30",
           "horizontal": "PARENT",
           "vertical": "DOWN"
         }
@@ -47,10 +47,10 @@
       "layout": {
         "class": "CLayout",
         "properties": {
-          "h": 1080,
-          "w": 1920,
-          "x": 0,
-          "y": 0
+          "h": "1080",
+          "w": "1920",
+          "x": "0",
+          "y": "0"
         }
       },
       "tileSize": 50
@@ -70,10 +70,10 @@
       "layout": {
         "class": "CLayout",
         "properties": {
-          "h": 220,
+          "h": "220",
           "horizontal": "RIGHT",
           "vertical": "DOWN",
-          "w": 220
+          "w": "220"
         }
       },
       "visible": {
@@ -140,10 +140,10 @@
       "layout": {
         "class": "CLayout",
         "properties": {
-          "h": 200,
+          "h": "200",
           "horizontal": "RIGHT",
           "vertical": "UP",
-          "w": 200
+          "w": "200"
         }
       },
       "panelKeys": {
@@ -169,10 +169,10 @@
       "layout": {
         "class": "CLayout",
         "properties": {
-          "h": 100,
+          "h": "100",
           "horizontal": "LEFT",
           "vertical": "UP",
-          "w": 200
+          "w": "200"
         }
       },
       "visible": {

--- a/res/config/panels.json
+++ b/res/config/panels.json
@@ -64,7 +64,7 @@
               "properties": {
                 "horizontal": "LEFT",
                 "vertical": "PARENT",
-                "w": 50
+                "w": "50"
               }
             },
             "priority": 1,
@@ -91,7 +91,7 @@
       "layout": {
         "class": "CLayout",
         "properties": {
-          "h": 200,
+          "h": "200",
           "horizontal": "PARENT",
           "vertical": "UP"
         }
@@ -192,10 +192,10 @@
             "layout": {
               "class": "CLayout",
               "properties": {
-                "h": 300,
-                "w": 200,
-                "x": 150,
-                "y": 100
+                "h": "300",
+                "w": "200",
+                "x": "150",
+                "y": "100"
               }
             }
           }
@@ -230,10 +230,10 @@
             "layout": {
               "class": "CLayout",
               "properties": {
-                "h": 300,
-                "w": 200,
-                "x": 450,
-                "y": 100
+                "h": "300",
+                "w": "200",
+                "x": "450",
+                "y": "100"
               }
             }
           }
@@ -442,7 +442,7 @@
       "layout": {
         "class": "CLayout",
         "properties": {
-          "h": 100,
+          "h": "100",
           "horizontal": "PARENT",
           "vertical": "DOWN"
         }
@@ -455,8 +455,8 @@
       "layout": {
         "class": "CCenteredLayout",
         "properties": {
-          "h": 300,
-          "w": 400
+          "h": "300",
+          "w": "400"
         }
       },
       "children": [
@@ -503,10 +503,10 @@
             "layout": {
               "class": "CLayout",
               "properties": {
-                "h": 100,
-                "w": 200,
-                "x": 200,
-                "y": 500
+                "h": "100",
+                "w": "200",
+                "x": "200",
+                "y": "500"
               }
             },
             "text": "SELL"
@@ -519,10 +519,10 @@
             "layout": {
               "class": "CLayout",
               "properties": {
-                "h": 100,
-                "w": 200,
-                "x": 400,
-                "y": 500
+                "h": "100",
+                "w": "200",
+                "x": "400",
+                "y": "500"
               }
             },
             "text": "BUY"
@@ -534,10 +534,10 @@
             "layout": {
               "class": "CLayout",
               "properties": {
-                "h": 200,
-                "w": 200,
-                "x": 200,
-                "y": 0
+                "h": "200",
+                "w": "200",
+                "x": "200",
+                "y": "0"
               }
             },
             "render": "renderSellCost"
@@ -549,10 +549,10 @@
             "layout": {
               "class": "CLayout",
               "properties": {
-                "h": 200,
-                "w": 200,
-                "x": 400,
-                "y": 0
+                "h": "200",
+                "w": "200",
+                "x": "400",
+                "y": "0"
               }
             },
             "render": "renderBuyCost"

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -87,6 +87,9 @@ REVIEWED_DYNAMIC_PROPERTIES = {
     "CDialogState": {"condition"},
     "CScroll": {"singleUse"},
 }
+REVIEWED_DYNAMIC_PROPERTY_PREFIXES = {
+    "CGameObject": ("campaign_", "plugin_", "quest_state_"),
+}
 PYTHON_REGISTRATION_DECORATORS = {"register", "trigger"}
 TYPE_REGISTRATION_EXCLUSIONS_PATH = Path("scripts/type_registration_exclusions.json")
 
@@ -1104,8 +1107,19 @@ class ContentValidator:
             return
         dynamic_properties = REVIEWED_DYNAMIC_PROPERTIES.get(class_name, set())
         properties_location = append_field(location, "properties")
-        for property_name in properties:
-            if property_name not in property_schema and property_name not in dynamic_properties:
+        for property_name, property_value in properties.items():
+            if property_name in property_schema:
+                self._validate_property_value_type(
+                    path,
+                    append_field(properties_location, property_name),
+                    class_name,
+                    property_schema[property_name],
+                    property_value,
+                )
+                continue
+            if property_name not in dynamic_properties and not self._is_reviewed_dynamic_property(
+                class_name, property_name
+            ):
                 self._issue(
                     path,
                     append_field(properties_location, property_name),
@@ -1153,6 +1167,37 @@ class ContentValidator:
         if seen_classes is None:
             self._metadata_property_schema_cache[class_name] = properties
         return properties
+
+    def _validate_property_value_type(
+        self, path: Path, location: str, class_name: str, cpp_property: CppMetadataProperty, value: Any
+    ) -> None:
+        expected_kind = expected_json_property_kind(cpp_property.type_token)
+        if expected_kind is None:
+            return
+        actual_kind = json_value_kind(value)
+        if actual_kind != expected_kind:
+            self._issue(
+                path,
+                location,
+                f'property "{cpp_property.name}" for class "{class_name}" expected {expected_kind}; got {actual_kind}',
+            )
+
+    def _is_reviewed_dynamic_property(self, class_name: str, property_name: str) -> bool:
+        for lineage_class in self._metadata_class_lineage(class_name):
+            prefixes = REVIEWED_DYNAMIC_PROPERTY_PREFIXES.get(lineage_class, ())
+            if any(property_name.startswith(prefix) for prefix in prefixes):
+                return True
+        return False
+
+    def _metadata_class_lineage(self, class_name: str) -> tuple[str, ...]:
+        lineage: list[str] = []
+        seen: set[str] = set()
+        current: str | None = class_name
+        while current and current not in seen:
+            lineage.append(current)
+            seen.add(current)
+            current = self.metadata_class_bases.get(current)
+        return tuple(lineage)
 
     def _validate_top_level_ref_cycles(self, context: MapContext, visible: dict[str, ConfigEntry]) -> None:
         for entry in list(context.config_entries.values()) + list(self.global_entries.values()):
@@ -1716,6 +1761,46 @@ def tile_types_by_id(map_data: Any) -> dict[int, str]:
         if isinstance(tile_config, dict) and isinstance(tile_config.get("type"), str):
             tile_types[tile_id] = tile_config["type"]
     return tile_types
+
+
+def expected_json_property_kind(type_token: str) -> str | None:
+    if type_token == "bool":
+        return "bool"
+    if type_token == "int":
+        return "int"
+    if type_token == "std::string":
+        return "string"
+    if type_token == "CTags" or re.match(r"^std::(?:set|list|vector)<", type_token):
+        return "array"
+    if type_token.startswith("std::shared_ptr<") or type_token in {
+        "CInteractionMap",
+        "CItemMap",
+        "CSlotMap",
+        "int_int_map",
+        "int_string_map",
+        "string_int_map",
+        "string_string_map",
+    }:
+        return "object"
+    return None
+
+
+def json_value_kind(value: Any) -> str:
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    if value is None:
+        return "null"
+    return type(value).__name__
 
 
 def normalize_cpp_type(raw: str) -> str:

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -566,6 +566,115 @@ class ContentValidatorTest(unittest.TestCase):
             'unknown property "bogus" for class "CPropertyDerived"',
         )
 
+    def test_cpp_property_schema_reports_scalar_type_mismatches(self):
+        root = self.make_fixture()
+        self.write_property_schema_fixture(root)
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["schemaWrongScalars"] = {
+            "class": "CPropertyDerived",
+            "properties": {
+                "active": 1,
+                "count": "2",
+                "name": False,
+            },
+        }
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "schemaWrongScalars.properties.active",
+            'property "active" for class "CPropertyDerived" expected bool; got int',
+        )
+        self.assertIssueContains(
+            issues,
+            "schemaWrongScalars.properties.count",
+            'property "count" for class "CPropertyDerived" expected int; got string',
+        )
+        self.assertIssueContains(
+            issues,
+            "schemaWrongScalars.properties.name",
+            'property "name" for class "CPropertyDerived" expected string; got bool',
+        )
+
+    def test_cpp_property_schema_reports_scalar_container_shape_mismatches(self):
+        root = self.make_fixture()
+        self.write_property_schema_fixture(root)
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["schemaWrongShapes"] = {
+            "class": "CPropertyDerived",
+            "properties": {
+                "count": [2],
+                "name": {"ref": "LifePotion"},
+            },
+        }
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "schemaWrongShapes.properties.count",
+            'property "count" for class "CPropertyDerived" expected int; got array',
+        )
+        self.assertIssueContains(
+            issues,
+            "schemaWrongShapes.properties.name",
+            'property "name" for class "CPropertyDerived" expected string; got object',
+        )
+
+    def test_cpp_property_schema_reports_array_and_object_shape_mismatches(self):
+        root = self.make_fixture()
+        self.write_property_schema_fixture(root)
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["schemaWrongContainers"] = {
+            "class": "CPropertyDerived",
+            "properties": {
+                "loot": {"ref": "LifePotion"},
+                "target": "LifePotion",
+            },
+        }
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "schemaWrongContainers.properties.loot",
+            'property "loot" for class "CPropertyDerived" expected array; got object',
+        )
+        self.assertIssueContains(
+            issues,
+            "schemaWrongContainers.properties.target",
+            'property "target" for class "CPropertyDerived" expected object; got string',
+        )
+
+    def test_cpp_property_schema_accepts_reviewed_dynamic_property_namespace(self):
+        root = self.make_fixture()
+        self.write_property_schema_fixture(root)
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["schemaDynamic"] = {
+            "class": "CPropertyDerived",
+            "properties": {
+                "campaign_gate_open": True,
+                "plugin_checkpoint": {"state": "armed"},
+                "quest_state_main": "done",
+            },
+        }
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
     def test_cpp_property_schema_resolves_ref_override_class(self):
         root = self.make_fixture()
         self.write_property_schema_fixture(root)
@@ -811,7 +920,9 @@ class ContentValidatorTest(unittest.TestCase):
 
                 class CPropertyDerived {
                     V_META(CPropertyDerived, CPropertyBase,
-                        V_PROPERTY(CPropertyDerived, int, count, getCount, setCount))
+                        V_PROPERTY(CPropertyDerived, int, count, getCount, setCount),
+                        V_PROPERTY(CPropertyDerived, bool, active, getActive, setActive),
+                        V_PROPERTY(CPropertyDerived, std::shared_ptr<CGameObject>, target, getTarget, setTarget))
                 };
             """).lstrip(),
             encoding="utf-8",


### PR DESCRIPTION
## What Changed
- Added metadata-backed validation for JSON `properties` value kinds so configured C++ properties now reject scalar/container shape mismatches.
- Allowed reviewed dynamic `CGameObject` property namespaces for campaign/plugin/quest-state metadata.
- Normalized existing `CLayout` dimension/coordinate config values to strings to match the registered C++ metadata type.
- Added focused content-validator regression tests for scalar mismatches, container/object mismatches, and reviewed dynamic property namespaces.

## Why
The queue item requires validating JSON property names and scalar types using the C++ metadata schema. Unknown-property checks already existed, but incorrect value shapes could pass until runtime.

## Validation
- `python3 scripts/validate_content.py`
- `python3 -m unittest tests.test_content_validator`
- `python3 -m black --check -l 120 scripts/validate_content.py tests/test_content_validator.py`
- `python3 -m json.tool res/config/graphics.json >/dev/null`
- `python3 -m json.tool res/config/panels.json >/dev/null`
- `git diff --check`
- `git diff --exit-code -- planning/fall_of_nouraajd_issue_proposals.xlsx`

Heavy Linux build/test evidence will come from GitHub Actions polling for the `linux` check.

## Known Limitations
- The validator intentionally checks only metadata types that have a clear JSON shape mapping; unknown or custom scalar aliases remain unchecked until a safe mapping is added.
