### PR TITLE
Add tile movement cost metadata

### DIFF
--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -369,8 +369,8 @@ bool CMap::canStep(int x, int y, int z) {
 bool CMap::canStep(Coords coords) { return canStep(coords.x, coords.y, coords.z); }
 
 int CMap::getMovementCost(int x, int y, int z) {
-    getTile(x, y, z);
-    return 1;
+    auto tile = getTile(x, y, z);
+    return tile ? std::max(1, tile->getMovementCost()) : 1;
 }
 
 int CMap::getMovementCost(Coords coords) {

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -607,8 +607,7 @@ void init_game_module(py::module_ &m) {
         .def("getObjectByName", &CMap::getObjectByName, "Return a map object by name or None.")
         .def("forObjects", &CMap::forObjects, "Apply a callback for objects matching an optional predicate.")
         .def("canStep", canStep, "Return whether coordinates are walkable.")
-        .def("getMovementCost", getMovementCost,
-             "Return movement cost at coordinates. One-step turns treat every tile as cost 1.")
+        .def("getMovementCost", getMovementCost, "Return the pathfinding movement cost at coordinates.")
         .def("getTile", getTile, "Return the tile at coordinates, creating the layer default when missing.")
         .def("dumpPaths", &CMap::dumpPaths, "Write pathfinding diagnostics to a file path.")
         .def("getNavigationRevision", &CMap::getNavigationRevision,
@@ -775,6 +774,8 @@ void init_game_module(py::module_ &m) {
         py::class_<CTile, CWrapper<CTile>, std::shared_ptr<CTile>, CGameObject>(m, "CTile", "Base tile class.");
     ctile.def(py::init_alias<>())
         .def("onStep", &CTile::onStep, "Handle a creature stepping on this tile.")
+        .def("getMovementCost", &CTile::getMovementCost, "Return this tile's pathfinding movement cost.")
+        .def("setMovementCost", &CTile::setMovementCost, "Set this tile's pathfinding movement cost.")
         .def("getTileType", &CTile::getTileType, "Return this tile's terrain type.");
     m.attr("CTileBase") = ctile;
 

--- a/src/object/CTile.cpp
+++ b/src/object/CTile.cpp
@@ -20,6 +20,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CGame.h"
 #include "core/CMap.h"
 #include "core/CPythonOverrides.h"
+
+#include <algorithm>
+
 CTile::CTile() {}
 
 CTile::~CTile() {}
@@ -58,6 +61,10 @@ void CTile::setPosy(int value) { posy = value; }
 int CTile::getPosz() const { return posz; }
 
 void CTile::setPosz(int value) { posz = value; }
+
+int CTile::getMovementCost() const { return std::max(1, movementCost); }
+
+void CTile::setMovementCost(int value) { movementCost = std::max(1, value); }
 
 void CTile::setXYZ(int x, int y, int z) {
     posx = x;

--- a/src/object/CTile.h
+++ b/src/object/CTile.h
@@ -29,6 +29,7 @@ class CTile : public CGameObject {
     V_META(CTile, CGameObject, V_PROPERTY(CTile, bool, canStep, canStep, setCanStep),
            V_PROPERTY(CTile, int, posx, getPosx, setPosx), V_PROPERTY(CTile, int, posy, getPosy, setPosy),
            V_PROPERTY(CTile, int, posz, getPosz, setPosz),
+           V_PROPERTY(CTile, int, movementCost, getMovementCost, setMovementCost),
            V_PROPERTY(CTile, std::string, tileType, getTileType, setTileType))
 
   public:
@@ -60,6 +61,10 @@ class CTile : public CGameObject {
 
     void setPosz(int value);
 
+    int getMovementCost() const;
+
+    void setMovementCost(int value);
+
     const std::string &getTileType() const;
 
     void setTileType(const std::string &tileType);
@@ -67,6 +72,7 @@ class CTile : public CGameObject {
   private:
     std::string tileType;
     bool step = false;
+    int movementCost = 1;
     int posx = 0, posy = 0, posz = 0;
 
     void setXYZ(int x, int y, int z);

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -27,6 +27,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CSerialization.h"
 #include "core/CStats.h"
 #include "core/CTypes.h"
+#include "handler/CObjectHandler.h"
 #include "object/CCreature.h"
 #include "object/CGameObject.h"
 #include "object/CMapObject.h"
@@ -533,6 +534,7 @@ void test_map_tiles_bounds_wrapping_and_object_cache() {
     auto floor = std::make_shared<CTile>();
     floor->setTileType("floor");
     floor->setCanStep(true);
+    expect_true(floor->getMovementCost() == 1, "tile movement cost should default to one");
     expect_true(!map->addTile(nullptr, 0, 0, 0), "addTile should reject null tiles");
     expect_true(map->addTile(floor, 1, 1, 0), "addTile should store a new tile");
     expect_true(floor->getCoords() == Coords(1, 1, 0), "addTile should synchronize tile coordinates");
@@ -547,6 +549,10 @@ void test_map_tiles_bounds_wrapping_and_object_cache() {
     expect_true(!map->contains(1, 1, 0) && map->contains(2, 1, 0), "moveTile should relocate the tile index");
     expect_true(map->getTile(2, 1, 0) == floor, "moved tiles should be indexed at their new coordinate");
     expect_true(map->getMovementCost(2, 1, 0) == 1, "movement cost should be available for existing tiles");
+    floor->setMovementCost(4);
+    expect_true(map->getMovementCost(2, 1, 0) == 4, "map movement cost should read the stored tile value");
+    floor->setMovementCost(0);
+    expect_true(map->getMovementCost(2, 1, 0) == 1, "map movement cost should clamp invalid tile values");
 
     auto wall = std::make_shared<CTile>();
     wall->setCanStep(false);
@@ -618,6 +624,33 @@ void test_map_tiles_bounds_wrapping_and_object_cache() {
     expect_true(map->getObjectByName("markerObject") == nullptr, "removeObjectByName should erase existing objects");
     map->removeObjects([](std::shared_ptr<CMapObject> object) { return object->getName() == "blockingObject"; });
     expect_true(map->getObjects().empty(), "removeObjects should erase matching objects from a cloned iteration");
+}
+
+void test_tile_movement_cost_deserialization() {
+    auto game = CGameLoader::loadGame();
+
+    auto omitted = game->createObject<CTile>("GrassTile");
+    expect_true(omitted && omitted->getMovementCost() == 1,
+                "configured tiles without movementCost should keep the default");
+
+    auto weighted_config = std::make_shared<json>();
+    (*weighted_config)["class"] = "CTile";
+    (*weighted_config)["properties"]["canStep"] = true;
+    (*weighted_config)["properties"]["movementCost"] = 6;
+    (*weighted_config)["properties"]["tileType"] = "weighted";
+    game->getObjectHandler()->registerConfig("WeightedTile", weighted_config);
+
+    auto weighted = game->createObject<CTile>("WeightedTile");
+    expect_true(weighted && weighted->getMovementCost() == 6, "configured movementCost should deserialize onto CTile");
+
+    auto invalid_config = std::make_shared<json>();
+    (*invalid_config)["class"] = "CTile";
+    (*invalid_config)["properties"]["movementCost"] = -3;
+    game->getObjectHandler()->registerConfig("InvalidCostTile", invalid_config);
+
+    auto invalid = game->createObject<CTile>("InvalidCostTile");
+    expect_true(invalid && invalid->getMovementCost() == 1,
+                "invalid configured movementCost should clamp to one during deserialization");
 }
 
 void test_map_navigation_edges_update_revision() {
@@ -1181,6 +1214,7 @@ int main() {
     test_scene_manager_null_and_legacy_missing_target_behavior();
     test_scene_manager_rejects_cross_game_requests();
     test_map_tiles_bounds_wrapping_and_object_cache();
+    test_tile_movement_cost_deserialization();
     test_map_navigation_edges_update_revision();
     test_map_navigation_neighbors_include_registered_edges();
     test_map_dump_paths_uses_navigation_neighbors();


### PR DESCRIPTION
## What changed
- Added a `movementCost` integer property to `CTile` with default value `1` and clamp-to-1 setters/getters.
- Exposed `CTile.getMovementCost()` / `setMovementCost()` through pybind and V_META.
- Updated `CMap::getMovementCost()` to read the stored tile cost while preserving default behavior when costs are omitted.
- Added unit coverage for default, configured, and invalid movement-cost deserialization and map lookup.

## Why
- Implements row 83, [EPIC_04][STORY_02][SUBSTORY_02]Add movementCost to CTile, without changing existing tile JSON costs.
- Leaves non-materializing lookup and path-consumer routing to downstream queued rows 84 and 85.

## Validation
- `git diff --check`
- `cmake --build cmake-build-release --target _game map_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R 'for_unit_tests\\.map_unit_tests$'`

## Known limitations / follow-up
- `CMap::getMovementCost()` still materializes default tiles; row 84 covers non-materializing lookup.
- Player/NPC path consumers are not switched to movement costs here; row 85 covers that behavior.
