### PR TITLE
[codex] Resolve merged workflow observations

### DIFF
--- a/planning/workflow_observations/resolutions/20260621T121548Z-optimizer-ledger-ci-routing-b41370d1.json
+++ b/planning/workflow_observations/resolutions/20260621T121548Z-optimizer-ledger-ci-routing-b41370d1.json
@@ -1,0 +1,25 @@
+{
+  "evidence": [
+    {
+      "mergeCommit": "9d2c1e2eac8624f21f0566cca230540d3e1a61a6",
+      "mergedPr": 822,
+      "observed": {
+        "recordsNativeNeeded": false,
+        "resolutionsNativeNeeded": false
+      },
+      "postMergeChecks": [
+        "python3 scripts/ci_change_classifier.py --path planning/workflow_observations/records/example.json",
+        "python3 scripts/ci_change_classifier.py --path planning/workflow_observations/resolutions/example.json"
+      ]
+    }
+  ],
+  "mergeCommit": "9d2c1e2eac8624f21f0566cca230540d3e1a61a6",
+  "mergedPr": 822,
+  "observationId": "20260621T121548Z-optimizer-ledger-ci-routing-b41370d1",
+  "resolutionSummary": "PR #822 classified workflow observation record and resolution JSON paths as lightweight CI; post-merge classifier checks return nativeNeeded=false for both paths.",
+  "resolvedAtUtc": "2026-06-21T16:32:03Z",
+  "resolver": "workflow-optimizer",
+  "schemaVersion": 1,
+  "sourceCommit": "9d2c1e2eac8624f21f0566cca230540d3e1a61a6",
+  "status": "resolved"
+}

--- a/planning/workflow_observations/resolutions/20260621T133018Z-ctrl-lis-2-b175230b-e328ca33.json
+++ b/planning/workflow_observations/resolutions/20260621T133018Z-ctrl-lis-2-b175230b-e328ca33.json
@@ -1,0 +1,25 @@
+{
+  "evidence": [
+    {
+      "mergeCommit": "5a8baf71de178a3f083adb340d58591e4bcbf1ba",
+      "mergedPr": 826,
+      "observed": {
+        "installFallbackPresent": true,
+        "saveRecoveredTreePresent": true,
+        "summaryReportsFallback": true
+      },
+      "postMergeChecks": [
+        "rg -n \"Install vcpkg deps when installed cache is missing|Save missing vcpkg installed tree|cache missing; installed with x-gha\" .github/workflows/build.yml"
+      ]
+    }
+  ],
+  "mergeCommit": "5a8baf71de178a3f083adb340d58591e4bcbf1ba",
+  "mergedPr": 826,
+  "observationId": "20260621T133018Z-ctrl-lis-2-b175230b-e328ca33",
+  "resolutionSummary": "PR #826 made the downstream Windows job recover missing vcpkg installed-cache keys by running vcpkg install with x-gha and saving the recovered installed tree.",
+  "resolvedAtUtc": "2026-06-21T16:32:10Z",
+  "resolver": "workflow-optimizer",
+  "schemaVersion": 1,
+  "sourceCommit": "9d2c1e2eac8624f21f0566cca230540d3e1a61a6",
+  "status": "resolved"
+}


### PR DESCRIPTION
## What changed
- Added immutable resolution receipts for two workflow observations that now have merged fixes:
  - `20260621T121548Z-optimizer-ledger-ci-routing-b41370d1` resolved by PR #822 / merge commit `9d2c1e2eac8624f21f0566cca230540d3e1a61a6`.
  - `20260621T133018Z-ctrl-lis-2-b175230b-e328ca33` resolved by PR #826 / merge commit `5a8baf71de178a3f083adb340d58591e4bcbf1ba`.

## Why
The fixes have landed on `main` and post-merge verification confirms the observed workflow failures are addressed. The ledger should retain immutable records and close them through separate resolution-only receipts.

## Validation
- `python3 scripts/workflow_observations.py validate`
- `python3 scripts/workflow_observations.py validate --base origin/main`
- `python3 scripts/workflow_observations.py list --state open`
- `python3 scripts/issue_queue.py validate`
- `python3 scripts/ci_change_classifier.py --path planning/workflow_observations/resolutions/20260621T121548Z-optimizer-ledger-ci-routing-b41370d1.json --path planning/workflow_observations/resolutions/20260621T133018Z-ctrl-lis-2-b175230b-e328ca33.json`
- `python3 -m unittest tests.test_workflow_observations tests.test_ci_change_classifier`
- `git diff --check origin/main..HEAD`

## Notes
- Resolution-only PR: no workbook, source, workflow, or implementation files changed.
- `issue_queue.py validate` still reports existing reclaim/heartbeat warnings on rows 11, 15, 42, 95, 128, and 132.
- The high-severity auto-merge-disabled observation remains open.