### PR TITLE
Stop fight loop on player cancellation

### DIFF
--- a/src/handler/CFightHandler.cpp
+++ b/src/handler/CFightHandler.cpp
@@ -220,6 +220,13 @@ void clear_combat_status(const std::shared_ptr<CMap> &encounterMap) {
     }
 }
 
+void cancel_fight(CFightResult &result, const std::shared_ptr<CCreature> &survivor,
+                  const std::shared_ptr<CCreature> &opponent) {
+    result.outcome = CFightOutcome::Cancelled;
+    result.survivor = survivor;
+    result.opponent = opponent;
+}
+
 encounter_type sanitize_opponents(const std::shared_ptr<CMap> &encounterMap, const std::shared_ptr<CCreature> &attacker,
                                   const encounter_type &opponents) {
     if (!is_active_participant(encounterMap, attacker)) {
@@ -413,14 +420,37 @@ CFightResult resolve_fight_many(std::shared_ptr<CCreature> attacker, const encou
         CPlaytestTrace::record("combat_started", fields);
     }
 
+    auto finish_result = [&]() -> CFightResult {
+        controllerEndGuard.endAll();
+
+        if (result.outcome != CFightOutcome::Invalid) {
+            const bool include_initiative = result.outcome != CFightOutcome::AttackerDefeat;
+            update_combat_status(encounterMap, attacker, opponents,
+                                 final_status_message(result.outcome, attackerName, result.rounds), include_initiative);
+        }
+
+        if (CPlaytestTrace::enabled()) {
+            json fields = {
+                {"attacker", CPlaytestTrace::objectRef(attacker)},
+                {"opponents", CPlaytestTrace::objectRefs(allOpponents)},
+                {"outcome", static_cast<int>(result.outcome)},
+                {"outcomeName", final_status_message(result.outcome, attackerName, result.rounds)},
+                {"rounds", result.rounds},
+                {"survivor", CPlaytestTrace::objectRef(result.survivor)},
+            };
+            CPlaytestTrace::addMapContext(fields, encounterMap);
+            CPlaytestTrace::record("combat_finished", fields);
+        }
+
+        return result;
+    };
+
     int stale_turns = 0;
     for (int turn = 0; turn < 100 && stale_turns < 20 && result.outcome == CFightOutcome::Invalid &&
                        is_active_participant(encounterMap, attacker) && !opponents.empty();
          ++turn) {
         if (SDL_HasEvent(SDL_QUIT)) {
-            result.outcome = CFightOutcome::Cancelled;
-            result.survivor = attacker;
-            result.opponent = current;
+            cancel_fight(result, attacker, current);
             break;
         }
         result.rounds = turn + 1;
@@ -451,10 +481,8 @@ CFightResult resolve_fight_many(std::shared_ptr<CCreature> attacker, const encou
                 if (!CTags::isTagPresent(attacker->getEffects(), CTag::Stun)) {
                     attackerController->control(attacker, current);
                     if (attackerController->isCancelled(attacker, current)) {
-                        result.outcome = CFightOutcome::Cancelled;
-                        result.survivor = attacker;
-                        result.opponent = current;
-                        break;
+                        cancel_fight(result, attacker, current);
+                        return finish_result();
                     }
                     remove_dead_opponents(encounterMap, attacker, opponents, attacker);
                     if (!attacker->isAlive()) {
@@ -501,10 +529,8 @@ CFightResult resolve_fight_many(std::shared_ptr<CCreature> attacker, const encou
                 if (auto controller = actor->getFightController()) {
                     controller->control(actor, attacker);
                     if (controller->isCancelled(actor, attacker)) {
-                        result.outcome = CFightOutcome::Cancelled;
-                        result.survivor = attacker;
-                        result.opponent = actor;
-                        break;
+                        cancel_fight(result, attacker, actor);
+                        return finish_result();
                     }
                 }
                 if (!attacker->isAlive()) {
@@ -558,28 +584,7 @@ CFightResult resolve_fight_many(std::shared_ptr<CCreature> attacker, const encou
         }
     }
 
-    controllerEndGuard.endAll();
-
-    if (result.outcome != CFightOutcome::Invalid) {
-        const bool include_initiative = result.outcome != CFightOutcome::AttackerDefeat;
-        update_combat_status(encounterMap, attacker, opponents,
-                             final_status_message(result.outcome, attackerName, result.rounds), include_initiative);
-    }
-
-    if (CPlaytestTrace::enabled()) {
-        json fields = {
-            {"attacker", CPlaytestTrace::objectRef(attacker)},
-            {"opponents", CPlaytestTrace::objectRefs(allOpponents)},
-            {"outcome", static_cast<int>(result.outcome)},
-            {"outcomeName", final_status_message(result.outcome, attackerName, result.rounds)},
-            {"rounds", result.rounds},
-            {"survivor", CPlaytestTrace::objectRef(result.survivor)},
-        };
-        CPlaytestTrace::addMapContext(fields, encounterMap);
-        CPlaytestTrace::record("combat_finished", fields);
-    }
-
-    return result;
+    return finish_result();
 }
 
 } // namespace

--- a/tests/unit/test_handler.cpp
+++ b/tests/unit/test_handler.cpp
@@ -728,6 +728,57 @@ void test_player_fight_controller_returns_cancelled_when_attached_fight_panel_ca
     controller->end(player, defender);
 }
 
+void test_fight_handler_returns_cancelled_when_player_control_cancels() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto game = load_empty_game();
+    CGameLoader::loadGui(game);
+    auto player = add_test_player(game);
+    player->setHp(10);
+
+    auto action = std::make_shared<CInteraction>();
+    action->setGame(game);
+    action->setName("unitLoopPanelCancelAction");
+    action->setManaCost(0);
+    player->addAction(action);
+
+    auto defender = add_test_creature(game, "unitLoopPanelCancelDefender", 1, 0);
+    auto defender_controller = std::dynamic_pointer_cast<NoProgressFightController>(defender->getFightController());
+    auto gui = game->getGui();
+    expect_true(gui != nullptr, "handler-level panel cancellation regression requires a loaded GUI");
+    expect_true(std::dynamic_pointer_cast<CPlayerFightController>(player->getFightController()) != nullptr,
+                "handler-level panel cancellation should use the real player fight controller");
+
+    auto cancellation_callback_ran = std::make_shared<bool>(false);
+    auto panel_was_cancelled = std::make_shared<bool>(false);
+    vstd::event_loop<>::instance()->invoke([game, cancellation_callback_ran, panel_was_cancelled]() {
+        *cancellation_callback_ran = true;
+        auto panel = game && game->getGui() ? vstd::cast<CGameFightPanel>(game->getGui()->findChild("CGameFightPanel"))
+                                            : nullptr;
+        if (panel) {
+            panel->cancel();
+            *panel_was_cancelled = panel->isCancelled();
+        }
+    });
+
+    const auto result = CFightHandler::fightManyResult(player, {defender});
+
+    expect_true(*cancellation_callback_ran, "fight panel cancellation should run while player control is waiting");
+    expect_true(*panel_was_cancelled, "queued cancellation should cancel the active fight panel");
+    expect_true(result.outcome == CFightOutcome::Cancelled,
+                "player fight controller cancellation should return cancelled instead of falling through to stalled");
+    expect_true(result.rounds == 1, "player fight controller cancellation should report the active combat round");
+    expect_true(result.survivor == player && result.opponent == defender,
+                "player fight controller cancellation should keep participant metadata");
+    expect_true(gui && gui->findChild("CGameFightPanel") == nullptr,
+                "player fight controller cleanup should close the cancelled fight panel");
+    expect_controller_lifecycle(defender_controller, 1, 1,
+                                "opponent cleanup should still run after player control cancellation");
+    expect_true(game->getMap()->getStringProperty("combatStatus").find("cancelled") != std::string::npos,
+                "player control cancellation should publish the cancelled status text");
+}
+
 void test_fight_panel_resets_status_between_sequential_encounters() {
     auto game = load_empty_game();
     auto encounterMap = game->getMap();
@@ -978,6 +1029,7 @@ int main() {
     test_fight_handler_ends_original_started_controllers();
     test_fight_handler_reports_cancelled_closed_fight_panel();
     test_player_fight_controller_returns_cancelled_when_attached_fight_panel_cancels();
+    test_fight_handler_returns_cancelled_when_player_control_cancels();
     test_fight_panel_resets_status_between_sequential_encounters();
     test_fight_handler_counts_effect_duration_as_progress();
     test_playtest_trace_records_native_limits_and_quest_completion();


### PR DESCRIPTION
## What changed
- Added an immediate cancellation finish path in `resolve_fight_many()` after player or opponent fight-controller cancellation.
- Kept controller `end()` cleanup, final combat status, and playtest trace emission on the shared finish path.
- Added a native handler regression using the real `CPlayerFightController` and fight panel cancellation path.

## Why
Queue row 18 (`[EPIC_01][STORY_03][SUBSTORY_05]Stop fight loop on panel cancellation`) requires closing/quitting the fight panel during action selection to exit the fight loop in the same round instead of falling through stale-turn handling.

## Validation performed
- `git submodule update --init --recursive`
- `./configure.sh` attempted and blocked by sudo password requirement
- `GAME_CONFIGURE_SKIP_APT=1 GAME_CONFIGURE_SKIP_SUBMODULES=1 GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh`
- `clang-format -i src/handler/CFightHandler.cpp tests/unit/test_handler.cpp`
- `cmake --build cmake-build-release --target handler_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests.handler_unit_tests`
- `git diff --check origin/main...HEAD`

## Known limitations / follow-up
- Full Linux and coverage validation are left to GitHub Actions polling for this PR.
