### PR TITLE
Record controller delivery blockers

### DIFF
--- a/planning/workflow_observations/records/20260621T133006Z-ctrl-lis-2-b175230b-ba6b96cf.json
+++ b/planning/workflow_observations/records/20260621T133006Z-ctrl-lis-2-b175230b-ba6b96cf.json
@@ -1,0 +1,44 @@
+{
+  "affectedPaths": [
+    ".github"
+  ],
+  "category": "prs",
+  "controllerId": "ctrl-lis-2-b175230b",
+  "createdAtUtc": "2026-06-21T13:30:06Z",
+  "details": "Validated implementation PRs cannot complete through the documented controller path because gh pr merge --auto --squash returns a repository setting error. Rows remain IN_PROGRESS and continue occupying controller slots even after required validation passes.",
+  "evidence": [
+    {
+      "command": "gh pr merge <PR> --auto --squash --delete-branch=false",
+      "prs": [
+        {
+          "autoMergeError": "GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)",
+          "checks": "all_success",
+          "number": 786,
+          "state": "OPEN"
+        },
+        {
+          "autoMergeError": "GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)",
+          "checks": "all_success",
+          "number": 788,
+          "state": "OPEN"
+        },
+        {
+          "autoMergeError": "GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)",
+          "checks": "all_success",
+          "number": 808,
+          "state": "OPEN"
+        }
+      ]
+    }
+  ],
+  "fingerprint": "implementation-auto-merge-disabled",
+  "id": "20260621T133006Z-ctrl-lis-2-b175230b-ba6b96cf",
+  "impact": "Controllers cannot mark completed implementation work DONE after validation because implementation PRs stay open until a human changes repository settings or authorizes a different merge path.",
+  "phase": "merge",
+  "role": "controller",
+  "schemaVersion": 1,
+  "severity": "high",
+  "sourceCommit": "cde103343a258a3d8f6a2ae3c831f98def4dd8f2",
+  "suggestedImprovement": "Enable repository auto-merge for protected PRs or update the controller policy to allow a direct squash merge after required checks pass.",
+  "summary": "Repository auto-merge disabled blocks validated implementation PRs"
+}

--- a/planning/workflow_observations/records/20260621T133018Z-ctrl-lis-2-b175230b-e328ca33.json
+++ b/planning/workflow_observations/records/20260621T133018Z-ctrl-lis-2-b175230b-e328ca33.json
@@ -1,0 +1,30 @@
+{
+  "affectedPaths": [
+    ".github/workflows/build.yml"
+  ],
+  "category": "ci",
+  "controllerId": "ctrl-lis-2-b175230b",
+  "createdAtUtc": "2026-06-21T13:30:18Z",
+  "details": "PR #802 Windows validation failed twice before compile or tests because the required restored vcpkg installed cache was absent and the job requires fast cached dependencies.",
+  "evidence": [
+    {
+      "cacheKey": "Windows-x64-windows-release-vcpkg-installed-v3-7a447d81dca11580d99640dce7f9f10e20cb6d152421fdf516db149c866b425c-27832965710-1",
+      "failedStep": "Validate vcpkg installed cache",
+      "pr": 802,
+      "rerunJob": 82574115261,
+      "restoreCacheHit": "none",
+      "validationReason": "vcpkg installed cache is missing expected files: include\\SDL2\\SDL.h, include\\SDL2\\SDL_image.h, include\\SDL2\\SDL_ttf.h, lib\\SDL2.lib, lib\\SDL2_image.lib, lib\\SDL2_ttf.lib, bin\\SDL2.dll, bin\\SDL2_image.dll, bin\\SDL2_ttf.dll",
+      "workflowRun": 27903644556
+    }
+  ],
+  "fingerprint": "windows-vcpkg-installed-cache-missing-sdl",
+  "id": "20260621T133018Z-ctrl-lis-2-b175230b-e328ca33",
+  "impact": "Implementation PR validation is blocked by infrastructure state rather than code, and reruns consume CI while reproducing the same setup failure.",
+  "phase": "validation",
+  "role": "controller",
+  "schemaVersion": 1,
+  "severity": "medium",
+  "sourceCommit": "cde103343a258a3d8f6a2ae3c831f98def4dd8f2",
+  "suggestedImprovement": "When the required Windows installed-cache key is missing, run the dependency install/build fallback or make the cache producer and consumer keys align before requiring the fast Windows job.",
+  "summary": "Windows build fails on missing vcpkg installed cache"
+}


### PR DESCRIPTION
## What changed
- Added workflow observation `20260621T133006Z-ctrl-lis-2-b175230b-ba6b96cf` for repository auto-merge being disabled on validated implementation PRs.
- Added workflow observation `20260621T133018Z-ctrl-lis-2-b175230b-e328ca33` for repeated Windows vcpkg installed-cache misses on PR #802.

## Why
- The controller hit durable workflow blockers while delivering queue work, and the workflow-observation ledger is the durable evidence channel for PR/merge failures and CI waste.

## Validation
- `python3 scripts/workflow_observations.py validate`
- `python3 scripts/workflow_observations.py validate --base origin/main`
- Confirmed the diff adds only record files under `planning/workflow_observations/records/`.

## Known limitations
- Observation-only PRs are not CI-exempt under current repository policy, so GitHub checks still need to run before merge readiness.