### PR TITLE
[codex] Resolve live main drift observation

### DIFF
--- a/planning/workflow_observations/resolutions/20260621T110915Z-optimizer-live-main-drift-9feca014.json
+++ b/planning/workflow_observations/resolutions/20260621T110915Z-optimizer-live-main-drift-9feca014.json
@@ -1,0 +1,28 @@
+{
+  "evidence": [
+    {
+      "postMergeVerification": {
+        "auditWarnings": [],
+        "commands": [
+          "python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes",
+          "python3 scripts/workflow_observations.py validate"
+        ],
+        "head": "36e7f6e9f381c1e5b9af01d61db26e95d95976f4",
+        "ledgerErrors": [],
+        "liveOriginMain": "36e7f6e9f381c1e5b9af01d61db26e95d95976f4",
+        "originMain": "36e7f6e9f381c1e5b9af01d61db26e95d95976f4",
+        "originMainMatchesLive": true,
+        "worktree": "/tmp/fon-opt-live-main-verify"
+      }
+    }
+  ],
+  "mergeCommit": "36e7f6e9f381c1e5b9af01d61db26e95d95976f4",
+  "mergedPr": 794,
+  "observationId": "20260621T110915Z-optimizer-live-main-drift-9feca014",
+  "resolutionSummary": "Fixed by PR #794, which adds a read-only live origin/main comparison to controller_resource_audit.py and exposes liveOriginMain, liveOriginMainError, and originMainMatchesLive in the audit payload.",
+  "resolvedAtUtc": "2026-06-21T11:56:12Z",
+  "resolver": "workflow-optimizer",
+  "schemaVersion": 1,
+  "sourceCommit": "36e7f6e9f381c1e5b9af01d61db26e95d95976f4",
+  "status": "resolved"
+}


### PR DESCRIPTION
## What changed
- Added the immutable resolution receipt for observation `20260621T110915Z-optimizer-live-main-drift-9feca014`.
- Marks the observation `resolved` after PR #794 merged at `36e7f6e9f381c1e5b9af01d61db26e95d95976f4`.
- Includes post-merge verification evidence showing `HEAD`, local `origin/main`, and live `origin/main` all matched and the resource audit emitted no warnings.

## Why
PR #794 fixed the recorded workflow observation by adding a read-only live `origin/main` comparison to the controller resource audit. This separate resolution-only PR closes the ledger item without mixing it into the implementation PR.

## Validation
- `python3 -m unittest tests.test_workflow_observations`
- `python3 scripts/workflow_observations.py validate --base origin/main`
- `python3 scripts/workflow_observations.py validate`
- `python3 scripts/workflow_observations.py next`
- `python3 scripts/issue_queue.py validate`
- `git diff --check origin/main..HEAD`

## Limitations / follow-up
- Existing queue validation heartbeat warnings are unrelated and unchanged.
