### PR TITLE
[codex] Warn when local origin main is stale

### DIFF
--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -285,10 +285,12 @@ python3 scripts/controller_resource_audit.py --json
 ```
 
 The audit reports Git repository health, disk usage, active and prunable worktree registrations, and matching controller
-run/worktrees such as `/tmp/nouraajd-*`, `/tmp/fall-of-nouraajd-codex`, and `/tmp/fon-workflow-optimizer-*`. It is
-report-only by default. Treat audit errors such as unreadable Git state, unresolved `HEAD` or `origin/main`, zero-byte
-loose Git objects, zero-byte Git ref files, or disk pressure as blockers to new heavy work, and treat warnings about
-prunable worktree metadata or large accumulated run/worktrees as cleanup prompts before refilling worker slots.
+run/worktrees such as `/tmp/nouraajd-*`, `/tmp/fall-of-nouraajd-codex`, and `/tmp/fon-workflow-optimizer-*`. It compares
+local `refs/remotes/origin/main` with live `origin` output read-only, without fetching or mutating refs. It is report-only
+by default. Treat audit errors such as unreadable Git state, unresolved `HEAD` or `origin/main`, zero-byte loose Git
+objects, zero-byte Git ref files, or disk pressure as blockers to new heavy work, and treat warnings about stale
+remote-tracking refs, prunable worktree metadata, or large accumulated run/worktrees as cleanup prompts before refilling
+worker slots.
 
 When auditing merge-policy drift or cleanup readiness, include the live GitHub branch-protection check:
 

--- a/scripts/controller_resource_audit.py
+++ b/scripts/controller_resource_audit.py
@@ -19,6 +19,7 @@ DEFAULT_MIN_FREE_GIB = 5.0
 DEFAULT_MAX_USED_PERCENT = 95.0
 DEFAULT_PROTECTED_BRANCH = "main"
 DEFAULT_REQUIRED_STATUS_CHECKS = ("linux", "windows-deps", "windows")
+DEFAULT_LIVE_REMOTE_TIMEOUT_SECONDS = 10.0
 
 
 @dataclass(frozen=True)
@@ -64,6 +65,9 @@ class GitHealthReport:
     headAheadOriginMainCount: int | None = None
     headBehindOriginMainCount: int | None = None
     headBehindOriginMain: bool | None = None
+    liveOriginMain: str | None = None
+    liveOriginMainError: str | None = None
+    originMainMatchesLive: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -196,6 +200,8 @@ def runGitWorktreeList(repoRoot: Path) -> list[WorktreeRecord]:
 def runGit(
     repoRoot: Path,
     args: Sequence[str],
+    *,
+    timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", "--no-optional-locks", *args],
@@ -204,7 +210,32 @@ def runGit(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        timeout=timeout,
     )
+
+
+def runGitLiveOriginMain(
+    repoRoot: Path, timeoutSeconds: float = DEFAULT_LIVE_REMOTE_TIMEOUT_SECONDS
+) -> tuple[str | None, str | None]:
+    remote = runGit(repoRoot, ["remote", "get-url", "origin"])
+    if remote.returncode != 0:
+        return None, None
+    try:
+        result = runGit(
+            repoRoot,
+            ["ls-remote", "--exit-code", "origin", "refs/heads/main"],
+            timeout=timeoutSeconds,
+        )
+    except subprocess.TimeoutExpired:
+        return None, f"git ls-remote origin refs/heads/main timed out after {timeoutSeconds:.1f}s"
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "git ls-remote failed"
+        return None, detail
+
+    parts = result.stdout.strip().split()
+    if len(parts) < 2 or parts[1] != "refs/heads/main":
+        return None, "git ls-remote origin refs/heads/main returned unexpected output"
+    return parts[0], None
 
 
 def resolveGitPath(repoRoot: Path, pathText: str | None) -> Path | None:
@@ -264,6 +295,10 @@ def runGitHealth(repoRoot: Path) -> GitHealthReport:
     headAheadOriginMainCount: int | None = None
     headBehindOriginMainCount: int | None = None
     headBehindOriginMain: bool | None = None
+    liveOriginMainText, liveOriginMainError = runGitLiveOriginMain(repoRoot)
+    originMainMatchesLive: bool | None = None
+    if liveOriginMainText and originMainText:
+        originMainMatchesLive = originMainText == liveOriginMainText
     if headText and originMainText:
         if headText == originMainText:
             headAheadOriginMainCount = 0
@@ -287,6 +322,9 @@ def runGitHealth(repoRoot: Path) -> GitHealthReport:
         statusStderr=status.stderr.strip(),
         head=headText,
         originMain=originMainText,
+        liveOriginMain=liveOriginMainText,
+        liveOriginMainError=liveOriginMainError,
+        originMainMatchesLive=originMainMatchesLive,
         gitCommonDir=str(gitCommonDir) if gitCommonDir is not None else None,
         emptyLooseObjects=findEmptyLooseObjects(gitCommonDir),
         emptyRefs=findEmptyRefs(gitCommonDir),
@@ -318,6 +356,13 @@ def evaluateGitHealth(report: GitHealthReport) -> tuple[list[str], list[str]]:
         errors.append(f"{len(report.emptyLooseObjects)} zero-byte loose git object(s) found")
     if report.emptyRefs:
         errors.append(f"{len(report.emptyRefs)} zero-byte git ref file(s) found")
+    if report.liveOriginMainError:
+        warnings.append(f"live origin/main could not be inspected: {report.liveOriginMainError}")
+    if report.originMainMatchesLive is False:
+        warnings.append(
+            "refs/remotes/origin/main differs from live origin/main; fetch before continuing because local "
+            "remote-tracking refs may be stale"
+        )
     if report.headBehindOriginMain or (
         report.headBehindOriginMain is None
         and report.head
@@ -524,6 +569,9 @@ def payload(
             "statusStderr": gitHealth.statusStderr,
             "head": gitHealth.head,
             "originMain": gitHealth.originMain,
+            "liveOriginMain": gitHealth.liveOriginMain,
+            "liveOriginMainError": gitHealth.liveOriginMainError,
+            "originMainMatchesLive": gitHealth.originMainMatchesLive,
             "headAheadOriginMainCount": gitHealth.headAheadOriginMainCount,
             "headBehindOriginMainCount": gitHealth.headBehindOriginMainCount,
             "headBehindOriginMain": gitHealth.headBehindOriginMain,
@@ -576,6 +624,7 @@ def printHuman(report: dict[str, Any]) -> None:
     print(f"  status exit code: {git['statusExitCode']}")
     print(f"  HEAD: {git['head'] or 'unresolved'}")
     print(f"  origin/main: {git['originMain'] or 'unresolved'}")
+    print(f"  live origin/main: {git['liveOriginMain'] or 'unavailable'}")
     print(f"  zero-byte loose objects: {git['emptyLooseObjects']['total']}")
     print(f"  zero-byte refs: {git['emptyRefs']['total']}")
     print("Disk:")

--- a/tests/test_controller_resource_audit.py
+++ b/tests/test_controller_resource_audit.py
@@ -318,6 +318,97 @@ detached
         self.assertEqual(0, report.headAheadOriginMainCount)
         self.assertEqual(1, report.headBehindOriginMainCount)
 
+    def test_run_git_health_warns_when_local_origin_main_is_stale_without_fetching(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            origin = root / "origin.git"
+            seed = root / "seed"
+            local = root / "local"
+            subprocess.run(
+                ["git", "init", "--bare", "-b", "main", str(origin)],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            subprocess.run(
+                ["git", "init", "-b", "main", str(seed)],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=seed, check=True)
+            subprocess.run(["git", "config", "user.name", "Test User"], cwd=seed, check=True)
+            (seed / "file.txt").write_text("base\n", encoding="utf-8")
+            subprocess.run(["git", "add", "file.txt"], cwd=seed, check=True)
+            subprocess.run(["git", "commit", "-m", "base"], cwd=seed, check=True, stdout=subprocess.PIPE)
+            subprocess.run(["git", "remote", "add", "origin", str(origin)], cwd=seed, check=True)
+            subprocess.run(
+                ["git", "push", "-u", "origin", "main"],
+                cwd=seed,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            base_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=seed,
+                check=True,
+                stdout=subprocess.PIPE,
+                text=True,
+            ).stdout.strip()
+
+            subprocess.run(
+                ["git", "clone", str(origin), str(local)],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            (seed / "file.txt").write_text("base\nnext\n", encoding="utf-8")
+            subprocess.run(["git", "commit", "-am", "next"], cwd=seed, check=True, stdout=subprocess.PIPE)
+            subprocess.run(
+                ["git", "push", "origin", "main"],
+                cwd=seed,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            next_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=seed,
+                check=True,
+                stdout=subprocess.PIPE,
+                text=True,
+            ).stdout.strip()
+            local_origin_before = subprocess.run(
+                ["git", "rev-parse", "refs/remotes/origin/main"],
+                cwd=local,
+                check=True,
+                stdout=subprocess.PIPE,
+                text=True,
+            ).stdout.strip()
+
+            report = controller_resource_audit.runGitHealth(local)
+            errors, warnings = controller_resource_audit.evaluateGitHealth(report)
+            local_origin_after = subprocess.run(
+                ["git", "rev-parse", "refs/remotes/origin/main"],
+                cwd=local,
+                check=True,
+                stdout=subprocess.PIPE,
+                text=True,
+            ).stdout.strip()
+
+        self.assertEqual(base_sha, local_origin_before)
+        self.assertEqual(base_sha, report.head)
+        self.assertEqual(base_sha, report.originMain)
+        self.assertEqual(next_sha, report.liveOriginMain)
+        self.assertFalse(report.originMainMatchesLive)
+        self.assertEqual(base_sha, local_origin_after)
+        self.assertEqual([], errors)
+        self.assertTrue(
+            any("refs/remotes/origin/main differs from live origin/main" in warning for warning in warnings),
+            warnings,
+        )
+
     def test_required_checks_support_contexts_and_rich_check_payloads(self) -> None:
         checks = controller_resource_audit.requiredChecksFromProtectionPayload(
             {
@@ -396,6 +487,8 @@ detached
             headAheadOriginMainCount=0,
             headBehindOriginMainCount=0,
             headBehindOriginMain=False,
+            liveOriginMain="abc123",
+            originMainMatchesLive=True,
         )
         branch = controller_resource_audit.BranchProtectionReport(
             repo="owner/repo",
@@ -423,6 +516,8 @@ detached
         self.assertEqual(False, payload["git"]["headBehindOriginMain"])
         self.assertEqual(0, payload["git"]["headAheadOriginMainCount"])
         self.assertEqual(0, payload["git"]["headBehindOriginMainCount"])
+        self.assertEqual("abc123", payload["git"]["liveOriginMain"])
+        self.assertTrue(payload["git"]["originMainMatchesLive"])
 
     def test_payload_marks_unmeasured_run_tree_sizes(self) -> None:
         git = controller_resource_audit.GitHealthReport(


### PR DESCRIPTION
## What changed
- Added a read-only live `origin/main` check to `scripts/controller_resource_audit.py` using `git ls-remote origin refs/heads/main`.
- Exposed `liveOriginMain`, `liveOriginMainError`, and `originMainMatchesLive` in the audit JSON payload.
- Warn when local `refs/remotes/origin/main` differs from live `origin/main`, so stale remote-tracking refs are visible even when `HEAD` equals the local remote-tracking ref.
- Added a regression that recreates observation `20260621T110915Z-optimizer-live-main-drift-9feca014` and asserts the audit does not fetch or mutate local refs.
- Documented the read-only live remote comparison in the queue controller guide.

## Why
Fixes workflow observation `20260621T110915Z-optimizer-live-main-drift-9feca014`. The audit previously compared `HEAD` only to the local `refs/remotes/origin/main`, so a stale checkout could look current when both local refs were stale while live `origin/main` had advanced.

## Validation
- `python3 -m py_compile scripts/controller_resource_audit.py tests/test_controller_resource_audit.py`
- `python3 -m unittest tests.test_controller_resource_audit tests.test_prompt_inventory`
- `python3 scripts/workflow_observations.py validate`
- `python3 scripts/issue_queue.py validate`
- `black -l 120 --check scripts/controller_resource_audit.py tests/test_controller_resource_audit.py`
- `git diff --check origin/main..HEAD`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`

## Limitations / follow-up
- The live remote check is advisory and read-only. If `origin` cannot be inspected, the audit emits a warning rather than mutating refs or failing the whole audit.
- A separate resolution-only receipt PR should close the observation after this PR merges and post-merge verification passes.
