### PR TITLE
Add multi-game lifecycle regression tests

### DIFF
--- a/test.py
+++ b/test.py
@@ -4810,6 +4810,95 @@ class GameTest(unittest.TestCase):
         return True, json.dumps(report, sort_keys=True)
 
     @game_test
+    def test_multi_game_lifecycle_shutdown_preserves_surviving_session(self):
+        game = load_game_module()
+
+        closing_game = game.CGameLoader.loadGame()
+        survivor_game = game.CGameLoader.loadGame()
+        closing_context = closing_game.getContext()
+        survivor_context = survivor_game.getContext()
+
+        try:
+            game.CGameLoader.startGameWithPlayer(closing_game, "test", "Warrior")
+            game.CGameLoader.startGameWithPlayer(survivor_game, "empty", "Warrior")
+            closing_map = closing_game.getMap()
+            survivor_map = survivor_game.getMap()
+            survivor_player = survivor_map.getPlayer()
+            self.assertIsNotNone(closing_map)
+            self.assertIsNotNone(survivor_map)
+            self.assertIsNotNone(survivor_player)
+
+            closing_object_handler = closing_game.getObjectHandler()
+            survivor_object_handler = survivor_game.getObjectHandler()
+            survivor_script_handler = survivor_context.getScriptHandler()
+            survivor_gui_handler = survivor_game.getGuiHandler()
+
+            closing_object_handler.registerConfigJson(
+                "closingLifecycleProbe",
+                json.dumps({"class": "CGameObject", "properties": {"label": "closing"}}),
+            )
+            survivor_object_handler.registerConfigJson(
+                "survivorLifecycleProbe",
+                json.dumps({"class": "CGameObject", "properties": {"label": "survivor"}}),
+            )
+            self.assertEqual("closing", closing_game.createObject("closingLifecycleProbe").getStringProperty("label"))
+            self.assertEqual(
+                "survivor", survivor_game.createObject("survivorLifecycleProbe").getStringProperty("label")
+            )
+            self.assertIsNone(survivor_game.createObject("closingLifecycleProbe"))
+            self.assertIsNone(closing_game.createObject("survivorLifecycleProbe"))
+
+            game.CGameLoader.loadGui(closing_game)
+            game.CGameLoader.loadGui(survivor_game)
+            closing_gui = closing_game.getGui()
+            survivor_gui = survivor_game.getGui()
+            self.assertIsNotNone(closing_gui)
+            self.assertIsNotNone(survivor_gui)
+            self.assertIsNot(closing_gui, survivor_gui)
+
+            closing_context.shutdown()
+            closing_context.shutdown()
+            game.event_loop.instance().run()
+
+            self.assertFalse(closing_context.isActive())
+            self.assertIsNone(closing_game.getMap())
+            self.assertIsNone(closing_game.getGui())
+            with self.assertRaisesRegex(RuntimeError, "shutdown"):
+                closing_game.getObjectHandler()
+            with self.assertRaisesRegex(RuntimeError, "shutdown"):
+                closing_context.getScriptHandler()
+            with self.assertRaisesRegex(RuntimeError, "shutdown"):
+                closing_game.getGuiHandler()
+
+            self.assertTrue(survivor_context.isActive())
+            self.assertIs(survivor_map, survivor_game.getMap())
+            self.assertIs(survivor_player, survivor_game.getMap().getPlayer())
+            self.assertIs(survivor_object_handler, survivor_game.getObjectHandler())
+            self.assertIs(survivor_script_handler, survivor_context.getScriptHandler())
+            self.assertIs(survivor_gui_handler, survivor_game.getGuiHandler())
+            self.assertIs(survivor_gui, survivor_game.getGui())
+
+            inventory_panel = survivor_gui_handler.openPanel("inventoryPanel")
+            self.assertIsNotNone(inventory_panel)
+            survivor_object = survivor_game.createObject("survivorLifecycleProbe")
+            self.assertIsNotNone(survivor_object)
+            self.assertEqual("survivor", survivor_object.getStringProperty("label"))
+
+            report = {
+                "closing_context_active": closing_context.isActive(),
+                "survivor_gui": survivor_gui.getType(),
+                "survivor_map": survivor_map.getType(),
+                "survivor_panel": inventory_panel.getType(),
+                "survivor_player": survivor_player.getType(),
+            }
+            return True, json.dumps(report, sort_keys=True)
+        finally:
+            if survivor_context.isActive():
+                survivor_context.shutdown()
+            if closing_context.isActive():
+                closing_context.shutdown()
+
+    @game_test
     def test_chest_on_enter_grants_random_loot_to_real_player(self):
         g, game_map, player = load_game_map_with_player("test", "Warrior")
         chest = game_map.getGame().createObject("chest")

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -23,6 +23,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CMap.h"
 #include "core/CPathFinder.h"
 #include "core/CPlaytestTrace.h"
+#include "core/CProvider.h"
 #include "core/CSaveFormat.h"
 #include "core/CSerialization.h"
 #include "core/CScript.h"
@@ -962,6 +963,65 @@ void test_game_context_transition_generation_helpers_and_shutdown() {
                 "shutdown should make previously captured transition generation stale");
 }
 
+void test_game_context_shutdown_is_idempotent_and_preserves_other_game_services() {
+    auto closing_game = std::make_shared<CGame>();
+    auto survivor_game = std::make_shared<CGame>();
+    auto closing_context = closing_game->getContext();
+    auto survivor_context = survivor_game->getContext();
+
+    auto closing_map = std::make_shared<CMap>();
+    closing_map->setGame(closing_game);
+    closing_game->setMap(closing_map);
+
+    auto survivor_map = std::make_shared<CMap>();
+    survivor_map->setGame(survivor_game);
+    survivor_game->setMap(survivor_map);
+
+    auto survivor_object_handler = survivor_game->getObjectHandler();
+    auto survivor_gui_handler = survivor_game->getGuiHandler();
+    auto survivor_resources = survivor_game->getResourcesProvider();
+    auto survivor_configuration = survivor_game->getConfigurationProvider();
+    auto survivor_items = survivor_configuration->getConfiguration("items.json");
+    expect_true(survivor_items && survivor_items->is_object(),
+                "surviving game resource provider should load configuration before shutdown");
+
+    closing_game->getObjectHandler();
+    closing_game->getGuiHandler();
+    closing_game->getResourcesProvider();
+    closing_game->getConfigurationProvider();
+
+    const auto shutdown_generation = closing_context->captureTransitionGeneration();
+    closing_context->shutdown();
+    closing_context->shutdown();
+
+    expect_true(!closing_context->isActive(), "explicit shutdown should mark the closed context inactive");
+    expect_true(closing_context->getTransitionGeneration() == shutdown_generation + 1,
+                "idempotent shutdown should advance transition generation only once");
+    expect_true(closing_game->getMap() == nullptr, "shutdown should detach the closed game's active map");
+    expect_runtime_error([&]() { closing_game->getObjectHandler(); },
+                         "closed game should reject object handler access");
+    expect_runtime_error([&]() { closing_game->getGuiHandler(); }, "closed game should reject GUI handler access");
+    expect_runtime_error([&]() { closing_game->getResourcesProvider(); },
+                         "closed game should reject resource provider access");
+    expect_runtime_error([&]() { closing_game->getConfigurationProvider(); },
+                         "closed game should reject configuration provider access");
+
+    expect_true(survivor_context->isActive(), "shutting down one game should not shut down another context");
+    expect_true(survivor_game->getMap() == survivor_map, "shutting down one game should not detach another game's map");
+    expect_true(survivor_map->getGame() == survivor_game,
+                "surviving map should retain its owning game after another game shuts down");
+    expect_true(survivor_game->getObjectHandler() == survivor_object_handler,
+                "surviving game should retain its object handler after another game shuts down");
+    expect_true(survivor_game->getGuiHandler() == survivor_gui_handler,
+                "surviving game should retain its GUI handler after another game shuts down");
+    expect_true(survivor_game->getResourcesProvider() == survivor_resources,
+                "surviving game should retain its resource provider after another game shuts down");
+    expect_true(survivor_game->getConfigurationProvider() == survivor_configuration,
+                "surviving game should retain its configuration provider after another game shuts down");
+    expect_true(survivor_configuration->getConfiguration("items.json") == survivor_items,
+                "surviving configuration provider cache should remain valid after another game shuts down");
+}
+
 void test_playtest_trace_records_and_helper_payloads() {
     CPlaytestTrace::configure(false);
     CPlaytestTrace::record("ignored");
@@ -1279,6 +1339,7 @@ int main() {
     test_game_context_owns_distinct_gui_handlers_per_game();
     test_game_context_rejects_services_without_owner_game();
     test_game_context_transition_generation_helpers_and_shutdown();
+    test_game_context_shutdown_is_idempotent_and_preserves_other_game_services();
     test_playtest_trace_records_and_helper_payloads();
     test_delayed_future_handlers_run_through_event_loop();
     test_script_rejects_executable_expressions();


### PR DESCRIPTION
## Summary
- add native regression coverage for idempotent context shutdown and service isolation across simultaneous games
- add Python integration coverage for two loaded headless games, independent object config registration, GUI creation, shutdown idempotence, and surviving-session usability

## Why
- row 34 requires lifecycle coverage proving one game can shut down without invalidating another active game or its providers, handlers, map, player, scripts, or GUI state

## Validation
- clang-format -i tests/unit/test_core.cpp
- black -l 120 test.py
- git diff --check origin/main
- black -l 120 --check test.py
- cmake --build cmake-build-release --target core_unit_tests -j8
- ctest --test-dir cmake-build-release --output-on-failure -R core_unit_tests
- cmake --build cmake-build-release --target _game -j8
- python3 test.py GameTest.test_multi_game_lifecycle_shutdown_preserves_surviving_session

## Known limitations
- full Python suite, performance guards, and coverage are left to GitHub Actions polling for this PR.