### PR TITLE
Enable SDL window resizing

### DIFF
--- a/src/gui/CGui.cpp
+++ b/src/gui/CGui.cpp
@@ -31,6 +31,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 namespace {
 constexpr int DRAG_PROXY_FALLBACK_SIZE = 50;
 constexpr int DRAG_PROXY_PRIORITY = std::numeric_limits<int>::max();
+constexpr int GUI_MIN_WIDTH = 320;
+constexpr int GUI_MIN_HEIGHT = 240;
 
 std::shared_ptr<CLayout> createDragProxyLayout(const std::shared_ptr<CGui> &gui, const SDL_Point &current) {
     const int size = gui ? std::clamp(gui->getTileSize(), 1, 512) : DRAG_PROXY_FALLBACK_SIZE;
@@ -101,7 +103,8 @@ CGui::CGui() {
     SDL_SAFE(SDL_Init(SDL_INIT_VIDEO));
     SDL_Window *rawWindow = nullptr;
     SDL_Renderer *rawRenderer = nullptr;
-    SDL_SAFE(SDL_CreateWindowAndRenderer(width, height, 0, &rawWindow, &rawRenderer));
+    SDL_SAFE(SDL_CreateWindowAndRenderer(width, height, SDL_WINDOW_RESIZABLE, &rawWindow, &rawRenderer));
+    SDL_SetWindowMinimumSize(rawWindow, GUI_MIN_WIDTH, GUI_MIN_HEIGHT);
     window.reset(rawWindow);
     renderer.reset(rawRenderer);
     // TODO: set icon
@@ -130,7 +133,7 @@ std::shared_ptr<CTextManager> CGui::getTextManager() {
 int CGui::getWidth() { return width; }
 
 void CGui::setWidth(int width) {
-    const int clampedWidth = std::clamp(width, 320, 7680);
+    const int clampedWidth = std::clamp(width, GUI_MIN_WIDTH, 7680);
     const bool changed = CGui::width != clampedWidth;
     CGui::width = clampedWidth;
     if (auto layout = getLayout()) {
@@ -144,7 +147,7 @@ void CGui::setWidth(int width) {
 int CGui::getHeight() { return height; }
 
 void CGui::setHeight(int height) {
-    const int clampedHeight = std::clamp(height, 240, 4320);
+    const int clampedHeight = std::clamp(height, GUI_MIN_HEIGHT, 4320);
     const bool changed = CGui::height != clampedHeight;
     CGui::height = clampedHeight;
     if (auto layout = getLayout()) {

--- a/test.py
+++ b/test.py
@@ -140,6 +140,7 @@ FAST_TEST_NAMES = {
     "McpServerTest.test_serialize_result_lists_python_methods_for_handles",
     "McpServerTest.test_stdio_batch_handles_initialize_and_tool_listing",
     "PanelLayoutManifestTest.test_panel_layout_manifest_matches_panels_json",
+    "PanelLayoutManifestTest.test_gui_window_is_created_resizable_with_minimum_size",
 }
 GAMEPLAY_TEST_PREFIXES = (
     "ConsoleEventIsolationTest.",
@@ -874,6 +875,9 @@ SDL_KEYUP = 0x301
 SDL_QUIT = 0x100
 SDL_WINDOWEVENT = 0x200
 SDL_WINDOWEVENT_SIZE_CHANGED = 0x06
+SDL_WINDOW_RESIZABLE = 0x20
+SDL_WINDOW_MIN_WIDTH = 320
+SDL_WINDOW_MIN_HEIGHT = 240
 SDL_INIT_EVENTS = 0x00004000
 SDL_MOUSEMOTION = 0x400
 SDL_MOUSEBUTTONDOWN = 0x401
@@ -1184,6 +1188,32 @@ def focused_sdl_window():
     sdl.SDL_GetKeyboardFocus.restype = ctypes.c_void_p
     sdl.SDL_GetMouseFocus.restype = ctypes.c_void_p
     return sdl.SDL_GetKeyboardFocus() or sdl.SDL_GetMouseFocus()
+
+
+def assert_focused_sdl_window_resizable(test_case):
+    import ctypes
+
+    sdl = load_sdl_library()
+    focused_window = focused_sdl_window()
+    if not focused_window:
+        raise AssertionError("Expected a focused SDL window for resize flag inspection.")
+
+    sdl.SDL_GetWindowFlags.argtypes = [ctypes.c_void_p]
+    sdl.SDL_GetWindowFlags.restype = ctypes.c_uint32
+    flags = sdl.SDL_GetWindowFlags(focused_window)
+    test_case.assertTrue(
+        flags & SDL_WINDOW_RESIZABLE,
+        f"SDL window flags should include SDL_WINDOW_RESIZABLE, got 0x{flags:x}.",
+    )
+    min_width = ctypes.c_int()
+    min_height = ctypes.c_int()
+    sdl.SDL_GetWindowMinimumSize.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.POINTER(ctypes.c_int),
+    ]
+    sdl.SDL_GetWindowMinimumSize(focused_window, ctypes.byref(min_width), ctypes.byref(min_height))
+    test_case.assertEqual((SDL_WINDOW_MIN_WIDTH, SDL_WINDOW_MIN_HEIGHT), (min_width.value, min_height.value))
 
 
 def push_sdl_key_event(keycode, scancode, event_type=SDL_KEYDOWN):
@@ -13777,6 +13807,17 @@ def make_unique_scroll_items(g, count, prefix):
 
 
 class PanelLayoutManifestTest(unittest.TestCase):
+    def test_gui_window_is_created_resizable_with_minimum_size(self):
+        gui_source = (REPO_ROOT / "src" / "gui" / "CGui.cpp").read_text(encoding="utf-8")
+        self.assertRegex(
+            gui_source,
+            r"SDL_CreateWindowAndRenderer\s*\(\s*width\s*,\s*height\s*,\s*SDL_WINDOW_RESIZABLE\s*,",
+        )
+        self.assertRegex(
+            gui_source,
+            r"SDL_SetWindowMinimumSize\s*\(\s*rawWindow\s*,\s*GUI_MIN_WIDTH\s*,\s*GUI_MIN_HEIGHT\s*\)",
+        )
+
     def test_panel_layout_manifest_matches_panels_json(self):
         panel_defs = json.loads((REPO_ROOT / "res" / "config" / "panels.json").read_text())
         self.assertEqual(set(panel_defs), set(PANEL_LAYOUT_CASES))
@@ -13829,6 +13870,7 @@ class XvfbGameplayProcessTest(unittest.TestCase):
         gui = g.getGui()
         map_graph = next(child for child in collect_gui_children(gui, "CMapGraphicsObject"))
 
+        assert_focused_sdl_window_resizable(self)
         width, height = push_sdl_window_size_changed_event(800, 600)
         tile_size = gui.getNumericProperty("tileSize")
         expected_proxy_count = (width // tile_size + 1) * (height // tile_size + 1)

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -296,6 +296,93 @@ std::shared_ptr<CLayout> fixed_layout(int x, int y, int w, int h) {
     return layout;
 }
 
+void test_gui_window_is_resizable_and_guard_paths_fail_closed() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    SDL_Window *window = SDL_RenderGetWindow(gui->getRenderer());
+    expect_true(window != nullptr, "GUI renderer should expose its SDL window");
+    if (window) {
+        const Uint32 flags = SDL_GetWindowFlags(window);
+        expect_true((flags & SDL_WINDOW_RESIZABLE) != 0, "GUI window should be created resizable");
+
+        int minimum_width = 0;
+        int minimum_height = 0;
+        SDL_GetWindowMinimumSize(window, &minimum_width, &minimum_height);
+        expect_true(minimum_width == 320 && minimum_height == 240,
+                    "GUI window should enforce the logical minimum size");
+    }
+
+    gui->setLayout(fixed_layout(0, 0, 1920, 1080));
+    gui->setWidth(100);
+    gui->setHeight(100);
+    expect_true(gui->getWidth() == 320 && gui->getHeight() == 240, "GUI logical size should clamp to the minimum");
+    gui->setWidth(9000);
+    gui->setHeight(5000);
+    expect_true(gui->getWidth() == 7680 && gui->getHeight() == 4320, "GUI logical size should clamp to the maximum");
+
+    expect_true(!gui->event(nullptr), "GUI should reject null SDL events");
+    expect_true(!gui->isPointerCapturedBy(nullptr), "GUI should reject null pointer capture probes");
+    expect_true(gui->getDragSession() == nullptr, "new GUI should not expose a drag session");
+    const std::shared_ptr<const CGui> const_gui = gui;
+    expect_true(const_gui->getDragSession() == nullptr, "const drag-session accessor should fail closed");
+
+    auto payload = std::make_shared<CGameObject>();
+    auto unattached_source = std::make_shared<MouseEventRecorder>();
+    gui->startDragSession(unattached_source, payload, 1, 10, 20);
+    expect_true(!gui->hasDragSession(), "unattached widgets should not start GUI drag sessions");
+
+    auto captured_source = attach_mouse_recorder(gui);
+    gui->capturePointer(captured_source);
+    expect_true(gui->isPointerCapturedBy(captured_source), "attached widgets should be eligible for pointer capture");
+    captured_source->setParent(nullptr);
+
+    SDL_Event captured_motion{};
+    captured_motion.type = SDL_MOUSEMOTION;
+    captured_motion.motion.x = 30;
+    captured_motion.motion.y = 40;
+    captured_motion.motion.xrel = 1;
+    captured_motion.motion.yrel = 1;
+    expect_true(!gui->event(&captured_motion), "detached pointer capture should be released without dispatch");
+    expect_true(!gui->hasPointerCapture(), "stale pointer capture should be cleared");
+    gui->removeChild(captured_source);
+
+    auto source = attach_mouse_recorder(gui);
+    auto target = attach_drop_target_recorder(gui);
+    gui->startDragSession(source, payload, 5, 20, 30);
+    expect_true(gui->hasDragSession(), "attached widgets should start GUI drag sessions");
+    expect_true(const_gui->getDragSession() != nullptr, "const drag-session accessor should expose active sessions");
+    gui->acceptDragSession(target);
+    gui->updateDragSession(80, 90);
+    gui->cancelDragSession();
+    expect_true(gui->getDragSession() && gui->getDragSession()->canceled, "canceling a drag session should mark it");
+    gui->clearDragSession();
+
+    gui->startDragSession(source, payload, 6, 20, 30);
+    SDL_Event release{};
+    release.type = SDL_MOUSEBUTTONUP;
+    release.button.button = SDL_BUTTON_LEFT;
+    release.button.x = 900;
+    release.button.y = 900;
+    gui->event(&release);
+    expect_true(!gui->hasDragSession(), "button release without an accepted target should clear the drag session");
+
+    if (window) {
+        const int previous_width = gui->getWidth();
+        const int previous_height = gui->getHeight();
+        SDL_Event wrong_window_resize{};
+        wrong_window_resize.type = SDL_WINDOWEVENT;
+        wrong_window_resize.window.event = SDL_WINDOWEVENT_SIZE_CHANGED;
+        wrong_window_resize.window.windowID = SDL_GetWindowID(window) + 1;
+        wrong_window_resize.window.data1 = 800;
+        wrong_window_resize.window.data2 = 600;
+        gui->event(&wrong_window_resize);
+        expect_true(gui->getWidth() == previous_width && gui->getHeight() == previous_height,
+                    "resize events for another SDL window should be ignored");
+    }
+}
+
 DragListHarness create_drag_list_harness() {
     SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
@@ -787,6 +874,7 @@ int main() {
     test_list_view_refresh_event_compatibility();
     test_list_view_property_subscriptions_follow_resolved_target_and_null();
     test_inventory_double_select_uses_selected_item_and_clears_selection();
+    test_gui_window_is_resizable_and_guard_paths_fail_closed();
     test_list_view_drag_callbacks_validate_and_drop_without_click_fallback();
     test_list_view_drag_callbacks_cancel_and_preserve_unmoved_clicks();
     test_list_view_legacy_click_callback_still_fires_without_drag_callbacks();


### PR DESCRIPTION
## Summary
- Create the SDL window with `SDL_WINDOW_RESIZABLE` so desktop/user-driven resize is enabled.
- Set the SDL minimum window size to the same 320x240 bounds used by `CGui` logical size clamps.
- Add a fast source-level regression for the constructor flag and minimum-size call.
- Extend the existing Xvfb resize regression to assert the live SDL window reports the resizable flag and minimum-size bounds before injecting a resize event.
- Add native GUI unit coverage for the resizable/minimum-size window contract and nearby `CGui` guard paths.

## Queue
- Issue: `[EPIC_05][STORY_02][SUBSTORY_01]Handle SDL window resize events`
- Claim ID: `33087ac6-5f6c-4556-9fc0-4130a890daef`
- Owner: `controller/ctrl-lis-2-36d0fa13/subagent-5`
- Follow-up for unresolved PR #696 review thread about missing `SDL_WINDOW_RESIZABLE`; also addresses PR #714 review feedback about SDL minimum size.

## Validation
- `clang-format -i src/gui/CGui.cpp`
- `clang-format -i tests/unit/test_gui.cpp`
- `black -l 120 test.py`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `python3 -m py_compile test.py`
- `python3 test.py --suite fast PanelLayoutManifestTest.test_gui_window_is_created_resizable_with_minimum_size PanelLayoutManifestTest.test_panel_layout_manifest_matches_panels_json`
- In progress: `python3 scripts/poll_pr_checks.py 714 --repo lisu188/fall-of-nouraajd --check linux-coverage --require-step coverage`

## Notes
- Local native builds, ctest, full Python suite, local coverage, Xvfb, and MCP were not run locally. Controller policy uses GitHub Actions for heavy build/UI/coverage evidence.
- This PR touches `src/gui/CGui.cpp`, `test.py`, and `tests/unit/test_gui.cpp`, so the controller requires the CI coverage step before enabling squash auto-merge.