### PR TITLE
Route animation invalidation through property events

### DIFF
--- a/src/object/CGameObject.cpp
+++ b/src/object/CGameObject.cpp
@@ -280,9 +280,7 @@ void CGameObject::removeTag(const std::string &tag) { removeTag(CTags::fromStrin
 std::string CGameObject::getAnimation() { return animation; }
 
 void CGameObject::setAnimation(std::string animation) {
-    // TODO: implement this in AOP way
-    graphicsObject.clear();
-    this->animation = animation;
+    this->animation = std::move(animation);
     recordDirectPropertyChanged("animation");
 }
 
@@ -336,11 +334,21 @@ void CGameObject::disconnect(const std::string &signal, const std::shared_ptr<CG
 }
 
 void CGameObject::notifyPropertyChanged(const std::string &name) {
+    invalidateCachedPropertyState(name);
+    notifyPropertyChangedWithoutInvalidation(name);
+}
+
+void CGameObject::notifyPropertyChangedWithoutInvalidation(const std::string &name) {
     signal("propertyChanged", name);
     signal(name + "Changed");
 }
 
 void CGameObject::notifyPropertiesChanged(const std::set<std::string> &names) {
+    invalidateCachedPropertyState(names);
+    notifyPropertiesChangedWithoutInvalidation(names);
+}
+
+void CGameObject::notifyPropertiesChangedWithoutInvalidation(const std::set<std::string> &names) {
     if (!names.empty()) {
         signal("propertiesChanged", names);
     }
@@ -358,15 +366,16 @@ void CGameObject::endPropertyNotificationBatch() {
     }
     auto names = std::move(batchedPropertyNotifications);
     batchedPropertyNotifications.clear();
-    notifyPropertiesChanged(names);
+    notifyPropertiesChangedWithoutInvalidation(names);
 }
 
 void CGameObject::recordPropertyChanged(const std::string &name) {
+    invalidateCachedPropertyState(name);
     if (propertyNotificationBatchDepth > 0) {
         batchedPropertyNotifications.insert(name);
         return;
     }
-    notifyPropertyChanged(name);
+    notifyPropertyChangedWithoutInvalidation(name);
 }
 
 void CGameObject::recordDirectPropertyChanged(const std::string &name) {
@@ -376,6 +385,18 @@ void CGameObject::recordDirectPropertyChanged(const std::string &name) {
         }
     }
     recordPropertyChanged(name);
+}
+
+void CGameObject::invalidateCachedPropertyState(const std::string &name) {
+    if (name == "animation") {
+        graphicsObject.clear();
+    }
+}
+
+void CGameObject::invalidateCachedPropertyState(const std::set<std::string> &names) {
+    if (names.contains("animation")) {
+        graphicsObject.clear();
+    }
 }
 
 bool CGameObject::hasProperty(std::string name) { return this->meta()->has_property<CGameObject>(name, this->ptr()); }

--- a/src/object/CGameObject.h
+++ b/src/object/CGameObject.h
@@ -227,6 +227,14 @@ class CGameObject : public vstd::stringable, public std::enable_shared_from_this
 
     void recordPropertyChanged(const std::string &name);
 
+    void notifyPropertyChangedWithoutInvalidation(const std::string &name);
+
+    void notifyPropertiesChangedWithoutInvalidation(const std::set<std::string> &names);
+
+    void invalidateCachedPropertyState(const std::string &name);
+
+    void invalidateCachedPropertyState(const std::set<std::string> &names);
+
     vstd::lazy<CAnimation> graphicsObject;
 
     std::string type;

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CStats.h"
 #include "core/CMap.h"
 #include "core/CTypes.h"
+#include "gui/CAnimation.h"
 #include "object/CCreature.h"
 #include "object/CDialog.h"
 #include "object/CEffect.h"
@@ -63,6 +64,13 @@ using StringIntProbeMap = std::map<std::string, int>;
 using StringStringProbeMap = std::map<std::string, std::string>;
 using IntVectorProbe = std::vector<int>;
 
+class PropertyChangeEmitter : public CGameObject {
+    V_META(PropertyChangeEmitter, CGameObject, vstd::meta::empty())
+
+  public:
+    void recordChangedProperty(const std::string &property_name) { recordDirectPropertyChanged(property_name); }
+};
+
 void drain_event_loop() {
     auto loop = vstd::event_loop<>::instance();
     for (int i = 0; i < 5; ++i) {
@@ -77,6 +85,14 @@ std::shared_ptr<CStats> stats_with_main(int stamina, int intelligence, int armor
     stats->setIntelligence(intelligence);
     stats->setArmor(armor);
     return stats;
+}
+
+std::shared_ptr<CGame> game_with_registered_types() {
+    auto game = std::make_shared<CGame>();
+    for (const auto &[name, builder] : *CTypes::builders()) {
+        game->getObjectHandler()->registerType(name, builder);
+    }
+    return game;
 }
 
 void test_market_guard_paths_and_item_transfers() {
@@ -436,6 +452,51 @@ void test_game_object_property_helpers_and_owned_tile_movement() {
                 "public tile coordinate setters should update all tile coordinates");
 }
 
+void test_animation_property_events_invalidate_cached_graphics_object() {
+    auto game = game_with_registered_types();
+    auto object = std::make_shared<PropertyChangeEmitter>();
+    object->setGame(game);
+    object->setAnimation("images/item");
+
+    auto static_animation = object->getGraphicsObject();
+    expect_true(static_animation && static_animation->meta()->inherits("CStaticAnimation"),
+                "initial graphics object should use the static animation source");
+
+    object->recordChangedProperty("label");
+    auto after_unrelated_property = object->getGraphicsObject();
+    expect_true(after_unrelated_property == static_animation,
+                "unrelated property events should not invalidate the cached graphics object");
+
+    object->notifyPropertyChanged("label");
+    auto after_unrelated_notification = object->getGraphicsObject();
+    expect_true(after_unrelated_notification == static_animation,
+                "unrelated property notifications should not invalidate the cached graphics object");
+
+    object->recordChangedProperty("animation");
+    auto after_animation_event = object->getGraphicsObject();
+    expect_true(after_animation_event && after_animation_event != static_animation,
+                "animation property events should invalidate the cached graphics object");
+    expect_true(after_animation_event && after_animation_event->meta()->inherits("CStaticAnimation"),
+                "animation property event refresh should keep using the current animation source");
+
+    object->notifyPropertiesChanged({"label"});
+    auto after_unrelated_notification_batch = object->getGraphicsObject();
+    expect_true(after_unrelated_notification_batch == after_animation_event,
+                "unrelated property notification batches should not invalidate the cached graphics object");
+
+    object->notifyPropertiesChanged({"animation", "label"});
+    auto after_animation_notification_batch = object->getGraphicsObject();
+    expect_true(after_animation_notification_batch && after_animation_notification_batch != after_animation_event,
+                "animation property notification batches should invalidate the cached graphics object");
+
+    object->setAnimation("images/monsters/octobogz");
+    auto dynamic_animation = object->getGraphicsObject();
+    expect_true(dynamic_animation && dynamic_animation != after_animation_notification_batch,
+                "changing animation should rebuild the cached graphics object");
+    expect_true(dynamic_animation && dynamic_animation->meta()->inherits("CDynamicAnimation"),
+                "rebuilt graphics object should use the updated animation source");
+}
+
 void test_creature_inventory_equipment_and_ratio_helpers() {
     auto creature = std::make_shared<CCreature>();
     creature->setBaseStats(stats_with_main(10, 10, 200));
@@ -675,6 +736,7 @@ int main() {
     test_game_object_get_map_prefers_owner_and_falls_back_to_active_map();
     test_game_object_equivalent_value_covers_supported_property_types();
     test_game_object_property_helpers_and_owned_tile_movement();
+    test_animation_property_events_invalidate_cached_graphics_object();
     test_creature_inventory_equipment_and_ratio_helpers();
     test_game_object_comparator_and_identity_sets_document_current_semantics();
     test_game_object_named_comparison_helpers_cover_explicit_semantics();


### PR DESCRIPTION
## What changed
- Routed animation graphics-cache invalidation through the property-change path instead of directly clearing in `setAnimation()`.
- Added cache invalidation helpers that only clear cached graphics for `animation` changes.
- Added object unit regression coverage proving unrelated property events keep the cache and animation changes rebuild with the updated animation source.

## Why
`setAnimation()` still had a one-off `graphicsObject.clear()` side effect. Animation invalidation should happen as part of property-change recording so direct and batched property notifications share the same cache behavior.

## Queue
- Issue: [EPIC_02][STORY_05][SUBSTORY_04] Route animation invalidation through property events
- Claim ID: 2ef4a1a3-2e99-4f31-b7fc-03530575049d
- Owner: controller/ctrl-lis-2-b17e29a3/subagent-3

## Validation
- `git diff --check` passed.
- `clang-format --dry-run --Werror src/object/CGameObject.cpp src/object/CGameObject.h tests/unit/test_object.cpp` passed.
- `git submodule update --init --recursive` passed.
- `GAME_CONFIGURE_SKIP_APT=1 GAME_CONFIGURE_SKIP_SUBMODULES=1 GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh` passed.
- `cmake --build cmake-build-release --target object_unit_tests -j$(nproc)` passed before rebase.
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests.object_unit_tests` passed before rebase.
- After rebasing onto current `origin/main`, `cmake --build cmake-build-release --target object_unit_tests -j8 && ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests.object_unit_tests` passed.

## Known limitations
- Full native tests, full Python suite, coverage, Xvfb, and MCP were not run locally; CI polling will provide required PR validation.
