### PR TITLE
Migrate comparison call sites

### DIFF
--- a/docs/object-comparison-semantics.md
+++ b/docs/object-comparison-semantics.md
@@ -19,18 +19,18 @@ an equality predicate, not a strict ordering comparator.
 
 | Site | Current semantic | Notes |
 | --- | --- | --- |
-| `src/object/CGameObject.cpp` `CGameObject::name_comparator` | Configured type equality / serialized reference-key equality | Nulls use shared-pointer identity. Non-empty `typeId` is the configured key. If both `typeId` values are empty, equality falls back to `type` plus `name`. Other serialized fields are ignored, so this is not full serialized value equality. |
-| `src/object/CCreature.cpp` `addEffect` and `setEffects` | Configured type equality | Effect insertion deduplicates by `CGameObject::name_comparator`, so two effect instances with the same `typeId` or `type` plus `name` are treated as the same active effect. |
+| `src/object/CGameObject.cpp` `CGameObject::name_comparator` | Deprecated configured type equality / serialized reference-key wrapper | Compatibility wrapper around `CGameObject::sameConfiguredType`. Nulls use shared-pointer identity. Non-empty `typeId` is the configured key. If both `typeId` values are empty, equality falls back to `type` plus `name`. Other serialized fields are ignored, so this is not full serialized value equality. |
+| `src/object/CCreature.cpp` `addEffect` and `setEffects` | Configured type equality | Effect insertion deduplicates by `CGameObject::sameConfiguredType`, so two effect instances with the same `typeId` or `type` plus `name` are treated as the same active effect. |
 
 ## Object Model
 
 | Site | Current semantic | Notes |
 | --- | --- | --- |
 | `src/object/CMarket.cpp` `CMarket::items`, `add`, `remove`, `sellItem`, `buyItem` | Shared-pointer identity | Market stock and inventory transfers operate on concrete item instances. |
-| `src/object/CCreature.cpp` `items`, `actions`, `addItems`, `removeItem`, `hasInInventory`, `useItem`, `getAllItems` | Shared-pointer identity | Inventory/action membership preserves distinct item/action instances even when configured ids match. |
-| `src/object/CCreature.cpp` `equipped`, `equipItem`, `hasEquipped`, `getSlotWithItem` | Shared-pointer identity | Equipment slot values point to concrete item instances. |
+| `src/object/CCreature.cpp` `items`, `actions`, `addItems`, `removeItem`, `hasInInventory`, `useItem`, `getAllItems` | Shared-pointer identity | Inventory/action membership uses `CGameObject::sameInstance` where explicit equality is needed, preserving distinct item/action instances even when configured ids match. |
+| `src/object/CCreature.cpp` `equipped`, `equipItem`, `hasEquipped`, `getSlotWithItem` | Shared-pointer identity | Equipment slot comparisons use `CGameObject::sameInstance`; slot values point to concrete item instances. |
 | `src/object/CCreature.cpp` `effects`, `removeEffect`, `getEffects` | Shared-pointer identity after configured de-duplication | The set stores concrete effect instances; only insertion through `addEffect` applies configured equality. |
-| `src/object/CCreature.cpp` `isPlayer`, `beforeMove`, `afterMove` fight predicates | Runtime map/object identity | Movement and combat events require the live creature still registered on the same map under the same object name. |
+| `src/object/CCreature.cpp` `isPlayer`, `beforeMove`, `afterMove` fight predicates | Runtime map/object identity | Player checks use `CGameObject::sameInstance`; movement and combat events use `CGameObject::sameRuntimeIdentity` where explicit equality is needed and require the live creature still registered on the same map under the same object name. |
 | `src/object/CMapObject.cpp` `move`, `setCoords`, `setPos*` registration checks | Runtime map/object identity | Coordinate-side effects only apply when the map name lookup returns the same live object. |
 | `src/object/CPlayer.cpp` `quests`, `completedQuests`, `checkQuests`, setters | Shared-pointer identity | Quest sets store concrete quest objects. |
 | `src/object/CPlayer.cpp` `addQuest` | Configured type equality | New quests are skipped by `typeId` when present, otherwise by `name`, across active and completed quests. |
@@ -41,7 +41,7 @@ an equality predicate, not a strict ordering comparator.
 
 | Site | Current semantic | Notes |
 | --- | --- | --- |
-| `src/handler/CEventHandler.cpp` `registerTrigger` | Shared-pointer identity or configured type equality | Duplicate trigger registration skips the same trigger pointer, or another trigger with the same `type`, `typeId`, and `name` for the same object/event key. |
+| `src/handler/CEventHandler.cpp` `registerTrigger` | Shared-pointer identity or configured type equality | Duplicate trigger registration uses `CGameObject::sameInstance` for the same trigger pointer, or `CGameObject::sameConfiguredType` plus matching `type` and `name` for the same object/event key. |
 | `src/handler/CEventHandler.cpp` `getTriggers` | Shared-pointer identity | The returned set contains concrete trigger instances. |
 | `src/handler/CFightHandler.cpp` `is_registered_on_map`, `is_active_participant`, `contains_participant`, turn-order comparisons, reward eligibility, `defeatedCreature` | Runtime map/object identity | Combat must track live participants, not configured creature types. Vector membership and winner/loser checks use pointer identity. |
 | `src/handler/CFightHandler.cpp` `sanitize_opponents` | Runtime object identity | Duplicate opponents are removed by raw `CCreature *` identity after map registration checks. |
@@ -62,9 +62,9 @@ an equality predicate, not a strict ordering comparator.
 | `src/gui/CGui.cpp` pointer capture, drag-session containment, `findChild` checks | Shared-pointer identity | GUI interaction state must follow the exact widget/root objects. |
 | `src/gui/panel/CListView.cpp` `calculateIndices` with grouping enabled | Configured type equality | Grouping collapses objects by `typeId`. |
 | `src/gui/panel/CListView.cpp` index maps and drag/callback payloads | Shared-pointer identity | Indexed objects and drag payloads are concrete object instances. |
-| `src/gui/panel/CGameInventoryPanel.cpp` selection/equipment callbacks | Shared-pointer identity | Selection and use/equip actions require the selected concrete item. |
-| `src/gui/panel/CGameTradePanel.cpp` selected inventory/market lists | Shared-pointer identity | Weak-pointer selections toggle and finalize concrete item instances. |
-| `src/gui/panel/CGameFightPanel.cpp` action/item/enemy selections | Shared-pointer identity | Current action, item, and selected enemy are live object instances. |
+| `src/gui/panel/CGameInventoryPanel.cpp` selection/equipment callbacks | Shared-pointer identity | Selection and use/equip actions use `CGameObject::sameInstance` and require the selected concrete item. |
+| `src/gui/panel/CGameTradePanel.cpp` selected inventory/market lists | Shared-pointer identity | Weak-pointer selections use `CGameObject::sameInstance` to toggle and finalize concrete item instances. |
+| `src/gui/panel/CGameFightPanel.cpp` action/item/enemy selections | Shared-pointer identity | Current action, item, and selected enemy use `CGameObject::sameInstance` and are live object instances. |
 | `src/gui/panel/CGameFightPanel.cpp` `setEnemies` | Configured/runtime name equality | The enemy list keeps one living enemy per object name, then subsequent selection uses pointer identity. |
 | `src/gui/panel/CGameDialogPanel.cpp` `getCurrentOptions` | Configured type equality | Options are ordered and deduplicated by configured option number. |
 | `src/gui/panel/CGameDialogPanel.cpp` `reload` widget set | Shared-pointer identity | Temporary text widgets are concrete GUI instances. |

--- a/src/gui/panel/CGameFightPanel.cpp
+++ b/src/gui/panel/CGameFightPanel.cpp
@@ -103,9 +103,11 @@ void CGameFightPanel::interactionsCallback(std::shared_ptr<CGui> gui, int index,
     auto player = active_player(gui);
     if (!player || !newSelection) {
         selected.reset();
-    } else if (selected.lock() != newSelection && newSelection->getManaCost() <= player->getMana()) {
+    } else if (!CGameObject::sameInstance(selected.lock(), newSelection) &&
+               newSelection->getManaCost() <= player->getMana()) {
         selected = newSelection;
-    } else if (newSelection && selected.lock() == newSelection && newSelection->getManaCost() <= player->getMana()) {
+    } else if (newSelection && CGameObject::sameInstance(selected.lock(), newSelection) &&
+               newSelection->getManaCost() <= player->getMana()) {
         finalSelected = newSelection;
     } else {
         // TODO: rethink moving selection to CListView
@@ -115,7 +117,7 @@ void CGameFightPanel::interactionsCallback(std::shared_ptr<CGui> gui, int index,
 }
 
 bool CGameFightPanel::interactionsSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
-    return selected.lock() && selected.lock() == object;
+    return selected.lock() && CGameObject::sameInstance(selected.lock(), object);
 }
 
 CListView::collection_pointer CGameFightPanel::itemsCollection(std::shared_ptr<CGui> gui) {
@@ -137,9 +139,9 @@ void CGameFightPanel::itemsCallback(std::shared_ptr<CGui> gui, int index, std::s
     if (newSelection && newSelection->hasTag(CTag::Quest)) {
         return;
     }
-    if (selectedItem.lock() != newSelection) {
+    if (!CGameObject::sameInstance(selectedItem.lock(), newSelection)) {
         selectedItem = newSelection;
-    } else if (selectedItem.lock() && selectedItem.lock() == newSelection) {
+    } else if (selectedItem.lock() && CGameObject::sameInstance(selectedItem.lock(), newSelection)) {
         player->useItem(newSelection);
         selectedItem.reset();
     }
@@ -163,7 +165,8 @@ bool CGameFightPanel::itemsRightClickCallback(std::shared_ptr<CGui> gui, int ind
 }
 
 bool CGameFightPanel::itemsSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
-    return object && !object->hasTag(CTag::Quest) && selectedItem.lock() && selectedItem.lock() == object;
+    return object && !object->hasTag(CTag::Quest) && selectedItem.lock() &&
+           CGameObject::sameInstance(selectedItem.lock(), object);
 }
 
 CGameFightPanel::CGameFightPanel() {}
@@ -236,7 +239,9 @@ void CGameFightPanel::close() {
 std::shared_ptr<CCreature> CGameFightPanel::getEnemy() { return enemy.lock(); }
 
 void CGameFightPanel::setEnemy(std::shared_ptr<CCreature> en) {
-    if (en && en->isAlive() && std::find(enemies.begin(), enemies.end(), en) == enemies.end()) {
+    const auto enemyIt = std::find_if(enemies.begin(), enemies.end(),
+                                      [en](const auto &enemy) { return CGameObject::sameInstance(enemy, en); });
+    if (en && en->isAlive() && enemyIt == enemies.end()) {
         enemies.push_back(en);
     }
     enemy = en && en->isAlive() ? en : nullptr;
@@ -258,7 +263,9 @@ void CGameFightPanel::setEnemies(const std::vector<std::shared_ptr<CCreature>> &
     }
 
     auto current = enemy.lock();
-    auto current_it = std::find(enemies.begin(), enemies.end(), current);
+    auto current_it = std::find_if(enemies.begin(), enemies.end(), [current](const auto &candidate) {
+        return CGameObject::sameInstance(candidate, current);
+    });
     enemy =
         current_it != enemies.end() ? *current_it : (enemies.empty() ? std::shared_ptr<CCreature>() : enemies.front());
     clear_stale_combat_status(getGui(), enemies, enemy.lock());
@@ -287,7 +294,7 @@ void CGameFightPanel::enemiesCallback(std::shared_ptr<CGui> gui, int index,
 }
 
 bool CGameFightPanel::enemiesSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
-    return object && enemy.lock() && enemy.lock() == object;
+    return object && enemy.lock() && CGameObject::sameInstance(enemy.lock(), object);
 }
 
 std::string CGameFightPanel::getCombatStatus(std::shared_ptr<CGui> gui) {

--- a/src/gui/panel/CGameInventoryPanel.cpp
+++ b/src/gui/panel/CGameInventoryPanel.cpp
@@ -33,10 +33,10 @@ void CGameInventoryPanel::inventoryCallback(std::shared_ptr<CGui> gui, int index
     if (newSelection && newSelection->hasTag(CTag::Quest)) {
         return;
     }
-    if (selectedInventory.lock() != newSelection) {
+    if (!CGameObject::sameInstance(selectedInventory.lock(), newSelection)) {
         selectedEquipped.reset();
         selectedInventory = newSelection;
-    } else if (selectedInventory.lock() && selectedInventory.lock() == newSelection) {
+    } else if (selectedInventory.lock() && CGameObject::sameInstance(selectedInventory.lock(), newSelection)) {
         gui->getGame()->getMap()->getPlayer()->useItem(newSelection);
         selectedInventory.reset();
     } else if (selectedInventory.lock() == nullptr && selectedEquipped.lock() != nullptr) {
@@ -60,7 +60,8 @@ bool CGameInventoryPanel::inventoryRightClickCallback(std::shared_ptr<CGui> gui,
 }
 
 bool CGameInventoryPanel::inventorySelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
-    return object && !object->hasTag(CTag::Quest) && selectedInventory.lock() && selectedInventory.lock() == object;
+    return object && !object->hasTag(CTag::Quest) && selectedInventory.lock() &&
+           CGameObject::sameInstance(selectedInventory.lock(), object);
 }
 
 CListView::collection_pointer CGameInventoryPanel::equippedCollection(std::shared_ptr<CGui> gui) {
@@ -101,7 +102,7 @@ bool CGameInventoryPanel::equippedSelect(std::shared_ptr<CGui> gui, int index, s
     return (!object || !object->hasTag(CTag::Quest)) &&
            ((selectedInventory.lock() &&
              gui->getGame()->getSlotConfiguration()->canFit(vstd::str(index), selectedInventory.lock())) ||
-            (selectedEquipped.lock() && selectedEquipped.lock() == object));
+            (selectedEquipped.lock() && CGameObject::sameInstance(selectedEquipped.lock(), object)));
 }
 
 CGameInventoryPanel::CGameInventoryPanel() {}

--- a/src/gui/panel/CGameTradePanel.cpp
+++ b/src/gui/panel/CGameTradePanel.cpp
@@ -21,6 +21,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CTextManager.h"
 #include "gui/CTextureCache.h"
 
+#include <algorithm>
+
 CListView::collection_pointer CGameTradePanel::inventoryCollection(std::shared_ptr<CGui> gui) {
     auto player = gui && gui->getGame() && gui->getGame()->getMap() ? gui->getGame()->getMap()->getPlayer() : nullptr;
     if (!player) {
@@ -36,7 +38,8 @@ void CGameTradePanel::inventoryCallback(std::shared_ptr<CGui> gui, int index,
 }
 
 bool CGameTradePanel::inventorySelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
-    return vstd::ctn(selectedInventory, object, [](auto a, auto b) { return a == b.lock(); });
+    return std::any_of(selectedInventory.begin(), selectedInventory.end(),
+                       [object](const auto &selection) { return CGameObject::sameInstance(selection.lock(), object); });
 }
 
 CListView::collection_pointer CGameTradePanel::marketCollection(std::shared_ptr<CGui> gui) {
@@ -52,7 +55,8 @@ void CGameTradePanel::marketCallback(std::shared_ptr<CGui> gui, int index, std::
 }
 
 bool CGameTradePanel::marketSelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
-    return vstd::ctn(selectedMarket, object, [](auto a, auto b) { return a == b.lock(); });
+    return std::any_of(selectedMarket.begin(), selectedMarket.end(),
+                       [object](const auto &selection) { return CGameObject::sameInstance(selection.lock(), object); });
 }
 
 bool CGameTradePanel::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int button, int x, int y) {
@@ -139,8 +143,12 @@ int CGameTradePanel::getTotalBuyCost() {
 
 void CGameTradePanel::selectMarket(std::weak_ptr<CItem> selection) {
     if (selection.lock()) {
-        if (vstd::ctn(selectedMarket, selection, [](auto a, auto b) { return a.lock() == b.lock(); })) {
-            vstd::erase(selectedMarket, selection, [](auto a, auto b) { return a.lock() == b.lock(); });
+        auto selected = selection.lock();
+        auto selectionIt = std::find_if(selectedMarket.begin(), selectedMarket.end(), [selected](const auto &item) {
+            return CGameObject::sameInstance(item.lock(), selected);
+        });
+        if (selectionIt != selectedMarket.end()) {
+            selectedMarket.erase(selectionIt);
         } else {
             selectedMarket.push_back(selection);
         }
@@ -149,8 +157,12 @@ void CGameTradePanel::selectMarket(std::weak_ptr<CItem> selection) {
 
 void CGameTradePanel::selectInventory(std::weak_ptr<CItem> selection) {
     if (selection.lock() && !selection.lock()->hasTag(CTag::Quest)) {
-        if (vstd::ctn(selectedInventory, selection, [](auto a, auto b) { return a.lock() == b.lock(); })) {
-            vstd::erase(selectedInventory, selection, [](auto a, auto b) { return a.lock() == b.lock(); });
+        auto selected = selection.lock();
+        auto selectionIt =
+            std::find_if(selectedInventory.begin(), selectedInventory.end(),
+                         [selected](const auto &item) { return CGameObject::sameInstance(item.lock(), selected); });
+        if (selectionIt != selectedInventory.end()) {
+            selectedInventory.erase(selectionIt);
         } else {
             selectedInventory.push_back(selection);
         }

--- a/src/handler/CEventHandler.cpp
+++ b/src/handler/CEventHandler.cpp
@@ -84,9 +84,10 @@ void CEventHandler::registerTrigger(std::shared_ptr<CTrigger> trigger) {
         if (!existing) {
             continue;
         }
-        const bool sameIdentity = existing == trigger || (existing->getType() == trigger->getType() &&
-                                                          existing->getTypeId() == trigger->getTypeId() &&
-                                                          existing->getName() == trigger->getName());
+        const bool sameIdentity =
+            CGameObject::sameInstance(existing, trigger) ||
+            (existing->getType() == trigger->getType() && CGameObject::sameConfiguredType(existing, trigger) &&
+             existing->getName() == trigger->getName());
         if (sameIdentity) {
             vstd::logger::debug("Ignoring duplicate trigger registration:", trigger->getTypeId(), trigger->getObject(),
                                 trigger->getEvent());

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -121,7 +121,11 @@ void CCreature::removeItem(std::shared_ptr<CItem> item, bool quest) {
     if (!quest && vstd::castable<CPlayer>(this->ptr<CCreature>()) && item->hasTag(CTag::Quest)) {
         vstd::logger::fatal("Tried to drop quest item");
     } else {
-        if (items.erase(item)) {
+        auto itemIt = std::find_if(items.begin(), items.end(), [item](const auto &candidate) {
+            return CGameObject::sameInstance(candidate, item);
+        });
+        if (itemIt != items.end()) {
+            items.erase(itemIt);
             if (CPlaytestTrace::enabled()) {
                 json fields = {
                     {"item", CPlaytestTrace::objectRef(item)},
@@ -302,7 +306,7 @@ void CCreature::addEffect(std::shared_ptr<CEffect> effect) {
         vstd::logger::warning("Skipping null effect for", to_string());
         return;
     }
-    if (vstd::ctn(effects, effect, CGameObject::name_comparator)) {
+    if (vstd::ctn(effects, effect, CGameObject::sameConfiguredType)) {
         vstd::logger::debug(effect->to_string(), "skipping already present effect for", this->to_string());
     } else {
         vstd::logger::debug(effect->to_string(), "starts for", this->to_string());
@@ -360,7 +364,7 @@ bool CCreature::isPlayer() {
         return false;
     }
     const std::shared_ptr<CPlayer> player = map->getPlayer();
-    return player && player == this->ptr<CPlayer>();
+    return player && CGameObject::sameInstance(player, this->ptr<CPlayer>());
 }
 
 int CCreature::getHpRatio() {
@@ -412,7 +416,7 @@ void CCreature::equipItem(std::string i, std::shared_ptr<CItem> newItem) {
         getMap()->getEventHandler()->gameEvent(
             oldItem, std::make_shared<CGameEventCaused>(CGameEvent::CType::onUnequip, this->ptr<CCreature>()));
         this->addItem(oldItem);
-        if (newItem == oldItem) {
+        if (CGameObject::sameInstance(newItem, oldItem)) {
             newItem = nullptr;
         }
     }
@@ -442,7 +446,10 @@ void CCreature::equipItem(std::string i, std::shared_ptr<CItem> newItem) {
     }
 }
 
-bool CCreature::hasInInventory(std::shared_ptr<CItem> item) { return vstd::ctn(items, item); }
+bool CCreature::hasInInventory(std::shared_ptr<CItem> item) {
+    return std::any_of(items.begin(), items.end(),
+                       [item](const auto &candidate) { return CGameObject::sameInstance(candidate, item); });
+}
 
 bool CCreature::hasInInventory(std::function<bool(std::shared_ptr<CItem>)> item) {
     return std::any_of(items.begin(), items.end(), item);
@@ -497,7 +504,7 @@ bool CCreature::hasEquipped(std::function<bool(std::shared_ptr<CItem>)> item) {
 
 bool CCreature::hasEquipped(std::shared_ptr<CItem> item) {
     for (auto it : equipped) {
-        if (it.second == item) {
+        if (CGameObject::sameInstance(it.second, item)) {
             return true;
         }
     }
@@ -526,7 +533,7 @@ std::shared_ptr<CItem> CCreature::getItemAtSlot(std::string slot) {
 
 std::string CCreature::getSlotWithItem(std::shared_ptr<CItem> item) {
     for (auto it = equipped.begin(); it != equipped.end(); it++) {
-        if ((*it).second == item) {
+        if (CGameObject::sameInstance((*it).second, item)) {
             return (*it).first;
         }
     }
@@ -583,15 +590,18 @@ void CCreature::afterMove() {
     const auto arrival = map->normalizeCoords(getCoords());
 
     auto moverStillAtArrival = [self, map, arrival]() {
-        return self->isAlive() && self->getMap() == map && map->getObjectByName(self->getName()) == self &&
+        return self->isAlive() && self->getMap() == map &&
+               CGameObject::sameRuntimeIdentity(map->getObjectByName(self->getName()), self) &&
                map->normalizeCoords(self->getCoords()) == arrival;
     };
 
     auto fightPred = [self, map](std::shared_ptr<CMapObject> object) {
         auto other = vstd::cast<CCreature>(object);
-        return other && self != object && !self->isNpc() && !other->isNpc() && !self->isAffiliatedWith(object) &&
-               self->getMap() == map && map->getObjectByName(self->getName()) == self && other->getMap() == map &&
-               map->getObjectByName(other->getName()) == other;
+        return other && !CGameObject::sameInstance(self, object) && !self->isNpc() && !other->isNpc() &&
+               !self->isAffiliatedWith(object) && self->getMap() == map &&
+               CGameObject::sameRuntimeIdentity(map->getObjectByName(self->getName()), self) &&
+               other->getMap() == map &&
+               CGameObject::sameRuntimeIdentity(map->getObjectByName(other->getName()), other);
     };
 
     std::vector<std::shared_ptr<CCreature>> opponents;
@@ -677,7 +687,9 @@ void CCreature::setNpc(bool value) { npc = value; }
 
 // TODO: make this a CGameEvent
 void CCreature::useAction(std::shared_ptr<CInteraction> action, std::shared_ptr<CCreature> creature) {
-    vstd::fail_if(!vstd::ctn(actions, action));
+    vstd::fail_if(!std::any_of(actions.begin(), actions.end(), [action](const auto &candidate) {
+        return CGameObject::sameInstance(candidate, action);
+    }));
     action->onAction(this->ptr<CCreature>(), creature);
     if (creature->getArmor()) {
         if (creature->getArmor()->getInteraction()) {
@@ -687,14 +699,18 @@ void CCreature::useAction(std::shared_ptr<CInteraction> action, std::shared_ptr<
 }
 
 void CCreature::removeEffect(std::shared_ptr<CEffect> effect) {
-    if (effects.erase(effect)) {
+    auto effectIt = std::find_if(effects.begin(), effects.end(), [effect](const auto &candidate) {
+        return CGameObject::sameInstance(candidate, effect);
+    });
+    if (effectIt != effects.end()) {
+        effects.erase(effectIt);
         recordDirectPropertyChanged("effects");
     }
     signal("effectsChanged");
 }
 
 void CCreature::useItem(std::shared_ptr<CItem> item) {
-    vstd::fail_if(!vstd::ctn(items, item), "Tried to use item not in inventory!");
+    vstd::fail_if(!hasInInventory(item), "Tried to use item not in inventory!");
     const bool restores_hp = item->hasTag(CTag::Heal);
     const bool restores_mana = item->hasTag(CTag::Mana);
     const bool can_restore_hp = restores_hp && getHp() < getHpMax();

--- a/tests/test_object_comparison_audit.py
+++ b/tests/test_object_comparison_audit.py
@@ -54,7 +54,9 @@ class ObjectComparisonAuditTest(unittest.TestCase):
         )
 
         creature = self.read("src/object/CCreature.cpp")
-        self.assertIn("vstd::ctn(effects, effect, CGameObject::name_comparator)", creature)
+        self.assertIn("vstd::ctn(effects, effect, CGameObject::sameConfiguredType)", creature)
+        self.assertIn("CGameObject::sameInstance((*it).second, item)", creature)
+        self.assertIn("CGameObject::sameRuntimeIdentity(map->getObjectByName(self->getName()), self)", creature)
         self.assertIn("std::set<std::shared_ptr<CItem>> allItems", creature)
 
         graphics = self.read("src/gui/object/CGameGraphicsObject.cpp")
@@ -68,12 +70,19 @@ class ObjectComparisonAuditTest(unittest.TestCase):
         self.assertIn("map->getObjectByName(creature->getName()) == creature", fight)
 
         events = self.read("src/handler/CEventHandler.cpp")
-        self.assertIn("existing == trigger", events)
-        self.assertIn("existing->getTypeId() == trigger->getTypeId()", events)
+        self.assertIn("CGameObject::sameInstance(existing, trigger)", events)
+        self.assertIn("CGameObject::sameConfiguredType(existing, trigger)", events)
 
         fight_panel = self.read("src/gui/panel/CGameFightPanel.cpp")
         self.assertIn("names.insert(candidate->getName()).second", fight_panel)
-        self.assertIn("enemy.lock() == object", fight_panel)
+        self.assertIn("CGameObject::sameInstance(enemy.lock(), object)", fight_panel)
+
+        inventory_panel = self.read("src/gui/panel/CGameInventoryPanel.cpp")
+        self.assertIn("CGameObject::sameInstance(selectedInventory.lock(), object)", inventory_panel)
+        self.assertIn("CGameObject::sameInstance(selectedEquipped.lock(), object)", inventory_panel)
+
+        trade_panel = self.read("src/gui/panel/CGameTradePanel.cpp")
+        self.assertIn("CGameObject::sameInstance(selection.lock(), object)", trade_panel)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -30,6 +30,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CTextureCache.h"
 #include "gui/object/CGameGraphicsObject.h"
 #include "gui/object/CWidget.h"
+#include "gui/panel/CGameFightPanel.h"
 #include "gui/panel/CGameInventoryPanel.h"
 #include "gui/panel/CGamePanel.h"
 #include "gui/panel/CListView.h"
@@ -568,6 +569,7 @@ void test_inventory_double_select_uses_selected_item_and_clears_selection() {
     auto gui = std::make_shared<CGui>();
     auto player = std::make_shared<CPlayer>();
     auto potion = std::make_shared<CPotion>();
+    auto same_type_potion = std::make_shared<CPotion>();
     auto panel = std::make_shared<CGameInventoryPanel>();
 
     game->setMap(map);
@@ -582,17 +584,40 @@ void test_inventory_double_select_uses_selected_item_and_clears_selection() {
 
     potion->setGame(game);
     potion->setName("coveredFullHealthPotion");
+    potion->setTypeId("coveredFullHealthPotionType");
     potion->addTag(CTag::Heal);
+    same_type_potion->setTypeId(potion->getTypeId());
     player->addItem(potion);
 
     const auto inventory_size = player->getItems().size();
     panel->inventoryCallback(gui, 0, potion);
     expect_true(panel->inventorySelect(gui, 0, potion), "first inventory click should select a usable item");
+    expect_true(!panel->inventorySelect(gui, 0, same_type_potion),
+                "inventory selection should not select a different item instance with the same configured id");
 
     panel->inventoryCallback(gui, 0, potion);
     expect_true(player->getItems().size() == inventory_size,
                 "full-health potion double-select should call useItem without consuming the item");
     expect_true(!panel->inventorySelect(gui, 0, potion), "second inventory click should clear the used selection");
+}
+
+void test_fight_panel_enemy_selection_uses_exact_instance() {
+    auto panel = std::make_shared<CGameFightPanel>();
+    auto enemy = std::make_shared<CCreature>();
+    auto same_type_enemy = std::make_shared<CCreature>();
+
+    enemy->setName("unitSelectedEnemy");
+    enemy->setTypeId("unitSelectedEnemyType");
+    enemy->setHp(1);
+    same_type_enemy->setName(enemy->getName());
+    same_type_enemy->setTypeId(enemy->getTypeId());
+    same_type_enemy->setHp(1);
+
+    panel->setEnemy(enemy);
+
+    expect_true(panel->enemiesSelect(nullptr, 0, enemy), "fight enemy selection should match the selected instance");
+    expect_true(!panel->enemiesSelect(nullptr, 0, same_type_enemy),
+                "fight enemy selection should not match a different creature with the same configured id");
 }
 
 void test_list_view_drag_callbacks_validate_and_drop_without_click_fallback() {
@@ -1025,6 +1050,7 @@ int main() {
     test_list_view_refresh_event_compatibility();
     test_list_view_property_subscriptions_follow_resolved_target_and_null();
     test_inventory_double_select_uses_selected_item_and_clears_selection();
+    test_fight_panel_enemy_selection_uses_exact_instance();
     test_gui_window_is_resizable_and_guard_paths_fail_closed();
     test_list_view_drag_callbacks_validate_and_drop_without_click_fallback();
     test_list_view_drag_callbacks_cancel_and_preserve_unmoved_clicks();

--- a/tests/unit/test_handler.cpp
+++ b/tests/unit/test_handler.cpp
@@ -35,6 +35,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CItem.h"
 #include "object/CPlayer.h"
 #include "object/CQuest.h"
+#include "object/CTrigger.h"
 #include "test_harness.h"
 
 #include <SDL.h>
@@ -314,6 +315,36 @@ void test_handler_constructors_are_covered_by_native_tests() {
     expect_true(rng_handler.getRandomEncounter(0).empty(),
                 "default RNG handler should return no encounters without a game");
     (void)quest_handler;
+}
+
+std::shared_ptr<CTrigger> make_unit_trigger(const std::string &name, const std::string &typeId) {
+    auto trigger = std::make_shared<CTrigger>();
+    trigger->setType("CTrigger");
+    trigger->setName(name);
+    trigger->setTypeId(typeId);
+    trigger->setObject("unitObject");
+    trigger->setEvent(CGameEvent::CType::onEnter);
+    return trigger;
+}
+
+void test_event_handler_trigger_registration_uses_named_comparison_helpers() {
+    CEventHandler handler;
+    auto first = make_unit_trigger("unitDuplicateTrigger", "unitDuplicateTriggerType");
+    auto duplicate = make_unit_trigger("unitDuplicateTrigger", "unitDuplicateTriggerType");
+    auto same_type_different_name = make_unit_trigger("unitDistinctTrigger", "unitDuplicateTriggerType");
+
+    handler.registerTrigger(first);
+    handler.registerTrigger(duplicate);
+    expect_true(handler.getTriggers().size() == 1,
+                "trigger registration should de-duplicate matching configured trigger registrations");
+
+    handler.registerTrigger(first);
+    expect_true(handler.getTriggers().size() == 1,
+                "trigger registration should de-duplicate the exact same trigger instance");
+
+    handler.registerTrigger(same_type_different_name);
+    expect_true(handler.getTriggers().size() == 2,
+                "trigger registration should preserve distinct trigger names with the same configured type id");
 }
 
 void test_fight_handler_rejects_stale_and_cross_map_participants() {
@@ -1021,6 +1052,7 @@ int main() {
 
     test_script_handler_executes_commands_and_wraps_functions();
     test_handler_constructors_are_covered_by_native_tests();
+    test_event_handler_trigger_registration_uses_named_comparison_helpers();
     test_fight_handler_rejects_stale_and_cross_map_participants();
     test_fight_handler_attributes_lethal_effects_to_valid_casters();
     test_fight_handler_reports_explicit_outcomes_and_final_status();

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -443,20 +443,30 @@ void test_creature_inventory_equipment_and_ratio_helpers() {
 
     auto inventory_item = std::make_shared<CItem>();
     inventory_item->setTypeId("potion");
+    auto same_type_inventory_item = std::make_shared<CItem>();
+    same_type_inventory_item->setTypeId("potion");
     auto equipped_item = std::make_shared<CItem>();
     equipped_item->setTypeId("sword");
+    auto same_type_equipped_item = std::make_shared<CItem>();
+    same_type_equipped_item->setTypeId("sword");
     auto null_slot_item = std::shared_ptr<CItem>();
 
     creature->setItems({nullptr, inventory_item});
     creature->setEquipped({{"0", equipped_item}, {"1", null_slot_item}});
     expect_true(creature->hasInInventory(inventory_item), "creature should track inventory items");
+    expect_true(!creature->hasInInventory(same_type_inventory_item),
+                "creature inventory identity should not collapse matching configured item ids");
     expect_true(creature->hasEquipped(equipped_item), "creature should find directly equipped items");
+    expect_true(!creature->hasEquipped(same_type_equipped_item),
+                "creature equipment identity should not collapse matching configured item ids");
     expect_true(creature->hasEquipped([](const auto &item) { return item && item->getTypeId() == "sword"; }),
                 "creature should find equipped items with predicates");
     expect_true(creature->hasItem(equipped_item) && creature->hasItem(inventory_item),
                 "hasItem should search inventory and equipped slots");
     expect_true(creature->getAllItems().size() == 2, "getAllItems should merge inventory and non-null equipment");
     expect_true(creature->getSlotWithItem(equipped_item) == "0", "creature should locate equipped item slots");
+    expect_true(creature->getSlotWithItem(same_type_equipped_item) == "-1",
+                "creature slot lookup should require the exact equipped item instance");
     expect_true(creature->getSlotWithItem(inventory_item) == "-1", "missing equipped items should report no slot");
     expect_true(creature->countItems("potion") == 1, "creature should count matching inventory type ids");
 


### PR DESCRIPTION
## What changed
- Migrated production comparison call sites from raw pointer comparisons or deprecated name_comparator use to purpose-named helpers.
- Uses sameConfiguredType for effect stacking, sameInstance for inventory/equipment/actions/effects and GUI selection, and sameRuntimeIdentity for runtime map movement/fight checks.
- Updated trigger duplicate registration to use sameInstance plus sameConfiguredType while preserving existing stricter type/name checks.
- Updated comparison docs and added focused native/Python regression coverage.

## Why
The named comparison helpers document the intended semantics at each call site and prevent configured-type equality from being used where concrete object identity is required.

## Validation performed
- clang-format -i on modified C++ files
- black -l 120 --check tests/test_object_comparison_audit.py
- python3 -m unittest tests.test_object_comparison_audit
- python3 -m unittest tests.security.test_resource_and_gui_hardening
- git diff --check
- rg audit of name_comparator / sameConfiguredType / sameInstance / sameRuntimeIdentity call sites

## Known limitations / follow-up
- Local native targeted build/tests were not run because this worktree has no cmake-build-release directory; object/gui/handler native tests and required coverage are delegated to GitHub Actions.