### PR TITLE
Audit branch protection policy drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,8 @@ checkpoint cleanup. Treat unreadable Git state, unresolved `HEAD` or `origin/mai
 zero-byte Git ref files, low free disk, high filesystem usage, large accumulated run/worktrees, or prunable worktree
 metadata as blockers to new work until reported or cleaned safely. Remove only completed clean worktrees, use
 `git worktree prune` only for prunable metadata after review, and do not delete branches unless explicitly asked.
+For merge-policy or cleanup-readiness audits, add `--github-repo lisu188/fall-of-nouraajd` to include live branch
+protection and required-check drift in the report.
 
 ## Project overview
 

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -287,6 +287,12 @@ errors such as unreadable Git state, unresolved `HEAD` or `origin/main`, zero-by
 files, or disk pressure as blockers to new heavy work, and treat warnings about prunable worktree metadata or large
 accumulated run/worktrees as cleanup prompts before refilling worker slots.
 
+When auditing merge-policy drift or cleanup readiness, include the live GitHub branch-protection check:
+
+```bash
+python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes --github-repo lisu188/fall-of-nouraajd
+```
+
 ## Subagent progress protocol
 
 A worker should report meaningful milestones to the controller after source inspection, root-cause analysis,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -165,6 +165,12 @@ Manual repository settings for `main`:
 - require branches to be up to date before merging
 - select the `linux`, `windows-deps`, and `windows` checks from the `build` workflow
 
+Audit the live repository settings before merge-policy or cleanup decisions with:
+
+```bash
+python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes --github-repo lisu188/fall-of-nouraajd
+```
+
 Do not use `Release / build` as a required PR check; `.github/workflows/release.yml` runs only for version tags.
 If future work splits fast, gameplay, UI/Xvfb, or coverage runs into separate PR jobs, add those jobs to branch
 protection only after they finish deterministically in CI.

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -676,7 +676,8 @@ After every controller loop, PR status poll, and merged checkpoint, run the read
 python3 scripts/controller_resource_audit.py --json
 ```
 
-Use the audit to report free disk, accumulated run/worktrees, and prunable worktree metadata. If disk pressure is high
+Use the audit to report free disk, accumulated run/worktrees, and prunable worktree metadata. Add
+`--github-repo lisu188/fall-of-nouraajd` when auditing branch-protection or merge-policy drift. If disk pressure is high
 or many stale worktree registrations exist, stop refilling worker slots until cleanup is reviewed and completed safely.
 
 After both implementation and terminal-status PRs merge:

--- a/prompts/codex-workflow-optimizer.md
+++ b/prompts/codex-workflow-optimizer.md
@@ -169,6 +169,7 @@ Repeat the following cycle:
    - Note current resource pressure before expensive local commands.
    - Run `python3 scripts/controller_resource_audit.py --json` before dispatch/refill decisions, before heavy
      validation, after each controller loop, and after merged-checkpoint cleanup.
+   - Add `--github-repo lisu188/fall-of-nouraajd` when auditing branch-protection or merge-policy drift.
    - Treat low free disk, high filesystem usage, large accumulated run/worktrees, or prunable worktree registrations as
      blockers to new heavy work until safely reported or cleaned.
    - Prefer GitHub Actions polling as the default path for heavy Linux compilation, native tests, full Python suites,

--- a/scripts/controller_resource_audit.py
+++ b/scripts/controller_resource_audit.py
@@ -17,6 +17,8 @@ from typing import Any, Sequence
 DEFAULT_RUN_TREE_PATTERNS = ("nouraajd-*", "fall-of-nouraajd-codex")
 DEFAULT_MIN_FREE_GIB = 5.0
 DEFAULT_MAX_USED_PERCENT = 95.0
+DEFAULT_PROTECTED_BRANCH = "main"
+DEFAULT_REQUIRED_STATUS_CHECKS = ("linux", "windows-deps", "windows")
 
 
 @dataclass(frozen=True)
@@ -58,6 +60,17 @@ class GitHealthReport:
     gitCommonDir: str | None
     emptyLooseObjects: tuple[str, ...]
     emptyRefs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BranchProtectionReport:
+    repo: str
+    branch: str
+    protected: bool | None
+    requiredChecks: tuple[str, ...]
+    expectedChecks: tuple[str, ...]
+    missingRequiredChecks: tuple[str, ...]
+    error: str | None = None
 
 
 def bytesToGib(value: int) -> float:
@@ -272,6 +285,132 @@ def evaluateGitHealth(report: GitHealthReport) -> tuple[list[str], list[str]]:
     return errors, warnings
 
 
+def runGhApiJson(path: str) -> dict[str, Any]:
+    result = subprocess.run(
+        ["gh", "api", path],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "gh api failed"
+        raise RuntimeError(detail)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh api {path} returned invalid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"gh api {path} returned unexpected JSON")
+    return payload
+
+
+def requiredChecksFromProtectionPayload(payload: dict[str, Any] | None) -> tuple[str, ...]:
+    if not isinstance(payload, dict):
+        return ()
+    statusChecks = payload.get("required_status_checks")
+    if not isinstance(statusChecks, dict):
+        return ()
+
+    checks: list[str] = []
+    contexts = statusChecks.get("contexts")
+    if isinstance(contexts, list):
+        checks.extend(str(item) for item in contexts if item)
+
+    richChecks = statusChecks.get("checks")
+    if isinstance(richChecks, list):
+        for item in richChecks:
+            if isinstance(item, dict) and item.get("context"):
+                checks.append(str(item["context"]))
+    return tuple(sorted(dict.fromkeys(checks)))
+
+
+def branchProtectionReportFromPayloads(
+    repo: str,
+    branch: str,
+    expectedChecks: Sequence[str],
+    branchPayload: dict[str, Any],
+    protectionPayload: dict[str, Any] | None,
+) -> BranchProtectionReport:
+    protected = bool(branchPayload.get("protected"))
+    requiredChecks = requiredChecksFromProtectionPayload(protectionPayload) if protected else ()
+    missingChecks = tuple(check for check in expectedChecks if check not in requiredChecks)
+    return BranchProtectionReport(
+        repo=repo,
+        branch=branch,
+        protected=protected,
+        requiredChecks=requiredChecks,
+        expectedChecks=tuple(expectedChecks),
+        missingRequiredChecks=missingChecks,
+    )
+
+
+def auditBranchProtection(repo: str, branch: str, expectedChecks: Sequence[str]) -> BranchProtectionReport:
+    try:
+        branchPayload = runGhApiJson(f"repos/{repo}/branches/{branch}")
+    except RuntimeError as exc:
+        return BranchProtectionReport(
+            repo=repo,
+            branch=branch,
+            protected=None,
+            requiredChecks=(),
+            expectedChecks=tuple(expectedChecks),
+            missingRequiredChecks=tuple(expectedChecks),
+            error=str(exc),
+        )
+
+    protectionPayload: dict[str, Any] | None = None
+    if branchPayload.get("protected"):
+        try:
+            protectionPayload = runGhApiJson(f"repos/{repo}/branches/{branch}/protection")
+        except RuntimeError as exc:
+            return BranchProtectionReport(
+                repo=repo,
+                branch=branch,
+                protected=True,
+                requiredChecks=(),
+                expectedChecks=tuple(expectedChecks),
+                missingRequiredChecks=tuple(expectedChecks),
+                error=str(exc),
+            )
+    return branchProtectionReportFromPayloads(repo, branch, expectedChecks, branchPayload, protectionPayload)
+
+
+def evaluateBranchProtection(report: BranchProtectionReport | None) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    if report is None:
+        return errors, warnings
+    if report.error:
+        warnings.append(f"{report.repo}:{report.branch}: branch protection could not be inspected: {report.error}")
+        return errors, warnings
+    if report.protected is False:
+        warnings.append(
+            f"{report.repo}:{report.branch}: branch is not protected; expected required checks "
+            f"{', '.join(report.expectedChecks)}"
+        )
+    elif report.missingRequiredChecks:
+        warnings.append(
+            f"{report.repo}:{report.branch}: branch protection missing required check(s): "
+            f"{', '.join(report.missingRequiredChecks)}"
+        )
+    return errors, warnings
+
+
+def branchProtectionPayload(report: BranchProtectionReport | None) -> dict[str, Any] | None:
+    if report is None:
+        return None
+    return {
+        "repo": report.repo,
+        "branch": report.branch,
+        "protected": report.protected,
+        "requiredChecks": list(report.requiredChecks),
+        "expectedChecks": list(report.expectedChecks),
+        "missingRequiredChecks": list(report.missingRequiredChecks),
+        "error": report.error,
+    }
+
+
 def directorySize(path: Path) -> int:
     total = 0
     for root, dirs, files in os.walk(path, topdown=True):
@@ -320,6 +459,7 @@ def payload(
     diskReports: Sequence[DiskReport],
     worktrees: Sequence[WorktreeRecord],
     runTrees: Sequence[RunTreeRecord],
+    branchProtection: BranchProtectionReport | None,
     errors: Sequence[str],
     warnings: Sequence[str],
 ) -> dict[str, Any]:
@@ -361,6 +501,7 @@ def payload(
                 for record in runTrees
             ],
         },
+        "branchProtection": branchProtectionPayload(branchProtection),
         "errors": list(errors),
         "warnings": list(warnings),
     }
@@ -382,6 +523,14 @@ def printHuman(report: dict[str, Any]) -> None:
     print(f"Worktrees: {worktrees['active']} active, " f"{worktrees['prunable']} prunable, {worktrees['total']} total")
     runTrees = report["runTrees"]
     print(f"Run trees: {runTrees['total']} matching, " f"{formatBytes(runTrees['totalBytes'])} total")
+    branchProtection = report.get("branchProtection")
+    if branchProtection:
+        protected = branchProtection["protected"]
+        protectedText = "unknown" if protected is None else str(protected).lower()
+        print(
+            f"Branch protection: {branchProtection['repo']}:{branchProtection['branch']} "
+            f"protected={protectedText}, missing checks={branchProtection['missingRequiredChecks']}"
+        )
     for warning in report["warnings"]:
         print(f"WARNING: {warning}")
     for error in report["errors"]:
@@ -420,6 +569,24 @@ def buildParser() -> argparse.ArgumentParser:
         action="store_true",
         help="List matching run/worktrees without recursively sizing them.",
     )
+    parser.add_argument(
+        "--github-repo",
+        help="Optional OWNER/REPO repository whose branch protection should be audited with gh api.",
+    )
+    parser.add_argument(
+        "--protected-branch",
+        default=DEFAULT_PROTECTED_BRANCH,
+        help=f"Branch to inspect with --github-repo. Defaults to {DEFAULT_PROTECTED_BRANCH}.",
+    )
+    parser.add_argument(
+        "--required-status-check",
+        action="append",
+        default=None,
+        help=(
+            "Expected required status check for --github-repo. May be repeated. Defaults to "
+            f"{', '.join(DEFAULT_REQUIRED_STATUS_CHECKS)}."
+        ),
+    )
     return parser
 
 
@@ -440,15 +607,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"controller_resource_audit: {exc}", file=sys.stderr)
         return 2
 
+    branchProtection = None
+    if args.github_repo:
+        expectedChecks = tuple(args.required_status_check or DEFAULT_REQUIRED_STATUS_CHECKS)
+        branchProtection = auditBranchProtection(args.github_repo, args.protected_branch, expectedChecks)
+
     minFreeBytes = int(args.min_free_gib * 1024 * 1024 * 1024)
     errors, warnings = evaluateDiskReports(diskReports, minFreeBytes, args.max_used_percent)
     gitErrors, gitWarnings = evaluateGitHealth(gitHealth)
     errors.extend(gitErrors)
     warnings.extend(gitWarnings)
+    branchErrors, branchWarnings = evaluateBranchProtection(branchProtection)
+    errors.extend(branchErrors)
+    warnings.extend(branchWarnings)
     summary = worktreeSummary(worktrees)
     if summary["prunable"]:
         warnings.append(f"{summary['prunable']} prunable worktree registration(s); review and run git worktree prune")
-    report = payload(repoRoot, gitHealth, diskReports, worktrees, runTrees, errors, warnings)
+    report = payload(repoRoot, gitHealth, diskReports, worktrees, runTrees, branchProtection, errors, warnings)
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:

--- a/tests/test_controller_resource_audit.py
+++ b/tests/test_controller_resource_audit.py
@@ -145,6 +145,105 @@ detached
         self.assertIn("1 zero-byte loose git object(s) found", errors)
         self.assertIn("1 zero-byte git ref file(s) found", errors)
 
+    def test_required_checks_support_contexts_and_rich_check_payloads(self) -> None:
+        checks = controller_resource_audit.requiredChecksFromProtectionPayload(
+            {
+                "required_status_checks": {
+                    "contexts": ["linux", "windows-deps"],
+                    "checks": [{"context": "windows"}, {"context": "linux"}],
+                }
+            }
+        )
+
+        self.assertEqual(("linux", "windows", "windows-deps"), checks)
+
+    def test_branch_protection_report_flags_unprotected_branch(self) -> None:
+        report = controller_resource_audit.branchProtectionReportFromPayloads(
+            "owner/repo",
+            "main",
+            ("linux", "windows-deps", "windows"),
+            {"protected": False},
+            None,
+        )
+
+        errors, warnings = controller_resource_audit.evaluateBranchProtection(report)
+
+        self.assertEqual([], errors)
+        self.assertEqual(("linux", "windows-deps", "windows"), report.missingRequiredChecks)
+        self.assertTrue(any("branch is not protected" in warning for warning in warnings), warnings)
+
+    def test_branch_protection_report_flags_missing_required_checks(self) -> None:
+        report = controller_resource_audit.branchProtectionReportFromPayloads(
+            "owner/repo",
+            "main",
+            ("linux", "windows-deps", "windows"),
+            {"protected": True},
+            {"required_status_checks": {"contexts": ["linux"], "checks": [{"context": "windows"}]}},
+        )
+
+        errors, warnings = controller_resource_audit.evaluateBranchProtection(report)
+
+        self.assertEqual([], errors)
+        self.assertEqual(("windows-deps",), report.missingRequiredChecks)
+        self.assertTrue(any("missing required check(s): windows-deps" in warning for warning in warnings), warnings)
+
+    def test_branch_protection_report_accepts_expected_checks(self) -> None:
+        report = controller_resource_audit.branchProtectionReportFromPayloads(
+            "owner/repo",
+            "main",
+            ("linux", "windows-deps", "windows"),
+            {"protected": True},
+            {
+                "required_status_checks": {
+                    "checks": [
+                        {"context": "linux"},
+                        {"context": "windows-deps"},
+                        {"context": "windows"},
+                    ]
+                }
+            },
+        )
+
+        errors, warnings = controller_resource_audit.evaluateBranchProtection(report)
+
+        self.assertEqual([], errors)
+        self.assertEqual([], warnings)
+        self.assertEqual((), report.missingRequiredChecks)
+
+    def test_payload_includes_optional_branch_protection_report(self) -> None:
+        git = controller_resource_audit.GitHealthReport(
+            statusExitCode=0,
+            statusStdout="",
+            statusStderr="",
+            head="abc123",
+            originMain="abc123",
+            gitCommonDir="/repo/.git",
+            emptyLooseObjects=(),
+            emptyRefs=(),
+        )
+        branch = controller_resource_audit.BranchProtectionReport(
+            repo="owner/repo",
+            branch="main",
+            protected=False,
+            requiredChecks=(),
+            expectedChecks=("linux",),
+            missingRequiredChecks=("linux",),
+        )
+
+        payload = controller_resource_audit.payload(
+            Path("/repo"),
+            git,
+            [],
+            [],
+            [],
+            branch,
+            [],
+            ["owner/repo:main: branch is not protected"],
+        )
+
+        self.assertEqual(False, payload["branchProtection"]["protected"])
+        self.assertEqual(["linux"], payload["branchProtection"]["missingRequiredChecks"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What Changed
- Added an optional branch-protection section to `scripts/controller_resource_audit.py` behind `--github-repo OWNER/REPO`.
- Reports whether the configured branch is protected, which status checks are required, and which expected checks are missing.
- Keeps the check read-only and warning-only so ordinary local resource audits remain unaffected.
- Documented the optional audit in `AGENTS.md`, queue docs, testing docs, and controller/optimizer prompts.
- Added focused unit tests for unprotected branches, missing required checks, rich GitHub branch-protection payloads, and JSON payload serialization.

## Why
Live repository state can drift from documented merge policy. Current source says `main` should require PR/status-check protection, but `gh api repos/lisu188/fall-of-nouraajd/branches/main` reports `protected:false`, and the branch-protection endpoint returns 404. Controllers had no standard read-only audit output for this before merge or cleanup decisions.

## Validation
- `python3 -m py_compile scripts/controller_resource_audit.py`
- `python3 -m unittest tests.test_controller_resource_audit tests.test_prompt_inventory`
- `python3 -m black --check -l 120 scripts/controller_resource_audit.py tests/test_controller_resource_audit.py`
- `python3 scripts/issue_queue.py validate`
- `python3 scripts/workflow_observations.py validate`
- `python3 -m unittest tests.test_issue_queue tests.test_workflow_observations tests.test_pr_review_audit`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes --github-repo lisu188/fall-of-nouraajd`
- `python3 scripts/issue_queue.py reclaim-stale --dry-run`
- `git diff --check`

Live audit result: `branchProtection.protected` is `false`; missing expected checks are `linux`, `windows-deps`, and `windows`.

## Known Limitations
- This PR reports branch-protection drift; it does not change GitHub repository settings.
- The GitHub audit is opt-in and requires `gh` authentication/network access.
