### PR TITLE
Add GUI render context facade

### DIFF
--- a/src/gui/CAnimation.cpp
+++ b/src/gui/CAnimation.cpp
@@ -49,9 +49,9 @@ void CStaticAnimation::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<S
         SDL_SetTextureAlphaMod(texture, colorA);
     }
     if (rotation == 0) {
-        SDL_SAFE(SDL_RenderCopy(gui->getRenderer(), texture, nullptr, rect.get()));
+        gui->getRenderContext().copy(texture, nullptr, rect.get());
     } else {
-        SDL_SAFE(SDL_RenderCopyEx(gui->getRenderer(), texture, nullptr, rect.get(), rotation, nullptr, SDL_FLIP_NONE));
+        gui->getRenderContext().copyEx(texture, nullptr, rect.get(), rotation, nullptr, SDL_FLIP_NONE);
     }
     if (useColorMod) {
         SDL_SetTextureColorMod(texture, 255, 255, 255);
@@ -123,7 +123,7 @@ void CDynamicAnimation::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<
             vstd::logger::error("CDynamicAnimation: missing frame", paths[currFrame]);
             return;
         }
-        SDL_SAFE(SDL_RenderCopy(gui->getRenderer(), texture, nullptr, rect.get()));
+        gui->getRenderContext().copy(texture, nullptr, rect.get());
     }
 }
 

--- a/src/gui/CGui.cpp
+++ b/src/gui/CGui.cpp
@@ -105,6 +105,7 @@ CGui::CGui() {
     SDL_SetWindowMinimumSize(rawWindow, GUI_MIN_WIDTH, GUI_MIN_HEIGHT);
     window.reset(rawWindow);
     renderer.reset(rawRenderer);
+    renderContext.setRenderer(renderer.get());
     // TODO: set icon
     // TODO: check render flags
 }
@@ -139,6 +140,10 @@ void CGui::render(int i1) {
 }
 
 SDL_Renderer *CGui::getRenderer() const { return renderer.get(); }
+
+CRenderContext &CGui::getRenderContext() { return renderContext; }
+
+const CRenderContext &CGui::getRenderContext() const { return renderContext; }
 
 std::shared_ptr<CTextureCache> CGui::getTextureCache() {
     return _textureCache.get([this]() { return std::make_shared<CTextureCache>(this->ptr<CGui>()); });

--- a/src/gui/CGui.h
+++ b/src/gui/CGui.h
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "core/CGame.h"
 #include "core/CGlobal.h"
+#include "gui/CRenderContext.h"
 #include "gui/CSdlResources.h"
 #include "gui/object/CGameGraphicsObject.h"
 #include "object/CGameObject.h"
@@ -34,6 +35,7 @@ class CGui : public CGameGraphicsObject {
            V_PROPERTY(CGui, int, width, getWidth, setWidth), V_PROPERTY(CGui, int, tileSize, getTileSize, setTileSize))
     fn::sdl::WindowPtr window;
     fn::sdl::RendererPtr renderer;
+    CRenderContext renderContext;
 
   public:
     struct DragSession {
@@ -51,6 +53,10 @@ class CGui : public CGameGraphicsObject {
     using CGameGraphicsObject::render;
 
     SDL_Renderer *getRenderer() const;
+
+    CRenderContext &getRenderContext();
+
+    const CRenderContext &getRenderContext() const;
 
     int getWidth();
 

--- a/src/gui/CRenderContext.cpp
+++ b/src/gui/CRenderContext.cpp
@@ -1,0 +1,160 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "gui/CRenderContext.h"
+
+namespace {
+class RenderClipGuard {
+  public:
+    RenderClipGuard(SDL_Renderer *renderer, const SDL_Rect *clip) : renderer(renderer), enabled(clip != nullptr) {
+        if (!renderer || !clip) {
+            return;
+        }
+        previousClipEnabled = SDL_RenderIsClipEnabled(renderer);
+        if (previousClipEnabled) {
+            SDL_RenderGetClipRect(renderer, &previousClip);
+        }
+        const auto normalizedClip = CRenderContext::normalizeTargetRect(*clip);
+        ready = SDL_RenderSetClipRect(renderer, &normalizedClip) == 0;
+        if (!ready) {
+            vstd::logger::error("CRenderContext: failed to set render clip", SDL_GetError());
+        }
+    }
+
+    ~RenderClipGuard() {
+        if (!renderer || !enabled || !ready) {
+            return;
+        }
+        if (previousClipEnabled) {
+            if (SDL_RenderSetClipRect(renderer, &previousClip) != 0) {
+                vstd::logger::error("CRenderContext: failed to restore render clip", SDL_GetError());
+            }
+        } else if (SDL_RenderSetClipRect(renderer, nullptr) != 0) {
+            vstd::logger::error("CRenderContext: failed to clear render clip", SDL_GetError());
+        }
+    }
+
+    bool isReady() const { return ready; }
+
+  private:
+    SDL_Renderer *renderer = nullptr;
+    bool enabled = false;
+    bool ready = true;
+    SDL_bool previousClipEnabled = SDL_FALSE;
+    SDL_Rect previousClip = {0, 0, 0, 0};
+};
+} // namespace
+
+CRenderContext::CRenderContext(SDL_Renderer *renderer) : renderer(renderer) {}
+
+void CRenderContext::setRenderer(SDL_Renderer *renderer) { this->renderer = renderer; }
+
+SDL_Renderer *CRenderContext::getRenderer() const { return renderer; }
+
+bool CRenderContext::copy(SDL_Texture *texture, const SDL_Rect *sourceRect, const SDL_Rect *targetRect,
+                          const SDL_Rect *clipRect) {
+    SDL_Rect normalizedTarget;
+    if (!prepareCopy(texture, targetRect, normalizedTarget, "CRenderContext::copy")) {
+        return false;
+    }
+    RenderClipGuard clipGuard(renderer, clipRect);
+    if (!clipGuard.isReady()) {
+        ++stats.failedCopies;
+        return false;
+    }
+    return finishCopy(SDL_RenderCopy(renderer, texture, sourceRect, &normalizedTarget), "CRenderContext::copy");
+}
+
+bool CRenderContext::copy(SDL_Texture *texture, const SDL_Rect *sourceRect, const SDL_Rect &targetRect,
+                          const SDL_Rect *clipRect) {
+    return copy(texture, sourceRect, &targetRect, clipRect);
+}
+
+bool CRenderContext::copyEx(SDL_Texture *texture, const SDL_Rect *sourceRect, const SDL_Rect *targetRect, double angle,
+                            const SDL_Point *center, SDL_RendererFlip flip, const SDL_Rect *clipRect) {
+    SDL_Rect normalizedTarget;
+    if (!prepareCopy(texture, targetRect, normalizedTarget, "CRenderContext::copyEx")) {
+        return false;
+    }
+    RenderClipGuard clipGuard(renderer, clipRect);
+    if (!clipGuard.isReady()) {
+        ++stats.failedCopies;
+        return false;
+    }
+    return finishCopy(SDL_RenderCopyEx(renderer, texture, sourceRect, &normalizedTarget, angle, center, flip),
+                      "CRenderContext::copyEx");
+}
+
+bool CRenderContext::copyEx(SDL_Texture *texture, const SDL_Rect *sourceRect, const SDL_Rect &targetRect, double angle,
+                            const SDL_Point *center, SDL_RendererFlip flip, const SDL_Rect *clipRect) {
+    return copyEx(texture, sourceRect, &targetRect, angle, center, flip, clipRect);
+}
+
+const CRenderContext::RenderStats &CRenderContext::getStats() const { return stats; }
+
+void CRenderContext::resetStats() { stats = {}; }
+
+SDL_Rect CRenderContext::normalizeTargetRect(const SDL_Rect &rect) {
+    SDL_Rect normalized = rect;
+    if (normalized.w < 0) {
+        normalized.x += normalized.w;
+        normalized.w = -normalized.w;
+    }
+    if (normalized.h < 0) {
+        normalized.y += normalized.h;
+        normalized.h = -normalized.h;
+    }
+    return normalized;
+}
+
+bool CRenderContext::prepareCopy(SDL_Texture *texture, const SDL_Rect *targetRect, SDL_Rect &normalizedTarget,
+                                 const char *operation) {
+    ++stats.attemptedCopies;
+    if (!renderer) {
+        ++stats.skippedCopies;
+        vstd::logger::error(operation, "missing renderer");
+        return false;
+    }
+    if (!texture) {
+        ++stats.skippedCopies;
+        vstd::logger::error(operation, "missing texture");
+        return false;
+    }
+    if (!targetRect) {
+        ++stats.skippedCopies;
+        vstd::logger::error(operation, "missing target rect");
+        return false;
+    }
+    normalizedTarget = normalizeTargetRect(*targetRect);
+    if (normalizedTarget.w <= 0 || normalizedTarget.h <= 0) {
+        ++stats.skippedCopies;
+        vstd::logger::warning(operation, "empty target rect", normalizedTarget.x, normalizedTarget.y,
+                              normalizedTarget.w, normalizedTarget.h);
+        return false;
+    }
+    return true;
+}
+
+bool CRenderContext::finishCopy(int result, const char *operation) {
+    if (result != 0) {
+        ++stats.failedCopies;
+        vstd::logger::error(operation, "failed", SDL_GetError());
+        return false;
+    }
+    ++stats.successfulCopies;
+    return true;
+}

--- a/src/gui/CRenderContext.h
+++ b/src/gui/CRenderContext.h
@@ -1,0 +1,63 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "core/CGlobal.h"
+
+class CRenderContext {
+  public:
+    struct RenderStats {
+        std::size_t attemptedCopies = 0;
+        std::size_t successfulCopies = 0;
+        std::size_t failedCopies = 0;
+        std::size_t skippedCopies = 0;
+    };
+
+    explicit CRenderContext(SDL_Renderer *renderer = nullptr);
+
+    void setRenderer(SDL_Renderer *renderer);
+
+    SDL_Renderer *getRenderer() const;
+
+    bool copy(SDL_Texture *texture, const SDL_Rect *sourceRect, const SDL_Rect *targetRect,
+              const SDL_Rect *clipRect = nullptr);
+
+    bool copy(SDL_Texture *texture, const SDL_Rect *sourceRect, const SDL_Rect &targetRect,
+              const SDL_Rect *clipRect = nullptr);
+
+    bool copyEx(SDL_Texture *texture, const SDL_Rect *sourceRect, const SDL_Rect *targetRect, double angle,
+                const SDL_Point *center, SDL_RendererFlip flip, const SDL_Rect *clipRect = nullptr);
+
+    bool copyEx(SDL_Texture *texture, const SDL_Rect *sourceRect, const SDL_Rect &targetRect, double angle,
+                const SDL_Point *center, SDL_RendererFlip flip, const SDL_Rect *clipRect = nullptr);
+
+    const RenderStats &getStats() const;
+
+    void resetStats();
+
+    static SDL_Rect normalizeTargetRect(const SDL_Rect &rect);
+
+  private:
+    bool prepareCopy(SDL_Texture *texture, const SDL_Rect *targetRect, SDL_Rect &normalizedTarget,
+                     const char *operation);
+
+    bool finishCopy(int result, const char *operation);
+
+    SDL_Renderer *renderer = nullptr;
+    RenderStats stats;
+};

--- a/src/gui/CTextManager.cpp
+++ b/src/gui/CTextManager.cpp
@@ -34,36 +34,6 @@ std::string boundedText(std::string text) {
 }
 
 int boundedWidth(int width) { return std::clamp(width, 0, MAX_TEXT_WRAP_WIDTH); }
-
-class RenderClipGuard {
-  public:
-    RenderClipGuard(SDL_Renderer *renderer, const SDL_Rect &clip) : renderer(renderer) {
-        if (!renderer) {
-            return;
-        }
-        clipWasEnabled = SDL_RenderIsClipEnabled(renderer);
-        if (clipWasEnabled) {
-            SDL_RenderGetClipRect(renderer, &previousClip);
-        }
-        SDL_RenderSetClipRect(renderer, &clip);
-    }
-
-    ~RenderClipGuard() {
-        if (!renderer) {
-            return;
-        }
-        if (clipWasEnabled) {
-            SDL_RenderSetClipRect(renderer, &previousClip);
-        } else {
-            SDL_RenderSetClipRect(renderer, nullptr);
-        }
-    }
-
-  private:
-    SDL_Renderer *renderer;
-    SDL_bool clipWasEnabled = SDL_FALSE;
-    SDL_Rect previousClip = {0, 0, 0, 0};
-};
 } // namespace
 
 SDL_Texture *CTextManager::getTexture(const std::string &text, int width) {
@@ -145,7 +115,7 @@ void CTextManager::drawText(const std::string &text, int x, int y, int w) {
             return;
         }
         SDL_SAFE(SDL_QueryTexture(pTexture, nullptr, nullptr, &actual.w, &actual.h));
-        SDL_SAFE(SDL_RenderCopy(_gui.lock()->getRenderer(), pTexture, nullptr, &actual));
+        _gui.lock()->getRenderContext().copy(pTexture, nullptr, &actual);
     }
 }
 
@@ -159,8 +129,7 @@ void CTextManager::drawTextCentered(const std::string &text, int x, int y, int w
         SDL_SAFE(SDL_QueryTexture(pTexture, nullptr, nullptr, &actual.w, &actual.h));
         auto centered = CUtil::boxInBox(CUtil::rect(x, y, w, h), CUtil::rect(0, 0, actual.w, actual.h));
         SDL_Rect clip = {x, y, std::max(0, w), std::max(0, h)};
-        RenderClipGuard clipGuard(_gui.lock()->getRenderer(), clip);
-        SDL_SAFE(SDL_RenderCopy(_gui.lock()->getRenderer(), pTexture, nullptr, centered.get()));
+        _gui.lock()->getRenderContext().copy(pTexture, nullptr, centered.get(), &clip);
     }
 }
 
@@ -173,8 +142,17 @@ void CTextManager::drawText(const std::string &text, const std::shared_ptr<SDL_R
         return;
     }
     SDL_Rect clip = {rect->x, rect->y, std::max(0, rect->w), std::max(0, rect->h)};
-    RenderClipGuard clipGuard(_gui.lock()->getRenderer(), clip);
-    drawText(text, rect->x, rect->y, rect->w);
+    if (text.length() != 0) {
+        SDL_Rect actual;
+        actual.x = rect->x;
+        actual.y = rect->y;
+        SDL_Texture *pTexture = getTexture(text, rect->w);
+        if (!pTexture) {
+            return;
+        }
+        SDL_SAFE(SDL_QueryTexture(pTexture, nullptr, nullptr, &actual.w, &actual.h));
+        _gui.lock()->getRenderContext().copy(pTexture, nullptr, &actual, &clip);
+    }
 }
 
 std::pair<int, int> CTextManager::getTextureSize(std::string text) {

--- a/src/gui/object/CGameGraphicsObject.cpp
+++ b/src/gui/object/CGameGraphicsObject.cpp
@@ -282,7 +282,7 @@ void CGameGraphicsObject::renderBackground(std::shared_ptr<CGui> gui, std::share
             vstd::logger::error("CGameGraphicsObject: missing background", background);
             return;
         }
-        SDL_SAFE(SDL_RenderCopy(gui->getRenderer(), texture, nullptr, rect.get()));
+        gui->getRenderContext().copy(texture, nullptr, rect.get());
     }
 }
 

--- a/src/gui/object/CMinimapGraphicsObject.cpp
+++ b/src/gui/object/CMinimapGraphicsObject.cpp
@@ -364,7 +364,7 @@ void CMinimapGraphicsObject::renderObject(std::shared_ptr<CGui> gui, std::shared
         terrainSignature = signature;
     }
     if (terrainTexture) {
-        SDL_SAFE(SDL_RenderCopy(renderer, terrainTexture.get(), nullptr, rect.get()));
+        gui->getRenderContext().copy(terrainTexture.get(), nullptr, rect.get());
     } else {
         fill_rect(renderer, rect, MINIMAP_BACKGROUND);
         draw_terrain(renderer, map, playerCoords.z, scale);

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -25,6 +25,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CTypes.h"
 #include "gui/CGui.h"
 #include "gui/CLayout.h"
+#include "gui/CRenderContext.h"
+#include "gui/CSdlResources.h"
 #include "gui/CTextureCache.h"
 #include "gui/object/CGameGraphicsObject.h"
 #include "gui/object/CWidget.h"
@@ -929,6 +931,44 @@ void test_texture_cache_without_gui_fails_closed() {
     expect_true(cache->getTexture("images/panel") == nullptr, "texture cache without GUI should return null");
 }
 
+void test_render_context_rejects_null_texture_and_copies_valid_texture() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto &renderContext = gui->getRenderContext();
+    renderContext.resetStats();
+
+    SDL_Rect target = {2, 3, 4, 5};
+    expect_true(!renderContext.copy(nullptr, nullptr, &target), "render context should reject null textures");
+
+    const auto normalized = CRenderContext::normalizeTargetRect(SDL_Rect{10, 12, -3, -4});
+    expect_true(normalized.x == 7 && normalized.y == 8 && normalized.w == 3 && normalized.h == 4,
+                "render context should normalize negative target extents");
+
+    auto surface = fn::sdl::SurfacePtr(SDL_SAFE(SDL_CreateRGBSurfaceWithFormat(0, 2, 2, 32, SDL_PIXELFORMAT_RGBA32)));
+    expect_true(surface != nullptr, "render context smoke test should create an SDL surface");
+    if (!surface) {
+        return;
+    }
+    SDL_SAFE(SDL_FillRect(surface.get(), nullptr, SDL_MapRGBA(surface->format, 255, 0, 0, 255)));
+    auto texture = fn::sdl::TexturePtr(SDL_SAFE(SDL_CreateTextureFromSurface(gui->getRenderer(), surface.get())));
+    expect_true(texture != nullptr, "render context smoke test should create an SDL texture");
+    if (!texture) {
+        return;
+    }
+
+    SDL_Rect source = {0, 0, 2, 2};
+    SDL_Rect clip = {0, 0, 8, 8};
+    expect_true(renderContext.copy(texture.get(), &source, target, &clip), "render context should copy valid textures");
+
+    const auto &stats = renderContext.getStats();
+    expect_true(stats.attemptedCopies == 2, "render context should count attempted copies");
+    expect_true(stats.successfulCopies == 1, "render context should count successful copies");
+    expect_true(stats.skippedCopies == 1, "render context should count skipped copies");
+    expect_true(stats.failedCopies == 0, "render context should not count failed copies for valid smoke path");
+}
+
 } // namespace
 
 int main() {
@@ -954,6 +994,7 @@ int main() {
     test_gui_pointer_capture_clears_when_captured_widget_is_removed();
     test_render_traversal_stops_after_detach();
     test_texture_cache_without_gui_fails_closed();
+    test_render_context_rejects_null_texture_and_copies_valid_texture();
 
     return finish_tests();
 }


### PR DESCRIPTION
## Summary
- Add CRenderContext as a GUI-owned rendering facade around SDL texture copy operations.
- Expose CGui::getRenderContext while keeping CGui::getRenderer for compatibility.
- Route existing GUI texture-copy call sites through the facade and add a focused GUI unit smoke test.

## Why
Row 103 ([EPIC_05][STORY_03][SUBSTORY_01] Add rendering facade) requires a centralized copy/clipping wrapper so new rendering code can avoid direct SDL_RenderCopy calls.

## Validation
- clang-format -i on touched C++/header files
- git diff --check
- python3 scripts/controller_resource_audit.py --json
- cmake --build cmake-build-release --target gui_unit_tests -j$(nproc) initially failed before submodules/configure: missing vstd.h
- git submodule update --init --recursive
- GAME_CONFIGURE_SKIP_APT=1 GAME_CONFIGURE_SKIP_SUBMODULES=1 GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh
- cmake --build cmake-build-release --target gui_unit_tests -j$(nproc) passed
- ctest --test-dir cmake-build-release --output-on-failure -R ^for_unit_tests\\.gui_unit_tests$ passed, 1/1

## Known limitations
- Full native/Python/performance/coverage validation is intentionally deferred to GitHub Actions polling for build / linux with coverage required.

Queue claim: e436d0a8-5d08-4a25-a9b3-72c2df9ab2ff, owner controller/ctrl-lis-2-b17e29a3/subagent-1.