### PR TITLE
[codex] Record ledger CI routing observation

### DIFF
--- a/planning/workflow_observations/records/20260621T121548Z-optimizer-ledger-ci-routing-b41370d1.json
+++ b/planning/workflow_observations/records/20260621T121548Z-optimizer-ledger-ci-routing-b41370d1.json
@@ -1,0 +1,44 @@
+{
+  "affectedPaths": [
+    ".github/workflows/build.yml",
+    "scripts/ci_change_classifier.py"
+  ],
+  "category": "ci",
+  "controllerId": "optimizer-ledger-ci-routing",
+  "createdAtUtc": "2026-06-21T12:15:48Z",
+  "details": "scripts/ci_change_classifier.py does not classify planning/workflow_observations record or resolution JSON as lightweight. Record-only or resolution-only ledger PRs therefore fail closed to native validation even though they contain immutable workflow evidence files and no gameplay, native, content, or workbook changes.",
+  "evidence": [
+    {
+      "commands": [
+        "python3 scripts/ci_change_classifier.py --path planning/workflow_observations/resolutions/example.json",
+        "gh pr view 799 --json files,statusCheckRollup"
+      ],
+      "expected": "Ledger record/resolution JSON-only PRs should remain non-CI-exempt but route as workflow-only changes, running fast ledger and queue validation without native Linux/Windows validation.",
+      "observed": {
+        "classifierNativeNeeded": true,
+        "classifierNativeReasons": [
+          "unclassified:planning/workflow_observations/resolutions/example.json"
+        ],
+        "pr799ChangedFiles": [
+          "planning/workflow_observations/resolutions/20260621T110915Z-optimizer-live-main-drift-9feca014.json"
+        ],
+        "pr799Merged": true,
+        "pr799SelectedNativeJobs": [
+          "linux",
+          "windows-deps",
+          "windows"
+        ]
+      }
+    }
+  ],
+  "fingerprint": "ledger-json-native-ci-routing",
+  "id": "20260621T121548Z-optimizer-ledger-ci-routing-b41370d1",
+  "impact": "Observation and resolution PRs spend Linux and Windows native CI minutes unnecessarily, delaying ledger publication and optimizer feedback.",
+  "phase": "validation",
+  "role": "optimizer",
+  "schemaVersion": 1,
+  "severity": "medium",
+  "sourceCommit": "77d3db60d860819ec16de7d3b14694c5b59a6554",
+  "suggestedImprovement": "Add planning/workflow_observations record and resolution JSON paths to lightweight CI classification and cover them with regression tests.",
+  "summary": "Ledger-only PRs trigger native CI"
+}


### PR DESCRIPTION
## What changed
- Added one immutable workflow observation record: `20260621T121548Z-optimizer-ledger-ci-routing-b41370d1`.
- Captures evidence that ledger record/resolution JSON paths currently classify as native and caused PR #799, a resolution-only PR, to run Linux/Windows native jobs.

## Why
This records CI waste as workflow evidence before the classifier fix. The ledger remains separate from the implementation change.

## Validation
- `python3 -m unittest tests.test_workflow_observations`
- `python3 scripts/workflow_observations.py validate`
- `python3 scripts/workflow_observations.py validate --base origin/main`
- `python3 scripts/issue_queue.py validate`
- `git diff --check`

## Limitations / follow-up
- This PR only records the observation. The fix should be published separately and then closed with a resolution receipt after post-merge verification.
