### PR TITLE
Pass movement costs to path consumers

### DIFF
--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -164,6 +164,10 @@ bool creature_can_follow_step(const std::shared_ptr<CMap> &map, const std::share
     return target != current && map->canStep(target) && contains_navigation_neighbor(map, current, target);
 }
 
+int movement_step_cost(const std::shared_ptr<CMap> &map, const Coords &, const Coords &to) {
+    return map ? map->lookupMovementCost(to) : 1;
+}
+
 std::shared_ptr<TargetFlowField> build_target_flow_field(const std::shared_ptr<CMap> &map, const Coords &goal,
                                                          std::uint64_t revision) {
     auto field = std::make_shared<TargetFlowField>();
@@ -198,7 +202,7 @@ std::shared_ptr<TargetFlowField> build_target_flow_field(const std::shared_ptr<C
                 continue;
             }
 
-            const int nextCost = current.cost + 1;
+            const int nextCost = current.cost + movement_step_cost(map, previous, current.coords);
             auto previousCost = costs.find(previous);
             if (previousCost == costs.end() || nextCost < previousCost->second) {
                 costs[previous] = nextCost;
@@ -368,7 +372,8 @@ std::shared_ptr<vstd::future<Coords, void>> CNpcRandomController::control(std::s
                         creature->getCoords(), candidate, [map](const Coords &c) { return map->canStep(c); },
                         [](auto) -> std::optional<Coords> { return std::nullopt; },
                         [map](const Coords &coords) { return map->getNavigationNeighbors(coords); },
-                        [map](const Coords &from, const Coords &to) { return map->getDistance(from, to); });
+                        [map](const Coords &from, const Coords &to) { return map->getDistance(from, to); },
+                        [map](const Coords &from, const Coords &to) { return movement_step_cost(map, from, to); });
                     self->currentStep = 0;
                     break;
                 }
@@ -625,7 +630,8 @@ std::vector<Coords> CPlayerController::calculatePath(std::shared_ptr<CPlayer> pl
         player->getCoords(), *target, [player](Coords coords) { return player->getMap()->canStep(coords); },
         [](auto) -> std::optional<Coords> { return std::nullopt; },
         [player](const Coords &coords) { return player->getMap()->getNavigationNeighbors(coords); },
-        [player](const Coords &from, const Coords &to) { return player->getMap()->getDistance(from, to); });
+        [player](const Coords &from, const Coords &to) { return player->getMap()->getDistance(from, to); },
+        [player](const Coords &from, const Coords &to) { return movement_step_cost(player->getMap(), from, to); });
 }
 
 bool CFightController::control(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent) {

--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -784,7 +784,8 @@ void CMap::dumpPaths(std::string path) {
         currentPlayer->getCoords(), [this](auto coords) { return this->canStep(coords); }, path,
         [](auto) -> std::optional<Coords> { return std::nullopt; },
         [this](auto coords) { return this->getNavigationNeighbors(coords); },
-        [this](auto from, auto to) { return this->getDistance(from, to); });
+        [this](auto from, auto to) { return this->getDistance(from, to); },
+        [this](auto, auto to) { return this->lookupMovementCost(to); });
 }
 
 std::set<std::shared_ptr<CTrigger>> CMap::getTriggers() {

--- a/tests/unit/test_controller.cpp
+++ b/tests/unit/test_controller.cpp
@@ -95,6 +95,28 @@ std::shared_ptr<CMap> open_tile_map(const std::shared_ptr<CGame> &game, int widt
     return map;
 }
 
+void set_tile_movement_cost(const std::shared_ptr<CMap> &map, Coords coords, int movement_cost) {
+    auto tile = map->getTile(coords);
+    expect_true(tile != nullptr, "weighted path fixture tile should exist");
+    if (tile) {
+        tile->setMovementCost(movement_cost);
+    }
+}
+
+std::shared_ptr<CMap> weighted_detour_map(const std::shared_ptr<CGame> &game) {
+    auto map = open_tile_map(game, 5, 2);
+    for (int x = 1; x <= 3; ++x) {
+        set_tile_movement_cost(map, Coords(x, 0, 0), 30);
+    }
+    return map;
+}
+
+std::vector<Coords> expected_weighted_detour_path() {
+    return {
+        Coords(0, 1, 0), Coords(1, 1, 0), Coords(2, 1, 0), Coords(3, 1, 0), Coords(4, 1, 0), Coords(4, 0, 0),
+    };
+}
+
 std::shared_ptr<CPlayer> player_at(const std::shared_ptr<CGame> &game, Coords coords) {
     auto player = std::make_shared<CPlayer>();
     player->setGame(game);
@@ -244,6 +266,72 @@ void test_ground_controller_ignores_stale_transition_generation() {
 
     expect_true(resolve_coords(pending) == Coords(0, 0, 0),
                 "ground controller should ignore deferred steps from stale transition generations");
+}
+
+void test_player_controller_prefers_longer_lower_cost_route() {
+    auto game = std::make_shared<CGame>();
+    weighted_detour_map(game);
+    auto player = player_at(game, Coords(0, 0, 0));
+    auto controller = std::make_shared<CPlayerController>();
+    player->setController(controller);
+    controller->setTarget(player, Coords(4, 0, 0));
+
+    for (const auto &expected_step : expected_weighted_detour_path()) {
+        auto actual_step = resolve_coords(controller->control(player));
+        expect_true(actual_step == expected_step, "player controller should follow the cheaper weighted detour");
+        player->moveTo(actual_step);
+        controller->onStepCommitted(player, actual_step);
+    }
+
+    expect_true(player->getCoords() == Coords(4, 0, 0), "player weighted detour should reach the target");
+    expect_true(controller->isCompleted(player), "player weighted detour should complete after the target step");
+}
+
+void test_npc_random_controller_prefers_longer_lower_cost_route() {
+    vstd::rng().seed(4);
+    auto game = std::make_shared<CGame>();
+    weighted_detour_map(game);
+    auto creature = creature_at(0, 0, 0);
+    creature->setGame(game);
+
+    auto controller = std::make_shared<CNpcRandomController>();
+    auto first = resolve_coords(controller->control(creature));
+    expect_true(first == Coords(0, 1, 0), "NPC random controller should start on the cheaper weighted detour");
+    creature->moveTo(first);
+    controller->onStepCommitted(creature, first);
+
+    auto second = resolve_coords(controller->control(creature));
+    expect_true(second == Coords(1, 1, 0), "NPC random controller should keep following the weighted detour path");
+}
+
+void test_target_controller_flow_field_prefers_longer_lower_cost_route() {
+    auto game = std::make_shared<CGame>();
+    auto map = weighted_detour_map(game);
+
+    auto target = std::make_shared<CMapObject>();
+    target->setGame(game);
+    target->setName("weightedTarget");
+    target->setCanStep(true);
+    target->setCoords(Coords(4, 0, 0));
+    map->addObject(target);
+
+    auto chaser = creature_at(0, 0, 0);
+    chaser->setGame(game);
+    chaser->setName("weightedChaser");
+    chaser->setHp(1);
+    auto controller = std::make_shared<CTargetController>();
+    controller->setTarget("weightedTarget");
+    chaser->setController(controller);
+    map->addObject(chaser);
+
+    performance_guard::clearTargetFlowCache();
+    for (const auto &expected_step : expected_weighted_detour_path()) {
+        auto actual_step = resolve_coords(controller->control(chaser));
+        expect_true(actual_step == expected_step, "target flow field should follow the cheaper weighted detour");
+        chaser->moveTo(actual_step);
+    }
+
+    expect_true(chaser->getCoords() == target->getCoords(), "target weighted detour should reach the target");
 }
 
 void test_player_controller_uses_navigation_neighbors_for_cross_level_route() {
@@ -640,6 +728,9 @@ int main() {
     test_npc_random_controller_clears_current_tile_path();
     test_npc_random_controller_clears_stale_blocked_path();
     test_ground_controller_ignores_stale_transition_generation();
+    test_player_controller_prefers_longer_lower_cost_route();
+    test_npc_random_controller_prefers_longer_lower_cost_route();
+    test_target_controller_flow_field_prefers_longer_lower_cost_route();
     test_player_controller_uses_navigation_neighbors_for_cross_level_route();
     test_target_controller_flow_field_uses_navigation_neighbors_for_cross_level_pursuit();
     test_player_controller_respects_disabled_and_one_way_cross_level_edges();


### PR DESCRIPTION
## Summary
- pass map movement costs into player and NPC pathfinding consumers
- use weighted costs when building target-controller flow fields and path dumps
- add controller regressions proving player, NPC random, and target flow-field movement prefer longer lower-cost routes

## Why
- CPathFinder supports weighted stepCost, but these consumers were still using unit-cost behavior

## Validation
- clang-format -i src/core/CController.cpp src/core/CMap.cpp tests/unit/test_controller.cpp
- git diff --check origin/main
- cmake --build cmake-build-release --target controller_unit_tests -j$(nproc)
- ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests.controller_unit_tests
- cmake --build cmake-build-release --target performance_guard_tests -j$(nproc)
- ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance initially failed before _game/native plugins were built in this local worktree
- cmake --build cmake-build-release --target _game -j$(nproc)
- ctest --test-dir cmake-build-release --output-on-failure --verbose -L performance passed after the full local build context was present

## Known limitations
- full Linux validation and coverage are left to GitHub Actions polling for this PR.