### PR TITLE
Add named game object comparison helpers

### DIFF
--- a/src/object/CGameObject.cpp
+++ b/src/object/CGameObject.cpp
@@ -23,22 +23,164 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CPythonOverrides.h"
 #include "gui/CAnimation.h"
 
+#include <any>
+#include <map>
+#include <typeindex>
 #include <utility>
+
+namespace {
+
+using ObjectPair = std::pair<const CGameObject *, const CGameObject *>;
+
+bool isEquivalentValueType(std::type_index type) {
+    return type == std::type_index(typeid(bool)) || type == std::type_index(typeid(int)) ||
+           type == std::type_index(typeid(std::string)) || type == std::type_index(typeid(CTags)) ||
+           type == std::type_index(typeid(std::set<int>)) || type == std::type_index(typeid(std::set<std::string>)) ||
+           type == std::type_index(typeid(std::map<int, int>)) ||
+           type == std::type_index(typeid(std::map<int, std::string>)) ||
+           type == std::type_index(typeid(std::map<std::string, int>)) ||
+           type == std::type_index(typeid(std::map<std::string, std::string>));
+}
+
+template <typename T> bool sameAnyValue(const std::any &a, const std::any &b) {
+    return std::any_cast<T>(a) == std::any_cast<T>(b);
+}
+
+bool sameEquivalentValue(const std::any &a, const std::any &b, std::type_index type) {
+    try {
+        if (type == std::type_index(typeid(bool))) {
+            return sameAnyValue<bool>(a, b);
+        }
+        if (type == std::type_index(typeid(int))) {
+            return sameAnyValue<int>(a, b);
+        }
+        if (type == std::type_index(typeid(std::string))) {
+            return sameAnyValue<std::string>(a, b);
+        }
+        if (type == std::type_index(typeid(CTags))) {
+            return sameAnyValue<CTags>(a, b);
+        }
+        if (type == std::type_index(typeid(std::set<int>))) {
+            return sameAnyValue<std::set<int>>(a, b);
+        }
+        if (type == std::type_index(typeid(std::set<std::string>))) {
+            return sameAnyValue<std::set<std::string>>(a, b);
+        }
+        if (type == std::type_index(typeid(std::map<int, int>))) {
+            return sameAnyValue<std::map<int, int>>(a, b);
+        }
+        if (type == std::type_index(typeid(std::map<int, std::string>))) {
+            return sameAnyValue<std::map<int, std::string>>(a, b);
+        }
+        if (type == std::type_index(typeid(std::map<std::string, int>))) {
+            return sameAnyValue<std::map<std::string, int>>(a, b);
+        }
+        if (type == std::type_index(typeid(std::map<std::string, std::string>))) {
+            return sameAnyValue<std::map<std::string, std::string>>(a, b);
+        }
+    } catch (const std::bad_any_cast &) {
+        return false;
+    }
+    return false;
+}
+
+bool collectEquivalentValueProperties(const std::shared_ptr<CGameObject> &object,
+                                      std::map<std::string, std::type_index> &properties) {
+    bool supported = true;
+    object->meta()->for_all_properties(object, [&](auto property) {
+        const auto type = property->value_type();
+        if (!isEquivalentValueType(type)) {
+            supported = false;
+            return;
+        }
+        properties.emplace(property->name(), type);
+    });
+    return supported;
+}
+
+bool equivalentValueInternal(const std::shared_ptr<CGameObject> &a, const std::shared_ptr<CGameObject> &b,
+                             std::set<ObjectPair> &visited) {
+    if (CGameObject::sameInstance(a, b)) {
+        return true;
+    }
+    if (!a || !b) {
+        return false;
+    }
+    if (!visited.insert({a.get(), b.get()}).second) {
+        return true;
+    }
+    if (a->meta()->name() != b->meta()->name()) {
+        return false;
+    }
+
+    std::map<std::string, std::type_index> aProperties;
+    std::map<std::string, std::type_index> bProperties;
+    if (!collectEquivalentValueProperties(a, aProperties) || !collectEquivalentValueProperties(b, bProperties) ||
+        aProperties != bProperties) {
+        return false;
+    }
+
+    for (const auto &[name, type] : aProperties) {
+        bool sameValue = false;
+        try {
+            sameValue = sameEquivalentValue(a->getProperty<std::any>(name), b->getProperty<std::any>(name), type);
+        } catch (const std::exception &) {
+            return false;
+        }
+        if (!sameValue) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
 
 std::function<bool(std::shared_ptr<CGameObject>, std::shared_ptr<CGameObject>)> CGameObject::name_comparator =
     [](std::shared_ptr<CGameObject> a, std::shared_ptr<CGameObject> b) {
-        if (!a || !b) {
-            return a == b;
-        }
-        if (!a->getTypeId().empty() || !b->getTypeId().empty()) {
-            return a->getTypeId() == b->getTypeId();
-        }
-        return a->getType() == b->getType() && a->getName() == b->getName();
+        return CGameObject::sameConfiguredType(a, b);
     };
 
 CGameObject::~CGameObject() { CPythonOverrides::release(this); }
 
 CGameObject::CGameObject() {}
+
+bool CGameObject::sameInstance(const std::shared_ptr<CGameObject> &a, const std::shared_ptr<CGameObject> &b) {
+    return a == b;
+}
+
+bool CGameObject::sameRuntimeIdentity(const std::shared_ptr<CGameObject> &a, const std::shared_ptr<CGameObject> &b) {
+    if (sameInstance(a, b)) {
+        return true;
+    }
+    if (!a || !b) {
+        return false;
+    }
+    auto aMap = a->owningMap.lock();
+    auto bMap = b->owningMap.lock();
+    if (!aMap || !bMap || aMap != bMap) {
+        return false;
+    }
+    return !a->getName().empty() && a->getName() == b->getName();
+}
+
+bool CGameObject::sameConfiguredType(const std::shared_ptr<CGameObject> &a, const std::shared_ptr<CGameObject> &b) {
+    if (sameInstance(a, b)) {
+        return true;
+    }
+    if (!a || !b) {
+        return false;
+    }
+    if (!a->getTypeId().empty() || !b->getTypeId().empty()) {
+        return a->getTypeId() == b->getTypeId();
+    }
+    return a->getType() == b->getType() && a->getName() == b->getName();
+}
+
+bool CGameObject::equivalentValue(const std::shared_ptr<CGameObject> &a, const std::shared_ptr<CGameObject> &b) {
+    std::set<ObjectPair> visited;
+    return equivalentValueInternal(a, b, visited);
+}
 
 CGameObject::PropertyNotificationBatch::PropertyNotificationBatch(CGameObject &object) : object(object) {
     this->object.beginPropertyNotificationBatch();

--- a/src/object/CGameObject.h
+++ b/src/object/CGameObject.h
@@ -47,6 +47,14 @@ class CGameObject : public vstd::stringable, public std::enable_shared_from_this
   public:
     static std::function<bool(std::shared_ptr<CGameObject>, std::shared_ptr<CGameObject>)> name_comparator;
 
+    static bool sameInstance(const std::shared_ptr<CGameObject> &a, const std::shared_ptr<CGameObject> &b);
+
+    static bool sameRuntimeIdentity(const std::shared_ptr<CGameObject> &a, const std::shared_ptr<CGameObject> &b);
+
+    static bool sameConfiguredType(const std::shared_ptr<CGameObject> &a, const std::shared_ptr<CGameObject> &b);
+
+    static bool equivalentValue(const std::shared_ptr<CGameObject> &a, const std::shared_ptr<CGameObject> &b);
+
     class PropertyNotificationBatch {
       public:
         explicit PropertyNotificationBatch(CGameObject &object);

--- a/tests/test_object_comparison_audit.py
+++ b/tests/test_object_comparison_audit.py
@@ -2,7 +2,6 @@ import re
 import unittest
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 DOC = ROOT / "docs" / "object-comparison-semantics.md"
 
@@ -44,10 +43,11 @@ class ObjectComparisonAuditTest(unittest.TestCase):
 
     def test_source_patterns_match_documented_current_semantics(self):
         game_object = self.read("src/object/CGameObject.cpp")
+        self.assertIn("return CGameObject::sameConfiguredType(a, b);", game_object)
         self.assertRegex(
             game_object,
             re.compile(
-                r"name_comparator.*?getTypeId\(\) == b->getTypeId\(\).*?"
+                r"sameConfiguredType.*?getTypeId\(\) == b->getTypeId\(\).*?"
                 r"getType\(\) == b->getType\(\) && a->getName\(\) == b->getName\(\)",
                 re.S,
             ),

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "core/CGame.h"
 #include "core/CStats.h"
 #include "core/CMap.h"
 #include "core/CTypes.h"
@@ -400,6 +401,101 @@ void test_game_object_comparator_and_identity_sets_document_current_semantics() 
                 "creature addEffect should de-duplicate current effects by configured comparator semantics");
 }
 
+void test_game_object_named_comparison_helpers_cover_explicit_semantics() {
+    std::shared_ptr<CGameObject> null_object;
+    auto first_item = std::make_shared<CItem>();
+    first_item->setType("CItem");
+    first_item->setName("potion-one");
+    first_item->setTypeId("LifePotion");
+
+    auto second_item = std::make_shared<CItem>();
+    second_item->setType("CItem");
+    second_item->setName("potion-two");
+    second_item->setTypeId("LifePotion");
+
+    expect_true(CGameObject::sameInstance(null_object, null_object),
+                "sameInstance should treat two null pointers as the same instance");
+    expect_true(CGameObject::sameInstance(first_item, first_item),
+                "sameInstance should recognize the exact same item pointer");
+    expect_true(!CGameObject::sameInstance(first_item, second_item),
+                "sameInstance should distinguish two item instances with the same configured type");
+    expect_true(CGameObject::sameConfiguredType(first_item, second_item),
+                "sameConfiguredType should match two item instances with the same non-empty typeId");
+    expect_true(CGameObject::name_comparator(first_item, second_item) ==
+                    CGameObject::sameConfiguredType(first_item, second_item),
+                "name_comparator should preserve the configured-type helper semantics");
+    expect_true(!CGameObject::equivalentValue(first_item, second_item),
+                "equivalentValue should not claim unsupported item object graphs are equivalent");
+
+    auto named_a = std::make_shared<CGameObject>();
+    named_a->setType("CEffect");
+    named_a->setName("haste");
+
+    auto named_b = std::make_shared<CGameObject>();
+    named_b->setType("CEffect");
+    named_b->setName("haste");
+
+    auto named_c = std::make_shared<CGameObject>();
+    named_c->setType("CEffect");
+    named_c->setName("slow");
+
+    expect_true(CGameObject::sameConfiguredType(named_a, named_b),
+                "sameConfiguredType should fall back to type/name when both typeIds are empty");
+    expect_true(!CGameObject::sameConfiguredType(named_a, named_c),
+                "sameConfiguredType should not collapse all objects with empty typeIds");
+
+    auto first_map = std::make_shared<CMap>();
+    auto second_map = std::make_shared<CMap>();
+    auto first_map_object = std::make_shared<CMapObject>();
+    first_map_object->setName("sharedName");
+    auto second_map_object = std::make_shared<CMapObject>();
+    second_map_object->setName("sharedName");
+    first_map->setObjects({first_map_object});
+    second_map->setObjects({second_map_object});
+
+    expect_true(!CGameObject::sameRuntimeIdentity(first_map_object, second_map_object),
+                "sameRuntimeIdentity should distinguish the same object name on different owning maps");
+
+    CTypes::register_type<CGameObject>();
+    auto game = std::make_shared<CGame>();
+    game->getObjectHandler()->registerType("CGameObject", []() { return std::make_shared<CGameObject>(); });
+
+    auto source = std::make_shared<CGameObject>();
+    source->setGame(game);
+    source->setType("CGameObject");
+    source->setTypeId("ConfiguredClone");
+    source->setName("cloneSource");
+    source->setLabel("Source Label");
+    source->setDescription("source description");
+
+    auto clone = source->clone<CGameObject>();
+    expect_true(!CGameObject::sameInstance(source, clone), "clones should be distinct live instances");
+    expect_true(CGameObject::sameConfiguredType(source, clone), "clones should retain the same configured typeId");
+    expect_true(!CGameObject::sameRuntimeIdentity(source, clone),
+                "detached clones should not be treated as the same runtime map/name identity");
+
+    clone->setName(source->getName());
+    expect_true(CGameObject::equivalentValue(source, clone),
+                "equivalentValue should match clones after reviewed primitive values match");
+    clone->setDescription("changed description");
+    expect_true(!CGameObject::equivalentValue(source, clone),
+                "equivalentValue should distinguish reviewed primitive value changes");
+
+    auto cycle_a = std::make_shared<CGameObject>();
+    cycle_a->setType("CGameObject");
+    cycle_a->setName("cycle");
+    cycle_a->setProperty("self", cycle_a);
+    auto cycle_b = std::make_shared<CGameObject>();
+    cycle_b->setType("CGameObject");
+    cycle_b->setName("cycle");
+    cycle_b->setProperty("self", cycle_b);
+
+    expect_true(CGameObject::equivalentValue(cycle_a, cycle_a),
+                "equivalentValue should handle a self-referential instance without recursion");
+    expect_true(!CGameObject::equivalentValue(cycle_a, cycle_b),
+                "equivalentValue should reject unsupported cyclic object-reference graphs safely");
+}
+
 } // namespace
 
 int main() {
@@ -411,6 +507,7 @@ int main() {
     test_map_direct_state_setters_notify_property_observers();
     test_creature_inventory_equipment_and_ratio_helpers();
     test_game_object_comparator_and_identity_sets_document_current_semantics();
+    test_game_object_named_comparison_helpers_cover_explicit_semantics();
 
     return finish_tests();
 }


### PR DESCRIPTION
## Summary
- Add explicit CGameObject comparison helpers for instance identity, runtime map/name identity, configured type equality, and reviewed value equivalence.
- Preserve name_comparator behavior by delegating it to sameConfiguredType.
- Add native regression coverage for two item instances, clones, same name on different maps, empty typeId fallback, and cyclic references; update the comparison audit test to track the helper delegation.

## Why
Row 63 requires call sites to be able to request explicit object comparison semantics instead of relying on the ambiguous name_comparator predicate.

## Validation
Local focused checks run:
- clang-format -i src/object/CGameObject.h src/object/CGameObject.cpp tests/unit/test_object.cpp
- black -l 120 tests/test_object_comparison_audit.py
- git diff --check
- python3 tests/test_object_comparison_audit.py

Heavy validation deferred to GitHub Actions per queue-controller policy:
- python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux --require-step coverage

## Known limitations
- equivalentValue intentionally supports only reviewed primitive/value property types and returns false for unsupported object graphs.
- Local native build, ctest, full Python suite, and coverage were not run locally; PR CI is the required validation evidence.