### PR TITLE
Add context-owned providers

### DIFF
--- a/src/core/CGame.cpp
+++ b/src/core/CGame.cpp
@@ -64,3 +64,9 @@ void CGame::setGui(std::shared_ptr<CGui> _gui) { CGame::_gui = _gui; }
 std::shared_ptr<CSlotConfig> CGame::getSlotConfiguration() { return getContext()->getSlotConfiguration(); }
 
 std::shared_ptr<CRngHandler> CGame::getRngHandler() { return getContext()->getRngHandler(); }
+
+std::shared_ptr<CResourcesProvider> CGame::getResourcesProvider() { return getContext()->getResourcesProvider(); }
+
+std::shared_ptr<CConfigurationProvider> CGame::getConfigurationProvider() {
+    return getContext()->getConfigurationProvider();
+}

--- a/src/core/CGame.h
+++ b/src/core/CGame.h
@@ -35,7 +35,11 @@ class CGameContext;
 
 class CGui;
 
+class CConfigurationProvider;
+
 class CSceneManager;
+
+class CResourcesProvider;
 
 class CRngHandler;
 
@@ -83,6 +87,10 @@ class CGame : public CGameObject {
     }
 
     std::shared_ptr<CSlotConfig> getSlotConfiguration();
+
+    std::shared_ptr<CResourcesProvider> getResourcesProvider();
+
+    std::shared_ptr<CConfigurationProvider> getConfigurationProvider();
 
   private:
     std::shared_ptr<CGameContext> context;

--- a/src/core/CGameContext.cpp
+++ b/src/core/CGameContext.cpp
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CGameContext.h"
 #include "core/CController.h"
 #include "core/CGame.h"
+#include "core/CProvider.h"
 #include "core/CSceneManager.h"
 #include "core/CSlotConfig.h"
 #include "gui/CGui.h"
@@ -83,6 +84,22 @@ std::shared_ptr<CSlotConfig> CGameContext::getSlotConfiguration() {
     });
 }
 
+std::shared_ptr<CResourcesProvider> CGameContext::getResourcesProvider() {
+    requireActiveService("CResourcesProvider");
+    if (!resourcesProvider) {
+        resourcesProvider = std::make_shared<CResourcesProvider>();
+    }
+    return resourcesProvider;
+}
+
+std::shared_ptr<CConfigurationProvider> CGameContext::getConfigurationProvider() {
+    requireActiveService("CConfigurationProvider");
+    if (!configurationProvider) {
+        configurationProvider = std::make_shared<CConfigurationProvider>(getResourcesProvider());
+    }
+    return configurationProvider;
+}
+
 bool CGameContext::isActive() const { return active.load(std::memory_order_acquire); }
 
 void CGameContext::shutdown() {
@@ -111,6 +128,8 @@ void CGameContext::shutdown(CGame *owner) {
         scriptHandler->releaseState();
     }
     slotConfiguration.clear();
+    configurationProvider.reset();
+    resourcesProvider.reset();
     scriptHandler.reset();
     guiHandler.reset();
     rngHandler.reset();

--- a/src/core/CGameContext.h
+++ b/src/core/CGameContext.h
@@ -25,7 +25,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 class CGame;
 class CGuiHandler;
+class CConfigurationProvider;
 class CObjectHandler;
+class CResourcesProvider;
 class CRngHandler;
 class CScriptHandler;
 class CSlotConfig;
@@ -47,6 +49,10 @@ class CGameContext {
     std::shared_ptr<CRngHandler> getRngHandler();
 
     std::shared_ptr<CSlotConfig> getSlotConfiguration();
+
+    std::shared_ptr<CResourcesProvider> getResourcesProvider();
+
+    std::shared_ptr<CConfigurationProvider> getConfigurationProvider();
 
     bool isActive() const;
 
@@ -70,6 +76,8 @@ class CGameContext {
     std::shared_ptr<CObjectHandler> objectHandler;
     std::shared_ptr<CScriptHandler> scriptHandler;
     std::shared_ptr<CRngHandler> rngHandler;
+    std::shared_ptr<CResourcesProvider> resourcesProvider;
+    std::shared_ptr<CConfigurationProvider> configurationProvider;
     vstd::lazy<CSlotConfig> slotConfiguration;
     std::atomic<bool> active = true;
     std::atomic<TransitionGeneration> transitionGeneration = 0;

--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -1184,6 +1184,8 @@ void CRandomMapGenerator::generateTiles(std::shared_ptr<CMap> &map, const rdg::D
 
 std::shared_ptr<CGame> CGameLoader::loadGame() {
     std::shared_ptr<CGame> game = std::make_shared<CGame>();
+    game->getResourcesProvider();
+    game->getConfigurationProvider();
     initObjectHandler(game->getObjectHandler());
     initConfigurations(game->getObjectHandler());
     initScriptHandler(game->getScriptHandler(), game);

--- a/src/core/CProvider.cpp
+++ b/src/core/CProvider.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <algorithm>
 #include <chrono>
 #include <cctype>
+#include <utility>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -309,6 +310,13 @@ const std::string CResType::MAP = "MAP";
 const std::string CResType::PLUGIN = "PLUGIN";
 const std::string CResType::SAVE = "SAVE";
 
+CConfigurationProvider::CConfigurationProvider(std::shared_ptr<CResourcesProvider> resourcesProvider)
+    : resourcesProvider(std::move(resourcesProvider)) {
+    if (!this->resourcesProvider) {
+        this->resourcesProvider = CResourcesProvider::getInstance();
+    }
+}
+
 std::shared_ptr<json> CConfigurationProvider::getConfig(const std::string &path) {
     static CConfigurationProvider instance;
     return instance.getConfiguration(path);
@@ -326,12 +334,13 @@ std::shared_ptr<json> CConfigurationProvider::getConfiguration(const std::string
 
 void CConfigurationProvider::loadConfig(const std::string &path) {
     if (isConfigResourcePath(path)) {
-        auto config = std::static_pointer_cast<CTextResource>(CConfigResourceLoader().load(path));
-        this->insert(std::make_pair(path, CJsonUtil::from_string(config->getText(), path)));
+        auto config = CConfigResourceLoader().load(path);
+        this->insert(
+            std::make_pair(path, CJsonUtil::from_string(resourcesProvider->load(config->getFilePath()), path)));
         return;
     }
 
-    this->insert(std::make_pair(path, CResourcesProvider::getInstance()->loadJson(path)));
+    this->insert(std::make_pair(path, resourcesProvider->loadJson(path)));
 }
 
 std::list<std::string> CResourcesProvider::searchPath = buildResourceSearchPath();

--- a/src/core/CProvider.h
+++ b/src/core/CProvider.h
@@ -138,16 +138,19 @@ class CResourcesProvider {
 
 class CConfigurationProvider : private std::map<std::string, std::shared_ptr<json>> {
   public:
-    static std::shared_ptr<json> getConfig(const std::string &path);
-
-  private:
-    CConfigurationProvider() = default;
+    explicit CConfigurationProvider(
+        std::shared_ptr<CResourcesProvider> resourcesProvider = CResourcesProvider::getInstance());
 
     ~CConfigurationProvider();
 
+    static std::shared_ptr<json> getConfig(const std::string &path);
+
     std::shared_ptr<json> getConfiguration(const std::string &path);
 
+  private:
     void loadConfig(const std::string &path);
+
+    std::shared_ptr<CResourcesProvider> resourcesProvider;
 };
 
 class CAnimationProvider {

--- a/tests/unit/test_resource.cpp
+++ b/tests/unit/test_resource.cpp
@@ -17,8 +17,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "core/CProvider.h"
+#include "core/CGame.h"
+#include "core/CGameContext.h"
+#include "core/CLoader.h"
 #include "core/CSaveFormat.h"
 #include "test_harness.h"
+
+#include <pybind11/embed.h>
 
 #include <algorithm>
 #include <chrono>
@@ -120,11 +125,47 @@ void test_resource_provider_save_uses_provider_root_when_cwd_changes() {
     std::filesystem::remove_all(tempRoot);
 }
 
+void test_load_game_creates_context_owned_providers() {
+    auto first_game = CGameLoader::loadGame();
+    auto second_game = CGameLoader::loadGame();
+
+    auto first_context = first_game->getContext();
+    auto second_context = second_game->getContext();
+
+    auto first_resources = first_context->getResourcesProvider();
+    auto first_resources_from_game = first_game->getResourcesProvider();
+    auto second_resources = second_game->getResourcesProvider();
+    expect_true(first_resources == first_resources_from_game,
+                "CGame should delegate resource provider access to CGameContext");
+    expect_true(first_resources != CResourcesProvider::getInstance(),
+                "context-owned resource providers should be distinct from the legacy singleton");
+    expect_true(first_resources != second_resources,
+                "CGameLoader::loadGame should create one resource provider instance per game context");
+
+    auto first_configuration = first_context->getConfigurationProvider();
+    auto first_configuration_from_game = first_game->getConfigurationProvider();
+    auto second_configuration = second_context->getConfigurationProvider();
+    expect_true(first_configuration == first_configuration_from_game,
+                "CGame should delegate configuration provider access to CGameContext");
+    expect_true(first_configuration != second_configuration,
+                "CGameLoader::loadGame should create one configuration provider instance per game context");
+
+    auto first_items = first_configuration->getConfiguration("items.json");
+    auto second_items = second_configuration->getConfiguration("items.json");
+    expect_true(first_items && second_items, "context-owned configuration providers should load config resources");
+    expect_true(first_items == first_configuration->getConfiguration("items.json"),
+                "context-owned configuration providers should cache configs per provider instance");
+    expect_true(first_items != second_items, "separate game contexts should not share configuration provider caches");
+}
+
 } // namespace
 
 int main() {
+    pybind11::scoped_interpreter guard{};
+
     test_resource_provider_paths_and_config_loader();
     test_resource_provider_save_uses_provider_root_when_cwd_changes();
+    test_load_game_creates_context_owned_providers();
 
     return finish_tests();
 }


### PR DESCRIPTION
## What changed
- Added lazy context-owned resource and configuration providers to CGameContext.
- Exposed CGame delegating accessors for those providers while preserving static provider compatibility.
- Materialized context providers when loading a game and added a native regression covering loaded-game provider ownership.

## Why
This starts moving provider lifetime under CGameContext so multiple game/session instances can isolate runtime services without breaking existing static call sites.

## Validation performed
- git diff --check
- ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests.resource_unit_tests
- worker: GAME_CONFIGURE_SKIP_APT=1 GAME_CONFIGURE_SKIP_SUBMODULES=1 GAME_CONFIGURE_BUILD_TYPES=Release ./configure.sh
- worker: cmake --build cmake-build-release --target resource_unit_tests -j$(nproc)
- worker: ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests.resource_unit_tests

## Known limitations / follow-up
- Full Linux build, native tests, Python suite, and required coverage are delegated to GitHub Actions for this PR.