### PR TITLE
Preload quest resources from saved dependencies

### DIFF
--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -934,9 +934,11 @@ bool config_matches_saved_quest_refs(const json &entry, const CSavedQuestRefs &r
     }
     if (entry.contains("properties") && entry["properties"].is_object()) {
         const json &properties = entry["properties"];
-        if (properties.contains("typeId") && properties["typeId"].is_string() &&
-            refs.typeIds.contains(properties["typeId"].get<std::string>())) {
-            return true;
+        for (const char *key : {"typeId", "name"}) {
+            if (properties.contains(key) && properties[key].is_string() &&
+                refs.typeIds.contains(properties[key].get<std::string>())) {
+                return true;
+            }
         }
     }
     return false;

--- a/test.py
+++ b/test.py
@@ -449,6 +449,29 @@ IMMUTABLE_SAVE_FIXTURE_EXPECTATIONS = {
             "objects": [{"name": "ritualLeader", "typeId": "ritualLeaderTemplate"}],
         },
     },
+    "ritual_completed_nouraajd_quest_v1": {
+        "primary": "ritual_completed_nouraajd_quest_v1.json",
+        "summary": {
+            "encoding": "versioned",
+            "schemaVersion": 1,
+            "map": "ritual",
+            "turn": 58,
+            "description": "immutable completed external quest fixture",
+            "player": {
+                "class": "CPlayer",
+                "name": "player",
+                "typeId": "Warrior",
+                "coords": [3, 22, 0],
+                "activeQuests": [],
+                "completedQuests": ["rolfQuest"],
+                "items": [],
+            },
+            "questStates": {},
+            "trueFlags": [],
+            "numericProperties": {},
+            "objects": [],
+        },
+    },
     "siege_progression_v1": {
         "primary": "siege_progression_v1.json",
         "summary": {
@@ -6853,6 +6876,7 @@ class GameTest(unittest.TestCase):
         map_dirs = [
             map_root / f"{map_prefix}_class_source",
             map_root / f"{map_prefix}_type_source",
+            map_root / f"{map_prefix}_name_source",
             map_root / f"{map_prefix}_empty_config",
             map_root / f"{map_prefix}_scalar_config",
             map_root / f"{map_prefix}_bad@map",
@@ -6867,7 +6891,10 @@ class GameTest(unittest.TestCase):
                         "def load(self, context):",
                         "    from game import CQuest, register",
                         "    @register(context)",
-                        "    class UnitClassOnlyQuest(CQuest):",
+                        "    class UnitActiveClassQuest(CQuest):",
+                        "        pass",
+                        "    @register(context)",
+                        "    class UnitCompletedClassQuest(CQuest):",
                         "        pass",
                     ]
                 )
@@ -6877,10 +6904,14 @@ class GameTest(unittest.TestCase):
             (class_source / "config.json").write_text(
                 json.dumps(
                     {
-                        "unitClassOnlyAlias": {
-                            "class": "UnitClassOnlyQuest",
-                            "properties": {"description": "Class-only dependency quest"},
-                        }
+                        "unitActiveClassAlias": {
+                            "class": "UnitActiveClassQuest",
+                            "properties": {"description": "Active class-only dependency quest"},
+                        },
+                        "unitCompletedClassAlias": {
+                            "class": "UnitCompletedClassQuest",
+                            "properties": {"description": "Completed class-only dependency quest"},
+                        },
                     }
                 ),
                 encoding="utf-8",
@@ -6888,28 +6919,81 @@ class GameTest(unittest.TestCase):
 
             type_source = map_dirs[1]
             type_source.mkdir(parents=True, exist_ok=True)
-            (type_source / "script.py").write_text("def load(self, context):\n    pass\n", encoding="utf-8")
+            (type_source / "script.py").write_text(
+                "\n".join(
+                    [
+                        "def load(self, context):",
+                        "    from game import CQuest, register",
+                        "    @register(context)",
+                        "    class UnitActiveTypeQuest(CQuest):",
+                        "        pass",
+                        "    @register(context)",
+                        "    class UnitCompletedTypeQuest(CQuest):",
+                        "        pass",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
             (type_source / "config.json").write_text(
                 json.dumps(
                     {
-                        "unitTypeOnlyAlias": {
-                            "class": "UnitTypeOnlyQuest",
-                            "properties": {"typeId": "externalTypeQuest"},
-                        }
+                        "unitActiveTypeAlias": {
+                            "class": "CQuest",
+                            "properties": {"typeId": "externalActiveTypeQuest"},
+                        },
+                        "unitCompletedTypeAlias": {
+                            "class": "CQuest",
+                            "properties": {"typeId": "externalCompletedTypeQuest"},
+                        },
                     }
                 ),
                 encoding="utf-8",
             )
 
-            empty_config = map_dirs[2]
+            name_source = map_dirs[2]
+            name_source.mkdir(parents=True, exist_ok=True)
+            (name_source / "script.py").write_text(
+                "\n".join(
+                    [
+                        "def load(self, context):",
+                        "    from game import CQuest, register",
+                        "    @register(context)",
+                        "    class UnitActiveNameQuest(CQuest):",
+                        "        pass",
+                        "    @register(context)",
+                        "    class UnitCompletedNameQuest(CQuest):",
+                        "        pass",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (name_source / "config.json").write_text(
+                json.dumps(
+                    {
+                        "unitActiveNameAlias": {
+                            "class": "CQuest",
+                            "properties": {"name": "externalActiveNameQuest"},
+                        },
+                        "unitCompletedNameAlias": {
+                            "class": "CQuest",
+                            "properties": {"name": "externalCompletedNameQuest"},
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            empty_config = map_dirs[3]
             empty_config.mkdir(parents=True, exist_ok=True)
             (empty_config / "config.json").write_text("[]\n", encoding="utf-8")
 
-            scalar_config = map_dirs[3]
+            scalar_config = map_dirs[4]
             scalar_config.mkdir(parents=True, exist_ok=True)
             (scalar_config / "config.json").write_text('{"notObject": false}\n', encoding="utf-8")
 
-            invalid_map = map_dirs[4]
+            invalid_map = map_dirs[5]
             invalid_map.mkdir(parents=True, exist_ok=True)
 
             save_path.parent.mkdir(exist_ok=True)
@@ -6934,28 +7018,54 @@ class GameTest(unittest.TestCase):
                                             False,
                                             {"class": "CQuest"},
                                             {
-                                                "class": "UnitClassOnlyQuest",
+                                                "class": "UnitActiveClassQuest",
                                                 "properties": {
-                                                    "name": "classQuest",
-                                                    "typeId": "externalClassQuest",
+                                                    "name": "activeClassQuest",
+                                                    "typeId": "externalActiveClassQuest",
                                                 },
                                             },
                                             {
-                                                "class": "CQuest",
+                                                "class": "UnitActiveTypeQuest",
                                                 "properties": {
-                                                    "name": "typeQuest",
-                                                    "typeId": "externalTypeQuest",
+                                                    "name": "activeTypeQuest",
+                                                    "typeId": "externalActiveTypeQuest",
+                                                },
+                                            },
+                                            {
+                                                "class": "UnitActiveNameQuest",
+                                                "properties": {
+                                                    "name": "externalActiveNameQuest",
                                                 },
                                             },
                                         ],
                                         "completedQuests": [
+                                            {
+                                                "class": "UnitCompletedClassQuest",
+                                                "properties": {
+                                                    "name": "completedClassQuest",
+                                                    "typeId": "externalCompletedClassQuest",
+                                                },
+                                            },
+                                            {
+                                                "class": "UnitCompletedTypeQuest",
+                                                "properties": {
+                                                    "name": "completedTypeQuest",
+                                                    "typeId": "externalCompletedTypeQuest",
+                                                },
+                                            },
+                                            {
+                                                "class": "UnitCompletedNameQuest",
+                                                "properties": {
+                                                    "name": "externalCompletedNameQuest",
+                                                },
+                                            },
                                             {
                                                 "class": "CQuest",
                                                 "properties": {
                                                     "name": "genericCompletedQuest",
                                                     "typeId": "genericCompletedQuest",
                                                 },
-                                            }
+                                            },
                                         ],
                                     },
                                 }
@@ -6974,8 +7084,12 @@ class GameTest(unittest.TestCase):
             self.assertEqual("ritual", loaded_map.mapName)
             self.assertEqual(7, loaded_map.getTurn())
             self.assertEqual((3, 22, 0), coords_tuple(loaded_player.getCoords()))
-            self.assertIn("externalClassQuest", quest_names(loaded_player))
-            self.assertIn("externalTypeQuest", quest_names(loaded_player))
+            self.assertIn("externalActiveClassQuest", quest_names(loaded_player))
+            self.assertIn("externalActiveTypeQuest", quest_names(loaded_player))
+            self.assertIn("externalActiveNameQuest", quest_names(loaded_player))
+            self.assertIn("externalCompletedClassQuest", completed_quest_names(loaded_player))
+            self.assertIn("externalCompletedTypeQuest", completed_quest_names(loaded_player))
+            self.assertIn("externalCompletedNameQuest", completed_quest_names(loaded_player))
             self.assertIn("genericCompletedQuest", completed_quest_names(loaded_player))
 
             return True, json.dumps(

--- a/tests/fixtures/save_compatibility/ritual_completed_nouraajd_quest_v1.json
+++ b/tests/fixtures/save_compatibility/ritual_completed_nouraajd_quest_v1.json
@@ -1,0 +1,38 @@
+{
+  "format": "fall-of-nouraajd-save",
+  "mapName": "ritual",
+  "schemaVersion": 1,
+  "snapshot": {
+    "class": "CMap",
+    "properties": {
+      "description": "immutable completed external quest fixture",
+      "mapName": "ritual",
+      "objects": [
+        {
+          "class": "CPlayer",
+          "properties": {
+            "completedQuests": [
+              {
+                "class": "RolfQuest",
+                "properties": {
+                  "name": "rolfQuest",
+                  "typeId": "rolfQuest"
+                }
+              }
+            ],
+            "items": [],
+            "name": "player",
+            "posx": 3,
+            "posy": 22,
+            "posz": 0,
+            "quests": [],
+            "typeId": "Warrior"
+          }
+        }
+      ],
+      "tiles": [],
+      "triggers": [],
+      "turn": 58
+    }
+  }
+}


### PR DESCRIPTION
## What changed
- Extended save dependency detection so quest config entries can be matched through `properties.name` as well as class/type identifiers.
- Expanded the saved quest dependency regression to cover active and completed quest refs by class, typeId, and name.
- Added an immutable save fixture with a completed Nouraajd quest from the non-active `nouraajd` map.

## Why
Saved quest refs from non-active maps need their defining map resources/scripts loaded before deserialization. The existing dependency scan collected names but did not match config entries that expose the quest identity only through `properties.name`.

## Queue
- Issue: [EPIC_03][STORY_05][SUBSTORY_04] Verify quest resource preloading for saves
- Claim ID: 7cb961ee-4631-4490-9f53-a4bbecce93a4
- Owner: controller/ctrl-lis-2-b17e29a3/subagent-1

## Validation
- `python3 -m py_compile test.py` passed.
- `python3 -m json.tool tests/fixtures/save_compatibility/ritual_completed_nouraajd_quest_v1.json >/dev/null` passed.
- `python3 test.py SaveFixtureTest.test_immutable_save_fixture_summaries_match_expected` passed.
- `GAME_CONFIGURE_SKIP_APT=1 GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh` passed.
- `cmake --build cmake-build-release --target _game -j$(nproc)` passed.
- `python3 test.py GameTest.test_saved_quest_dependency_loader_uses_class_and_type_refs GameTest.test_save_migration_fixtures_are_idempotent_and_round_trip_current_format` passed.
- `git diff --check` passed.
- `black --check -l 120 test.py` passed.
- `clang-format --dry-run --Werror src/core/CLoader.cpp` passed.

## Known limitations
- Full Python suite, ctest, coverage, Xvfb, and MCP were not run locally; CI polling will provide heavy validation.
