### PR TITLE
Reject mixed ledger observation PRs

### DIFF
--- a/scripts/workflow_observations.py
+++ b/scripts/workflow_observations.py
@@ -498,7 +498,7 @@ def validatePrChanges(root: Path, baseRef: str) -> list[str]:
 
     rootPath = gitPathForRoot(root)
     result = subprocess.run(
-        ["git", "diff", "--name-status", "--no-renames", baseRef, "--", rootPath],
+        ["git", "diff", "--name-status", "--no-renames", baseRef],
         check=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -510,6 +510,8 @@ def validatePrChanges(root: Path, baseRef: str) -> list[str]:
 
     errors: list[str] = []
     rootParts = tuple(PurePosixPath(rootPath).parts)
+    ledgerChanges: list[tuple[str, str]] = []
+    nonLedgerChanges: list[str] = []
     for line in result.stdout.splitlines():
         columns = line.split("\t")
         if len(columns) < 2:
@@ -520,8 +522,19 @@ def validatePrChanges(root: Path, baseRef: str) -> list[str]:
         path = PurePosixPath(changedPath)
         parts = path.parts
         if rootParts and parts[: len(rootParts)] != rootParts:
-            errors.append(f"{changedPath}: changed path is outside ledger root {rootPath}")
+            nonLedgerChanges.append(changedPath)
             continue
+        ledgerChanges.append((status, changedPath))
+
+    if not ledgerChanges:
+        return errors
+
+    for changedPath in nonLedgerChanges:
+        errors.append(f"{changedPath}: ledger PR changes must not be mixed with non-ledger changes")
+
+    for status, changedPath in ledgerChanges:
+        path = PurePosixPath(changedPath)
+        parts = path.parts
         relativeParts = parts[len(rootParts) :]
         if len(relativeParts) != 2 or relativeParts[0] not in LEDGER_FILE_DIRS:
             errors.append(
@@ -812,7 +825,10 @@ def parseArgs(argv: Sequence[str]) -> argparse.Namespace:
 
     validate = subparsers.add_parser("validate", help="validate the ledger")
     addCommonRoot(validate)
-    validate.add_argument("--base", help="reject PR diffs that modify or delete existing ledger files")
+    validate.add_argument(
+        "--base",
+        help="reject PR diffs that mix ledger and non-ledger changes or modify/delete existing ledger files",
+    )
 
     listCommand = subparsers.add_parser("list", help="list observations")
     addCommonRoot(listCommand)

--- a/tests/test_workflow_observations.py
+++ b/tests/test_workflow_observations.py
@@ -611,6 +611,7 @@ class WorkflowObservationsTest(unittest.TestCase):
                 os.chdir(repo)
                 added = self.observation_payload("20260620T150200Z-ctrl-test-33333333")
                 self.write_record(Path("planning/workflow_observations"), added)
+                self.run_git(repo, ["add", f"planning/workflow_observations/records/{added['id']}.json"])
                 exitCode, stdout, stderr = self.run_cli(
                     ["validate", "--root", "planning/workflow_observations", "--base", "HEAD"]
                 )
@@ -639,6 +640,72 @@ class WorkflowObservationsTest(unittest.TestCase):
         errors = "\n".join(json.loads(stdout)["errors"])
         self.assertIn("may only be added", errors)
         self.assertIn("ledger PR changes must be JSON files", errors)
+
+    def test_validate_base_rejects_mixed_ledger_and_non_ledger_pr_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir) / "repo"
+            repo.mkdir()
+            self.run_git(repo, ["init"])
+            self.run_git(repo, ["config", "user.email", "test@example.invalid"])
+            self.run_git(repo, ["config", "user.name", "Workflow Test"])
+            (repo / "scripts").mkdir()
+            (repo / "scripts" / "placeholder.py").write_text("print('base')\n", encoding="utf-8")
+            self.run_git(repo, ["add", "scripts/placeholder.py"])
+            self.run_git(repo, ["commit", "-m", "base non-ledger file"])
+
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(repo)
+                added = self.observation_payload("20260620T150200Z-ctrl-test-33333333")
+                self.write_record(Path("planning/workflow_observations"), added)
+                Path("scripts/placeholder.py").write_text("print('changed')\n", encoding="utf-8")
+                self.run_git(
+                    repo,
+                    [
+                        "add",
+                        f"planning/workflow_observations/records/{added['id']}.json",
+                        "scripts/placeholder.py",
+                    ],
+                )
+
+                exitCode, stdout, stderr = self.run_cli(
+                    ["validate", "--root", "planning/workflow_observations", "--base", "HEAD"]
+                )
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(1, exitCode)
+        self.assertEqual("", stderr)
+        self.assertIn(
+            "scripts/placeholder.py: ledger PR changes must not be mixed with non-ledger changes",
+            "\n".join(json.loads(stdout)["errors"]),
+        )
+
+    def test_validate_base_allows_non_ledger_pr_without_ledger_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir) / "repo"
+            repo.mkdir()
+            self.run_git(repo, ["init"])
+            self.run_git(repo, ["config", "user.email", "test@example.invalid"])
+            self.run_git(repo, ["config", "user.name", "Workflow Test"])
+            (repo / "scripts").mkdir()
+            (repo / "scripts" / "placeholder.py").write_text("print('base')\n", encoding="utf-8")
+            self.run_git(repo, ["add", "scripts/placeholder.py"])
+            self.run_git(repo, ["commit", "-m", "base non-ledger file"])
+
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(repo)
+                Path("scripts/placeholder.py").write_text("print('changed')\n", encoding="utf-8")
+
+                exitCode, stdout, stderr = self.run_cli(
+                    ["validate", "--root", "planning/workflow_observations", "--base", "HEAD"]
+                )
+            finally:
+                os.chdir(old_cwd)
+
+        self.assertEqual(0, exitCode, stderr)
+        self.assertEqual([], json.loads(stdout)["errors"])
 
     def test_workflow_ledger_operations_preserve_xlsx_bytes_and_queue_compatibility(self) -> None:
         workbook = REPO_ROOT / issue_queue.DEFAULT_WORKBOOK


### PR DESCRIPTION
## What Changed
- Updated `scripts/workflow_observations.py validate --base` to inspect the full PR diff instead of only paths under `planning/workflow_observations`.
- If a PR includes ledger record/receipt changes, validation now rejects any non-ledger changed path in the same PR.
- Non-ledger PRs without ledger changes still pass the ledger `--base` validation path, preserving the current CI behavior where this validator runs on every PR.
- Added temp-git regressions for mixed ledger/code PR rejection and non-ledger-only pass-through.

## Why
The workflow observation policy requires observation-only and resolution-only PRs. The previous `--base` implementation scoped `git diff` to the ledger root, so a PR could add a ledger record and edit code/docs in the same branch without the ledger validator seeing the non-ledger changes.

## Validation
- `python3 -m py_compile scripts/workflow_observations.py`
- `python3 -m unittest tests.test_workflow_observations`
- `python3 -m black --check -l 120 scripts/workflow_observations.py tests/test_workflow_observations.py`
- `python3 scripts/workflow_observations.py validate`
- `python3 scripts/workflow_observations.py validate --base origin/main`
- `python3 scripts/issue_queue.py validate`
- `python3 -m unittest tests.test_issue_queue tests.test_prompt_inventory tests.test_controller_resource_audit tests.test_pr_review_audit`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`
- `python3 scripts/issue_queue.py reclaim-stale --dry-run`
- `git diff --check`

## Known Limitations
- This only enforces mixed-PR scope when ledger files are present. Ordinary non-ledger PRs remain unaffected.
- This does not change the observation ledger schema or publication workflow.
