### PR TITLE
Track owning map for retained map objects

### DIFF
--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -135,6 +135,7 @@ void CMap::setPlayer(std::shared_ptr<CPlayer> player) {
         vstd::logger::warning("Ignoring null player assignment");
         return;
     }
+    player->setOwningMap(this->ptr<CMap>());
     player->setName("player");
     player->setController(getGame()->createObject<CPlayerController>());
     player->setFightController(getGame()->createObject<CPlayerFightController>());
@@ -271,6 +272,7 @@ void CMap::bumpNavigationRevision() {
 void CMap::moveTile(std::shared_ptr<CTile> tile, int x, int y, int z) {
     Coords coords = normalizeCoords(tile->getCoords());
     Coords target = normalizeCoords(Coords(x, y, z));
+    tile->setOwningMap(this->ptr<CMap>());
     auto it = tiles.find(coords);
     if (it != tiles.end()) {
         tiles.erase(it);
@@ -289,6 +291,7 @@ bool CMap::addTile(std::shared_ptr<CTile> tile, int x, int y, int z) {
     if (this->contains(coords.x, coords.y, coords.z)) {
         return false;
     }
+    tile->setOwningMap(this->ptr<CMap>());
     tile->setPosx(coords.x);
     tile->setPosy(coords.y);
     tile->setPosz(coords.z);
@@ -303,7 +306,11 @@ void CMap::removeTile(int x, int y, int z) {
     Coords coords = normalizeCoords(Coords(x, y, z));
     auto it = this->tiles.find(coords);
     if (it != this->tiles.end()) {
+        auto tile = it->second;
         this->tiles.erase(it);
+        if (tile) {
+            tile->clearOwningMap(this->ptr<CMap>());
+        }
     }
     bumpNavigationRevision();
     recordDirectPropertyChanged("tiles");
@@ -387,6 +394,7 @@ void CMap::addObject(const std::shared_ptr<CMapObject> &mapObject) {
         return;
     }
     std::shared_ptr<CCreature> creature = vstd::cast<CCreature>(mapObject);
+    mapObject->setOwningMap(this->ptr<CMap>());
     if (creature.get()) {
         if (creature->getLevel() == 0) {
             creature->addExp(0);
@@ -418,6 +426,10 @@ void CMap::removeObject(const std::shared_ptr<CMapObject> &mapObject) {
     bumpNavigationRevision();
     recordDirectPropertyChanged("objects");
     getEventHandler()->gameEvent(mapObject, std::make_shared<CGameEvent>(CGameEvent::CType::onDestroy));
+    auto current_object_it = mapObjects.find(mapObject->getName());
+    if (current_object_it == mapObjects.end() || current_object_it->second != mapObject) {
+        mapObject->clearOwningMap(this->ptr<CMap>());
+    }
     signal("objectChanged", mapObject->getCoords());
 }
 
@@ -595,11 +607,18 @@ void CMap::setTurn(int turn) {
 }
 
 void CMap::setTiles(std::set<std::shared_ptr<CTile>> objects) {
+    auto map = this->ptr<CMap>();
+    for (const auto &[coords, tile] : tiles) {
+        if (tile) {
+            tile->clearOwningMap(map);
+        }
+    }
     tiles.clear();
     for (const auto &ob : objects) {
         if (!ob) {
             continue;
         }
+        ob->setOwningMap(map);
         tiles[normalizeCoords(ob->getCoords())] = ob;
     }
     bumpNavigationRevision();
@@ -629,6 +648,12 @@ void CMap::setObjects(std::set<std::shared_ptr<CMapObject>> objects) {
             }
         }
     }
+    auto map = this->ptr<CMap>();
+    for (const auto &[name, object] : mapObjects) {
+        if (object) {
+            object->clearOwningMap(map);
+        }
+    }
     mapObjects.clear();
     mapObjectsCache.clear();
     for (auto ob : objects) {
@@ -636,6 +661,7 @@ void CMap::setObjects(std::set<std::shared_ptr<CMapObject>> objects) {
             vstd::logger::warning("Ignoring null map object in CMap::setObjects");
             continue;
         }
+        ob->setOwningMap(map);
         mapObjects[ob->getName()] = ob;
         mapObjectsCache.insert(std::make_pair(normalizeCoords(ob->getCoords()), ob->getName()));
     }

--- a/src/object/CGameObject.cpp
+++ b/src/object/CGameObject.cpp
@@ -47,6 +47,9 @@ CGameObject::PropertyNotificationBatch::PropertyNotificationBatch(CGameObject &o
 CGameObject::PropertyNotificationBatch::~PropertyNotificationBatch() { object.endPropertyNotificationBatch(); }
 
 std::shared_ptr<CMap> CGameObject::getMap() {
+    if (auto map = owningMap.lock()) {
+        return map;
+    }
     auto currentGame = getGame();
     return currentGame ? currentGame->getMap() : nullptr;
 }
@@ -54,6 +57,16 @@ std::shared_ptr<CMap> CGameObject::getMap() {
 std::shared_ptr<CGame> CGameObject::getGame() { return game.lock(); }
 
 void CGameObject::setGame(std::shared_ptr<CGame> map) { this->game = map; }
+
+void CGameObject::setOwningMap(std::shared_ptr<CMap> map) { this->owningMap = std::move(map); }
+
+void CGameObject::clearOwningMap(const std::shared_ptr<CMap> &expectedMap) {
+    auto map = owningMap.lock();
+    if (!map || (expectedMap && map != expectedMap)) {
+        return;
+    }
+    owningMap.reset();
+}
 
 void CGameObject::setStringProperty(std::string name, std::string value) {
     std::string previous;

--- a/src/object/CGameObject.h
+++ b/src/object/CGameObject.h
@@ -34,6 +34,8 @@ class CGame;
 class CAnimation;
 
 class CGameObject : public vstd::stringable, public std::enable_shared_from_this<CGameObject> {
+    friend class CMap;
+
     V_META(CGameObject, vstd::meta::empty, V_PROPERTY(CGameObject, std::string, name, getName, setName),
            V_PROPERTY(CGameObject, std::string, type, getType, setType),
            V_PROPERTY(CGameObject, std::string, typeId, getTypeId, setTypeId),
@@ -207,6 +209,10 @@ class CGameObject : public vstd::stringable, public std::enable_shared_from_this
 
     std::shared_ptr<CGameObject> _clone();
 
+    void setOwningMap(std::shared_ptr<CMap> map);
+
+    void clearOwningMap(const std::shared_ptr<CMap> &expectedMap);
+
     void beginPropertyNotificationBatch();
 
     void endPropertyNotificationBatch();
@@ -225,6 +231,7 @@ class CGameObject : public vstd::stringable, public std::enable_shared_from_this
     CTags tags;
 
     std::weak_ptr<CGame> game;
+    std::weak_ptr<CMap> owningMap;
 
     int propertyNotificationBatchDepth = 0;
     std::vector<std::string> directPropertyNotificationSuppressedNames;

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -987,6 +987,80 @@ void test_map_object_relocate_without_move_hooks_updates_spatial_state_once() {
                 "relocateWithoutMoveHooks should emit one old-coordinate and one new-coordinate signal");
 }
 
+void test_map_owned_objects_and_tiles_remember_owner_when_active_map_changes() {
+    auto game = std::make_shared<CGame>();
+    auto old_map = std::make_shared<CMap>();
+    auto new_map = std::make_shared<CMap>();
+    old_map->setGame(game);
+    new_map->setGame(game);
+    old_map->setMapName("oldMap");
+    new_map->setMapName("newMap");
+    game->setMap(old_map);
+
+    auto retained_object = std::make_shared<CMapObject>();
+    retained_object->setGame(game);
+    retained_object->setName("retainedObject");
+    old_map->addObject(retained_object);
+
+    auto retained_tile = std::make_shared<CTile>();
+    retained_tile->setGame(game);
+    expect_true(old_map->addTile(retained_tile, 1, 1, 0), "fixture tile should be added to the old map");
+
+    auto rehomed_object = std::make_shared<CMapObject>();
+    rehomed_object->setGame(game);
+    rehomed_object->setName("rehomedObject");
+    old_map->addObject(rehomed_object);
+
+    auto rehomed_tile = std::make_shared<CTile>();
+    rehomed_tile->setGame(game);
+    expect_true(old_map->addTile(rehomed_tile, 3, 1, 0), "rehomed tile should start on the old map");
+
+    new_map->addObject(rehomed_object);
+    expect_true(new_map->addTile(rehomed_tile, 3, 1, 0), "rehomed tile should move to the new map");
+
+    game->setMap(new_map);
+
+    expect_true(retained_object->getMap() == old_map,
+                "retained old-map objects should resolve their owning map after the active map changes");
+    expect_true(retained_tile->getMap() == old_map,
+                "retained old-map tiles should resolve their owning map after the active map changes");
+    expect_true(rehomed_object->getMap() == new_map, "rehomed objects should resolve their new map owner");
+    expect_true(rehomed_tile->getMap() == new_map, "rehomed tiles should resolve their new map owner");
+
+    auto restored_object = std::make_shared<CMapObject>();
+    restored_object->setGame(game);
+    restored_object->setName("restoredObject");
+    auto restored_tile = std::make_shared<CTile>();
+    restored_tile->setGame(game);
+    restored_tile->setPosx(2);
+    restored_tile->setPosy(1);
+    restored_tile->setPosz(0);
+
+    old_map->setObjects({retained_object, restored_object});
+    old_map->setTiles({retained_tile, restored_tile});
+
+    expect_true(restored_object->getMap() == old_map,
+                "objects restored through setObjects should resolve the restoring map");
+    expect_true(restored_tile->getMap() == old_map, "tiles restored through setTiles should resolve the restoring map");
+    expect_true(rehomed_object->getMap() == new_map,
+                "setObjects should not clear objects already rehomed to another map");
+    expect_true(rehomed_tile->getMap() == new_map, "setTiles should not clear tiles already rehomed to another map");
+
+    bool destroy_callback_saw_old_map = false;
+    old_map->setTriggers(
+        {std::make_shared<CCustomTrigger>("retainedObject", CGameEvent::CType::onDestroy,
+                                          [&](std::shared_ptr<CGameObject> object, std::shared_ptr<CGameEvent>) {
+                                              destroy_callback_saw_old_map = object && object->getMap() == old_map;
+                                          })});
+
+    old_map->removeObject(retained_object);
+
+    expect_true(destroy_callback_saw_old_map,
+                "destroy callbacks should still resolve the object owner before ownership is cleared");
+    expect_true(retained_object->getMap() == new_map,
+                "removed objects should fall back to the active game map after destroy callbacks finish");
+}
+
 void test_map_player_trigger_registration_is_idempotent() {
     auto game = CGameLoader::loadGame();
     auto map = std::make_shared<CMap>();
@@ -1114,6 +1188,7 @@ int main() {
     test_map_move_interrupts_invalid_planned_steps();
     test_creature_tracks_pending_move_origin_only_during_after_move();
     test_map_object_relocate_without_move_hooks_updates_spatial_state_once();
+    test_map_owned_objects_and_tiles_remember_owner_when_active_map_changes();
     test_map_player_trigger_registration_is_idempotent();
     test_map_keeps_tiles_and_objects_separate_by_z();
     test_can_step_checks_default_tile_passability_without_materializing();


### PR DESCRIPTION
## What changed
- Added a runtime-only weak owning-map reference to `CGameObject` so retained objects and tiles can resolve the map that still owns them after the active game map changes.
- Updated `CMap` object/tile/player add, restore, move, and removal paths to set or clear that owner at the right lifecycle points.
- Added map unit coverage for retained old-map objects/tiles, restored objects/tiles, and destroy callback ordering before ownership is cleared.

## Why
Queue issue `[EPIC_02][STORY_03][SUBSTORY_01]Add owning-map references` fixes retained map objects following `CGame::getMap()` after a transition. That made old-map objects appear to belong to the active map instead of the map that still indexed them.

## Validation
- `git submodule update --init --recursive`
- `GAME_CONFIGURE_SKIP_APT=1 GAME_CONFIGURE_SKIP_SUBMODULES=1 GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh`
- `clang-format -i src/object/CGameObject.h src/object/CGameObject.cpp src/core/CMap.cpp tests/unit/test_map.cpp`
- `cmake --build cmake-build-release --target _game native_marker_plugin native_gameplay map_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests.map_unit_tests`
- `git diff --check`

## Known limitations / follow-up
- Full Linux and coverage evidence is left to GitHub Actions polling for this PR.
