### PR TITLE
Warn when resource audit HEAD lags origin/main

### DIFF
--- a/scripts/controller_resource_audit.py
+++ b/scripts/controller_resource_audit.py
@@ -60,6 +60,9 @@ class GitHealthReport:
     gitCommonDir: str | None
     emptyLooseObjects: tuple[str, ...]
     emptyRefs: tuple[str, ...]
+    headAheadOriginMainCount: int | None = None
+    headBehindOriginMainCount: int | None = None
+    headBehindOriginMain: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -255,17 +258,49 @@ def runGitHealth(repoRoot: Path) -> GitHealthReport:
     originMain = runGit(repoRoot, ["rev-parse", "--verify", "refs/remotes/origin/main"])
     commonDir = runGit(repoRoot, ["rev-parse", "--git-common-dir"])
     gitCommonDir = resolveGitPath(repoRoot, commonDir.stdout.strip()) if commonDir.returncode == 0 else None
+    headText = head.stdout.strip() if head.returncode == 0 else None
+    originMainText = originMain.stdout.strip() if originMain.returncode == 0 else None
+    headAheadOriginMainCount: int | None = None
+    headBehindOriginMainCount: int | None = None
+    headBehindOriginMain: bool | None = None
+    if headText and originMainText:
+        if headText == originMainText:
+            headAheadOriginMainCount = 0
+            headBehindOriginMainCount = 0
+            headBehindOriginMain = False
+        else:
+            revList = runGit(repoRoot, ["rev-list", "--left-right", "--count", "HEAD...refs/remotes/origin/main"])
+            if revList.returncode == 0:
+                parts = revList.stdout.strip().split()
+                if len(parts) == 2:
+                    try:
+                        headAheadOriginMainCount = int(parts[0])
+                        headBehindOriginMainCount = int(parts[1])
+                        headBehindOriginMain = headBehindOriginMainCount > 0
+                    except ValueError:
+                        pass
 
     return GitHealthReport(
         statusExitCode=status.returncode,
         statusStdout=status.stdout.strip(),
         statusStderr=status.stderr.strip(),
-        head=head.stdout.strip() if head.returncode == 0 else None,
-        originMain=originMain.stdout.strip() if originMain.returncode == 0 else None,
+        head=headText,
+        originMain=originMainText,
         gitCommonDir=str(gitCommonDir) if gitCommonDir is not None else None,
         emptyLooseObjects=findEmptyLooseObjects(gitCommonDir),
         emptyRefs=findEmptyRefs(gitCommonDir),
+        headAheadOriginMainCount=headAheadOriginMainCount,
+        headBehindOriginMainCount=headBehindOriginMainCount,
+        headBehindOriginMain=headBehindOriginMain,
     )
+
+
+def statusReportsBehindOriginMain(statusStdout: str) -> bool:
+    _, marker, remainder = statusStdout.partition("[")
+    if not marker:
+        return False
+    details, _, _ = remainder.partition("]")
+    return any(part.strip().startswith("behind ") for part in details.split(","))
 
 
 def evaluateGitHealth(report: GitHealthReport) -> tuple[list[str], list[str]]:
@@ -282,6 +317,20 @@ def evaluateGitHealth(report: GitHealthReport) -> tuple[list[str], list[str]]:
         errors.append(f"{len(report.emptyLooseObjects)} zero-byte loose git object(s) found")
     if report.emptyRefs:
         errors.append(f"{len(report.emptyRefs)} zero-byte git ref file(s) found")
+    if report.headBehindOriginMain or (
+        report.headBehindOriginMain is None
+        and report.head
+        and report.originMain
+        and report.head != report.originMain
+        and statusReportsBehindOriginMain(report.statusStdout)
+    ):
+        detail = ""
+        if report.headBehindOriginMainCount is not None:
+            detail = f" by {report.headBehindOriginMainCount} commit(s)"
+        warnings.append(
+            f"HEAD is missing refs/remotes/origin/main commit(s){detail}; "
+            "fetch/rebase or recreate the controller checkout from latest origin/main before continuing"
+        )
     return errors, warnings
 
 
@@ -471,6 +520,9 @@ def payload(
             "statusStderr": gitHealth.statusStderr,
             "head": gitHealth.head,
             "originMain": gitHealth.originMain,
+            "headAheadOriginMainCount": gitHealth.headAheadOriginMainCount,
+            "headBehindOriginMainCount": gitHealth.headBehindOriginMainCount,
+            "headBehindOriginMain": gitHealth.headBehindOriginMain,
             "gitCommonDir": gitHealth.gitCommonDir,
             "emptyLooseObjects": {
                 "total": len(gitHealth.emptyLooseObjects),

--- a/tests/test_controller_resource_audit.py
+++ b/tests/test_controller_resource_audit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -145,6 +146,144 @@ detached
         self.assertIn("1 zero-byte loose git object(s) found", errors)
         self.assertIn("1 zero-byte git ref file(s) found", errors)
 
+    def test_evaluate_git_health_warns_when_head_is_behind_origin_main(self) -> None:
+        report = controller_resource_audit.GitHealthReport(
+            statusExitCode=0,
+            statusStdout="## main...origin/main [behind 1]",
+            statusStderr="",
+            head="old",
+            originMain="new",
+            gitCommonDir="/repo/.git",
+            emptyLooseObjects=(),
+            emptyRefs=(),
+            headAheadOriginMainCount=0,
+            headBehindOriginMainCount=1,
+            headBehindOriginMain=True,
+        )
+
+        errors, warnings = controller_resource_audit.evaluateGitHealth(report)
+
+        self.assertEqual([], errors)
+        self.assertTrue(
+            any("HEAD is missing refs/remotes/origin/main commit(s) by 1" in warning for warning in warnings),
+            warnings,
+        )
+
+    def test_evaluate_git_health_falls_back_to_status_behind_marker(self) -> None:
+        report = controller_resource_audit.GitHealthReport(
+            statusExitCode=0,
+            statusStdout="## main...origin/main [behind 2]",
+            statusStderr="",
+            head="old",
+            originMain="new",
+            gitCommonDir="/repo/.git",
+            emptyLooseObjects=(),
+            emptyRefs=(),
+            headBehindOriginMain=None,
+        )
+
+        errors, warnings = controller_resource_audit.evaluateGitHealth(report)
+
+        self.assertEqual([], errors)
+        self.assertTrue(
+            any("HEAD is missing refs/remotes/origin/main commit(s)" in warning for warning in warnings),
+            warnings,
+        )
+
+    def test_evaluate_git_health_fallback_handles_diverged_status(self) -> None:
+        report = controller_resource_audit.GitHealthReport(
+            statusExitCode=0,
+            statusStdout="## feature...origin/main [ahead 1, behind 2]",
+            statusStderr="",
+            head="feature",
+            originMain="main",
+            gitCommonDir="/repo/.git",
+            emptyLooseObjects=(),
+            emptyRefs=(),
+            headBehindOriginMain=None,
+        )
+
+        errors, warnings = controller_resource_audit.evaluateGitHealth(report)
+
+        self.assertEqual([], errors)
+        self.assertTrue(
+            any("HEAD is missing refs/remotes/origin/main commit(s)" in warning for warning in warnings),
+            warnings,
+        )
+
+    def test_evaluate_git_health_does_not_warn_for_ahead_only_head(self) -> None:
+        report = controller_resource_audit.GitHealthReport(
+            statusExitCode=0,
+            statusStdout="## feature...origin/main [ahead 1]",
+            statusStderr="",
+            head="feature",
+            originMain="main",
+            gitCommonDir="/repo/.git",
+            emptyLooseObjects=(),
+            emptyRefs=(),
+            headAheadOriginMainCount=1,
+            headBehindOriginMainCount=0,
+            headBehindOriginMain=False,
+        )
+
+        errors, warnings = controller_resource_audit.evaluateGitHealth(report)
+
+        self.assertEqual([], errors)
+        self.assertEqual([], warnings)
+
+    def test_evaluate_git_health_warns_for_diverged_head_missing_origin_commits(self) -> None:
+        report = controller_resource_audit.GitHealthReport(
+            statusExitCode=0,
+            statusStdout="## feature...origin/main [ahead 1, behind 2]",
+            statusStderr="",
+            head="feature",
+            originMain="main",
+            gitCommonDir="/repo/.git",
+            emptyLooseObjects=(),
+            emptyRefs=(),
+            headAheadOriginMainCount=1,
+            headBehindOriginMainCount=2,
+            headBehindOriginMain=True,
+        )
+
+        errors, warnings = controller_resource_audit.evaluateGitHealth(report)
+
+        self.assertEqual([], errors)
+        self.assertTrue(any("by 2 commit(s)" in warning for warning in warnings), warnings)
+
+    def test_run_git_health_detects_head_behind_origin_main(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, stdout=subprocess.PIPE)
+            subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+            (repo / "file.txt").write_text("base\n", encoding="utf-8")
+            subprocess.run(["git", "add", "file.txt"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-m", "base"], cwd=repo, check=True, stdout=subprocess.PIPE)
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                stdout=subprocess.PIPE,
+                text=True,
+            ).stdout.strip()
+            (repo / "file.txt").write_text("base\nnext\n", encoding="utf-8")
+            subprocess.run(["git", "commit", "-am", "next"], cwd=repo, check=True, stdout=subprocess.PIPE)
+            subprocess.run(["git", "update-ref", "refs/remotes/origin/main", "HEAD"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "checkout", "--detach", base_sha],
+                cwd=repo,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            report = controller_resource_audit.runGitHealth(repo)
+
+        self.assertTrue(report.headBehindOriginMain)
+        self.assertEqual(0, report.headAheadOriginMainCount)
+        self.assertEqual(1, report.headBehindOriginMainCount)
+
     def test_required_checks_support_contexts_and_rich_check_payloads(self) -> None:
         checks = controller_resource_audit.requiredChecksFromProtectionPayload(
             {
@@ -220,6 +359,9 @@ detached
             gitCommonDir="/repo/.git",
             emptyLooseObjects=(),
             emptyRefs=(),
+            headAheadOriginMainCount=0,
+            headBehindOriginMainCount=0,
+            headBehindOriginMain=False,
         )
         branch = controller_resource_audit.BranchProtectionReport(
             repo="owner/repo",
@@ -243,6 +385,9 @@ detached
 
         self.assertEqual(False, payload["branchProtection"]["protected"])
         self.assertEqual(["linux"], payload["branchProtection"]["missingRequiredChecks"])
+        self.assertEqual(False, payload["git"]["headBehindOriginMain"])
+        self.assertEqual(0, payload["git"]["headAheadOriginMainCount"])
+        self.assertEqual(0, payload["git"]["headBehindOriginMainCount"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed
- Added an explicit `HEAD...refs/remotes/origin/main` distance check to `scripts/controller_resource_audit.py`.
- Added additive JSON fields for `headAheadOriginMainCount`, `headBehindOriginMainCount`, and `headBehindOriginMain`.
- Warns when a controller checkout is missing commits from `origin/main`, including diverged branches.
- Added focused regression tests for behind, ahead-only, diverged, fallback status parsing, payload fields, and a real temporary git repo.

## Why
Optimizer/controller runs can continue from a stale checkout after `origin/main` advances. The audit previously resolved both refs but did not compare them, so a controller could miss that its local `HEAD` lacked current shared workflow or workbook state.

## Validation
- `python3 -m py_compile scripts/controller_resource_audit.py tests/test_controller_resource_audit.py`
- `python3 -m unittest tests.test_controller_resource_audit`
- `python3 -m unittest tests.test_issue_queue tests.test_pr_review_audit tests.test_workflow_observations`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes --github-repo lisu188/fall-of-nouraajd`
- `python3 scripts/issue_queue.py validate`
- `python3 scripts/workflow_observations.py validate`
- `black -l 120 --check scripts/controller_resource_audit.py tests/test_controller_resource_audit.py`
- `git diff --check`

## Notes
- The only local resource-audit warning after the change is the existing branch-protection warning for `main`.
- No workbook, gameplay, queue schema, or dependency changes.
