### PR TITLE
Move slot configuration ownership to context

### DIFF
--- a/src/core/CGame.cpp
+++ b/src/core/CGame.cpp
@@ -61,8 +61,6 @@ std::shared_ptr<CGui> CGame::getGui() const { return _gui; }
 
 void CGame::setGui(std::shared_ptr<CGui> _gui) { CGame::_gui = _gui; }
 
-std::shared_ptr<CSlotConfig> CGame::getSlotConfiguration() {
-    return slotConfiguration.get([this]() { return createObject<CSlotConfig>("slotConfiguration"); });
-}
+std::shared_ptr<CSlotConfig> CGame::getSlotConfiguration() { return getContext()->getSlotConfiguration(); }
 
 std::shared_ptr<CRngHandler> CGame::getRngHandler() { return getContext()->getRngHandler(); }

--- a/src/core/CGame.h
+++ b/src/core/CGame.h
@@ -17,7 +17,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
 
-#include "CSlotConfig.h"
 #include "core/CConcepts.h"
 #include "core/CGlobal.h"
 #include "core/CPlugin.h"
@@ -43,6 +42,8 @@ class CRngHandler;
 class CGuiHandler;
 
 class CScriptHandler;
+
+class CSlotConfig;
 
 class CGame : public CGameObject {
     V_META(CGame, CGameObject, vstd::meta::empty())
@@ -82,8 +83,6 @@ class CGame : public CGameObject {
     std::shared_ptr<CSlotConfig> getSlotConfiguration();
 
   private:
-    vstd::lazy<CSlotConfig> slotConfiguration;
-
     std::shared_ptr<CGameContext> context;
     std::shared_ptr<CSceneManager> sceneManager;
     std::shared_ptr<CMap> map;

--- a/src/core/CGameContext.cpp
+++ b/src/core/CGameContext.cpp
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "core/CGameContext.h"
 #include "core/CGame.h"
+#include "core/CSlotConfig.h"
 #include "handler/CGuiHandler.h"
 #include "handler/CObjectHandler.h"
 #include "handler/CRngHandler.h"
@@ -62,6 +63,16 @@ std::shared_ptr<CRngHandler> CGameContext::getRngHandler() {
         rngHandler = std::make_shared<CRngHandler>(owner);
     }
     return rngHandler;
+}
+
+std::shared_ptr<CSlotConfig> CGameContext::getSlotConfiguration() {
+    return slotConfiguration.get([this]() {
+        auto owner = game.lock();
+        if (!owner) {
+            throw std::runtime_error("Cannot create CSlotConfig without an active CGame.");
+        }
+        return owner->createObject<CSlotConfig>("slotConfiguration");
+    });
 }
 
 CGameContext::TransitionGeneration CGameContext::getTransitionGeneration() const {

--- a/src/core/CGameContext.h
+++ b/src/core/CGameContext.h
@@ -21,11 +21,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <cstdint>
 #include <memory>
 
+#include "core/CGlobal.h"
+
 class CGame;
 class CGuiHandler;
 class CObjectHandler;
 class CRngHandler;
 class CScriptHandler;
+class CSlotConfig;
 
 class CGameContext {
   public:
@@ -41,6 +44,8 @@ class CGameContext {
 
     std::shared_ptr<CRngHandler> getRngHandler();
 
+    std::shared_ptr<CSlotConfig> getSlotConfiguration();
+
     TransitionGeneration getTransitionGeneration() const;
 
     TransitionGeneration captureTransitionGeneration() const;
@@ -55,5 +60,6 @@ class CGameContext {
     std::shared_ptr<CObjectHandler> objectHandler;
     std::shared_ptr<CScriptHandler> scriptHandler;
     std::shared_ptr<CRngHandler> rngHandler;
+    vstd::lazy<CSlotConfig> slotConfiguration;
     std::atomic<TransitionGeneration> transitionGeneration = 0;
 };

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -66,6 +66,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CPythonOverrides.h"
 #include "core/CRuntimeBridge.h"
 #include "core/CSceneManager.h"
+#include "core/CSlotConfig.h"
 #include "core/CTags.h"
 #include "core/CTypes.h"
 #include "core/CUtil.h"

--- a/src/gui/panel/CGameInventoryPanel.cpp
+++ b/src/gui/panel/CGameInventoryPanel.cpp
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CGameInventoryPanel.h"
 #include "core/CGame.h"
 #include "core/CMap.h"
+#include "core/CSlotConfig.h"
 #include "gui/CGui.h"
 #include "gui/CTextureCache.h"
 

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CJsonUtil.h"
 #include "core/CMap.h"
 #include "core/CPlaytestTrace.h"
+#include "core/CSlotConfig.h"
 
 #include <utility>
 

--- a/tests/test_slot_context_ownership.py
+++ b/tests/test_slot_context_ownership.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import re
+import unittest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def readSource(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+class SlotContextOwnershipTest(unittest.TestCase):
+    def test_slot_configuration_lazy_owner_lives_on_game_context(self) -> None:
+        context_header = readSource("src/core/CGameContext.h")
+
+        self.assertIn("class CSlotConfig;", context_header)
+        self.assertIn("std::shared_ptr<CSlotConfig> getSlotConfiguration();", context_header)
+        self.assertIn("vstd::lazy<CSlotConfig> slotConfiguration;", context_header)
+
+    def test_game_keeps_slot_configuration_facade_without_lazy_owner(self) -> None:
+        game_header = readSource("src/core/CGame.h")
+        game_source = readSource("src/core/CGame.cpp")
+
+        self.assertIn("class CSlotConfig;", game_header)
+        self.assertIn("std::shared_ptr<CSlotConfig> getSlotConfiguration();", game_header)
+        self.assertNotIn("vstd::lazy<CSlotConfig> slotConfiguration;", game_header)
+        self.assertRegex(
+            game_source,
+            re.compile(
+                r"std::shared_ptr<CSlotConfig>\s+CGame::getSlotConfiguration\(\)\s*\{\s*"
+                r"return\s+getContext\(\)->getSlotConfiguration\(\);\s*\}"
+            ),
+        )
+
+    def test_context_creates_slot_configuration_through_owner_game(self) -> None:
+        context_source = readSource("src/core/CGameContext.cpp")
+
+        self.assertIn('throw std::runtime_error("Cannot create CSlotConfig without an active CGame.");', context_source)
+        self.assertIn('owner->createObject<CSlotConfig>("slotConfiguration")', context_source)
+
+    def test_inventory_and_equipment_call_existing_game_facade(self) -> None:
+        creature_source = readSource("src/object/CCreature.cpp")
+        inventory_panel_source = readSource("src/gui/panel/CGameInventoryPanel.cpp")
+
+        self.assertIn("getMap()->getGame()->getSlotConfiguration()->canFit", creature_source)
+        self.assertGreaterEqual(inventory_panel_source.count("gui->getGame()->getSlotConfiguration()"), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What Changed
- Moved `CSlotConfig` lazy ownership from `CGame` to `CGameContext`.
- Kept `CGame::getSlotConfiguration()` as the backward-compatible facade, delegating to the context.
- Added a focused source-level regression covering the ownership location, facade delegation, owner-game creation path, and existing inventory/equipment facade callers.

## Why
Issue: `[EPIC_02][STORY_02][SUBSTORY_02]Move slot configuration ownership to context`
Owner: `controller/ctrl-lis-2-b17e29a3/subagent-6`
Claim ID: `4e0ffc1a-23d7-44ef-b81c-6ec12f0ea2cc`

The slot configuration was the remaining lazy runtime service still owned directly by `CGame` instead of the per-game context.

## Validation
Local focused checks:
- `clang-format -i src/core/CGame.h src/core/CGame.cpp src/core/CGameContext.h src/core/CGameContext.cpp`
- `black -l 120 tests/test_slot_context_ownership.py`
- `python3 -m unittest tests.test_slot_context_ownership`
- `git diff --check`
- `git diff --exit-code -- planning/fall_of_nouraajd_issue_proposals.xlsx`

Heavy validation delegated to GitHub Actions:
- `python3 scripts/poll_pr_checks.py <PR> --check linux --require-step coverage`

## Known Limitations
Local native build, CTest, full Python suite, coverage, Xvfb, and MCP were not run locally per controller policy; CI will provide the heavy validation evidence.
