### PR TITLE
Coalesce list view subscription refreshes

### DIFF
--- a/src/gui/object/CProxyTargetGraphicsObject.h
+++ b/src/gui/object/CProxyTargetGraphicsObject.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -46,7 +46,7 @@ class CProxyTargetGraphicsObject : public CGameGraphicsObject {
 
     void setProxyLayout(std::string _layout);
 
-    void refresh();
+    virtual void refresh();
 
     void refreshObject(int x, int y);
 

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -590,6 +590,12 @@ void CListView::initialize() {
         });
 }
 
+void CListView::refresh() {
+    refreshSubscriptions();
+    CProxyTargetGraphicsObject::refresh();
+    refreshAll();
+}
+
 void CListView::refreshFromRefreshEvent() { refreshFromSubscription(); }
 
 void CListView::refreshFromPropertyChanged(std::string propertyName) {
@@ -693,9 +699,27 @@ void CListView::connectRefreshSubscriptions(const std::shared_ptr<CGameObject> &
 }
 
 void CListView::refreshFromSubscription() {
-    refreshSubscriptions();
-    refresh();
-    refreshAll();
+    if (refreshFromSubscriptionQueued) {
+        return;
+    }
+
+    refreshFromSubscriptionQueued = true;
+    std::weak_ptr<CListView> weakSelf = this->ptr<CListView>();
+    vstd::call_later([weakSelf]() {
+        auto self = weakSelf.lock();
+        if (!self) {
+            return;
+        }
+
+        self->refreshFromSubscriptionQueued = false;
+        auto gui = self->getGui();
+        if (!self->isAttachedToGui(gui)) {
+            return;
+        }
+
+        self->refreshSubscriptions();
+        self->refresh();
+    });
 }
 
 bool CListView::shouldRefreshForProperty(const std::string &propertyName) const {

--- a/src/gui/panel/CListView.h
+++ b/src/gui/panel/CListView.h
@@ -92,6 +92,8 @@ class CListView : public CProxyTargetGraphicsObject {
 
     void initialize();
 
+    void refresh() override;
+
     void refreshFromRefreshEvent();
 
     void refreshFromPropertyChanged(std::string propertyName);
@@ -114,6 +116,8 @@ class CListView : public CProxyTargetGraphicsObject {
     bool subscribedRefreshOnPropertyChanged = false;
 
     std::set<std::string> subscribedRefreshProperties;
+
+    bool refreshFromSubscriptionQueued = false;
 
     bool allowOversize = true;
 

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -477,6 +477,55 @@ void test_list_view_refreshes_from_generic_property_notifications() {
                 "generic propertyChanged subscription should refresh the list for any changed property");
 }
 
+void test_list_view_coalesces_property_refreshes_per_event_loop_tick() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto game = create_gui_game(gui);
+    auto refresh_target = std::make_shared<CGameObject>();
+    auto list = std::make_shared<RefreshCountingListView>();
+    gui->pushChild(list);
+    list->setResolvedRefreshTarget(refresh_target);
+    list->setRefreshOnPropertyChanged(true);
+
+    list->refresh();
+    const int after_initial_refresh = list->refresh_count;
+
+    refresh_target->setNumericProperty("threat", 1);
+    refresh_target->setStringProperty("label", "first");
+    refresh_target->setBoolProperty("enabled", true);
+    expect_true(list->refresh_count == after_initial_refresh,
+                "property notifications should queue refresh work instead of refreshing synchronously");
+
+    drain_event_loop();
+
+    expect_true(list->refresh_count == after_initial_refresh + 1,
+                "multiple property notifications in one event-loop turn should coalesce to one list refresh");
+}
+
+void test_list_view_skips_queued_property_refresh_after_detach() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto game = create_gui_game(gui);
+    auto refresh_target = std::make_shared<CGameObject>();
+    auto list = std::make_shared<RefreshCountingListView>();
+    gui->pushChild(list);
+    list->setResolvedRefreshTarget(refresh_target);
+    list->setRefreshOnPropertyChanged(true);
+
+    list->refresh();
+    const int after_initial_refresh = list->refresh_count;
+
+    refresh_target->setNumericProperty("threat", 1);
+    gui->removeChild(list);
+    drain_event_loop();
+
+    expect_true(list->refresh_count == after_initial_refresh, "detached list views should ignore queued refresh work");
+}
+
 void test_list_view_refresh_event_compatibility() {
     SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
@@ -526,8 +575,7 @@ void test_list_view_property_subscriptions_follow_resolved_target_and_null() {
                 "property-specific subscription should ignore unrelated property notifications");
 
     list->setResolvedRefreshTarget(second_target);
-    first_target->setStringProperty("label", "handoff");
-    drain_event_loop();
+    list->refresh();
     expect_true(list->refresh_count == after_initial_refresh + 2,
                 "subscription refresh should reconnect when the resolved refresh target changes");
 
@@ -542,8 +590,7 @@ void test_list_view_property_subscriptions_follow_resolved_target_and_null() {
                 "new refresh target should drive later property-specific refreshes");
 
     list->setResolvedRefreshTarget(nullptr);
-    second_target->setStringProperty("label", "to-null");
-    drain_event_loop();
+    list->refresh();
     expect_true(list->refresh_count == after_initial_refresh + 4,
                 "subscription refresh should handle the refresh script resolving to null");
 
@@ -1047,6 +1094,8 @@ int main() {
 
     test_widget_ignores_unarmed_non_left_clicks();
     test_list_view_refreshes_from_generic_property_notifications();
+    test_list_view_coalesces_property_refreshes_per_event_loop_tick();
+    test_list_view_skips_queued_property_refresh_after_detach();
     test_list_view_refresh_event_compatibility();
     test_list_view_property_subscriptions_follow_resolved_target_and_null();
     test_inventory_double_select_uses_selected_item_and_clears_selection();


### PR DESCRIPTION
## What changed
- Coalesced `CListView` subscription-driven refresh work through the event loop so bursts of property notifications trigger one refresh pass.
- Skipped stale queued refreshes after the list view detaches from the GUI.
- Reconciled refresh subscriptions before list refresh so resolved target changes do not rely on the old target emitting another event.
- Refreshed existing proxy cells during explicit list refresh so handoffs update visible content even when grid dimensions do not change.
- Added native GUI regressions for coalescing, detach safety, and refresh-target handoff.

## Why
Bulk inventory/equipment property changes could trigger one full list rebuild per property notification, and queued refresh work needed to avoid touching detached views while still keeping visible proxy cells current after target handoff.

## Validation
- `clang-format -i src/gui/object/CProxyTargetGraphicsObject.h src/gui/panel/CListView.h src/gui/panel/CListView.cpp tests/unit/test_gui.cpp`
- `git diff --check`
- Local native build/ctest/full Python/coverage not run; this GUI/unit-test change will use GitHub Actions `build / linux` with coverage-step polling for PR delivery.

## Known limitations
- Open PR #731 also touches `CListView.cpp/.h`; this branch is narrow but may need ordinary rebase handling if #731 lands first.