### PR TITLE
[codex] Fix aggregate workbook queue discovery

### DIFF
--- a/docs/multi-workbook-queue.md
+++ b/docs/multi-workbook-queue.md
@@ -16,13 +16,17 @@ Current queue-compatible workbooks are:
 
 - `planning/fall_of_nouraajd_issue_proposals.xlsx`
 - `planning/fall_of_nouraajd_creature_archetype_jira_plan.xlsx`
-- `planning/fall_of_nouraajd_github_issues_implementation_workbook.xlsx`
+- `planning/fall_of_nouraajd_github_issues_implementation_workbook_migrated.xlsx`
 
-The GitHub issues implementation workbook retains its original planning sheets
+The migrated GitHub issues implementation workbook retains the original planning sheets
 (`Dashboard`, `GitHub Issues`, `Implementation Briefs`, `Source Evidence`, and
 `Validation & Close Log`) and adds a canonical `Issue Proposals` sheet. The
 queue rows preserve the source issue number and source-backed implementation
 notes while initializing workflow state as unclaimed `NOT_STARTED` work.
+
+The original `planning/fall_of_nouraajd_github_issues_implementation_workbook.xlsx`
+does not contain `Issue Proposals`; discovery reports it as a skipped reference
+workbook and controllers must not mutate it as a queue.
 
 Inspect discovery before dispatching:
 

--- a/scripts/workbook_queue.py
+++ b/scripts/workbook_queue.py
@@ -12,7 +12,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
-from scripts import issue_queue
+try:
+    from scripts import issue_queue
+except ModuleNotFoundError:  # Support `python3 scripts/workbook_queue.py`.
+    import issue_queue
 
 DEFAULT_PATTERN = "planning/*.xlsx"
 ENV_WORKBOOKS = "GAME_ISSUE_QUEUE_FILES"
@@ -52,9 +55,7 @@ def resolveWorkbookPaths(rawPaths: Sequence[str] | None = None) -> list[Path]:
         candidates.extend(Path(item).expanduser() for item in rawPaths if item)
     elif os.environ.get(ENV_WORKBOOKS):
         candidates.extend(
-            Path(item).expanduser()
-            for item in os.environ[ENV_WORKBOOKS].split(os.pathsep)
-            if item.strip()
+            Path(item).expanduser() for item in os.environ[ENV_WORKBOOKS].split(os.pathsep) if item.strip()
         )
     elif os.environ.get("GAME_ISSUE_QUEUE_FILE"):
         candidates.append(Path(os.environ["GAME_ISSUE_QUEUE_FILE"]).expanduser())

--- a/tests/test_workbook_queue.py
+++ b/tests/test_workbook_queue.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -158,9 +161,10 @@ class WorkbookQueueTest(unittest.TestCase):
         expected = {
             "fall_of_nouraajd_issue_proposals.xlsx",
             "fall_of_nouraajd_creature_archetype_jira_plan.xlsx",
-            "fall_of_nouraajd_github_issues_implementation_workbook.xlsx",
+            "fall_of_nouraajd_github_issues_implementation_workbook_migrated.xlsx",
         }
-        paths = [repository_root / "planning" / name for name in sorted(expected)]
+        reference = "fall_of_nouraajd_github_issues_implementation_workbook.xlsx"
+        paths = [repository_root / "planning" / name for name in sorted(expected | {reference})]
         missing = [path.name for path in paths if not path.is_file()]
         self.assertEqual(missing, [], f"Missing planning workbooks: {missing}")
 
@@ -171,11 +175,38 @@ class WorkbookQueueTest(unittest.TestCase):
                 expected,
                 f"Skipped workbook details: {discovery.skipped}",
             )
-            self.assertEqual(discovery.skipped, [])
+            self.assertEqual([Path(item["workbook"]).name for item in discovery.skipped], [reference])
+            self.assertIn("Issue Proposals", discovery.skipped[0]["reason"])
             errors, _ = workbook_queue.validateDiscovery(discovery)
             self.assertEqual(errors, [])
         finally:
             discovery.close()
+
+    def test_direct_script_workbooks_command_runs_without_pythonpath(self) -> None:
+        issue = "[EPIC_01][STORY_01][SUBSTORY_01] Direct CLI issue"
+        workbook = self.create_queue("direct.xlsx", [self.row(issue)])
+        repository_root = Path(__file__).resolve().parents[1]
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/workbook_queue.py",
+                "workbooks",
+                "--json",
+                "--workbook",
+                str(workbook),
+            ],
+            cwd=repository_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["compatibleCount"], 1)
+        self.assertEqual(payload["skippedCount"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed
- Treat `planning/fall_of_nouraajd_github_issues_implementation_workbook_migrated.xlsx` as the queue-compatible GitHub issues workbook in the aggregate workbook queue regression test.
- Keep the original `planning/fall_of_nouraajd_github_issues_implementation_workbook.xlsx` as a skipped reference workbook because it lacks the `Issue Proposals` queue sheet.
- Allow `python3 scripts/workbook_queue.py ...` to import `issue_queue` without requiring `PYTHONPATH=.`.
- Update the multi-workbook queue documentation to name the migrated queue workbook and warn controllers not to mutate the original reference workbook as a queue.

## Why
The current workbook queue CI gate was failing because the repository compatibility test expected the original GitHub issues workbook to be queue-compatible even though the current file has only reference/planning sheets and no `Issue Proposals` sheet. The GitHub Actions command also invokes the script directly, so the direct-script import path needs to work.

## Validation
- `python3 -m py_compile scripts/workbook_queue.py tests/test_workbook_queue.py`
- `python3 -m unittest tests.test_workbook_queue`
- `python3 scripts/workbook_queue.py validate`
- `python3 scripts/workbook_queue.py workbooks --json`
- `python3 -m unittest tests.test_issue_queue tests.test_ci_change_classifier tests.test_prompt_inventory tests.test_controller_resource_audit`
- `python3 scripts/issue_queue.py validate`
- `python3 scripts/workflow_observations.py validate`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`
- `black -l 120 --check scripts/workbook_queue.py tests/test_workbook_queue.py`
- `git diff --check origin/main..HEAD`

## Limitations / follow-up
- Existing queue validation warnings about heartbeat-overdue claims are unchanged by this PR.
