### PR TITLE
Track optimizer run trees in resource audit

### DIFF
--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -282,16 +282,19 @@ python3 scripts/controller_resource_audit.py --json
 ```
 
 The audit reports Git repository health, disk usage, active and prunable worktree registrations, and matching controller
-run/worktrees such as `/tmp/nouraajd-*` and `/tmp/fall-of-nouraajd-codex`. It is report-only by default. Treat audit
-errors such as unreadable Git state, unresolved `HEAD` or `origin/main`, zero-byte loose Git objects, zero-byte Git ref
-files, or disk pressure as blockers to new heavy work, and treat warnings about prunable worktree metadata or large
-accumulated run/worktrees as cleanup prompts before refilling worker slots.
+run/worktrees such as `/tmp/nouraajd-*`, `/tmp/fall-of-nouraajd-codex`, and `/tmp/fon-workflow-optimizer-*`. It is
+report-only by default. Treat audit errors such as unreadable Git state, unresolved `HEAD` or `origin/main`, zero-byte
+loose Git objects, zero-byte Git ref files, or disk pressure as blockers to new heavy work, and treat warnings about
+prunable worktree metadata or large accumulated run/worktrees as cleanup prompts before refilling worker slots.
 
 When auditing merge-policy drift or cleanup readiness, include the live GitHub branch-protection check:
 
 ```bash
 python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes --github-repo lisu188/fall-of-nouraajd
 ```
+
+`--skip-run-tree-sizes` is discovery-only. Its JSON output marks `runTrees.sizesMeasured` and each record's
+`sizeMeasured` as `false`; run it without that flag before relying on run-tree byte totals for cleanup priority.
 
 ## Subagent progress protocol
 

--- a/prompts/codex-workflow-optimizer.md
+++ b/prompts/codex-workflow-optimizer.md
@@ -137,6 +137,7 @@ Repeat the following cycle:
      - `python3 -m unittest tests.test_pr_review_audit`
      - `python3 -m unittest tests.test_workflow_observations`
      - `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`
+       This is run-tree discovery evidence only; rerun without `--skip-run-tree-sizes` before relying on byte totals.
    - Collect relevant evidence such as failures, test duration, queue conflicts, stale claims, PR-state errors,
      unnecessary rebuilds, resource pressure, disk pressure, stale run/worktrees, prunable worktree metadata, and
      prompt/document drift.

--- a/scripts/controller_resource_audit.py
+++ b/scripts/controller_resource_audit.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Sequence
 
-DEFAULT_RUN_TREE_PATTERNS = ("nouraajd-*", "fall-of-nouraajd-codex")
+DEFAULT_RUN_TREE_PATTERNS = ("nouraajd-*", "fall-of-nouraajd-codex", "fon-workflow-optimizer-*")
 DEFAULT_MIN_FREE_GIB = 5.0
 DEFAULT_MAX_USED_PERCENT = 95.0
 DEFAULT_PROTECTED_BRANCH = "main"
@@ -48,6 +48,7 @@ class WorktreeRecord:
 class RunTreeRecord:
     path: str
     sizeBytes: int
+    sizeMeasured: bool = True
 
 
 @dataclass(frozen=True)
@@ -497,8 +498,10 @@ def discoverRunTrees(
                 continue
             if matchesRunTreePattern(entry.name, patterns):
                 seen.add(resolved)
-                size = directorySize(entry) if includeSizes else 0
-                records.append(RunTreeRecord(path=str(entry), sizeBytes=size))
+                if includeSizes:
+                    records.append(RunTreeRecord(path=str(entry), sizeBytes=directorySize(entry)))
+                else:
+                    records.append(RunTreeRecord(path=str(entry), sizeBytes=0, sizeMeasured=False))
     return sorted(records, key=lambda record: record.path)
 
 
@@ -508,6 +511,7 @@ def payload(
     diskReports: Sequence[DiskReport],
     worktrees: Sequence[WorktreeRecord],
     runTrees: Sequence[RunTreeRecord],
+    runTreeSizesMeasured: bool,
     branchProtection: BranchProtectionReport | None,
     errors: Sequence[str],
     warnings: Sequence[str],
@@ -548,8 +552,14 @@ def payload(
         "runTrees": {
             "total": len(runTrees),
             "totalBytes": sum(record.sizeBytes for record in runTrees),
+            "sizesMeasured": runTreeSizesMeasured,
             "records": [
-                {"path": record.path, "sizeBytes": record.sizeBytes, "sizeHuman": formatBytes(record.sizeBytes)}
+                {
+                    "path": record.path,
+                    "sizeBytes": record.sizeBytes,
+                    "sizeHuman": formatBytes(record.sizeBytes),
+                    "sizeMeasured": record.sizeMeasured,
+                }
                 for record in runTrees
             ],
         },
@@ -574,7 +584,10 @@ def printHuman(report: dict[str, Any]) -> None:
     worktrees = report["worktrees"]
     print(f"Worktrees: {worktrees['active']} active, " f"{worktrees['prunable']} prunable, {worktrees['total']} total")
     runTrees = report["runTrees"]
-    print(f"Run trees: {runTrees['total']} matching, " f"{formatBytes(runTrees['totalBytes'])} total")
+    if runTrees["sizesMeasured"]:
+        print(f"Run trees: {runTrees['total']} matching, " f"{formatBytes(runTrees['totalBytes'])} total")
+    else:
+        print(f"Run trees: {runTrees['total']} matching, sizes not measured")
     branchProtection = report.get("branchProtection")
     if branchProtection:
         protected = branchProtection["protected"]
@@ -610,7 +623,7 @@ def buildParser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Glob for controller run/worktree directory names. May be repeated. Defaults to "
-            "nouraajd-* and fall-of-nouraajd-codex."
+            f"{', '.join(DEFAULT_RUN_TREE_PATTERNS)}."
         ),
     )
     parser.add_argument("--min-free-gib", type=float, default=DEFAULT_MIN_FREE_GIB)
@@ -675,7 +688,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     summary = worktreeSummary(worktrees)
     if summary["prunable"]:
         warnings.append(f"{summary['prunable']} prunable worktree registration(s); review and run git worktree prune")
-    report = payload(repoRoot, gitHealth, diskReports, worktrees, runTrees, branchProtection, errors, warnings)
+    report = payload(
+        repoRoot,
+        gitHealth,
+        diskReports,
+        worktrees,
+        runTrees,
+        not args.skip_run_tree_sizes,
+        branchProtection,
+        errors,
+        warnings,
+    )
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:

--- a/tests/test_controller_resource_audit.py
+++ b/tests/test_controller_resource_audit.py
@@ -97,6 +97,40 @@ detached
         self.assertTrue(records[0].path.endswith("fall-of-nouraajd-codex"))
         self.assertEqual(23, records[0].sizeBytes)
 
+    def test_discover_run_trees_includes_workflow_optimizer_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_tree = root / "fon-workflow-optimizer-demo"
+            run_tree.mkdir()
+            (run_tree / "artifact.txt").write_text("x" * 19, encoding="utf-8")
+
+            records = controller_resource_audit.discoverRunTrees(
+                [root],
+                controller_resource_audit.DEFAULT_RUN_TREE_PATTERNS,
+            )
+
+        self.assertEqual(1, len(records))
+        self.assertTrue(records[0].path.endswith("fon-workflow-optimizer-demo"))
+        self.assertEqual(19, records[0].sizeBytes)
+        self.assertTrue(records[0].sizeMeasured)
+
+    def test_discover_run_trees_marks_skipped_size_measurements(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            run_tree = root / "fon-workflow-optimizer-demo"
+            run_tree.mkdir()
+            (run_tree / "artifact.txt").write_text("x" * 19, encoding="utf-8")
+
+            records = controller_resource_audit.discoverRunTrees(
+                [root],
+                controller_resource_audit.DEFAULT_RUN_TREE_PATTERNS,
+                includeSizes=False,
+            )
+
+        self.assertEqual(1, len(records))
+        self.assertEqual(0, records[0].sizeBytes)
+        self.assertFalse(records[0].sizeMeasured)
+
     def test_find_empty_loose_objects_reports_relative_object_paths(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             git_common_dir = Path(temp_dir)
@@ -378,6 +412,7 @@ detached
             [],
             [],
             [],
+            True,
             branch,
             [],
             ["owner/repo:main: branch is not protected"],
@@ -388,6 +423,63 @@ detached
         self.assertEqual(False, payload["git"]["headBehindOriginMain"])
         self.assertEqual(0, payload["git"]["headAheadOriginMainCount"])
         self.assertEqual(0, payload["git"]["headBehindOriginMainCount"])
+
+    def test_payload_marks_unmeasured_run_tree_sizes(self) -> None:
+        git = controller_resource_audit.GitHealthReport(
+            statusExitCode=0,
+            statusStdout="",
+            statusStderr="",
+            head="abc123",
+            originMain="abc123",
+            gitCommonDir="/repo/.git",
+            emptyLooseObjects=(),
+            emptyRefs=(),
+        )
+
+        payload = controller_resource_audit.payload(
+            Path("/repo"),
+            git,
+            [],
+            [],
+            [controller_resource_audit.RunTreeRecord("/tmp/fon-workflow-optimizer-demo", 0, sizeMeasured=False)],
+            False,
+            None,
+            [],
+            [],
+        )
+
+        self.assertEqual(0, payload["runTrees"]["totalBytes"])
+        self.assertFalse(payload["runTrees"]["sizesMeasured"])
+        self.assertFalse(payload["runTrees"]["records"][0]["sizeMeasured"])
+        self.assertEqual("0.0 MiB", payload["runTrees"]["records"][0]["sizeHuman"])
+
+    def test_payload_preserves_skipped_size_mode_with_no_run_tree_records(self) -> None:
+        git = controller_resource_audit.GitHealthReport(
+            statusExitCode=0,
+            statusStdout="",
+            statusStderr="",
+            head="abc123",
+            originMain="abc123",
+            gitCommonDir="/repo/.git",
+            emptyLooseObjects=(),
+            emptyRefs=(),
+        )
+
+        payload = controller_resource_audit.payload(
+            Path("/repo"),
+            git,
+            [],
+            [],
+            [],
+            False,
+            None,
+            [],
+            [],
+        )
+
+        self.assertEqual(0, payload["runTrees"]["total"])
+        self.assertEqual(0, payload["runTrees"]["totalBytes"])
+        self.assertFalse(payload["runTrees"]["sizesMeasured"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed
- Added `fon-workflow-optimizer-*` to the default resource-audit run-tree patterns.
- Added additive run-tree size metadata: top-level `runTrees.sizesMeasured` and per-record `sizeMeasured`.
- Human output now says sizes were not measured when `--skip-run-tree-sizes` was used.
- Updated queue docs and optimizer prompt to treat `--skip-run-tree-sizes` output as discovery-only.
- Added regressions for optimizer run-tree detection, skipped size records, empty skipped-size results, and payload metadata.

## Why
The optimizer uses `/tmp/fon-workflow-optimizer-*` worktrees, but the resource audit only detected `nouraajd-*` and `fall-of-nouraajd-codex`. That hid active optimizer run trees from resource summaries. Also, `--skip-run-tree-sizes` reported `sizeBytes: 0` and `0.0 MiB` with no marker, making skipped measurement look like a real zero-byte directory.

Reviewer feedback also found that empty discovery-only results could incorrectly report `sizesMeasured: true`; this PR passes the measurement mode explicitly so even zero-record discovery output remains unambiguous.

## Validation
- `python3 -m py_compile scripts/controller_resource_audit.py tests/test_controller_resource_audit.py`
- `python3 -m unittest tests.test_controller_resource_audit tests.test_prompt_inventory`
- `python3 -m unittest tests.test_issue_queue tests.test_pr_review_audit tests.test_workflow_observations`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes --github-repo lisu188/fall-of-nouraajd`
- `python3 scripts/controller_resource_audit.py --json --github-repo lisu188/fall-of-nouraajd`
- `python3 scripts/issue_queue.py validate`
- `python3 scripts/workflow_observations.py validate`
- `black -l 120 --check scripts/controller_resource_audit.py tests/test_controller_resource_audit.py`
- `git diff --check`

## Notes
- Existing `sizeBytes`, `sizeHuman`, and `totalBytes` fields are preserved for compatibility.
- The only resource-audit warning remains the existing `main` branch-protection warning.
- No workbook, gameplay, queue schema, or dependency changes.
