### PR TITLE
Classify ledger records as lightweight CI

### DIFF
--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -163,8 +163,9 @@ publish a separate resolution-only PR that adds only `planning/workflow_observat
 
 Observation-only and resolution-only PRs are not CI-exempt under the current repository policy. They do not need the
 global XLSX serialization lane because each record or receipt is a unique immutable path, but same-ID publication must
-fail and the normal PR merge policy still applies. Include pending observation IDs in live status when a record or
-resolution is awaiting publication.
+fail and the normal PR merge policy still applies. Record/receipt JSON-only PRs are workflow-only for
+`scripts/ci_change_classifier.py`: they run fast ledger and queue validation without native Linux/Windows validation.
+Include pending observation IDs in live status when a record or resolution is awaiting publication.
 
 Assign one read-only QA role when subagent capacity permits. QA reviews issue selection risk, diff scope, regression
 coverage, validation commands, GitHub Actions evidence, and merge readiness. QA must not claim issues, edit the

--- a/docs/codex-workflow-observations.md
+++ b/docs/codex-workflow-observations.md
@@ -96,9 +96,11 @@ Publish observation files through observation-only pull requests after evidence 
   deletions of immutable records and receipts;
 - same-ID publication fails because files are created with exclusive no-overwrite semantics.
 
-Observation-only and resolution-only PRs are not CI-exempt under the current repository policy. They do not need global
-serialization because each record or receipt has a distinct immutable path, but branch protection and the normal PR merge
-policy still apply unless the repository owner adds an explicit exemption later.
+Observation-only and resolution-only PRs are not CI-exempt under the current repository policy. They are workflow-only
+inputs to `scripts/ci_change_classifier.py`: they must run the fast ledger and queue validation path, but record/receipt
+JSON alone must not require native Linux/Windows validation. They do not need global serialization because each record or
+receipt has a distinct immutable path, but branch protection and the normal PR merge policy still apply unless the
+repository owner adds an explicit exemption later.
 
 At each optimizer cycle, validate the ledger and review open observations before selecting new workflow work. Use
 `next` as deterministic evidence, not as an automatic claim. The optimizer must still inspect current source, reproduce

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -201,8 +201,9 @@ python3 scripts/poll_pr_checks.py <PR_NUMBER>
 ```
 
 When no `--check` is supplied, the poller inspects PR paths with `scripts/ci_change_classifier.py`: lightweight
-workflow/docs/tooling PRs require `linux`, while native/source/content PRs require `linux`, `windows-deps`, and
-`windows`. Use explicit `--check` values only to intentionally override the path-selected set for a documented reason:
+workflow/docs/tooling PRs, including workflow-observation record/receipt JSON-only PRs, require `linux`, while
+native/source/content PRs require `linux`, `windows-deps`, and `windows`. Use explicit `--check` values only to
+intentionally override the path-selected set for a documented reason:
 
 ```bash
 python3 scripts/poll_pr_checks.py <PR_NUMBER> --check linux --check windows-deps --check windows

--- a/scripts/ci_change_classifier.py
+++ b/scripts/ci_change_classifier.py
@@ -46,6 +46,8 @@ LIGHTWEIGHT_PATH_PATTERNS = (
     "AGENTS.md",
     "docs/*",
     "planning/*.xlsx",
+    "planning/workflow_observations/records/*.json",
+    "planning/workflow_observations/resolutions/*.json",
     "prompts/*",
     "scripts/ci_change_classifier.py",
     "scripts/controller_resource_audit.py",

--- a/tests/test_ci_change_classifier.py
+++ b/tests/test_ci_change_classifier.py
@@ -30,6 +30,16 @@ class CiChangeClassifierTest(unittest.TestCase):
         self.assertEqual((), classification.nativeReasons)
         self.assertIn(".github/workflows/build.yml", classification.paths)
 
+    def test_workflow_observation_ledger_json_does_not_need_native_validation(self) -> None:
+        classification = self.classify(
+            "planning/workflow_observations/records/20260621T120000Z-controller-example-1234abcd.json",
+            "planning/workflow_observations/resolutions/20260621T120000Z-controller-example-1234abcd.json",
+        )
+
+        self.assertFalse(classification.nativeNeeded)
+        self.assertFalse(classification.coverageNeeded)
+        self.assertEqual((), classification.nativeReasons)
+
     def test_gui_cpp_requires_native_and_coverage_validation(self) -> None:
         classification = self.classify("src/gui/panel/CListView.cpp")
 

--- a/tests/test_poll_pr_checks.py
+++ b/tests/test_poll_pr_checks.py
@@ -70,6 +70,12 @@ class PollPrChecksTest(unittest.TestCase):
     def test_default_jobs_follow_changed_path_validation_class(self) -> None:
         self.assertEqual(("linux",), poll_pr_checks.defaultJobsForChangedFiles(["docs/testing.md"]))
         self.assertEqual(
+            ("linux",),
+            poll_pr_checks.defaultJobsForChangedFiles(
+                ["planning/workflow_observations/resolutions/example-observation.json"]
+            ),
+        )
+        self.assertEqual(
             ("linux", "windows-deps", "windows"),
             poll_pr_checks.defaultJobsForChangedFiles(["src/handler/CFightHandler.cpp"]),
         )


### PR DESCRIPTION
## What changed
- Classified immutable workflow-observation record and resolution JSON files as lightweight workflow paths in `scripts/ci_change_classifier.py`.
- Added regression coverage for record/resolution JSON classification and poller default job selection.
- Updated queue, observation, and testing docs to state that ledger JSON-only PRs still run validation but do not require native Linux/Windows validation.

## Why
Observation `20260621T121548Z-optimizer-ledger-ci-routing-b41370d1` showed that ledger-only JSON PRs were unclassified, so they triggered native validation even though the files only contain immutable workflow evidence or receipts. That wastes CI time and delays observation/resolution publication.

## Validation
- `python3 -m py_compile scripts/ci_change_classifier.py tests/test_ci_change_classifier.py tests/test_poll_pr_checks.py`
- `python3 -m unittest tests.test_ci_change_classifier tests.test_poll_pr_checks`
- `python3 scripts/ci_change_classifier.py --path planning/workflow_observations/records/example.json`
- `python3 scripts/ci_change_classifier.py --path planning/workflow_observations/resolutions/example.json`
- `python3 scripts/workflow_observations.py validate`
- `python3 scripts/issue_queue.py validate`
- `black -l 120 --check scripts/ci_change_classifier.py tests/test_ci_change_classifier.py tests/test_poll_pr_checks.py`
- `git diff --check HEAD~1..HEAD`

## Notes
- Fixes workflow observation lead: `20260621T121548Z-optimizer-ledger-ci-routing-b41370d1`.
- Existing queue reclaim/heartbeat warnings are unchanged.
