### PR TITLE
[codex] Classify auto-merge policy blockers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,15 +41,18 @@ python3 scripts/pr_review_audit.py --input /tmp/pr-review-snapshot.json --format
 ```
 
 Feed it a normalized JSON snapshot containing changed files, merge state, check rollup, queue linkage, and recovery
-state. The audit separates `actionCategory` from `prType` so workbook-only queue PRs, active-claim implementation PRs,
-workflow PRs, stale linked claims, and cleanup candidates can be reviewed consistently. Its output is advisory and
-read-only: it must never close PRs, delete branches, edit the workbook, or override failed checks. Destructive cleanup,
-obsolete/duplicate PR closure, stale-claim recovery, dirty worktree recovery, and any merge with missing signals require
-explicit human approval. A controller-owned implementation PR marked `failing_ci`, `needs_update_rebase`,
+state. Include `autoMergeError` or `autoMergeRequest.error` when an attempted auto-merge fails. The audit separates
+`actionCategory` from `prType` so workbook-only queue PRs, active-claim implementation PRs, workflow PRs, stale linked
+claims, and cleanup candidates can be reviewed consistently. It reports `merge_policy_blocked` when repository settings
+or permissions prevent auto-merge; request the repository setting change or explicit alternate merge authorization
+instead of repeatedly retrying the same merge command. Its output is advisory and read-only: it must never close PRs,
+delete branches, edit the workbook, or override failed checks. Destructive cleanup, obsolete/duplicate PR closure,
+stale-claim recovery, dirty worktree recovery, and any merge with missing signals require explicit human approval. A
+controller-owned implementation PR marked `failing_ci`, `merge_policy_blocked`, `needs_update_rebase`,
 `human_review_required`, or `never_touch` is controller attention debt; resolve or assign recovery for that PR, but do
 not use source overlap alone to leave the controller below its four owned implementation slots when eligible work exists.
-Unresolved heartbeat-overdue, lease-expired, suspect, or reclaimable rows remain occupied recovery slots until a
-workbook heartbeat, release, reclaim, or terminal-status update has actually merged.
+Unresolved heartbeat-overdue, lease-expired, suspect, or reclaimable rows remain occupied recovery slots until a workbook
+heartbeat, release, reclaim, or terminal-status update has actually merged.
 
 ## Workflow observation ledger
 

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -131,19 +131,23 @@ a normalized snapshot that includes changed files, merge state, CI rollup, queue
 python3 scripts/pr_review_audit.py --input /tmp/pr-review-snapshot.json --format table
 ```
 
-The audit emits an `actionCategory` such as `ready_to_merge`, `poll`, `failing_ci`, `needs_update_rebase`,
+Include `autoMergeError` or `autoMergeRequest.error` when an attempted auto-merge fails. The audit emits an
+`actionCategory` such as `ready_to_merge`, `poll`, `failing_ci`, `merge_policy_blocked`, `needs_update_rebase`,
 `human_review_required`, `obsolete_duplicate_close`, `branch_cleanup_candidate`, or `never_touch`, plus a separate
 `prType` such as `workbook_only_queue_pr`, `implementation_pr_with_active_workbook_claim`, `workflow_pr`, or
 `unknown_pr`. Treat the result as advisory evidence for the controller and project-manager brief. It does not close PRs,
-delete branches, touch the workbook, or bypass failing checks. Human approval is required before closing obsolete or
-duplicate PRs, deleting local or remote branches, reclaiming recoverable stale claims, touching dirty worktrees, or
-merging any PR with missing classification signals.
+delete branches, touch the workbook, or bypass failing checks. A `merge_policy_blocked` result means the controller
+should request the repository setting change or explicit alternate merge authorization instead of repeatedly retrying
+the same auto-merge command. Human approval is required before closing obsolete or duplicate PRs, deleting local or
+remote branches, reclaiming recoverable stale claims, touching dirty worktrees, or merging any PR with missing
+classification signals.
 
-Controller-owned implementation PRs classified as `failing_ci`, `needs_update_rebase`, `human_review_required`, or
-`never_touch` require controller attention or explicit recovery assignment before the controller treats their issues as
-resolved. They do not reintroduce source-overlap as a hard claim exclusion: keep the exact four owned implementation
-slots whenever status-and-dependency eligible work exists and no concrete non-source blocker prevents dispatch, but do
-not refill through unresolved heartbeat-overdue, lease-expired, suspect, or reclaimable rows.
+Controller-owned implementation PRs classified as `failing_ci`, `merge_policy_blocked`, `needs_update_rebase`,
+`human_review_required`, or `never_touch` require controller attention or explicit recovery assignment before the
+controller treats their issues as resolved. They do not reintroduce source-overlap as a hard claim exclusion: keep the
+exact four owned implementation slots whenever status-and-dependency eligible work exists and no concrete non-source
+blocker prevents dispatch, but do not refill through unresolved heartbeat-overdue, lease-expired, suspect, or
+reclaimable rows.
 
 ## Workflow observations
 

--- a/scripts/pr_review_audit.py
+++ b/scripts/pr_review_audit.py
@@ -36,6 +36,10 @@ HUMAN_MERGE_STATES = {"blocked", "draft", "unknown", "unstable"}
 
 OPEN_STATES = {"open"}
 OBSOLETE_LABELS = {"duplicate", "obsolete", "superseded"}
+AUTO_MERGE_DISABLED_MARKERS = (
+    "auto_merge_is_not_allowed",
+    "enablepullrequestautomerge",
+)
 
 
 @dataclass(frozen=True)
@@ -419,6 +423,31 @@ def localSafetyBlockers(record: dict[str, Any]) -> list[str]:
     return blockers
 
 
+def autoMergePolicyBlocker(record: dict[str, Any]) -> str | None:
+    candidates = [
+        firstValue(
+            record,
+            "autoMergeError",
+            "auto_merge_error",
+            "autoMergeFailure",
+            "auto_merge_failure",
+            "mergeError",
+            "merge_error",
+            default="",
+        ),
+        nestedValue(record, "autoMerge", "error"),
+        nestedValue(record, "auto_merge", "error"),
+        nestedValue(record, "autoMergeRequest", "error"),
+        nestedValue(record, "auto_merge_request", "error"),
+    ]
+    for value in candidates:
+        text = str(value or "").strip()
+        normalized = normalizeToken(text)
+        if text and any(marker in normalized for marker in AUTO_MERGE_DISABLED_MARKERS):
+            return "repository auto-merge is disabled or unavailable"
+    return None
+
+
 def actionFromSignals(
     record: dict[str, Any],
     prType: str,
@@ -489,6 +518,11 @@ def actionFromSignals(
         blockers.append("check rollup is missing or unrecognized")
         buckets.append("human_review_required")
 
+    autoMergeBlocker = autoMergePolicyBlocker(record)
+    if autoMergeBlocker:
+        blockers.append(autoMergeBlocker)
+        buckets.append("merge_policy_blocked")
+
     queue = queuePayload(record)
     if queueClaimIsStale(queue):
         blockers.append("linked workbook claim requires recovery before merge or cleanup")
@@ -503,6 +537,8 @@ def actionFromSignals(
         return "failing_ci", buckets
     if "human_review_required" in buckets:
         return "human_review_required", buckets
+    if "merge_policy_blocked" in buckets:
+        return "merge_policy_blocked", buckets
     if "poll" in buckets:
         return "poll", buckets
     buckets.append("ready_to_merge")
@@ -520,6 +556,10 @@ def recommendedActions(actionCategory: str, prType: str, blockers: Sequence[str]
         return ["fix or re-run failed required checks before merge or cleanup"]
     if actionCategory == "needs_update_rebase":
         return ["update or rebase the branch before any merge decision"]
+    if actionCategory == "merge_policy_blocked":
+        return [
+            "request repository auto-merge settings or explicit alternate merge authorization before retrying merge"
+        ]
     if actionCategory == "obsolete_duplicate_close":
         return ["request explicit human approval before closing obsolete or duplicate work"]
     if actionCategory == "branch_cleanup_candidate":
@@ -556,6 +596,7 @@ def classifyPr(record: dict[str, Any]) -> dict[str, Any]:
         in {
             "failing_ci",
             "human_review_required",
+            "merge_policy_blocked",
             "needs_update_rebase",
             "never_touch",
             "obsolete_duplicate_close",
@@ -564,6 +605,7 @@ def classifyPr(record: dict[str, Any]) -> dict[str, Any]:
     humanApproval = actionCategory in {
         "branch_cleanup_candidate",
         "human_review_required",
+        "merge_policy_blocked",
         "never_touch",
         "obsolete_duplicate_close",
     }

--- a/tests/test_pr_review_audit.py
+++ b/tests/test_pr_review_audit.py
@@ -39,6 +39,48 @@ class PrReviewAuditTest(unittest.TestCase):
         self.assertTrue(review["mergeAllowed"])
         self.assertFalse(review["controllerDispatchAttention"])
 
+    def test_auto_merge_disabled_blocks_ready_controller_pr(self) -> None:
+        review = self.classify(
+            {
+                "number": 134,
+                "title": "Fix validated implementation",
+                "files": ["src/core/CGameContext.cpp"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [successCheck()],
+                "autoMergeError": "GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)",
+                "queue": {
+                    "status": "IN_PROGRESS",
+                    "owner": "controller/ctrl-a/subagent-9",
+                    "claimId": "validated-claim",
+                },
+            }
+        )
+
+        self.assertEqual("merge_policy_blocked", review["actionCategory"])
+        self.assertEqual("implementation_pr_with_active_workbook_claim", review["prType"])
+        self.assertIn("merge_policy_blocked", review["buckets"])
+        self.assertIn("repository auto-merge is disabled or unavailable", review["blockers"])
+        self.assertFalse(review["mergeAllowed"])
+        self.assertTrue(review["controllerDispatchAttention"])
+        self.assertTrue(review["humanApprovalRequired"])
+        self.assertIn("explicit alternate merge authorization", review["recommendedActions"][0])
+
+    def test_nested_auto_merge_error_blocks_ready_workflow_pr(self) -> None:
+        review = self.classify(
+            {
+                "number": 135,
+                "files": ["scripts/pr_review_audit.py"],
+                "mergeStateStatus": "CLEAN",
+                "checks": [successCheck()],
+                "autoMergeRequest": {"error": "GraphQL: Auto merge is not allowed for this repository"},
+            }
+        )
+
+        self.assertEqual("merge_policy_blocked", review["actionCategory"])
+        self.assertEqual("workflow_pr", review["prType"])
+        self.assertFalse(review["mergeAllowed"])
+        self.assertTrue(review["humanApprovalRequired"])
+
     def test_workbook_only_queue_pr_is_ready_only_after_successful_signals(self) -> None:
         review = self.classify(
             {

--- a/tests/test_prompt_inventory.py
+++ b/tests/test_prompt_inventory.py
@@ -64,6 +64,14 @@ class PromptInventoryTest(unittest.TestCase):
                         "ordinary PR polling should use the path-selected default, not a Linux-only command",
                     )
 
+    def test_pr_audit_policy_documents_auto_merge_blockers(self) -> None:
+        combined = "\n".join(path.read_text(encoding="utf-8") for path in WORKFLOW_TEXT_PATHS).lower()
+
+        self.assertIn("automergeerror", combined)
+        self.assertIn("automergerequest.error", combined)
+        self.assertIn("merge_policy_blocked", combined)
+        self.assertIn("explicit alternate merge authorization", combined)
+
     def test_queue_controller_observation_policy_is_direct_and_append_only(self) -> None:
         combined = "\n".join(path.read_text(encoding="utf-8") for path in OBSERVATION_POLICY_TEXT_PATHS).lower()
 


### PR DESCRIPTION
## What changed
- Added `merge_policy_blocked` classification in `scripts/pr_review_audit.py` for GitHub auto-merge-disabled errors such as `enablePullRequestAutoMerge`.
- Made those PRs non-mergeable in the audit, human-approval-required, and controller-attention debt when tied to active controller claims.
- Documented the snapshot fields (`autoMergeError` / `autoMergeRequest.error`) and the required response in `AGENTS.md` and `docs/codex-agent-queue.md`.
- Added regression coverage in `tests/test_pr_review_audit.py` and `tests/test_prompt_inventory.py`.

## Why
The open workflow-observation ledger currently ranks `implementation-auto-merge-disabled` as the highest-severity lead. Without a distinct classifier bucket, a validated PR can look `ready_to_merge` even after `gh pr merge --auto --squash` already failed because repository auto-merge is unavailable.

This change is a triage improvement, not the repository-setting fix. It prevents repeated merge retries and tells controllers to request a repository setting change or explicit alternate merge authorization.

## Validation
- `python3 -m py_compile scripts/pr_review_audit.py tests/test_pr_review_audit.py tests/test_prompt_inventory.py`
- `python3 -m unittest tests.test_pr_review_audit tests.test_prompt_inventory`
- `python3 -m unittest tests.test_pr_review_audit tests.test_prompt_inventory tests.test_ci_change_classifier tests.test_controller_resource_audit`
- `python3 -m unittest tests.test_workflow_observations`
- `python3 scripts/workflow_observations.py validate`
- `python3 scripts/workflow_observations.py validate --base origin/main`
- `python3 scripts/workflow_observations.py next`
- `python3 scripts/issue_queue.py validate`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes --github-repo lisu188/fall-of-nouraajd`
- `python3 scripts/ci_change_classifier.py --path AGENTS.md --path docs/codex-agent-queue.md --path scripts/pr_review_audit.py --path tests/test_pr_review_audit.py --path tests/test_prompt_inventory.py`
- `python3 scripts/pr_review_audit.py --format json` with an auto-merge-disabled fixture
- `black -l 120 --check scripts/pr_review_audit.py tests/test_pr_review_audit.py tests/test_prompt_inventory.py`
- `git diff --check`

## Notes
- No workbook files changed.
- `issue_queue.py validate` still reports existing queue warnings on rows 11, 15, 42, 95, 128, and 132.
- PR #855 is still the throughput gate for the stale multi-workbook apply workflow on `main`; this PR may inherit that stale workflow failure until #855 lands.