### PR TITLE
Exercise pending seal finalization through map turn

### DIFF
--- a/test.py
+++ b/test.py
@@ -12745,8 +12745,10 @@ class GameTest(unittest.TestCase):
 
             exit_coords = find_adjacent_walkable_tile(game_map, spawn_coords)
             player.moveTo(exit_coords.x, exit_coords.y, exit_coords.z)
-            spawn_point.onTurn(None)
+            turn_before_finalize = game_map.getTurn()
+            advance_map_only(game_map, 1)
 
+            self.assertEqual(turn_before_finalize + 1, game_map.getTurn())
             self.assertTrue(spawn_point.getBoolProperty("destroyed"))
             self.assertFalse(spawn_point.getBoolProperty("pendingSeal"))
             self.assertFalse(spawn_point.getBoolProperty("canStep"))


### PR DESCRIPTION
## What changed
- Tightened the siege pending-seal regression to advance the map by one turn instead of directly calling SpawnPoint.onTurn().
- Asserted the turn advanced before verifying pendingSeal clears and the gate becomes blocking.

## Why
Row 23 requires pending seals to resolve automatically on turn/leave without reload or manual interaction. The production finalization hook already exists; this change locks the automatic map-turn path into regression coverage.

## Validation
- GAME_CONFIGURE_SKIP_APT=1 GAME_CONFIGURE_SKIP_SUBMODULES=1 GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh
- git submodule update --init --recursive
- cmake --build cmake-build-release --target _game -j$(nproc)
- python3 -m black -l 120 test.py
- python3 -m py_compile test.py
- python3 test.py GameTest.test_siege_spawn_point_defers_blocking_sealed_occupied_gate
- python3 test.py GameTest.test_siege_spawn_point_ignores_dead_gate_creatures_when_completing_seal GameTest.test_map_walkthrough_siege
- python3 test.py GameTest.test_siege_spawn_point_defers_blocking_sealed_occupied_gate GameTest.test_siege_spawn_point_ignores_dead_gate_creatures_when_completing_seal GameTest.test_map_walkthrough_siege
- git diff --check

## Known limitations / follow-up
- Full Linux, Python suite, and coverage validation are delegated to GitHub Actions for this PR.
