### PR TITLE
Guard deferred transition callbacks

### DIFF
--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <algorithm>
 
 #include "core/CGame.h"
+#include "core/CGameContext.h"
 #include "core/CMap.h"
 #include "gui/panel/CGameFightPanel.h"
 #include "object/CMapObject.h"
@@ -45,6 +46,68 @@ struct TargetFlowField {
 
 std::mutex targetFlowMutex;
 std::vector<std::shared_ptr<TargetFlowField>> targetFlowCache;
+
+struct DeferredCreatureContext {
+    std::weak_ptr<CCreature> creature;
+    std::weak_ptr<CMap> map;
+    std::weak_ptr<CGame> game;
+    std::weak_ptr<CGameContext> context;
+    CGameContext::TransitionGeneration generation = 0;
+    std::string creatureName;
+    Coords fallback = ZERO;
+    bool hadContext = false;
+    bool wasRegistered = false;
+};
+
+DeferredCreatureContext capture_deferred_creature_context(const std::shared_ptr<CCreature> &creature) {
+    DeferredCreatureContext result;
+    result.creature = creature;
+    if (!creature) {
+        return result;
+    }
+
+    result.fallback = creature->getCoords();
+    result.creatureName = creature->getName();
+    auto map = creature->getMap();
+    result.map = map;
+    auto game = creature->getGame();
+    result.game = game;
+    if (game) {
+        auto context = game->getContext();
+        result.context = context;
+        result.generation = context->captureTransitionGeneration();
+        result.hadContext = true;
+    }
+    result.wasRegistered = map && !result.creatureName.empty() && map->getObjectByName(result.creatureName) == creature;
+    return result;
+}
+
+bool resolve_deferred_creature_context(const DeferredCreatureContext &context, std::shared_ptr<CCreature> &creature,
+                                       std::shared_ptr<CMap> &map) {
+    creature = context.creature.lock();
+    map = context.map.lock();
+    if (!creature || !map) {
+        return false;
+    }
+
+    auto transitionContext = context.context.lock();
+    if (context.hadContext &&
+        (!transitionContext || !transitionContext->isTransitionGenerationCurrent(context.generation))) {
+        return false;
+    }
+
+    const bool stillRegistered =
+        context.wasRegistered && !context.creatureName.empty() && map->getObjectByName(context.creatureName) == creature;
+    auto game = context.game.lock();
+    const bool expectedMapActive = !game || game->getMap() == map;
+    if (!expectedMapActive && !stillRegistered) {
+        return false;
+    }
+    if (context.wasRegistered && !stillRegistered) {
+        return false;
+    }
+    return true;
+}
 
 bool contains_navigation_neighbor(const std::shared_ptr<CMap> &map, Coords from, Coords to) {
     if (!map) {
@@ -91,11 +154,11 @@ std::vector<Coords> get_reverse_navigation_neighbors(const std::shared_ptr<CMap>
     return reachable;
 }
 
-bool creature_can_follow_step(const std::shared_ptr<CCreature> &creature, const Coords &step) {
-    if (!creature || !creature->getMap()) {
+bool creature_can_follow_step(const std::shared_ptr<CMap> &map, const std::shared_ptr<CCreature> &creature,
+                              const Coords &step) {
+    if (!map || !creature) {
         return false;
     }
-    auto map = creature->getMap();
     auto current = map->normalizeCoords(creature->getCoords());
     auto target = map->normalizeCoords(step);
     return target != current && map->canStep(target) && contains_navigation_neighbor(map, current, target);
@@ -172,13 +235,12 @@ std::shared_ptr<TargetFlowField> get_target_flow_field(const std::shared_ptr<CMa
     return field;
 }
 
-Coords find_shared_target_next_step(const std::shared_ptr<CCreature> &creature,
+Coords find_shared_target_next_step(const std::shared_ptr<CMap> &map, const std::shared_ptr<CCreature> &creature,
                                     const std::shared_ptr<CMapObject> &targetObject) {
-    if (!creature || !targetObject || !creature->getMap()) {
+    if (!map || !creature || !targetObject) {
         return creature ? creature->getCoords() : ZERO;
     }
 
-    auto map = creature->getMap();
     auto start = map->normalizeCoords(creature->getCoords());
     auto goal = map->normalizeCoords(targetObject->getCoords());
     if (start == goal || !map->canStep(goal)) {
@@ -191,7 +253,7 @@ Coords find_shared_target_next_step(const std::shared_ptr<CCreature> &creature,
         return start;
     }
     auto step = map->normalizeCoords(next->second);
-    if (!creature_can_follow_step(creature, step)) {
+    if (!creature_can_follow_step(map, creature, step)) {
         return start;
     }
     return step;
@@ -217,18 +279,36 @@ std::shared_ptr<vstd::future<Coords, void>> CTargetController::control(std::shar
     if (!creature || !creature->getMap()) {
         return vstd::later([]() { return ZERO; });
     }
-    auto target_object = creature->getMap()->getObjectByName(target);
+    auto deferredContext = capture_deferred_creature_context(creature);
+    auto sourceMap = deferredContext.map.lock();
+    auto target_object = sourceMap ? sourceMap->getObjectByName(target) : nullptr;
     if (!target_object) {
-        return vstd::later([creature]() { return creature->getCoords(); });
+        return vstd::later([deferredContext]() { return deferredContext.fallback; });
     }
-    return vstd::async([creature, target_object]() { return find_shared_target_next_step(creature, target_object); });
+    return vstd::async([deferredContext, target_object]() {
+        std::shared_ptr<CCreature> creature;
+        std::shared_ptr<CMap> map;
+        if (!resolve_deferred_creature_context(deferredContext, creature, map)) {
+            return deferredContext.fallback;
+        }
+        if (!target_object->getName().empty() && map->getObjectByName(target_object->getName()) != target_object) {
+            return deferredContext.fallback;
+        }
+        return find_shared_target_next_step(map, creature, target_object);
+    });
 }
 
 std::shared_ptr<vstd::future<Coords, void>> CController::control(std::shared_ptr<CCreature> c) {
     if (!c) {
         return vstd::later([]() { return ZERO; });
     }
-    return vstd::later([c]() { return c->getCoords(); });
+    auto deferredContext = capture_deferred_creature_context(c);
+    return vstd::later([deferredContext]() {
+        std::shared_ptr<CCreature> creature;
+        std::shared_ptr<CMap> map;
+        return resolve_deferred_creature_context(deferredContext, creature, map) ? creature->getCoords()
+                                                                                : deferredContext.fallback;
+    });
 }
 
 void CController::onStepCommitted(std::shared_ptr<CCreature>, const Coords &) {}
@@ -245,9 +325,15 @@ std::shared_ptr<vstd::future<Coords, void>> CRandomController::control(std::shar
     if (!creature) {
         return vstd::later([]() { return ZERO; });
     }
-    return vstd::later([creature]() {
+    auto deferredContext = capture_deferred_creature_context(creature);
+    return vstd::later([deferredContext]() {
+        std::shared_ptr<CCreature> creature;
+        std::shared_ptr<CMap> map;
+        if (!resolve_deferred_creature_context(deferredContext, creature, map)) {
+            return deferredContext.fallback;
+        }
         Coords target = creature->getCoords() + Coords(vstd::rand(-1, 1), vstd::rand(-1, 1), 0);
-        return creature->getMap() ? creature->getMap()->normalizeCoords(target) : target;
+        return map->normalizeCoords(target);
     });
 }
 
@@ -256,10 +342,16 @@ std::shared_ptr<vstd::future<Coords, void>> CNpcRandomController::control(std::s
     if (!creature || !creature->getMap()) {
         return vstd::later([creature]() { return creature ? creature->getCoords() : ZERO; });
     }
-    return vstd::later([self, creature]() -> Coords {
+    auto deferredContext = capture_deferred_creature_context(creature);
+    return vstd::later([self, deferredContext]() -> Coords {
+        std::shared_ptr<CCreature> creature;
+        std::shared_ptr<CMap> map;
+        if (!resolve_deferred_creature_context(deferredContext, creature, map)) {
+            return deferredContext.fallback;
+        }
         if (!self->path.empty() && self->currentStep < static_cast<int>(self->path.size())) {
-            auto next = creature->getMap()->normalizeCoords(self->path[self->currentStep]);
-            if (creature_can_follow_step(creature, next)) {
+            auto next = map->normalizeCoords(self->path[self->currentStep]);
+            if (creature_can_follow_step(map, creature, next)) {
                 return next;
             }
             self->path.clear();
@@ -270,16 +362,13 @@ std::shared_ptr<vstd::future<Coords, void>> CNpcRandomController::control(std::s
             for (int i = 0; i < 10; i++) {
                 auto dx = vstd::rand(-5, 5);
                 auto dy = vstd::rand(-5, 5);
-                auto candidate = creature->getMap()->normalizeCoords(creature->getCoords() + Coords(dx, dy, 0));
-                if (creature->getMap()->canStep(candidate)) {
+                auto candidate = map->normalizeCoords(creature->getCoords() + Coords(dx, dy, 0));
+                if (map->canStep(candidate)) {
                     self->path = CPathFinder::findPath(
-                        creature->getCoords(), candidate,
-                        [creature](const Coords &c) { return creature->getMap()->canStep(c); },
+                        creature->getCoords(), candidate, [map](const Coords &c) { return map->canStep(c); },
                         [](auto) -> std::optional<Coords> { return std::nullopt; },
-                        [creature](const Coords &coords) { return creature->getMap()->getNavigationNeighbors(coords); },
-                        [creature](const Coords &from, const Coords &to) {
-                            return creature->getMap()->getDistance(from, to);
-                        });
+                        [map](const Coords &coords) { return map->getNavigationNeighbors(coords); },
+                        [map](const Coords &from, const Coords &to) { return map->getDistance(from, to); });
                     self->currentStep = 0;
                     break;
                 }
@@ -287,8 +376,8 @@ std::shared_ptr<vstd::future<Coords, void>> CNpcRandomController::control(std::s
         }
 
         if (!self->path.empty() && self->currentStep < static_cast<int>(self->path.size())) {
-            auto next = creature->getMap()->normalizeCoords(self->path[self->currentStep]);
-            if (creature_can_follow_step(creature, next)) {
+            auto next = map->normalizeCoords(self->path[self->currentStep]);
+            if (creature_can_follow_step(map, creature, next)) {
                 return next;
             }
             self->path.clear();
@@ -315,11 +404,17 @@ std::shared_ptr<vstd::future<Coords, void>> CGroundController::control(std::shar
     if (!creature || !creature->getMap()) {
         return vstd::later([creature]() { return creature ? creature->getCoords() : ZERO; });
     }
-    return vstd::later([self, creature]() -> Coords {
+    auto deferredContext = capture_deferred_creature_context(creature);
+    return vstd::later([self, deferredContext]() -> Coords {
+        std::shared_ptr<CCreature> creature;
+        std::shared_ptr<CMap> map;
+        if (!resolve_deferred_creature_context(deferredContext, creature, map)) {
+            return deferredContext.fallback;
+        }
         std::vector<Coords> possible;
-        for (auto c : creature->getMap()->getAdjacentCoords(creature->getCoords(), true)) {
-            std::string type = creature->getMap()->getTile(c)->getTileType();
-            if (type == self->getTileType() && creature->getMap()->canStep(c)) {
+        for (auto c : map->getAdjacentCoords(creature->getCoords(), true)) {
+            std::string type = map->getTile(c)->getTileType();
+            if (type == self->getTileType() && map->canStep(c)) {
                 possible.push_back(c);
             }
         }
@@ -337,12 +432,17 @@ std::shared_ptr<vstd::future<Coords, void>> CRangeController::control(std::share
     if (!creature || !creature->getMap()) {
         return vstd::later([creature]() { return creature ? creature->getCoords() : ZERO; });
     }
-    return vstd::later([self, creature]() -> Coords {
+    auto deferredContext = capture_deferred_creature_context(creature);
+    return vstd::later([self, deferredContext]() -> Coords {
+        std::shared_ptr<CCreature> creature;
+        std::shared_ptr<CMap> map;
+        if (!resolve_deferred_creature_context(deferredContext, creature, map)) {
+            return deferredContext.fallback;
+        }
         std::vector<Coords> possible;
-        std::shared_ptr<CMapObject> targetObject = creature->getMap()->getObjectByName(self->getTarget());
-        for (auto c : creature->getMap()->getAdjacentCoords(creature->getCoords(), true)) {
-            if ((!targetObject || creature->getMap()->getDistance(targetObject->getCoords(), c) < self->distance) &&
-                creature->getMap()->canStep(c)) {
+        std::shared_ptr<CMapObject> targetObject = map->getObjectByName(self->getTarget());
+        for (auto c : map->getAdjacentCoords(creature->getCoords(), true)) {
+            if ((!targetObject || map->getDistance(targetObject->getCoords(), c) < self->distance) && map->canStep(c)) {
                 possible.push_back(c);
             }
         }
@@ -548,12 +648,17 @@ void CPlayerFightController::start(std::shared_ptr<CCreature> me, std::shared_pt
     fightPanel = nullptr;
     encounterMap.reset();
     controlledCreature.reset();
+    encounterGeneration = 0;
+    hasEncounterGeneration = false;
     if (!me || !me->getMap() || !me->getMap()->getGame()) {
         cancelled = true;
         return;
     }
     encounterMap = me->getMap();
     controlledCreature = me;
+    auto context = me->getMap()->getGame()->getContext();
+    encounterGeneration = context->captureTransitionGeneration();
+    hasEncounterGeneration = true;
     auto gui = me->getMap()->getGame()->getGui();
     if (!gui) {
         cancelled = true;
@@ -647,6 +752,10 @@ bool CPlayerFightController::hasCancelledContext(std::shared_ptr<CCreature> me) 
 
     auto game = me->getGame();
     if (!game || game->getMap() != startedMap) {
+        return true;
+    }
+    auto context = game->getContext();
+    if (hasEncounterGeneration && (!context || !context->isTransitionGenerationCurrent(encounterGeneration))) {
         return true;
     }
 

--- a/src/core/CController.h
+++ b/src/core/CController.h
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <unordered_map>
 #include <vector>
 
@@ -122,6 +123,8 @@ class CPlayerFightController : public CFightController {
     std::shared_ptr<CGameFightPanel> fightPanel;
     std::weak_ptr<CMap> encounterMap;
     std::weak_ptr<CCreature> controlledCreature;
+    std::uint64_t encounterGeneration = 0;
+    bool hasEncounterGeneration = false;
     bool cancelled = false;
 
     bool hasCancelledContext(std::shared_ptr<CCreature> me);

--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <algorithm>
 #include "core/CController.h"
 #include "core/CGame.h"
+#include "core/CGameContext.h"
 #include "core/CPlaytestTrace.h"
 #include "core/CSerialization.h"
 #include "object/CItem.h"
@@ -488,6 +489,18 @@ void CMap::move() {
 
     vstd::logger::debug("Turn:", map->turn);
 
+    auto game = map->getGame();
+    auto transitionContext = game ? game->getContext() : nullptr;
+    const auto expectedGeneration =
+        transitionContext ? transitionContext->captureTransitionGeneration() : CGameContext::TransitionGeneration{0};
+    auto canApplyDeferredMoveWork = [map, transitionContext, expectedGeneration]() {
+        if (transitionContext && !transitionContext->isTransitionGenerationCurrent(expectedGeneration)) {
+            return false;
+        }
+        auto game = map->getGame();
+        return !game || game->getMap() == map;
+    };
+
     // TODO: map->applyEffects();
 
     map->forObjects([map](std::shared_ptr<CMapObject> mapObject) {
@@ -520,10 +533,14 @@ void CMap::move() {
         active_objects.push_back(object);
     }
 
-    auto controller = [coordinates](std::shared_ptr<CMapObject> object) {
+    auto controller = [coordinates, canApplyDeferredMoveWork, map](std::shared_ptr<CMapObject> object) {
         auto creature = vstd::cast<CCreature>(object);
         return creature->getController()->control(creature)->thenLater(
-            [creature, coordinates](Coords coords) { coordinates->push_back(std::make_pair(creature, coords)); });
+            [creature, coordinates, canApplyDeferredMoveWork, map](Coords coords) {
+                if (canApplyDeferredMoveWork() && creature && map->getObjectByName(creature->getName()) == creature) {
+                    coordinates->push_back(std::make_pair(creature, coords));
+                }
+            });
     };
 
     std::vector<std::shared_ptr<vstd::future<void, Coords>>> pending;
@@ -542,6 +559,9 @@ void CMap::move() {
     vstd::wait_until([&round_complete]() { return round_complete; });
 
     for (auto [creature, coords] : *coordinates) {
+        if (!canApplyDeferredMoveWork()) {
+            break;
+        }
         auto controller_ptr = creature->getController();
         if (!is_active_creature(creature)) {
             controller_ptr->interrupt(creature);

--- a/src/core/CSceneManager.cpp
+++ b/src/core/CSceneManager.cpp
@@ -78,7 +78,9 @@ bool CSceneManager::requestMapChange(const std::shared_ptr<CGame> &game, MapTran
     auto manager = shared_from_this();
     std::weak_ptr<CGame> weakGame = game;
     std::weak_ptr<CGameContext> weakContext = context;
-    vstd::call_later([manager, weakGame, weakContext, expectedGeneration, mapName]() {
+    std::weak_ptr<CMap> weakExpectedMap = game->getMap();
+    const bool hadExpectedMap = game->getMap() != nullptr;
+    vstd::call_later([manager, weakGame, weakContext, weakExpectedMap, hadExpectedMap, expectedGeneration, mapName]() {
         auto resetIfStillPending = [&manager, &mapName]() {
             if (manager->transitionState == TransitionState::TransitionPending && manager->pendingMapName == mapName) {
                 manager->resetTransition();
@@ -86,7 +88,12 @@ bool CSceneManager::requestMapChange(const std::shared_ptr<CGame> &game, MapTran
         };
         auto game = weakGame.lock();
         auto context = weakContext.lock();
+        auto expectedMap = weakExpectedMap.lock();
         if (!game || !context || !context->isTransitionGenerationCurrent(expectedGeneration)) {
+            resetIfStillPending();
+            return;
+        }
+        if (hadExpectedMap && (!expectedMap || game->getMap() != expectedMap)) {
             resetIfStillPending();
             return;
         }
@@ -94,13 +101,15 @@ bool CSceneManager::requestMapChange(const std::shared_ptr<CGame> &game, MapTran
             return;
         }
         vstd::call_when(
-            [weakGame, weakContext, expectedGeneration]() {
+            [weakGame, weakContext, weakExpectedMap, hadExpectedMap, expectedGeneration]() {
                 auto game = weakGame.lock();
                 auto context = weakContext.lock();
+                auto expectedMap = weakExpectedMap.lock();
                 return !game || !context || !context->isTransitionGenerationCurrent(expectedGeneration) ||
-                       !game->getMap() || !game->getMap()->isMoving();
+                       (hadExpectedMap && (!expectedMap || game->getMap() != expectedMap)) || !game->getMap() ||
+                       !game->getMap()->isMoving();
             },
-            [manager, weakGame, weakContext, expectedGeneration, mapName]() {
+            [manager, weakGame, weakContext, weakExpectedMap, hadExpectedMap, expectedGeneration, mapName]() {
                 auto resetIfStillPending = [&manager, &mapName]() {
                     if (manager->transitionState == TransitionState::TransitionPending &&
                         manager->pendingMapName == mapName) {
@@ -109,7 +118,12 @@ bool CSceneManager::requestMapChange(const std::shared_ptr<CGame> &game, MapTran
                 };
                 auto game = weakGame.lock();
                 auto context = weakContext.lock();
+                auto expectedMap = weakExpectedMap.lock();
                 if (!game || !context || !context->isTransitionGenerationCurrent(expectedGeneration)) {
+                    resetIfStillPending();
+                    return;
+                }
+                if (hadExpectedMap && (!expectedMap || game->getMap() != expectedMap)) {
                     resetIfStillPending();
                     return;
                 }

--- a/src/gui/panel/CGameFightPanel.cpp
+++ b/src/gui/panel/CGameFightPanel.cpp
@@ -20,6 +20,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <unordered_set>
 
+#include "core/CGame.h"
+#include "core/CGameContext.h"
 #include "core/CMap.h"
 #include "gui/CAnimation.h"
 #include "gui/CTextManager.h"
@@ -185,12 +187,29 @@ void CGameFightPanel::refreshEncounterViews() {
 
 std::shared_ptr<CInteraction> CGameFightPanel::selectInteraction() {
     auto self = this->ptr<CGameFightPanel>();
-    vstd::call_later_block([self]() {
+    auto gui = self->getGui();
+    auto game = gui ? gui->getGame() : nullptr;
+    auto context = game ? game->getContext() : nullptr;
+    std::weak_ptr<CMap> weakExpectedMap;
+    if (game) {
+        weakExpectedMap = game->getMap();
+    }
+    const bool hadExpectedMap = game && game->getMap() != nullptr;
+    const auto expectedGeneration =
+        context ? context->captureTransitionGeneration() : CGameContext::TransitionGeneration{0};
+    vstd::call_later_block([self, weakExpectedMap, hadExpectedMap, context, expectedGeneration]() {
         while (self->finalSelected.lock() == nullptr) {
             if (self->isCancelled()) {
                 return;
             }
             auto gui = self->getGui();
+            auto game = gui ? gui->getGame() : nullptr;
+            auto expectedMap = weakExpectedMap.lock();
+            if ((context && !context->isTransitionGenerationCurrent(expectedGeneration)) ||
+                (hadExpectedMap && (!game || !expectedMap || game->getMap() != expectedMap))) {
+                self->cancel();
+                return;
+            }
             if (!gui || gui->findChild(self) == nullptr) {
                 self->cancel();
                 return;

--- a/tests/unit/test_controller.cpp
+++ b/tests/unit/test_controller.cpp
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "core/CController.h"
 #include "core/CGame.h"
+#include "core/CGameContext.h"
 #include "core/CMap.h"
 #include "core/CStats.h"
 #include "object/CCreature.h"
@@ -215,6 +216,28 @@ void test_npc_random_controller_clears_stale_blocked_path() {
                 "NPC random controller should either stay put or replan to a passable step");
 }
 
+void test_ground_controller_ignores_stale_transition_generation() {
+    auto game = std::make_shared<CGame>();
+    auto map = open_tile_map(game, 2, 1);
+    map->getTile(0, 0, 0)->setTileType("stone");
+    map->getTile(1, 0, 0)->setTileType("floor");
+
+    auto creature = creature_at(0, 0, 0);
+    creature->setGame(game);
+    creature->setName("unitStaleGroundWalker");
+    creature->setHp(1);
+    auto controller = std::make_shared<CGroundController>();
+    controller->setTileType("floor");
+    creature->setController(controller);
+    map->addObject(creature);
+
+    auto pending = controller->control(creature);
+    game->getContext()->advanceTransitionGeneration();
+
+    expect_true(resolve_coords(pending) == Coords(0, 0, 0),
+                "ground controller should ignore deferred steps from stale transition generations");
+}
+
 void test_player_controller_uses_navigation_neighbors_for_cross_level_route() {
     auto game = std::make_shared<CGame>();
     auto map = open_tile_map(game, 3, 1, 2);
@@ -344,6 +367,7 @@ int main() {
     test_movement_controller_null_and_no_map_paths();
     test_npc_random_controller_clears_current_tile_path();
     test_npc_random_controller_clears_stale_blocked_path();
+    test_ground_controller_ignores_stale_transition_generation();
     test_player_controller_uses_navigation_neighbors_for_cross_level_route();
     test_target_controller_flow_field_uses_navigation_neighbors_for_cross_level_pursuit();
     test_fight_controller_guard_paths_and_fallbacks();

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -45,6 +45,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <set>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -416,6 +417,32 @@ class FixedStepController : public CController {
     int turnEndedCount = 0;
 };
 
+class TransitionDuringControlController : public CController {
+  public:
+    TransitionDuringControlController(std::string map_name, Coords target)
+        : mapName(std::move(map_name)), target(target) {}
+
+    std::shared_ptr<vstd::future<Coords, void>> control(std::shared_ptr<CCreature> creature) override {
+        return vstd::later([this, creature]() {
+            futureRan = true;
+            if (creature && creature->getGame()) {
+                creature->getGame()->changeMap(mapName);
+            }
+            return target;
+        });
+    }
+
+    void onStepCommitted(std::shared_ptr<CCreature>, const Coords &) override { committedCount++; }
+
+    void interrupt(std::shared_ptr<CCreature>) override { interruptCount++; }
+
+    std::string mapName;
+    Coords target;
+    bool futureRan = false;
+    int committedCount = 0;
+    int interruptCount = 0;
+};
+
 class MovementOriginProbeCreature : public CCreature {
   public:
     void afterMove() override {
@@ -475,6 +502,64 @@ std::shared_ptr<CCreature> test_creature(const std::shared_ptr<CGame> &game, con
     creature->setPosZ(coords.z);
     creature->setHp(creature->getHpMax());
     return creature;
+}
+
+void test_map_move_ignores_controller_future_after_transition_generation_changes() {
+    auto game = CGameLoader::loadGame();
+    CGameLoader::startGameWithPlayer(game, "test", "Warrior");
+    auto map = game->getMap();
+
+    Coords origin = ZERO;
+    Coords planned = ZERO;
+    bool found = false;
+    for (const auto &[z, bounds] : map->getBounds()) {
+        for (int y = 0; y <= bounds.second && !found; ++y) {
+            for (int x = 0; x <= bounds.first && !found; ++x) {
+                Coords candidate(x, y, z);
+                if (!map->canStep(candidate)) {
+                    continue;
+                }
+                for (const auto &delta : {EAST, WEST, SOUTH, NORTH}) {
+                    Coords step = map->normalizeCoords(candidate + delta);
+                    if (step != candidate && map->canStep(step)) {
+                        origin = candidate;
+                        planned = step;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (found) {
+            break;
+        }
+    }
+    expect_true(found, "transition-stale controller fixture should find a walkable planned step");
+    if (!found) {
+        return;
+    }
+
+    auto controller = std::make_shared<TransitionDuringControlController>("ritual", planned);
+    auto creature = test_creature(game, "transitionStaleFutureWalker", origin, controller);
+    map->addObject(creature);
+
+    map->move();
+
+    expect_true(controller->futureRan, "controller future should run during map movement");
+    expect_true(game->getSceneManager()->isTransitionPending(),
+                "controller future should queue a transition while map movement is still resolving");
+    expect_true(creature->getCoords() == origin,
+                "stale controller future result should not move a creature after transition generation changes");
+    expect_true(controller->committedCount == 0,
+                "stale controller future result should not be reported as a committed step");
+    expect_true(controller->interruptCount == 0,
+                "stale controller future result should be dropped before movement interruption callbacks");
+
+    pump_event_loop_iterations();
+
+    expect_true(game->getMap()->getMapName() == "ritual", "queued transition should still commit after movement ends");
+    expect_true(game->getMap()->getObjectByName("transitionStaleFutureWalker") == nullptr,
+                "non-player object from the old map should not be carried into the new map");
 }
 
 template <typename Func> void expect_runtime_error(Func func, const char *message) {
@@ -1106,6 +1191,7 @@ int main() {
     test_scene_manager_repeated_transitions_and_controller_usability();
     test_scene_manager_null_and_legacy_missing_target_behavior();
     test_scene_manager_rejects_cross_game_requests();
+    test_map_move_ignores_controller_future_after_transition_generation_changes();
     test_map_tiles_bounds_wrapping_and_object_cache();
     test_map_navigation_edges_update_revision();
     test_map_navigation_neighbors_include_registered_edges();


### PR DESCRIPTION
## What changed
- Captured transition generation and expected map context for deferred controller, fight-panel, scene-manager, and map-move callbacks.
- Dropped deferred movement/fight work when the owning map or transition generation is no longer current.
- Added native unit coverage for stale deferred controller work and stale transition-generation controller callbacks.

## Why
Queue row 42: `[EPIC_02][STORY_04][SUBSTORY_02]Guard deferred transition callbacks`.

Deferred callbacks could resolve after a map transition changed the active game/map context. This PR keeps those callbacks tied to the map and transition generation they were created from, so stale work cannot mutate the new context.

## Validation
- `git diff --check`
- `git diff --exit-code -- planning/fall_of_nouraajd_issue_proposals.xlsx`
- `python3 -m py_compile test.py`
- `python3 scripts/issue_queue.py validate`

`issue_queue.py validate` passed with the pre-existing heartbeat-overdue lease-valid warnings for rows 11, 15, 128, and 132. Local native builds/tests were not run in this controller worktree; GitHub Actions is the native validation gate.
