### PR TITLE
[codex] Audit repository auto-merge policy

### DIFF
--- a/scripts/controller_resource_audit.py
+++ b/scripts/controller_resource_audit.py
@@ -81,6 +81,14 @@ class BranchProtectionReport:
     error: str | None = None
 
 
+@dataclass(frozen=True)
+class MergePolicyReport:
+    repo: str
+    allowAutoMerge: bool | None
+    deleteBranchOnMerge: bool | None
+    error: str | None = None
+
+
 def bytesToGib(value: int) -> float:
     return value / (1024.0**3)
 
@@ -492,6 +500,41 @@ def evaluateBranchProtection(report: BranchProtectionReport | None) -> tuple[lis
     return errors, warnings
 
 
+def mergePolicyReportFromPayload(repo: str, payload: dict[str, Any]) -> MergePolicyReport:
+    allowAutoMerge = payload.get("allow_auto_merge")
+    deleteBranchOnMerge = payload.get("delete_branch_on_merge")
+    return MergePolicyReport(
+        repo=repo,
+        allowAutoMerge=allowAutoMerge if isinstance(allowAutoMerge, bool) else None,
+        deleteBranchOnMerge=deleteBranchOnMerge if isinstance(deleteBranchOnMerge, bool) else None,
+    )
+
+
+def auditMergePolicy(repo: str) -> MergePolicyReport:
+    try:
+        return mergePolicyReportFromPayload(repo, runGhApiJson(f"repos/{repo}"))
+    except RuntimeError as exc:
+        return MergePolicyReport(repo=repo, allowAutoMerge=None, deleteBranchOnMerge=None, error=str(exc))
+
+
+def evaluateMergePolicy(report: MergePolicyReport | None) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    if report is None:
+        return errors, warnings
+    if report.error:
+        warnings.append(f"{report.repo}: repository merge policy could not be inspected: {report.error}")
+        return errors, warnings
+    if report.allowAutoMerge is False:
+        warnings.append(
+            f"{report.repo}: repository auto-merge is disabled; gh pr merge --auto will fail until settings change "
+            "or explicit alternate merge authorization is recorded"
+        )
+    elif report.allowAutoMerge is None:
+        warnings.append(f"{report.repo}: repository auto-merge setting is missing from GitHub metadata")
+    return errors, warnings
+
+
 def branchProtectionPayload(report: BranchProtectionReport | None) -> dict[str, Any] | None:
     if report is None:
         return None
@@ -502,6 +545,17 @@ def branchProtectionPayload(report: BranchProtectionReport | None) -> dict[str, 
         "requiredChecks": list(report.requiredChecks),
         "expectedChecks": list(report.expectedChecks),
         "missingRequiredChecks": list(report.missingRequiredChecks),
+        "error": report.error,
+    }
+
+
+def mergePolicyPayload(report: MergePolicyReport | None) -> dict[str, Any] | None:
+    if report is None:
+        return None
+    return {
+        "repo": report.repo,
+        "allowAutoMerge": report.allowAutoMerge,
+        "deleteBranchOnMerge": report.deleteBranchOnMerge,
         "error": report.error,
     }
 
@@ -560,6 +614,7 @@ def payload(
     branchProtection: BranchProtectionReport | None,
     errors: Sequence[str],
     warnings: Sequence[str],
+    mergePolicy: MergePolicyReport | None = None,
 ) -> dict[str, Any]:
     return {
         "repoRoot": str(repoRoot),
@@ -612,6 +667,7 @@ def payload(
             ],
         },
         "branchProtection": branchProtectionPayload(branchProtection),
+        "mergePolicy": mergePolicyPayload(mergePolicy),
         "errors": list(errors),
         "warnings": list(warnings),
     }
@@ -645,6 +701,11 @@ def printHuman(report: dict[str, Any]) -> None:
             f"Branch protection: {branchProtection['repo']}:{branchProtection['branch']} "
             f"protected={protectedText}, missing checks={branchProtection['missingRequiredChecks']}"
         )
+    mergePolicy = report.get("mergePolicy")
+    if mergePolicy:
+        allowAutoMerge = mergePolicy["allowAutoMerge"]
+        allowText = "unknown" if allowAutoMerge is None else str(allowAutoMerge).lower()
+        print(f"Merge policy: {mergePolicy['repo']} allow_auto_merge={allowText}")
     for warning in report["warnings"]:
         print(f"WARNING: {warning}")
     for error in report["errors"]:
@@ -722,9 +783,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 2
 
     branchProtection = None
+    mergePolicy = None
     if args.github_repo:
         expectedChecks = tuple(args.required_status_check or DEFAULT_REQUIRED_STATUS_CHECKS)
         branchProtection = auditBranchProtection(args.github_repo, args.protected_branch, expectedChecks)
+        mergePolicy = auditMergePolicy(args.github_repo)
 
     minFreeBytes = int(args.min_free_gib * 1024 * 1024 * 1024)
     errors, warnings = evaluateDiskReports(diskReports, minFreeBytes, args.max_used_percent)
@@ -734,6 +797,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     branchErrors, branchWarnings = evaluateBranchProtection(branchProtection)
     errors.extend(branchErrors)
     warnings.extend(branchWarnings)
+    mergePolicyErrors, mergePolicyWarnings = evaluateMergePolicy(mergePolicy)
+    errors.extend(mergePolicyErrors)
+    warnings.extend(mergePolicyWarnings)
     summary = worktreeSummary(worktrees)
     if summary["prunable"]:
         warnings.append(f"{summary['prunable']} prunable worktree registration(s); review and run git worktree prune")
@@ -747,6 +813,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         branchProtection,
         errors,
         warnings,
+        mergePolicy=mergePolicy,
     )
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/test_controller_resource_audit.py
+++ b/tests/test_controller_resource_audit.py
@@ -474,6 +474,28 @@ detached
         self.assertEqual([], warnings)
         self.assertEqual((), report.missingRequiredChecks)
 
+    def test_merge_policy_report_flags_disabled_auto_merge(self) -> None:
+        report = controller_resource_audit.mergePolicyReportFromPayload(
+            "owner/repo",
+            {"allow_auto_merge": False, "delete_branch_on_merge": True},
+        )
+
+        errors, warnings = controller_resource_audit.evaluateMergePolicy(report)
+
+        self.assertEqual([], errors)
+        self.assertFalse(report.allowAutoMerge)
+        self.assertTrue(report.deleteBranchOnMerge)
+        self.assertTrue(any("repository auto-merge is disabled" in warning for warning in warnings), warnings)
+
+    def test_merge_policy_report_warns_when_auto_merge_field_is_missing(self) -> None:
+        report = controller_resource_audit.mergePolicyReportFromPayload("owner/repo", {})
+
+        errors, warnings = controller_resource_audit.evaluateMergePolicy(report)
+
+        self.assertEqual([], errors)
+        self.assertIsNone(report.allowAutoMerge)
+        self.assertTrue(any("auto-merge setting is missing" in warning for warning in warnings), warnings)
+
     def test_payload_includes_optional_branch_protection_report(self) -> None:
         git = controller_resource_audit.GitHealthReport(
             statusExitCode=0,
@@ -498,6 +520,11 @@ detached
             expectedChecks=("linux",),
             missingRequiredChecks=("linux",),
         )
+        merge_policy = controller_resource_audit.MergePolicyReport(
+            repo="owner/repo",
+            allowAutoMerge=False,
+            deleteBranchOnMerge=True,
+        )
 
         payload = controller_resource_audit.payload(
             Path("/repo"),
@@ -509,10 +536,13 @@ detached
             branch,
             [],
             ["owner/repo:main: branch is not protected"],
+            mergePolicy=merge_policy,
         )
 
         self.assertEqual(False, payload["branchProtection"]["protected"])
         self.assertEqual(["linux"], payload["branchProtection"]["missingRequiredChecks"])
+        self.assertEqual(False, payload["mergePolicy"]["allowAutoMerge"])
+        self.assertEqual(True, payload["mergePolicy"]["deleteBranchOnMerge"])
         self.assertEqual(False, payload["git"]["headBehindOriginMain"])
         self.assertEqual(0, payload["git"]["headAheadOriginMainCount"])
         self.assertEqual(0, payload["git"]["headBehindOriginMainCount"])


### PR DESCRIPTION
## What changed
- Extended `scripts/controller_resource_audit.py` to query repository merge policy metadata when `--github-repo` is provided.
- Added a `mergePolicy` JSON section with `allowAutoMerge`, `deleteBranchOnMerge`, and any inspection error.
- Added a warning when GitHub reports repository auto-merge is disabled, so controllers can see the policy blocker before retrying `gh pr merge --auto`.
- Added focused unit tests for disabled/missing auto-merge metadata and payload serialization.

## Why
The open workflow-observation ledger ranks `implementation-auto-merge-disabled` as the highest-severity lead. PR #861 classifies the failed merge attempt after the fact; this checkpoint makes the existing resource audit surface the repository policy preflight directly. Live `gh api repos/lisu188/fall-of-nouraajd` reports `allow_auto_merge=false`.

## Validation
- `python3 -m py_compile scripts/controller_resource_audit.py tests/test_controller_resource_audit.py`
- `python3 -m unittest tests.test_controller_resource_audit`
- `python3 scripts/controller_resource_audit.py --json --skip-run-tree-sizes --github-repo lisu188/fall-of-nouraajd`
- `black -l 120 --check scripts/controller_resource_audit.py tests/test_controller_resource_audit.py`
- `git diff --check`
- `python3 -m unittest tests.test_controller_resource_audit tests.test_pr_review_audit tests.test_workflow_observations tests.test_ci_change_classifier`
- `python3 scripts/workflow_observations.py validate`
- `python3 scripts/workflow_observations.py validate --base origin/main`
- `python3 scripts/issue_queue.py validate`
- `python3 scripts/ci_change_classifier.py --path scripts/controller_resource_audit.py --path tests/test_controller_resource_audit.py`

## Notes
- No workbook files changed.
- `issue_queue.py validate` still reports existing queue warnings on rows 11, 15, 42, 95, 128, and 132.
- PR #855 is still the throughput gate for the stale `apply multi-workbook workflow patch` workflow on `main`; this PR may inherit that stale workflow failure until #855 lands.