### PR TITLE
Add player class and race identity fields

### DIFF
--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -1007,6 +1007,10 @@ void init_game_module(py::module_ &m) {
         .def("setQuests", &CPlayer::setQuests, "Replace active quests.")
         .def("getCompletedQuests", &CPlayer::getCompletedQuests, "Return the player's completed quests.")
         .def("setCompletedQuests", &CPlayer::setCompletedQuests, "Replace completed quests.")
+        .def("getPlayerClassId", &CPlayer::getPlayerClassId, "Return the player's class identity id.")
+        .def("setPlayerClassId", &CPlayer::setPlayerClassId, "Set the player's class identity id.")
+        .def("getRaceId", &CPlayer::getRaceId, "Return the player's race identity id.")
+        .def("setRaceId", &CPlayer::setRaceId, "Set the player's race identity id.")
         .def("checkQuests", &CPlayer::checkQuests, "Move completed quests into the completed quest log.");
 
     py::class_<CListString, CGameObject, std::shared_ptr<CListString>>(m, "CListString", "String list wrapper object.")

--- a/src/object/CPlayer.cpp
+++ b/src/object/CPlayer.cpp
@@ -23,6 +23,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <utility>
 
 namespace {
+constexpr const char *DEFAULT_PLAYER_RACE_ID = "human";
+
 std::string questId(const std::shared_ptr<CQuest> &quest) {
     if (!quest) {
         return "";
@@ -97,6 +99,30 @@ void CPlayer::setCompletedQuests(std::set<std::shared_ptr<CQuest>> _completedQue
     std::erase_if(_completedQuests, [](const auto &quest) { return quest == nullptr; });
     completedQuests = std::move(_completedQuests);
     recordDirectPropertyChanged("completedQuests");
+}
+
+std::string CPlayer::getPlayerClassId() {
+    if (!playerClassId.empty()) {
+        return playerClassId;
+    }
+    return getTypeId();
+}
+
+void CPlayer::setPlayerClassId(std::string _playerClassId) {
+    playerClassId = std::move(_playerClassId);
+    recordDirectPropertyChanged("playerClassId");
+}
+
+std::string CPlayer::getRaceId() {
+    if (!raceId.empty()) {
+        return raceId;
+    }
+    return DEFAULT_PLAYER_RACE_ID;
+}
+
+void CPlayer::setRaceId(std::string _raceId) {
+    raceId = std::move(_raceId);
+    recordDirectPropertyChanged("raceId");
 }
 
 void CPlayer::incTurn() { turn++; }

--- a/src/object/CPlayer.h
+++ b/src/object/CPlayer.h
@@ -24,7 +24,9 @@ class CQuest;
 class CPlayer : public CCreature {
     V_META(CPlayer, CCreature, V_PROPERTY(CPlayer, std::set<std::shared_ptr<CQuest>>, quests, getQuests, setQuests),
            V_PROPERTY(CPlayer, std::set<std::shared_ptr<CQuest>>, completedQuests, getCompletedQuests,
-                      setCompletedQuests))
+                      setCompletedQuests),
+           V_PROPERTY(CPlayer, std::string, playerClassId, getPlayerClassId, setPlayerClassId),
+           V_PROPERTY(CPlayer, std::string, raceId, getRaceId, setRaceId))
 
   public:
     CPlayer() = default;
@@ -41,6 +43,14 @@ class CPlayer : public CCreature {
 
     void setCompletedQuests(std::set<std::shared_ptr<CQuest>> completedQuests);
 
+    std::string getPlayerClassId();
+
+    void setPlayerClassId(std::string playerClassId);
+
+    std::string getRaceId();
+
+    void setRaceId(std::string raceId);
+
     void checkQuests();
 
     void incTurn();
@@ -48,6 +58,8 @@ class CPlayer : public CCreature {
   private:
     std::set<std::shared_ptr<CQuest>> quests;
     std::set<std::shared_ptr<CQuest>> completedQuests;
+    std::string playerClassId;
+    std::string raceId;
 
     int turn = 0;
 };

--- a/test.py
+++ b/test.py
@@ -535,6 +535,14 @@ def fixture_player_summary(snapshot):
     raise AssertionError("Save fixture snapshot does not contain a canonical player object.")
 
 
+def snapshot_player_properties(snapshot):
+    for obj in snapshot.get("properties", {}).get("objects", []):
+        properties = obj.get("properties", {}) if isinstance(obj, dict) else {}
+        if obj.get("class") == "CPlayer" or properties.get("name") == "player":
+            return properties
+    raise AssertionError("Save snapshot does not contain a canonical player object.")
+
+
 def fixture_quest_ids(quests):
     if not isinstance(quests, list):
         return []
@@ -8801,6 +8809,76 @@ class GameTest(unittest.TestCase):
                 {
                     "old_schema_loaded": True,
                     "resaved_schema": saved_json.get("schemaVersion"),
+                },
+                sort_keys=True,
+            )
+        finally:
+            cleanup_save_slot(save_name)
+
+    @game_test
+    def test_legacy_player_identity_defaults_from_type_id(self):
+        game = load_game_module()
+
+        save_name = unique_save_name("legacy_player_identity")
+        install_save_fixture_slot(save_name, IMMUTABLE_SAVE_FIXTURE_EXPECTATIONS["schema_v1_test_map"])
+        try:
+            loaded_game = game.CGameLoader.loadGame()
+            game.CGameLoader.loadSavedGame(loaded_game, save_name)
+            loaded_map = loaded_game.getMap()
+            loaded_player = loaded_map.getPlayer()
+
+            self.assertEqual("Warrior", loaded_player.getTypeId())
+            self.assertEqual("Warrior", loaded_player.getPlayerClassId())
+            self.assertEqual("human", loaded_player.getRaceId())
+
+            game.CMapLoader.save(loaded_map, save_name)
+            saved_json = json.loads(save_primary_path(save_name).read_text(encoding="utf-8"))
+            player_properties = snapshot_player_properties(assert_save_envelope(self, saved_json, "test"))
+            self.assertEqual("Warrior", player_properties.get("playerClassId"))
+            self.assertEqual("human", player_properties.get("raceId"))
+
+            return True, json.dumps(
+                {
+                    "playerClassId": loaded_player.getPlayerClassId(),
+                    "raceId": loaded_player.getRaceId(),
+                    "savedPlayerClassId": player_properties.get("playerClassId"),
+                    "savedRaceId": player_properties.get("raceId"),
+                },
+                sort_keys=True,
+            )
+        finally:
+            cleanup_save_slot(save_name)
+
+    @game_test
+    def test_player_identity_properties_round_trip_explicit_values(self):
+        game = load_game_module()
+
+        save_name = unique_save_name("player_identity_round_trip")
+        cleanup_save_slot(save_name)
+        try:
+            _source_game, source_map, source_player = load_game_map_with_player("test", "Sorcerer")
+            source_player.setPlayerClassId("Wayfarer")
+            source_player.setRaceId("riverFolk")
+
+            game.CMapLoader.save(source_map, save_name)
+            saved_json = json.loads(save_primary_path(save_name).read_text(encoding="utf-8"))
+            saved_properties = snapshot_player_properties(assert_save_envelope(self, saved_json, "test"))
+            self.assertEqual("Sorcerer", saved_properties.get("typeId"))
+            self.assertEqual("Wayfarer", saved_properties.get("playerClassId"))
+            self.assertEqual("riverFolk", saved_properties.get("raceId"))
+
+            loaded_game = game.CGameLoader.loadGame()
+            game.CGameLoader.loadSavedGame(loaded_game, save_name)
+            loaded_player = loaded_game.getMap().getPlayer()
+            self.assertEqual("Sorcerer", loaded_player.getTypeId())
+            self.assertEqual("Wayfarer", loaded_player.getPlayerClassId())
+            self.assertEqual("riverFolk", loaded_player.getRaceId())
+
+            return True, json.dumps(
+                {
+                    "typeId": loaded_player.getTypeId(),
+                    "playerClassId": loaded_player.getPlayerClassId(),
+                    "raceId": loaded_player.getRaceId(),
                 },
                 sort_keys=True,
             )


### PR DESCRIPTION
What changed
- Added metadata-backed playerClassId and raceId string properties to CPlayer.
- Exposed get/set methods through Python bindings.
- Derived missing playerClassId from typeId and defaulted missing raceId to human for old saves.
- Added save/load regressions for legacy default derivation and explicit class/race round-trip persistence.

Why
- Row 116 requires player identity to distinguish class and race without breaking current player templates or old saves.

Local validation
- python3 -m py_compile test.py
- black --check -l 120 test.py
- clang-format --dry-run --Werror src/object/CPlayer.h src/object/CPlayer.cpp src/core/CModule.cpp
- git diff --check origin/main...HEAD
- git diff --exit-code -- planning/fall_of_nouraajd_issue_proposals.xlsx

CI validation plan
- Poll python3 scripts/poll_pr_checks.py <PR> --check linux --require-step coverage for Linux build, native tests, Python suites, performance guards, and coverage.

Known limitations
- Local native build/full Python/coverage were not run; CI polling is the planned heavy validation path.