### PR TITLE
Degrade resource audit gracefully when gh CLI is absent

### DIFF
--- a/scripts/controller_resource_audit.py
+++ b/scripts/controller_resource_audit.py
@@ -389,13 +389,18 @@ def evaluateGitHealth(report: GitHealthReport) -> tuple[list[str], list[str]]:
 
 
 def runGhApiJson(path: str) -> dict[str, Any]:
-    result = subprocess.run(
-        ["gh", "api", path],
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["gh", "api", path],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("gh CLI not found on PATH; cannot query GitHub metadata") from exc
+    except OSError as exc:
+        raise RuntimeError(f"gh api {path} could not be executed: {exc}") from exc
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh api failed"
         raise RuntimeError(detail)

--- a/tests/test_controller_resource_audit.py
+++ b/tests/test_controller_resource_audit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 from scripts import controller_resource_audit
@@ -605,6 +606,56 @@ detached
         self.assertEqual(0, payload["runTrees"]["total"])
         self.assertEqual(0, payload["runTrees"]["totalBytes"])
         self.assertFalse(payload["runTrees"]["sizesMeasured"])
+
+    def test_run_gh_api_json_reports_missing_cli_as_runtime_error(self) -> None:
+        def raise_missing_gh(*_args: object, **_kwargs: object) -> None:
+            raise FileNotFoundError(2, "No such file or directory", "gh")
+
+        with unittest.mock.patch.object(
+            controller_resource_audit.subprocess, "run", side_effect=raise_missing_gh
+        ):
+            with self.assertRaises(RuntimeError) as caught:
+                controller_resource_audit.runGhApiJson("repos/owner/repo")
+
+        self.assertIn("gh CLI not found on PATH", str(caught.exception))
+
+    def test_audit_branch_protection_degrades_when_gh_cli_is_missing(self) -> None:
+        def raise_missing_gh(*_args: object, **_kwargs: object) -> None:
+            raise FileNotFoundError(2, "No such file or directory", "gh")
+
+        with unittest.mock.patch.object(
+            controller_resource_audit.subprocess, "run", side_effect=raise_missing_gh
+        ):
+            report = controller_resource_audit.auditBranchProtection(
+                "owner/repo", "main", ("linux",)
+            )
+
+        self.assertIsNone(report.protected)
+        self.assertIn("gh CLI not found on PATH", report.error or "")
+        errors, warnings = controller_resource_audit.evaluateBranchProtection(report)
+        self.assertEqual([], errors)
+        self.assertTrue(
+            any("branch protection could not be inspected" in warning for warning in warnings),
+            warnings,
+        )
+
+    def test_audit_merge_policy_degrades_when_gh_cli_is_missing(self) -> None:
+        def raise_missing_gh(*_args: object, **_kwargs: object) -> None:
+            raise FileNotFoundError(2, "No such file or directory", "gh")
+
+        with unittest.mock.patch.object(
+            controller_resource_audit.subprocess, "run", side_effect=raise_missing_gh
+        ):
+            report = controller_resource_audit.auditMergePolicy("owner/repo")
+
+        self.assertIsNone(report.allowAutoMerge)
+        self.assertIn("gh CLI not found on PATH", report.error or "")
+        errors, warnings = controller_resource_audit.evaluateMergePolicy(report)
+        self.assertEqual([], errors)
+        self.assertTrue(
+            any("repository merge policy could not be inspected" in warning for warning in warnings),
+            warnings,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Root cause

`scripts/controller_resource_audit.py` `runGhApiJson()` invoked `gh api` via `subprocess.run(["gh", ...])` without guarding the exec call. When the `gh` CLI is not on PATH (the case in the remote execution environment), `subprocess.run` raises `FileNotFoundError` — an `OSError`, **not** a `RuntimeError`.

The gh-backed audits `auditBranchProtection` and `auditMergePolicy` only catch `RuntimeError`, and they run *after* `main()`'s `except (OSError, subprocess.CalledProcessError)` block (which already protects the `git` calls). So a missing `gh` crashed the entire `controller_resource_audit.py --github-repo lisu188/fall-of-nouraajd` invocation with an uncaught traceback, destroying the disk, worktree, and git-health evidence the audit otherwise produces — exactly the command the optimizer prompt recommends for branch-protection / merge-policy drift.

## Changes

- `scripts/controller_resource_audit.py`: catch `FileNotFoundError`/`OSError` inside `runGhApiJson` and re-raise as `RuntimeError`, so the existing graceful-degradation path records the failure as a branch-protection / merge-policy warning while the rest of the audit still emits valid JSON. `FileNotFoundError` is caught before the generic `OSError` so a missing CLI yields the precise "gh CLI not found on PATH" message.
- `tests/test_controller_resource_audit.py`: add regressions for the missing-`gh` path across `runGhApiJson`, `auditBranchProtection` (→ `protected=None`, warning `branch protection could not be inspected`), and `auditMergePolicy` (→ `allowAutoMerge=None`, warning `repository merge policy could not be inspected`).

## Evidence

- `python3 -m unittest tests.test_controller_resource_audit` → Ran 28 tests, OK (+3 new)
- `python3 -m unittest tests.test_issue_queue tests.test_pr_review_audit tests.test_workflow_observations` → Ran 92 tests, OK
- `python3 scripts/issue_queue.py validate` → OK
- `python3 scripts/workflow_observations.py validate` → OK
- Before: `controller_resource_audit.py --github-repo lisu188/fall-of-nouraajd` aborted with `FileNotFoundError: 'gh'`. After: returns valid JSON with two warnings (`branch protection could not be inspected: gh CLI not found on PATH`, `repository merge policy could not be inspected: gh CLI not found on PATH`) and the full disk/worktree/git evidence intact.

## Risks

Low. The `try` wraps only the `subprocess.run` invocation; the success path and the existing non-zero-exit `RuntimeError(detail)` path are unchanged, so behavior when `gh` is present and succeeds (or fails normally) is identical. Read-only audit tooling; no Git-safety or gameplay impact.

## Manual review items

None outstanding. Independently reviewed: confirmed exception ordering, backward compatibility, real (not over-mocked) test coverage, and that no other same-class `subprocess.run` site in the file remains unguarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016D8Ra7XE7j7cBsVqzKfbou)_