### PR TITLE
Add runtime layout overrides

### DIFF
--- a/src/gui/CGui.cpp
+++ b/src/gui/CGui.cpp
@@ -170,7 +170,7 @@ void CGui::setWidth(int width) {
     const bool changed = CGui::width != clampedWidth;
     CGui::width = clampedWidth;
     if (auto layout = getLayout()) {
-        layout->setW(std::to_string(CGui::width));
+        layout->setRuntimeW(CGui::width);
     }
     if (changed) {
         recordDirectPropertyChanged("width");
@@ -184,7 +184,7 @@ void CGui::setHeight(int height) {
     const bool changed = CGui::height != clampedHeight;
     CGui::height = clampedHeight;
     if (auto layout = getLayout()) {
-        layout->setH(std::to_string(CGui::height));
+        layout->setRuntimeH(CGui::height);
     }
     if (changed) {
         recordDirectPropertyChanged("height");

--- a/src/gui/CLayout.cpp
+++ b/src/gui/CLayout.cpp
@@ -77,6 +77,40 @@ void CLayout::setRect(int x, int y, int w, int h) {
 
 void CLayout::setRect(const std::shared_ptr<SDL_Rect> &rect) { setRect(rect->x, rect->y, rect->w, rect->h); }
 
+void CLayout::setRuntimeX(int x) { runtimeX = x; }
+
+void CLayout::setRuntimeY(int y) { runtimeY = y; }
+
+void CLayout::setRuntimeW(int w) { runtimeW = w; }
+
+void CLayout::setRuntimeH(int h) { runtimeH = h; }
+
+void CLayout::setRuntimeRect(int x, int y, int w, int h) {
+    setRuntimeX(x);
+    setRuntimeY(y);
+    setRuntimeW(w);
+    setRuntimeH(h);
+}
+
+void CLayout::setRuntimeRect(const std::shared_ptr<SDL_Rect> &rect) {
+    setRuntimeRect(rect->x, rect->y, rect->w, rect->h);
+}
+
+void CLayout::clearRuntimeX() { runtimeX.reset(); }
+
+void CLayout::clearRuntimeY() { runtimeY.reset(); }
+
+void CLayout::clearRuntimeW() { runtimeW.reset(); }
+
+void CLayout::clearRuntimeH() { runtimeH.reset(); }
+
+void CLayout::clearRuntimeRect() {
+    clearRuntimeX();
+    clearRuntimeY();
+    clearRuntimeW();
+    clearRuntimeH();
+}
+
 void CLayout::setHorizontal(std::string horizontal) { CLayout::horizontal = horizontal; }
 
 std::string CLayout::getHorizontal() { return horizontal; }
@@ -115,8 +149,18 @@ std::shared_ptr<SDL_Rect> CLayout::getRect(std::shared_ptr<CGameGraphicsObject> 
 
     int x = parseValue(getX(), parent->w);
     int y = parseValue(getY(), parent->h);
-    int w = horizontal == "PARENT" ? parent->w : parseValue(getW(), parent->w);
-    int h = vertical == "PARENT" ? parent->h : parseValue(getH(), parent->h);
+    int w = 0;
+    if (runtimeW) {
+        w = *runtimeW;
+    } else {
+        w = horizontal == "PARENT" ? parent->w : parseValue(getW(), parent->w);
+    }
+    int h = 0;
+    if (runtimeH) {
+        h = *runtimeH;
+    } else {
+        h = vertical == "PARENT" ? parent->h : parseValue(getH(), parent->h);
+    }
 
     if (horizontal == "LEFT" || horizontal == "PARENT") {
         x = 0;
@@ -137,6 +181,9 @@ std::shared_ptr<SDL_Rect> CLayout::getRect(std::shared_ptr<CGameGraphicsObject> 
     } else if (!vertical.empty()) {
         vstd::logger::debug("Unknown vertical layout:", vertical);
     }
+
+    x = runtimeX.value_or(x);
+    y = runtimeY.value_or(y);
 
     return CUtil::rect(parent->x + x, parent->y + y, w, h);
 }

--- a/src/gui/CLayout.h
+++ b/src/gui/CLayout.h
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -19,6 +19,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "gui/object/CGameGraphicsObject.h"
 #include "object/CGameObject.h"
+
+#include <optional>
 
 class CLayout : public CGameObject {
     V_META(CLayout, CGameObject, V_PROPERTY(CLayout, std::string, w, getW, setW),
@@ -62,6 +64,28 @@ class CLayout : public CGameObject {
 
     void setRect(const std::shared_ptr<SDL_Rect> &rect);
 
+    void setRuntimeX(int x);
+
+    void setRuntimeY(int y);
+
+    void setRuntimeW(int w);
+
+    void setRuntimeH(int h);
+
+    void setRuntimeRect(int x, int y, int w, int h);
+
+    void setRuntimeRect(const std::shared_ptr<SDL_Rect> &rect);
+
+    void clearRuntimeX();
+
+    void clearRuntimeY();
+
+    void clearRuntimeW();
+
+    void clearRuntimeH();
+
+    void clearRuntimeRect();
+
     std::string getVertical();
 
     void setVertical(std::string vertical);
@@ -77,6 +101,10 @@ class CLayout : public CGameObject {
     std::string y = "0";
     std::string vertical;
     std::string horizontal;
+    std::optional<int> runtimeX;
+    std::optional<int> runtimeY;
+    std::optional<int> runtimeW;
+    std::optional<int> runtimeH;
 };
 
 class CCenteredLayout : public CLayout {

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -324,6 +324,57 @@ std::shared_ptr<CLayout> fixed_layout(int x, int y, int w, int h) {
     return layout;
 }
 
+void expect_rect(std::shared_ptr<SDL_Rect> rect, int x, int y, int w, int h, const char *message) {
+    expect_true(rect && rect->x == x && rect->y == y && rect->w == w && rect->h == h, message);
+}
+
+void test_layout_runtime_overrides_preserve_serialized_percentage_layouts() {
+    auto parent = std::make_shared<CGameGraphicsObject>();
+    auto parentLayout = std::make_shared<CLayout>();
+    parentLayout->setRect(10, 20, 200, 100);
+    parent->setLayout(parentLayout);
+
+    auto child = std::make_shared<CGameGraphicsObject>();
+    auto childLayout = std::make_shared<CLayout>();
+    childLayout->setX("10%");
+    childLayout->setY("20%");
+    childLayout->setW("50%");
+    childLayout->setH("25%");
+    child->setLayout(childLayout);
+    parent->addChild(child);
+
+    expect_rect(childLayout->getRect(child), 30, 40, 100, 25,
+                "percentage child layout should resolve from the serialized parent rectangle");
+
+    parentLayout->setRuntimeRect(15, 25, 400, 200);
+    expect_rect(childLayout->getRect(child), 55, 65, 200, 50,
+                "percentage child layout should recompute from the runtime parent rectangle");
+    expect_true(parentLayout->getX() == "10" && parentLayout->getY() == "20" && parentLayout->getW() == "200" &&
+                    parentLayout->getH() == "100",
+                "parent runtime rectangle should not rewrite serialized layout values");
+
+    childLayout->setRuntimeW(90);
+    childLayout->setRuntimeH(40);
+    expect_rect(childLayout->getRect(child), 55, 65, 90, 40,
+                "partial runtime size overrides should preserve percentage position");
+
+    childLayout->setRuntimeX(7);
+    childLayout->setRuntimeY(8);
+    expect_rect(childLayout->getRect(child), 22, 33, 90, 40,
+                "partial runtime position overrides should move relative to the current parent rectangle");
+    expect_true(childLayout->getX() == "10%" && childLayout->getY() == "20%" && childLayout->getW() == "50%" &&
+                    childLayout->getH() == "25%",
+                "child runtime rectangle should not rewrite serialized percentage layout values");
+
+    childLayout->clearRuntimeRect();
+    expect_rect(childLayout->getRect(child), 55, 65, 200, 50,
+                "clearing child runtime overrides should restore percentage resolution against the runtime parent");
+
+    parentLayout->clearRuntimeRect();
+    expect_rect(childLayout->getRect(child), 30, 40, 100, 25,
+                "clearing parent runtime overrides should restore the serialized parent rectangle");
+}
+
 void test_gui_window_is_resizable_and_guard_paths_fail_closed() {
     SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
@@ -346,6 +397,8 @@ void test_gui_window_is_resizable_and_guard_paths_fail_closed() {
     gui->setWidth(100);
     gui->setHeight(100);
     expect_true(gui->getWidth() == 320 && gui->getHeight() == 240, "GUI logical size should clamp to the minimum");
+    expect_true(gui->getLayout()->getW() == "1920" && gui->getLayout()->getH() == "1080",
+                "GUI runtime resize should not rewrite serialized root layout dimensions");
     gui->setWidth(9000);
     gui->setHeight(5000);
     expect_true(gui->getWidth() == 7680 && gui->getHeight() == 4320, "GUI logical size should clamp to the maximum");
@@ -1045,6 +1098,7 @@ void test_render_context_rejects_null_texture_and_copies_valid_texture() {
 int main() {
     pybind11::scoped_interpreter guard{};
 
+    test_layout_runtime_overrides_preserve_serialized_percentage_layouts();
     test_widget_ignores_unarmed_non_left_clicks();
     test_list_view_refreshes_from_generic_property_notifications();
     test_list_view_refresh_event_compatibility();


### PR DESCRIPTION
## What changed
- Added runtime-only optional `x/y/w/h` overrides to `CLayout` without changing serialized layout strings.
- Applied runtime size overrides before alignment and runtime position overrides relative to the current parent rectangle.
- Updated GUI window resizing to use runtime root-layout dimensions instead of rewriting resource-defined `w/h` strings.
- Added native GUI unit coverage for percentage layouts, runtime parent/child overrides, clear behavior, and GUI resize preservation.

## Why
Runtime window and panel geometry needs to change without mutating the JSON-backed layout definitions that should remain the stable resource source.

## Validation
- `clang-format -i src/gui/CLayout.h src/gui/CLayout.cpp src/gui/CGui.cpp tests/unit/test_gui.cpp`
- `git diff --check`
- Local native build/ctest/full Python/coverage not run; this GUI/unit-test change will use GitHub Actions `build / linux` with coverage-step polling for PR delivery.

## Known limitations
- The `CGui.cpp` edit is intentionally included because it is the runtime resize path that previously rewrote serialized root layout dimensions.
