### PR TITLE
Guard stale GUI callbacks after shutdown

### DIFF
--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -779,6 +779,11 @@ bool load_plugin_entries(const std::shared_ptr<CGame> &game, const json &entries
     }
     return loadedAll;
 }
+
+bool isLiveGuiSession(const std::shared_ptr<CGame> &game, const std::shared_ptr<CGameContext> &context,
+                      const std::shared_ptr<CGui> &gui) {
+    return game && context && context->isActive() && gui && gui->isActive() && game->getGui() == gui;
+}
 } // namespace
 
 void CMapLoader::loadFromTmx(const std::shared_ptr<CMap> &map, const std::shared_ptr<json> &mapc) {
@@ -1256,7 +1261,7 @@ void CGameLoader::loadGui(const std::shared_ptr<CGame> &game) {
         auto game = weakGame.lock();
         auto context = weakContext.lock();
         auto gui = weakGui.lock();
-        if (game && context && context->isActive() && gui && game->getGui() == gui) {
+        if (isLiveGuiSession(game, context, gui)) {
             gui->render(time);
         }
     });
@@ -1264,7 +1269,7 @@ void CGameLoader::loadGui(const std::shared_ptr<CGame> &game) {
         auto game = weakGame.lock();
         auto context = weakContext.lock();
         auto gui = weakGui.lock();
-        return game && context && context->isActive() && gui && game->getGui() == gui && gui->event(event);
+        return isLiveGuiSession(game, context, gui) && gui->event(event);
     });
 }
 

--- a/src/gui/CGui.cpp
+++ b/src/gui/CGui.cpp
@@ -113,6 +113,10 @@ CGui::CGui() {
 CGui::~CGui() = default;
 
 void CGui::shutdown() {
+    if (!active.exchange(false, std::memory_order_acq_rel)) {
+        return;
+    }
+
     clearDragSession();
     releasePointerCapture();
 
@@ -132,7 +136,13 @@ void CGui::shutdown() {
     _textManager.clear();
 }
 
+bool CGui::isActive() const { return active.load(std::memory_order_acquire); }
+
 void CGui::render(int i1) {
+    if (!isActive()) {
+        return;
+    }
+
     CUtil::setRenderDrawColor(renderer.get(), CColors::Black);
     SDL_SAFE(SDL_RenderClear(renderer.get()));
     CGameGraphicsObject::render(this->ptr<CGui>(), i1);
@@ -190,7 +200,7 @@ int CGui::getTileCountX() { return width / tileSize + 1; }
 int CGui::getTileCountY() { return height / tileSize + 1; }
 
 bool CGui::event(SDL_Event *event) {
-    if (!event) {
+    if (!isActive() || !event) {
         return false;
     }
     if (event->type == SDL_WINDOWEVENT && event->window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {

--- a/src/gui/CGui.h
+++ b/src/gui/CGui.h
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/object/CGameGraphicsObject.h"
 #include "object/CGameObject.h"
 
+#include <atomic>
 #include <optional>
 
 class CTextureCache;
@@ -86,6 +87,8 @@ class CGui : public CGameGraphicsObject {
 
     void shutdown();
 
+    bool isActive() const;
+
     void render(int i1);
 
     bool event(SDL_Event *event);
@@ -142,4 +145,6 @@ class CGui : public CGameGraphicsObject {
     std::optional<DragSession> dragSession;
 
     std::weak_ptr<CGameGraphicsObject> pointerCapture;
+
+    std::atomic<bool> active = true;
 };

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -63,6 +63,18 @@ class CountingRenderObject : public CGameGraphicsObject {
     int &render_count;
 };
 
+class CountingGui : public CGui {
+    V_META(CountingGui, CGui, vstd::meta::empty())
+
+  public:
+    explicit CountingGui(int &render_count) : render_count(render_count) {}
+
+    void renderObject(std::shared_ptr<CGui>, std::shared_ptr<SDL_Rect>, int) override { ++render_count; }
+
+  private:
+    int &render_count;
+};
+
 class MouseEventRecorder : public CGameGraphicsObject {
   public:
     bool mouseEvent(std::shared_ptr<CGui>, SDL_EventType type, int button, int x, int y) override {
@@ -286,13 +298,13 @@ std::shared_ptr<CGame> create_gui_game(const std::shared_ptr<CGui> &gui) {
     return game;
 }
 
-std::shared_ptr<CGame> create_loader_gui_game() {
+std::shared_ptr<CGame> create_loader_gui_game(const std::string &guiClass = "CGui") {
     auto game = std::make_shared<CGame>();
     for (const auto &[name, builder] : *CTypes::builders()) {
         game->getObjectHandler()->registerType(name, builder);
     }
     auto guiConfig = std::make_shared<json>();
-    (*guiConfig)["class"] = "CGui";
+    (*guiConfig)["class"] = guiClass;
     game->getObjectHandler()->registerConfig("gui", guiConfig);
     return game;
 }
@@ -735,6 +747,40 @@ void test_loader_gui_sessions_shutdown_stale_callbacks() {
     drain_event_loop();
     expect_true(secondRecorder->button_count == 1, "second shutdown should stop later event dispatch");
     expect_true(secondRenderCount == renderCountAfterShutdown, "second shutdown should stop later frame rendering");
+
+    int directRenderCount = 0;
+    int directEventCount = 0;
+    CTypes::register_type_metadata<CountingGui, CGui, CGameGraphicsObject, CGameObject>();
+    auto directShutdownGame = create_loader_gui_game("CountingGui");
+    directShutdownGame->getObjectHandler()->registerType(
+        "CountingGui", [&directRenderCount]() { return std::make_shared<CountingGui>(directRenderCount); });
+    CGameLoader::loadGui(directShutdownGame);
+    auto directShutdownGui = vstd::cast<CountingGui>(directShutdownGame->getGui());
+    expect_true(directShutdownGui != nullptr, "direct shutdown test should load a counting GUI");
+    expect_true(directShutdownGame->getContext()->isActive(),
+                "direct GUI shutdown should leave the game context active before the shutdown");
+
+    directShutdownGui->registerEventCallback(
+        [](std::shared_ptr<CGui>, std::shared_ptr<CGameGraphicsObject>, SDL_Event *) { return true; },
+        [&directEventCount](std::shared_ptr<CGui>, std::shared_ptr<CGameGraphicsObject>, SDL_Event *) {
+            ++directEventCount;
+            return true;
+        });
+    directShutdownGui->shutdown();
+    expect_true(!directShutdownGui->isActive(), "direct GUI shutdown should mark the GUI inactive");
+    expect_true(directShutdownGame->getGui() == directShutdownGui,
+                "direct GUI shutdown should leave the game GUI pointer intact for stale callback coverage");
+
+    SDL_Event staleEvent{};
+    staleEvent.type = SDL_MOUSEBUTTONDOWN;
+    staleEvent.button.button = SDL_BUTTON_LEFT;
+    staleEvent.button.x = 35;
+    staleEvent.button.y = 55;
+    SDL_PushEvent(&staleEvent);
+    drain_event_loop();
+
+    expect_true(directRenderCount == 0, "direct GUI shutdown should prevent stale frame rendering");
+    expect_true(directEventCount == 0, "direct GUI shutdown should prevent stale root event dispatch");
 }
 
 void test_gui_routes_mouse_motion_to_target_child() {


### PR DESCRIPTION
## What changed
- Added an active lifecycle flag to CGui and made shutdown idempotently mark GUI instances inactive.
- Gated CGui render/event handling and loader-installed frame/event callbacks on the active GUI session.
- Added a gui_unit_tests regression for direct GUI shutdown where CGame still retains the GUI pointer and queued callbacks must fail closed.

## Why
- Row 33 ([EPIC_02][STORY_02][SUBSTORY_04]) requires stale GUI event-loop callbacks to stop dispatching after explicit session or GUI shutdown.

## Validation
- python3 scripts/controller_resource_audit.py --json
- clang-format -i src/core/CLoader.cpp src/gui/CGui.cpp src/gui/CGui.h tests/unit/test_gui.cpp
- git diff --check
- cmake --build cmake-build-release --target gui_unit_tests -j8
- ctest --test-dir cmake-build-release --output-on-failure -R '^for_unit_tests\.gui_unit_tests$'

## Known limitations
- Full native, Python, and coverage validation were not run locally; this PR should use GitHub Actions build/linux with coverage evidence because it touches src/core.