### PR TITLE
Add explicit player transfer APIs

### DIFF
--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -145,6 +145,60 @@ void CMap::setPlayer(std::shared_ptr<CPlayer> player) {
     player->moveTo(entryx, entryy, entryz);
 }
 
+std::shared_ptr<CPlayer> CMap::detachPlayer() {
+    auto detachedPlayer = player ? player : vstd::cast<CPlayer>(getObjectByName("player"));
+    auto canonicalPlayer = vstd::cast<CPlayer>(getObjectByName("player"));
+    if (!detachedPlayer && !canonicalPlayer) {
+        return nullptr;
+    }
+
+    if (detachedPlayer) {
+        removeObjectWithoutEvents(detachedPlayer);
+    }
+    if (canonicalPlayer && canonicalPlayer != detachedPlayer) {
+        removeObjectWithoutEvents(canonicalPlayer);
+    }
+    if (detachedPlayer) {
+        detachedPlayer->clearOwningMap(this->ptr<CMap>());
+    }
+    player.reset();
+    return detachedPlayer ? detachedPlayer : canonicalPlayer;
+}
+
+void CMap::attachPlayer(std::shared_ptr<CPlayer> player) { attachPlayer(std::move(player), getEntry()); }
+
+void CMap::attachPlayer(std::shared_ptr<CPlayer> player, Coords coords) {
+    if (!player) {
+        vstd::logger::warning("Ignoring null player attachment");
+        return;
+    }
+
+    auto existingCanonicalObject = getObjectByName("player");
+    if (existingCanonicalObject && existingCanonicalObject != player) {
+        removeObjectWithoutEvents(existingCanonicalObject);
+    }
+    if (this->player && this->player != player) {
+        removeObjectWithoutEvents(this->player);
+    }
+
+    auto map = this->ptr<CMap>();
+    player->setOwningMap(map);
+    player->setName("player");
+    player->setController(getGame()->createObject<CPlayerController>());
+    player->setFightController(getGame()->createObject<CPlayerFightController>());
+    this->player = player;
+    registerPlayerTriggers();
+
+    const auto target = normalizeCoords(coords);
+    if (getObjectByName("player") == player) {
+        player->moveTo(target);
+        return;
+    }
+
+    addObject(player);
+    player->moveTo(target);
+}
+
 bool CMap::restorePlayerAfterLoad(std::string &error) {
     std::shared_ptr<CPlayer> restoredPlayer;
     int restoredPlayerCount = 0;
@@ -428,6 +482,27 @@ void CMap::removeObject(const std::shared_ptr<CMapObject> &mapObject) {
         mapObject->clearOwningMap(this->ptr<CMap>());
     }
     signal("objectChanged", mapObject->getCoords());
+}
+
+bool CMap::removeObjectWithoutEvents(const std::shared_ptr<CMapObject> &mapObject) {
+    if (!mapObject) {
+        return false;
+    }
+
+    auto map_object_it = std::ranges::find_if(mapObjects, [&](const auto &entry) { return entry.second == mapObject; });
+    if (map_object_it == mapObjects.end()) {
+        return false;
+    }
+
+    const auto registeredName = map_object_it->first;
+    const auto coords = mapObject->getCoords();
+    mapObjects.erase(map_object_it);
+    vstd::erase_if(mapObjectsCache, [&registeredName](auto it) { return it.second == registeredName; });
+    mapObject->clearOwningMap(this->ptr<CMap>());
+    bumpNavigationRevision();
+    recordDirectPropertyChanged("objects");
+    signal("objectChanged", coords);
+    return true;
 }
 
 int CMap::getEntryX() { return entryx; }

--- a/src/core/CMap.h
+++ b/src/core/CMap.h
@@ -142,6 +142,12 @@ class CMap : public CGameObject {
 
     void setPlayer(std::shared_ptr<CPlayer> player);
 
+    std::shared_ptr<CPlayer> detachPlayer();
+
+    void attachPlayer(std::shared_ptr<CPlayer> player);
+
+    void attachPlayer(std::shared_ptr<CPlayer> player, Coords coords);
+
     bool restorePlayerAfterLoad(std::string &error);
 
     void moveTile(std::shared_ptr<CTile> tile, int x, int y, int z);
@@ -270,6 +276,8 @@ class CMap : public CGameObject {
     std::string fallbackTileType(Coords coords) const;
 
     std::shared_ptr<CTile> resolveTileForLookup(Coords coords);
+
+    bool removeObjectWithoutEvents(const std::shared_ptr<CMapObject> &mapObject);
 
     int normalizeAxis(int value, int z, bool wrapAxis, const IntMap &bounds) const;
 

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -589,6 +589,8 @@ void init_game_module(py::module_ &m) {
     int (CMap::*getMovementCost)(Coords) = &CMap::getMovementCost;
     std::shared_ptr<CTile> (CMap::*getTile)(int, int, int) = &CMap::getTile;
     void (CMap::*addObject)(const std::shared_ptr<CMapObject> &) = &CMap::addObject;
+    void (CMap::*attachPlayerAtEntry)(std::shared_ptr<CPlayer>) = &CMap::attachPlayer;
+    void (CMap::*attachPlayerAtCoords)(std::shared_ptr<CPlayer>, Coords) = &CMap::attachPlayer;
     std::vector<Coords> (CMap::*getNavigationNeighbors)(Coords, bool) const = &CMap::getNavigationNeighbors;
 
     py::class_<CMap, CGameObject, std::shared_ptr<CMap>>(
@@ -598,6 +600,10 @@ void init_game_module(py::module_ &m) {
         .def("removeObject", &CMap::removeObject, "Remove a map object instance.")
         .def("replaceTile", &CMap::replaceTile, "Replace a tile at coordinates with a tile type id.")
         .def("getPlayer", &CMap::getPlayer, "Return the player object assigned to this map.")
+        .def("detachPlayer", &CMap::detachPlayer, "Detach and return the active player without destroy events.")
+        .def("attachPlayer", attachPlayerAtEntry,
+             "Attach a player at the map entry and run destination movement hooks.")
+        .def("attachPlayer", attachPlayerAtCoords, "Attach a player at coordinates and run destination movement hooks.")
         .def("getLocationByName", &CMap::getLocationByName, "Return Coords for a named location object.")
         .def("removeAll", &CMap::removeObjects, "Remove objects matching a predicate.")
         .def("getEventHandler", &CMap::getEventHandler, "Return the map event handler.")

--- a/src/core/CSceneManager.cpp
+++ b/src/core/CSceneManager.cpp
@@ -150,9 +150,9 @@ void CSceneManager::performMapChange(const std::shared_ptr<CGame> &game, const s
         std::shared_ptr<CMap> map = CMapLoader::loadNewMap(game, mapName);
         game->setMap(map);
         if (oldMap && game->getMap()) {
-            std::shared_ptr<CPlayer> player = oldMap->getPlayer();
+            std::shared_ptr<CPlayer> player = oldMap->detachPlayer();
             if (player) {
-                game->getMap()->setPlayer(player);
+                game->getMap()->attachPlayer(player);
             }
             game->getMap()->setTurn(oldMap->getTurn());
         }

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -27,6 +27,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CSerialization.h"
 #include "core/CStats.h"
 #include "core/CTypes.h"
+#include "handler/CEventHandler.h"
 #include "handler/CObjectHandler.h"
 #include "object/CCreature.h"
 #include "object/CGameObject.h"
@@ -116,6 +117,26 @@ int count_trace_event(const std::vector<json> &records, const std::string &event
     return count;
 }
 
+int count_players_on_map(const std::shared_ptr<CMap> &map) {
+    int count = 0;
+    for (const auto &object : map->getObjects()) {
+        if (std::dynamic_pointer_cast<CPlayer>(object)) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+std::size_t count_player_event_triggers(const std::shared_ptr<CMap> &map) {
+    std::size_t count = 0;
+    for (const auto &trigger : map->getEventHandler()->getTriggers()) {
+        if (trigger && trigger->getObject() == "player") {
+            ++count;
+        }
+    }
+    return count;
+}
+
 bool has_trace_event_reason(const std::vector<json> &records, const std::string &event, const std::string &reason) {
     for (const auto &record : records) {
         if (record.contains("event") && record["event"].get<std::string>() == event && record.contains("reason") &&
@@ -155,6 +176,10 @@ void test_scene_manager_state_duplicate_and_player_transfer() {
     expect_true(new_map->getTurn() == 17, "scene transition should preserve the old map turn");
     expect_true(new_map->getPlayer() == player, "scene transition should transfer the same player object");
     expect_true(player->getCoords() == new_map->getEntry(), "transferred player should land at the target map entry");
+    expect_true(old_map->getObjectByName("player") == nullptr,
+                "scene transition should detach the transferred player from the old map");
+    expect_true(count_players_on_map(old_map) == 0, "old map should not retain a stale player object after transfer");
+    expect_true(count_players_on_map(new_map) == 1, "new map should contain exactly one player after transfer");
     expect_true(manager->getTransitionState() == CSceneManager::TransitionState::Idle,
                 "scene manager should return to idle after transition completion");
     expect_true(!manager->isTransitionPending(), "completed scene transition should clear pending state");
@@ -1151,6 +1176,73 @@ void test_map_player_trigger_registration_is_idempotent() {
     expect_true(map->getPlayer() == second_player, "setPlayer should still replace the active player");
 }
 
+void test_map_player_detach_attach_transfer_api() {
+    auto game = CGameLoader::loadGame();
+    CGameLoader::startGameWithPlayer(game, "test", "Warrior");
+    auto old_map = game->getMap();
+    auto player = old_map->getPlayer();
+    player->setHp(7);
+    const auto old_trigger_count = count_player_event_triggers(old_map);
+
+    auto detached_player = old_map->detachPlayer();
+
+    expect_true(detached_player == player, "detachPlayer should return the active player");
+    expect_true(old_map->getObjectByName("player") == nullptr, "detachPlayer should remove the canonical player name");
+    expect_true(count_players_on_map(old_map) == 0, "detachPlayer should leave no player object on the source map");
+    expect_true(player->getHp() == 7, "detachPlayer should not run the player onDestroy restart trigger");
+    expect_true(count_player_event_triggers(old_map) == old_trigger_count,
+                "detachPlayer should not add duplicate source-map player triggers");
+
+    auto new_map = std::make_shared<CMap>();
+    game->setMap(new_map);
+    new_map->setGame(game);
+    new_map->setEntryX(2);
+    new_map->setEntryY(1);
+    new_map->setEntryZ(0);
+
+    new_map->attachPlayer(player);
+    const auto first_attach_trigger_count = count_player_event_triggers(new_map);
+
+    expect_true(new_map->getPlayer() == player, "attachPlayer should set the active player pointer");
+    expect_true(new_map->getObjectByName("player") == player, "attachPlayer should add the canonical player object");
+    expect_true(player->getName() == "player", "attachPlayer should assign canonical player identity");
+    expect_true(std::dynamic_pointer_cast<CPlayerController>(player->getController()) != nullptr,
+                "attachPlayer should install a player controller");
+    expect_true(std::dynamic_pointer_cast<CPlayerFightController>(player->getFightController()) != nullptr,
+                "attachPlayer should install a player fight controller");
+    expect_true(player->getMap() == new_map, "attachPlayer should update map ownership");
+    expect_true(player->getCoords() == new_map->getEntry(), "attachPlayer should place the player at the entry");
+    expect_true(count_players_on_map(new_map) == 1, "attachPlayer should leave exactly one player object");
+    expect_true(new_map->getObjectCacheEntryCountForTesting() == 1,
+                "attachPlayer should create exactly one spatial cache entry for the player");
+    expect_true(first_attach_trigger_count >= 2, "attachPlayer should register player lifecycle triggers");
+
+    new_map->attachPlayer(player, Coords(4, 3, 0));
+
+    expect_true(player->getCoords() == Coords(4, 3, 0), "attachPlayer(coords) should relocate the same player");
+    expect_true(count_players_on_map(new_map) == 1, "reattaching the same player should not duplicate player objects");
+    expect_true(new_map->getObjectsAtCoords(new_map->getEntry()).empty(),
+                "reattaching the same player should clear the old spatial cache entry");
+    expect_true(new_map->getObjectsAtCoords(Coords(4, 3, 0)).contains(player),
+                "reattaching the same player should index the new spatial cache entry");
+    expect_true(new_map->getObjectCacheEntryCountForTesting() == 1,
+                "reattaching the same player should keep exactly one spatial cache entry");
+    expect_true(count_player_event_triggers(new_map) == first_attach_trigger_count,
+                "reattaching the same player should not duplicate player triggers");
+
+    auto replacement_player = game->createObject<CPlayer>("Warrior");
+    new_map->attachPlayer(replacement_player, Coords(1, 1, 0));
+
+    expect_true(new_map->getPlayer() == replacement_player, "attachPlayer should replace the active player pointer");
+    expect_true(new_map->getObjectByName("player") == replacement_player,
+                "attachPlayer should replace the canonical player object");
+    expect_true(count_players_on_map(new_map) == 1, "replacing the player should preserve the one-player invariant");
+    expect_true(!new_map->getObjects().contains(player),
+                "replacing the player should remove the previous player object");
+    expect_true(count_player_event_triggers(new_map) == first_attach_trigger_count,
+                "replacing the player should not duplicate player triggers");
+}
+
 void test_map_keeps_tiles_and_objects_separate_by_z() {
     auto map = std::make_shared<CMap>();
     map->setXBounds({{0, 4}, {1, 4}});
@@ -1265,6 +1357,7 @@ int main() {
     test_map_object_relocate_without_move_hooks_updates_spatial_state_once();
     test_map_owned_objects_and_tiles_remember_owner_when_active_map_changes();
     test_map_player_trigger_registration_is_idempotent();
+    test_map_player_detach_attach_transfer_api();
     test_map_keeps_tiles_and_objects_separate_by_z();
     test_can_step_checks_default_tile_passability_without_materializing();
     test_animation_provider_uses_dynamic_animation_for_directory_resources();


### PR DESCRIPTION
## What changed
- Added `CMap::detachPlayer()` and `CMap::attachPlayer(...)` for map-to-map player transfer without destroy hooks on detach.
- Preserved destination entry movement hooks during attach so authored map-entry triggers still run after scene transitions.
- Updated scene transitions to transfer the active player through the new APIs.
- Exposed the transfer APIs to Python and added native map regressions for one-player ownership, spatial cache updates, and trigger registration counts.
- Corrected Python binding help text for `attachPlayer` to describe destination movement hooks.

## Why
Map transitions need to move the real player object without treating travel as death and without leaving a stale player registered on the source map, while still honoring destination entry behavior.

## Validation
- `clang-format -i src/core/CMap.h src/core/CMap.cpp src/core/CSceneManager.cpp src/core/CModule.cpp tests/unit/test_map.cpp`
- `git diff --check`
- Local native build/ctest/full Python/coverage not run; this core/test change will use GitHub Actions `build / linux` with coverage-step polling for PR delivery.
- Earlier CI on the pre-fix head failed `linux` gameplay transition tests because attach skipped destination movement hooks; subsequent head `c405735d` passed `linux`. Head `a21e1e43` is rebased onto latest `origin/main` after stale workflow cleanup and has fresh checks queued.

## Known limitations
- `CMap::setPlayer()` is left behavior-compatible for initial game setup; scene transitions use the new transfer API.