### PR TITLE
Avoid materializing tiles for movement cost lookups

### DIFF
--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -322,14 +322,7 @@ std::shared_ptr<CTile> CMap::getTile(int x, int y, int z) {
     std::shared_ptr<CTile> tile;
     auto it = this->tiles.find(coords);
     if (it == this->tiles.end()) {
-        if (hasBounds(z) && (coords.x < 0 || coords.y < 0 || coords.x > xBounds.at(z) || coords.y > yBounds.at(z))) {
-            tile = getGame()->createObject<CTile>(vstd::ctn(outOfBoundsTiles, z) && !outOfBoundsTiles.at(z).empty()
-                                                      ? outOfBoundsTiles.at(z)
-                                                      : "MountainTile");
-        } else {
-            tile = getGame()->createObject<CTile>(
-                vstd::ctn(defaultTiles, z) && !defaultTiles.at(z).empty() ? defaultTiles.at(z) : "GrassTile");
-        }
+        tile = getGame()->createObject<CTile>(fallbackTileType(coords));
         if (tile) {
             this->addTile(tile, coords.x, coords.y, coords.z);
         }
@@ -348,22 +341,16 @@ bool CMap::canStep(int x, int y, int z) {
             return false;
         }
     }
-    auto it = this->tiles.find(coords);
-    if (it != this->tiles.end()) {
-        return (*it).second->canStep();
+    auto tile = resolveTileForLookup(coords);
+    if (tile) {
+        return tile->canStep();
     }
-    if (!getGame()) {
-        const int x_bound = vstd::ctn(xBounds, z) ? xBounds.at(z) : 0;
-        const int y_bound = vstd::ctn(yBounds, z) ? yBounds.at(z) : 0;
-        return !(coords.x < 0 || coords.y < 0 || coords.x > x_bound || coords.y > y_bound);
+    if (getGame()) {
+        return false;
     }
-    const auto tile_type =
-        hasBounds(z) && (coords.x < 0 || coords.y < 0 || coords.x > xBounds.at(z) || coords.y > yBounds.at(z))
-            ? (vstd::ctn(outOfBoundsTiles, z) && !outOfBoundsTiles.at(z).empty() ? outOfBoundsTiles.at(z)
-                                                                                 : "MountainTile")
-            : (vstd::ctn(defaultTiles, z) && !defaultTiles.at(z).empty() ? defaultTiles.at(z) : "GrassTile");
-    auto tile = getGame()->createObject<CTile>(tile_type);
-    return tile && tile->canStep();
+    const int x_bound = vstd::ctn(xBounds, z) ? xBounds.at(z) : 0;
+    const int y_bound = vstd::ctn(yBounds, z) ? yBounds.at(z) : 0;
+    return !(coords.x < 0 || coords.y < 0 || coords.x > x_bound || coords.y > y_bound);
 }
 
 bool CMap::canStep(Coords coords) { return canStep(coords.x, coords.y, coords.z); }
@@ -376,6 +363,16 @@ int CMap::getMovementCost(int x, int y, int z) {
 int CMap::getMovementCost(Coords coords) {
     coords = normalizeCoords(coords);
     return getMovementCost(coords.x, coords.y, coords.z);
+}
+
+int CMap::lookupMovementCost(int x, int y, int z) {
+    auto tile = resolveTileForLookup(Coords(x, y, z));
+    return tile ? std::max(1, tile->getMovementCost()) : 1;
+}
+
+int CMap::lookupMovementCost(Coords coords) {
+    coords = normalizeCoords(coords);
+    return lookupMovementCost(coords.x, coords.y, coords.z);
 }
 
 bool CMap::contains(int x, int y, int z) {
@@ -776,6 +773,31 @@ void CMap::addObject(const std::shared_ptr<CMapObject> &mapObject, Coords coords
 Coords CMap::getEntry() { return Coords(getEntryX(), getEntryY(), getEntryZ()); }
 
 bool CMap::hasBounds(int z) const { return vstd::ctn(xBounds, z) && vstd::ctn(yBounds, z); }
+
+bool CMap::isOutOfBounds(Coords coords) const {
+    return hasBounds(coords.z) &&
+           (coords.x < 0 || coords.y < 0 || coords.x > xBounds.at(coords.z) || coords.y > yBounds.at(coords.z));
+}
+
+std::string CMap::fallbackTileType(Coords coords) const {
+    if (isOutOfBounds(coords)) {
+        return vstd::ctn(outOfBoundsTiles, coords.z) && !outOfBoundsTiles.at(coords.z).empty()
+                   ? outOfBoundsTiles.at(coords.z)
+                   : "MountainTile";
+    }
+    return vstd::ctn(defaultTiles, coords.z) && !defaultTiles.at(coords.z).empty() ? defaultTiles.at(coords.z)
+                                                                                   : "GrassTile";
+}
+
+std::shared_ptr<CTile> CMap::resolveTileForLookup(Coords coords) {
+    coords = normalizeCoords(coords);
+    auto it = tiles.find(coords);
+    if (it != tiles.end()) {
+        return it->second;
+    }
+    auto game = getGame();
+    return game ? game->createObject<CTile>(fallbackTileType(coords)) : nullptr;
+}
 
 int CMap::normalizeAxis(int value, int z, bool wrapAxis, const std::map<int, int> &bounds) const {
     if (!wrapAxis || !vstd::ctn(bounds, z)) {

--- a/src/core/CMap.h
+++ b/src/core/CMap.h
@@ -156,6 +156,10 @@ class CMap : public CGameObject {
 
     int getMovementCost(Coords coords);
 
+    int lookupMovementCost(int x, int y, int z);
+
+    int lookupMovementCost(Coords coords);
+
     Coords normalizeCoords(Coords coords) const;
 
     std::vector<Coords> getAdjacentCoords(Coords coords, bool includeSelf = false) const;
@@ -260,6 +264,12 @@ class CMap : public CGameObject {
     std::shared_ptr<vstd::future<void, void>> _moveHelper = vstd::later([]() {});
 
     bool hasBounds(int z) const;
+
+    bool isOutOfBounds(Coords coords) const;
+
+    std::string fallbackTileType(Coords coords) const;
+
+    std::shared_ptr<CTile> resolveTileForLookup(Coords coords);
 
     int normalizeAxis(int value, int z, bool wrapAxis, const IntMap &bounds) const;
 

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -653,6 +653,46 @@ void test_tile_movement_cost_deserialization() {
                 "invalid configured movementCost should clamp to one during deserialization");
 }
 
+void test_map_movement_cost_default_lookup_without_materializing() {
+    auto game = CGameLoader::loadGame();
+    auto map = std::make_shared<CMap>();
+    game->setMap(map);
+    map->setGame(game);
+    map->setXBounds({{0, 3}});
+    map->setYBounds({{0, 3}});
+
+    auto default_config = std::make_shared<json>();
+    (*default_config)["class"] = "CTile";
+    (*default_config)["properties"]["canStep"] = true;
+    (*default_config)["properties"]["movementCost"] = 7;
+    (*default_config)["properties"]["tileType"] = "weightedDefault";
+    game->getObjectHandler()->registerConfig("WeightedDefaultTile", default_config);
+
+    auto edge_config = std::make_shared<json>();
+    (*edge_config)["class"] = "CTile";
+    (*edge_config)["properties"]["canStep"] = false;
+    (*edge_config)["properties"]["movementCost"] = 9;
+    (*edge_config)["properties"]["tileType"] = "weightedEdge";
+    game->getObjectHandler()->registerConfig("WeightedEdgeTile", edge_config);
+
+    map->setDefaultTiles({{0, "WeightedDefaultTile"}});
+    map->setOutOfBoundsTiles({{0, "WeightedEdgeTile"}});
+
+    const auto initial_tile_count = map->getTiles().size();
+    const auto initial_navigation_revision = map->getNavigationRevision();
+
+    expect_true(map->lookupMovementCost(1, 1, 0) == 7,
+                "movement cost should read configured default tile cost without an explicit tile");
+    expect_true(map->lookupMovementCost(4, 1, 0) == 9,
+                "movement cost should read configured out-of-bounds tile cost without an explicit tile");
+    expect_true(map->getTiles().size() == initial_tile_count,
+                "movement cost lookup should not materialize default or out-of-bounds tiles");
+    expect_true(!map->contains(1, 1, 0), "default cost lookup should leave the sparse coordinate empty");
+    expect_true(!map->contains(4, 1, 0), "out-of-bounds cost lookup should leave the sparse coordinate empty");
+    expect_true(map->getNavigationRevision() == initial_navigation_revision,
+                "non-materializing movement cost lookup should not bump navigation revision");
+}
+
 void test_map_navigation_edges_update_revision() {
     auto map = std::make_shared<CMap>();
     map->setXBounds({{0, 4}});
@@ -1215,6 +1255,7 @@ int main() {
     test_scene_manager_rejects_cross_game_requests();
     test_map_tiles_bounds_wrapping_and_object_cache();
     test_tile_movement_cost_deserialization();
+    test_map_movement_cost_default_lookup_without_materializing();
     test_map_navigation_edges_update_revision();
     test_map_navigation_neighbors_include_registered_edges();
     test_map_dump_paths_uses_navigation_neighbors();

--- a/tests/unit/test_pathfinder_performance.cpp
+++ b/tests/unit/test_pathfinder_performance.cpp
@@ -17,10 +17,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "core/CPathFinder.h"
+#include "core/CGame.h"
+#include "core/CLoader.h"
+#include "core/CMap.h"
 #include "test_harness.h"
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 #include <map>
 #include <optional>
 #include <set>
@@ -500,6 +504,40 @@ void testMultiSizeScaling() {
                        small.distance * 3 + large.size);
 }
 
+void testMapMovementCostLookupDoesNotMaterializeSparseDefaultTiles() {
+    constexpr int size = 64;
+    constexpr int expected_steps = (size - 1) * 2;
+    auto game = CGameLoader::loadGame();
+    auto map = std::make_shared<CMap>();
+    game->setMap(map);
+    map->setGame(game);
+    map->setXBounds({{0, size - 1}});
+    map->setYBounds({{0, size - 1}});
+    map->setDefaultTiles({{0, "GrassTile"}});
+    map->setOutOfBoundsTiles({{0, "MountainTile"}});
+
+    const auto initial_tile_count = map->getTiles().size();
+    const auto initial_navigation_revision = map->getNavigationRevision();
+    const Coords start(0, 0, 0);
+    const Coords goal(size - 1, size - 1, 0);
+
+    auto can_step = [map](const Coords &coords) { return map->canStep(coords); };
+    auto waypoint = [](const Coords &) -> std::optional<Coords> { return std::nullopt; };
+    auto neighbors = [map](const Coords &coords) { return map->getNavigationNeighbors(coords); };
+    auto distance = [map](const Coords &from, const Coords &to) { return map->getDistance(from, to); };
+    auto step_cost = [map](const Coords &, const Coords &to) { return map->lookupMovementCost(to); };
+
+    const auto path = CPathFinder::findPath(start, goal, can_step, waypoint, neighbors, distance, step_cost);
+
+    expectMetricEquals("sparse-map path length", static_cast<long long>(path.size()), expected_steps);
+    expect_true(!path.empty() && path.front() != start, "sparse-map path should advance from the start");
+    expect_true(!path.empty() && path.back() == goal, "sparse-map path should reach the goal");
+    expectMetricEquals("sparse-map materialized tile count", static_cast<long long>(map->getTiles().size()),
+                       static_cast<long long>(initial_tile_count));
+    expectMetricEquals("sparse-map navigation revision", static_cast<long long>(map->getNavigationRevision()),
+                       static_cast<long long>(initial_navigation_revision));
+}
+
 } // namespace
 
 void run_pathfinder_performance_tests() {
@@ -512,4 +550,5 @@ void run_pathfinder_performance_tests() {
     testToroidalNeighborDistanceBehavior();
     testRepeatedAsyncFindNextStep();
     testMultiSizeScaling();
+    testMapMovementCostLookupDoesNotMaterializeSparseDefaultTiles();
 }


### PR DESCRIPTION
## What changed
- Added a non-materializing CMap lookup path for movement-cost checks.
- Preserved CMap::getMovementCost materializing behavior for existing callers and save/load compatibility.
- Kept CMap::getTile materializing behavior intact for callers that explicitly request tile objects.
- Added map unit coverage for default and out-of-bounds movement costs without sparse tile insertion.
- Added a deterministic performance guard asserting sparse pathfinding uses lookupMovementCost without materializing default tiles or bumping navigation revision.

## Why
- Row 84 ([EPIC_04][STORY_02][SUBSTORY_03]) requires movement-cost lookup without materializing default tiles during path search while maintaining existing materializing APIs.

## Validation
- python3 scripts/controller_resource_audit.py --json
- clang-format -i src/core/CMap.h src/core/CMap.cpp tests/unit/test_map.cpp tests/unit/test_pathfinder_performance.cpp
- git diff --check
- git diff --exit-code -- planning/fall_of_nouraajd_issue_proposals.xlsx docs/codex-workflow-observations.md planning/workflow_observations
- git submodule update --init --recursive
- GAME_CONFIGURE_SKIP_APT=1 GAME_CONFIGURE_SKIP_SUBMODULES=1 GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh
- cmake --build cmake-build-release --target map_unit_tests performance_guard_tests -j$(nproc)
- cmake --build cmake-build-release --target _game -j$(nproc)
- ctest --test-dir cmake-build-release --output-on-failure -R map_unit_tests
- ctest --test-dir cmake-build-release --output-on-failure --verbose -R performance.performance_guard_tests
- GAME_BUILD_DIR=cmake-build-release python3 test.py GameTest.test_out_of_bounds_tile_override_survives_save_load

## Known limitations
- A plain ./configure.sh attempt failed because it requested non-interactive sudo; the skip-APT/submodule configure command passed.
- The first pre-fix CI run failed in Python gameplay on test_out_of_bounds_tile_override_survives_save_load; the compatibility fix now passes that focused regression locally.
- Full suite and coverage are delegated to GitHub Actions build/linux with coverage evidence because this PR touches src/core.