### PR TITLE
Add multilevel topology regression tests

### DIFF
--- a/test.py
+++ b/test.py
@@ -5372,6 +5372,40 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_teleporter_clears_navigation_edge_when_target_is_removed(self):
+        _g, game_map, _player = load_game_map_with_player("test", "Warrior")
+        active_teleporter = find_runtime_object(game_map, "teleporter1")
+        teleporter = find_runtime_object(game_map, "teleporter2")
+        teleporter_coords = coords_tuple(teleporter.getCoords())
+
+        def navigation_neighbors(obj):
+            return sorted(coords_tuple(coord) for coord in game_map.getNavigationNeighbors(obj.getCoords()))
+
+        advance_map_only(game_map, 1)
+
+        self.assertTrue(active_teleporter.getBoolProperty("waypoint"))
+        self.assertIn(teleporter_coords, navigation_neighbors(active_teleporter))
+        revision_with_edge = game_map.getNavigationRevision()
+
+        game_map.removeObject(teleporter)
+        active_teleporter.onTurn(None)
+
+        self.assertFalse(active_teleporter.getBoolProperty("waypoint"))
+        self.assertNotIn(teleporter_coords, navigation_neighbors(active_teleporter))
+        self.assertGreater(game_map.getNavigationRevision(), revision_with_edge)
+
+        return True, json.dumps(
+            {
+                "active_name": active_teleporter.getName(),
+                "active_waypoint": active_teleporter.getBoolProperty("waypoint"),
+                "removed_target": teleporter.getName(),
+                "revision_after_remove": game_map.getNavigationRevision(),
+                "revision_with_edge": revision_with_edge,
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_take_mana_clamps_at_zero(self):
         game = load_game_module()
         g = game.CGameLoader.loadGame()
@@ -6805,8 +6839,56 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_multilevel_map_disables_stairs_when_target_is_blocked(self):
+        game = load_game_module()
+        g, game_map, _player = load_game_map_with_player("multilevel")
+        stairs_up = find_runtime_object(game_map, "stairsUp")
+        upper_landing = game.Coords(4, 1, 1)
+
+        def navigation_neighbors(obj):
+            return sorted(coords_tuple(coord) for coord in game_map.getNavigationNeighbors(obj.getCoords()))
+
+        advance_map_only(game_map, 1)
+
+        self.assertTrue(stairs_up.getBoolProperty("waypoint"))
+        self.assertIn(coords_tuple(upper_landing), navigation_neighbors(stairs_up))
+        revision_with_edge = game_map.getNavigationRevision()
+
+        blocker = g.createObject("CEvent")
+        blocker.setStringProperty("name", "unitBlockedUpperStairsLanding")
+        blocker.setBoolProperty("canStep", False)
+        game_map.addObject(blocker)
+        try:
+            blocker.moveTo(upper_landing.x, upper_landing.y, upper_landing.z)
+            self.assertFalse(game_map.canStep(upper_landing))
+
+            stairs_up.onTurn(None)
+            self.assertFalse(stairs_up.getBoolProperty("waypoint"))
+            self.assertNotIn(coords_tuple(upper_landing), navigation_neighbors(stairs_up))
+            revision_blocked = game_map.getNavigationRevision()
+            self.assertGreater(revision_blocked, revision_with_edge)
+
+            game_map.removeObject(blocker)
+            stairs_up.onTurn(None)
+            self.assertTrue(stairs_up.getBoolProperty("waypoint"))
+            self.assertIn(coords_tuple(upper_landing), navigation_neighbors(stairs_up))
+            self.assertGreater(game_map.getNavigationRevision(), revision_blocked)
+
+            return True, json.dumps(
+                {
+                    "landing": coords_tuple(upper_landing),
+                    "revision_blocked": revision_blocked,
+                    "revision_restored": game_map.getNavigationRevision(),
+                    "revision_with_edge": revision_with_edge,
+                    "stairs_waypoint": stairs_up.getBoolProperty("waypoint"),
+                },
+                sort_keys=True,
+            )
+        finally:
+            game_map.removeObject(blocker)
+
+    @game_test
     def test_multilevel_map_player_uses_stairs_both_directions(self):
-        _game_module = load_game_module()
         _g, game_map, player = load_game_map_with_player("multilevel")
         player_name = player.getName()
         player_hp_max = player.getHpMax()
@@ -6815,6 +6897,11 @@ class GameTest(unittest.TestCase):
 
         route = drive_multilevel_route(game_map, player)
         controller = get_player_controller(player)
+        deterministic_route = [
+            tuple(int(value) for value in step.split(","))
+            for step in game_map.getStringProperty("deterministicRoute").split(";")
+            if step
+        ]
 
         self.assertEqual((6, 5, 0), coords_tuple(player.getCoords()))
         self.assertTrue(controller.isCompleted(player))
@@ -6827,9 +6914,15 @@ class GameTest(unittest.TestCase):
         self.assertTrue(game_map.getBoolProperty("visited_upper_goal"))
         self.assertTrue(game_map.getBoolProperty("visited_lower_goal"))
         self.assertGreater(route["turns"], 0)
+        self.assertEqual((1, 1, 0), deterministic_route[0])
+        self.assertIn(route["upper_landing"], deterministic_route)
+        self.assertIn(route["upper_goal"], deterministic_route)
+        self.assertIn(route["lower_landing"], deterministic_route)
+        self.assertEqual(route["lower_goal"], deterministic_route[-1])
 
         return True, json.dumps(
             {
+                "deterministic_route": deterministic_route,
                 "final_player": coords_tuple(player.getCoords()),
                 "potion_count": player.countItems("LesserLifePotion"),
                 "route": route,
@@ -6837,6 +6930,43 @@ class GameTest(unittest.TestCase):
             },
             sort_keys=True,
         )
+
+    @game_test
+    def test_multilevel_map_monster_pursues_player_across_levels(self):
+        g, game_map, player = load_game_map_with_player("multilevel")
+        upper_goal = find_runtime_object(game_map, "multilevelUpperGoal")
+
+        chaser = g.createObject("Cultist")
+        chaser.setStringProperty("name", "unitMultilevelPursuer")
+        controller = g.createObject("CTargetController")
+        controller.setTarget(player.getName())
+        chaser.setController(controller)
+        chaser.setBoolProperty("npc", True)
+        game_map.addObject(chaser)
+        try:
+            chaser.moveTo(upper_goal.getCoords().x, upper_goal.getCoords().y, upper_goal.getCoords().z)
+            trail = [coords_tuple(chaser.getCoords())]
+
+            for _ in range(10):
+                game_map.move()
+                pump_event_loop(2)
+                trail.append(coords_tuple(chaser.getCoords()))
+                if chaser.getCoords().z == player.getCoords().z:
+                    break
+
+            self.assertIn((4, 1, 0), trail)
+            self.assertEqual(player.getCoords().z, chaser.getCoords().z)
+
+            return True, json.dumps(
+                {
+                    "chaser": chaser.getName(),
+                    "player": coords_tuple(player.getCoords()),
+                    "trail": trail,
+                },
+                sort_keys=True,
+            )
+        finally:
+            game_map.removeObject(chaser)
 
     @game_test
     def test_multilevel_map_z_state_persists_after_save_load(self):

--- a/tests/unit/test_controller.cpp
+++ b/tests/unit/test_controller.cpp
@@ -95,11 +95,12 @@ std::shared_ptr<CPlayer> player_at(const std::shared_ptr<CGame> &game, Coords co
     return player;
 }
 
-void add_navigation_edge(const std::shared_ptr<CMap> &map, Coords source, Coords target, bool bidirectional = false) {
+void add_navigation_edge(const std::shared_ptr<CMap> &map, Coords source, Coords target, bool bidirectional = false,
+                         bool enabled = true) {
     CNavigationEdge edge;
     edge.source = source;
     edge.target = target;
-    edge.enabled = true;
+    edge.enabled = enabled;
     edge.bidirectional = bidirectional;
     map->registerNavigationEdge(edge);
 }
@@ -268,6 +269,97 @@ void test_target_controller_flow_field_uses_navigation_neighbors_for_cross_level
     expect_true(second == Coords(1, 0, 1), "target flow field should cross the authored z-level edge");
 }
 
+void test_player_controller_respects_disabled_and_one_way_cross_level_edges() {
+    auto game = std::make_shared<CGame>();
+    auto map = open_tile_map(game, 3, 1, 2);
+    add_navigation_edge(map, Coords(1, 0, 0), Coords(1, 0, 1), false, false);
+
+    auto player = player_at(game, Coords(1, 0, 0));
+    auto controller = std::make_shared<CPlayerController>();
+    player->setController(controller);
+
+    controller->setTarget(player, Coords(1, 0, 1));
+    expect_true(resolve_coords(controller->control(player)) == Coords(1, 0, 0),
+                "disabled cross-level edges should not produce a player route");
+
+    map = open_tile_map(game, 3, 1, 2);
+    add_navigation_edge(map, Coords(1, 0, 1), Coords(1, 0, 0));
+
+    auto lower_player = player_at(game, Coords(1, 0, 0));
+    auto lower_controller = std::make_shared<CPlayerController>();
+    lower_player->setController(lower_controller);
+    lower_controller->setTarget(lower_player, Coords(1, 0, 1));
+    expect_true(resolve_coords(lower_controller->control(lower_player)) == Coords(1, 0, 0),
+                "one-way drops should not be usable in reverse");
+
+    auto upper_player = player_at(game, Coords(1, 0, 1));
+    auto upper_controller = std::make_shared<CPlayerController>();
+    upper_player->setController(upper_controller);
+    upper_controller->setTarget(upper_player, Coords(1, 0, 0));
+    expect_true(resolve_coords(upper_controller->control(upper_player)) == Coords(1, 0, 0),
+                "one-way drops should route from the upper level to the lower level");
+}
+
+void test_player_controller_uses_bidirectional_cross_level_edge_both_ways() {
+    auto game = std::make_shared<CGame>();
+    auto map = open_tile_map(game, 3, 1, 2);
+    add_navigation_edge(map, Coords(1, 0, 0), Coords(1, 0, 1), true);
+
+    auto lower_player = player_at(game, Coords(0, 0, 0));
+    auto lower_controller = std::make_shared<CPlayerController>();
+    lower_player->setController(lower_controller);
+    lower_controller->setTarget(lower_player, Coords(2, 0, 1));
+
+    auto lower_first = resolve_coords(lower_controller->control(lower_player));
+    expect_true(lower_first == Coords(1, 0, 0), "bidirectional stairs should be reachable from the lower level");
+    lower_player->moveTo(lower_first);
+    lower_controller->onStepCommitted(lower_player, lower_first);
+
+    auto lower_second = resolve_coords(lower_controller->control(lower_player));
+    expect_true(lower_second == Coords(1, 0, 1), "bidirectional stairs should cross upward");
+
+    auto upper_player = player_at(game, Coords(2, 0, 1));
+    auto upper_controller = std::make_shared<CPlayerController>();
+    upper_player->setController(upper_controller);
+    upper_controller->setTarget(upper_player, Coords(0, 0, 0));
+
+    auto upper_first = resolve_coords(upper_controller->control(upper_player));
+    expect_true(upper_first == Coords(1, 0, 1), "bidirectional stairs should be reachable from the upper level");
+    upper_player->moveTo(upper_first);
+    upper_controller->onStepCommitted(upper_player, upper_first);
+
+    auto upper_second = resolve_coords(upper_controller->control(upper_player));
+    expect_true(upper_second == Coords(1, 0, 0), "bidirectional stairs should cross downward");
+}
+
+void test_target_controller_flow_field_invalidates_when_cross_level_edge_is_added() {
+    auto game = std::make_shared<CGame>();
+    auto map = open_tile_map(game, 3, 1, 2);
+
+    auto target = std::make_shared<CMapObject>();
+    target->setGame(game);
+    target->setName("unitTargetAfterEdgeChange");
+    target->setCoords(Coords(1, 0, 1));
+    map->addObject(target);
+
+    auto chaser = creature_at(1, 0, 0);
+    chaser->setGame(game);
+    chaser->setName("unitChaserAfterEdgeChange");
+    chaser->setHp(1);
+    auto controller = std::make_shared<CTargetController>();
+    controller->setTarget("unitTargetAfterEdgeChange");
+    chaser->setController(controller);
+    map->addObject(chaser);
+
+    performance_guard::clearTargetFlowCache();
+    expect_true(resolve_coords(controller->control(chaser)) == Coords(1, 0, 0),
+                "target flow field should stay put before the cross-level edge exists");
+
+    add_navigation_edge(map, Coords(1, 0, 0), Coords(1, 0, 1));
+    expect_true(resolve_coords(controller->control(chaser)) == Coords(1, 0, 1),
+                "target flow field should use a newly added cross-level edge");
+}
+
 void test_fight_controller_guard_paths_and_fallbacks() {
     auto attacker = creature_at(0, 0, 0);
     auto opponent = creature_at(1, 0, 0);
@@ -346,6 +438,9 @@ int main() {
     test_npc_random_controller_clears_stale_blocked_path();
     test_player_controller_uses_navigation_neighbors_for_cross_level_route();
     test_target_controller_flow_field_uses_navigation_neighbors_for_cross_level_pursuit();
+    test_player_controller_respects_disabled_and_one_way_cross_level_edges();
+    test_player_controller_uses_bidirectional_cross_level_edge_both_ways();
+    test_target_controller_flow_field_invalidates_when_cross_level_edge_is_added();
     test_fight_controller_guard_paths_and_fallbacks();
     test_monster_fight_controller_uses_mana_item_when_mana_is_low();
 


### PR DESCRIPTION
## What changed
- Added Python regression coverage for teleporter navigation-edge cleanup and authored multilevel map behavior.
- Added native controller tests for disabled cross-level edges, one-way drops, bidirectional cross-level routing, and target-flow cache invalidation after edge changes.
- Kept `res/maps/multilevel/script.py` unchanged; tests cover the current authored behavior.

## Why
- Implements row 81, [EPIC_04][STORY_01][SUBSTORY_06]Add multilevel topology tests.
- Locks in generalized topology behavior before more complex maps are added.

## Validation
- `git diff --check`
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R '^for_unit_tests\\.controller_unit_tests$'`
- `python3 test.py GameTest.test_teleporter_clears_navigation_edge_when_target_is_removed GameTest.test_multilevel_map_disables_stairs_when_target_is_blocked GameTest.test_multilevel_map_player_uses_stairs_both_directions GameTest.test_multilevel_map_monster_pursues_player_across_levels`

## Known limitations / follow-up
- Full native/performance/Python/coverage validation is left to GitHub Actions polling.
