### PR TITLE
[codex] Recover Windows vcpkg installed-cache misses

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -646,11 +646,18 @@ jobs:
           path: ${{ env.VCPKG_INSTALLED_DIR }}
           key: ${{ needs.windows-deps.outputs.vcpkg-installed-cache-key }}
       - *validate-vcpkg-installed
-      - name: Require vcpkg installed cache
+      - name: Install vcpkg deps when installed cache is missing
+        id: install-missing-vcpkg-installed
         if: steps.restore-vcpkg-installed.outputs.cache-hit != 'true'
         shell: pwsh
+        timeout-minutes: 20
         run: |
-          throw "windows-deps did not seed a valid vcpkg installed cache for key '${{ needs.windows-deps.outputs.vcpkg-installed-cache-key }}'."
+          "Cache key '${{ needs.windows-deps.outputs.vcpkg-installed-cache-key }}' was not restored; running vcpkg install with x-gha binary cache."
+          & "$env:VCPKG_ROOT\vcpkg.exe" install `
+            --triplet "$env:VCPKG_TARGET_TRIPLET" `
+            --overlay-triplets "$env:VCPKG_OVERLAY_TRIPLETS" `
+            "--x-install-root=$env:VCPKG_INSTALLED_DIR"
+          "installed=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
       - name: Repair vcpkg installed tree
         id: repair-vcpkg-installed
         if: steps.restore-vcpkg-installed.outputs.cache-hit == 'true' && steps.validate-vcpkg-installed.outputs.valid != 'true'
@@ -663,6 +670,13 @@ jobs:
             --overlay-triplets "$env:VCPKG_OVERLAY_TRIPLETS" `
             "--x-install-root=$env:VCPKG_INSTALLED_DIR"
           "repaired=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+      - name: Save missing vcpkg installed tree
+        if: steps.install-missing-vcpkg-installed.outputs.installed == 'true'
+        continue-on-error: true
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ${{ env.VCPKG_INSTALLED_DIR }}
+          key: ${{ needs.windows-deps.outputs.vcpkg-installed-cache-key }}
       - name: Save repaired vcpkg installed tree
         if: steps.repair-vcpkg-installed.outputs.repaired == 'true'
         continue-on-error: true
@@ -686,10 +700,13 @@ jobs:
           $cacheHit = Format-Value "${{ steps.restore-vcpkg-installed.outputs.cache-hit }}"
           $valid = Format-Value "${{ steps.validate-vcpkg-installed.outputs.valid }}"
           $reason = Format-Value "${{ steps.validate-vcpkg-installed.outputs.reason }}"
+          $installed = Format-Value "${{ steps.install-missing-vcpkg-installed.outputs.installed }}"
           $repaired = Format-Value "${{ steps.repair-vcpkg-installed.outputs.repaired }}"
 
-          if ($cacheHit -ne "true") {
-            $cacheAction = "required cache missing"
+          if ($cacheHit -ne "true" -and $installed -eq "true") {
+            $cacheAction = "cache missing; installed with x-gha"
+          } elseif ($cacheHit -ne "true") {
+            $cacheAction = "cache missing and install not completed"
           } elseif ($repaired -eq "true") {
             $cacheAction = "repaired"
           } elseif ($valid -eq "true") {
@@ -710,7 +727,9 @@ jobs:
             "- Selected key: ``$selected``",
             "- Cache hit: $cacheHit",
             "- Validation: $valid",
-            "- Reason: $reason"
+            "- Reason: $reason",
+            "- Installed on miss: $installed",
+            "- Repaired: $repaired"
           ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
       - name: Detect sccache metadata
         id: windows-sccache

--- a/tests/security/test_configure_supply_chain.py
+++ b/tests/security/test_configure_supply_chain.py
@@ -71,6 +71,21 @@ class ConfigureSupplyChainTest(unittest.TestCase):
         self.assertRegex(requirements_text, re.compile(r"^black==[0-9]+(?:\.[0-9]+)*$", re.MULTILINE))
         self.assertNotRegex(requirements_text, re.compile(r"^pybind11\b", re.IGNORECASE | re.MULTILINE))
 
+    def test_windows_job_installs_vcpkg_when_installed_cache_is_missing(self):
+        workflow_text = (REPO_ROOT / ".github" / "workflows" / "build.yml").read_text()
+        match = re.search(r"(?ms)^  windows:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:|\Z)", workflow_text)
+        self.assertIsNotNone(match)
+        job_body = match.group("body")
+
+        self.assertIn("- name: Install vcpkg deps when installed cache is missing", job_body)
+        self.assertIn("id: install-missing-vcpkg-installed", job_body)
+        self.assertIn("if: steps.restore-vcpkg-installed.outputs.cache-hit != 'true'", job_body)
+        self.assertIn('& "$env:VCPKG_ROOT\\vcpkg.exe" install `', job_body)
+        self.assertIn('"--x-install-root=$env:VCPKG_INSTALLED_DIR"', job_body)
+        self.assertIn("- name: Save missing vcpkg installed tree", job_body)
+        self.assertIn("key: ${{ needs.windows-deps.outputs.vcpkg-installed-cache-key }}", job_body)
+        self.assertNotIn("windows-deps did not seed a valid vcpkg installed cache", job_body)
+
     def test_linux_coverage_job_uploads_failure_report_artifact(self):
         workflow_text = (REPO_ROOT / ".github" / "workflows" / "build.yml").read_text()
         match = re.search(r"(?ms)^  linux-coverage:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:|\Z)", workflow_text)


### PR DESCRIPTION
## What changed
- Replaced the downstream Windows job's hard failure on a missing vcpkg installed-tree cache with a `vcpkg install` fallback that uses the existing `x-gha` binary cache.
- Save the recovered installed tree under the selected cache key when that fallback runs.
- Added a focused workflow regression test so the Windows job keeps rebuilding instead of aborting on cache misses.

## Why
Workflow observation `20260621T133018Z-ctrl-lis-2-b175230b-e328ca33` showed Windows validation could fail when `windows-deps` selected a cache key but the consumer job could not restore that exact installed-tree cache. The consumer aborted before recovery, wasting CI and blocking otherwise-valid PRs.

## Validation
- `python3 -m py_compile tests/security/test_configure_supply_chain.py`
- `python3 -m unittest tests.security.test_configure_supply_chain`
- `python3 -m unittest tests.test_poll_pr_checks`
- `python3 scripts/ci_change_classifier.py --path .github/workflows/build.yml`
- `python3 scripts/workflow_observations.py validate`
- `python3 scripts/issue_queue.py validate`
- `black -l 120 --check tests/security/test_configure_supply_chain.py`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes`
- `git diff --check`

## Notes
- Production workbook was not edited.
- `scripts/issue_queue.py validate` still reports pre-existing reclaim/heartbeat warnings on `main`; this change does not touch queue state.