### PR TITLE
Degrade PR check poller gracefully when gh CLI is absent

### DIFF
--- a/scripts/poll_pr_checks.py
+++ b/scripts/poll_pr_checks.py
@@ -280,13 +280,18 @@ def evaluatePrState(prPayload: dict[str, Any]) -> CheckEvaluation | None:
 
 
 def runGhJson(command: Sequence[str]) -> Any:
-    result = subprocess.run(
-        list(command),
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            list(command),
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise PollError("gh CLI not found on PATH; cannot poll GitHub checks") from exc
+    except OSError as exc:
+        raise PollError(f"{' '.join(command)} could not be executed: {exc}") from exc
     if result.returncode != 0:
         raise PollError(result.stderr.strip() or result.stdout.strip() or f"{' '.join(command)} failed")
     try:
@@ -316,13 +321,18 @@ def runGhPrView(pr: str, repo: str | None) -> dict[str, Any]:
 
 def runGhPrFiles(pr: str, repo: str | None) -> tuple[str, ...]:
     command = ghCommandWithRepo(["gh", "pr", "diff", pr, "--name-only"], repo)
-    result = subprocess.run(
-        command,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise PollError("gh CLI not found on PATH; cannot poll GitHub checks") from exc
+    except OSError as exc:
+        raise PollError(f"{' '.join(command)} could not be executed: {exc}") from exc
     if result.returncode != 0:
         raise PollError(result.stderr.strip() or result.stdout.strip() or f"{' '.join(command)} failed")
     return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())

--- a/tests/test_poll_pr_checks.py
+++ b/tests/test_poll_pr_checks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import io
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
@@ -558,6 +558,38 @@ class PollPrChecksTest(unittest.TestCase):
         self.assertIn("already merged", evaluation.message)
         run_list.assert_called_once_with("abc123", "build.yml", None)
         sleep.assert_called_once_with(30)
+
+    def test_run_gh_json_reports_missing_cli_as_poll_error(self) -> None:
+        def raise_missing_gh(*_args: object, **_kwargs: object) -> None:
+            raise FileNotFoundError(2, "No such file or directory", "gh")
+
+        with patch.object(poll_pr_checks.subprocess, "run", side_effect=raise_missing_gh):
+            with self.assertRaises(poll_pr_checks.PollError) as caught:
+                poll_pr_checks.runGhJson(["gh", "pr", "view", "1"])
+
+        self.assertIn("gh CLI not found on PATH", str(caught.exception))
+
+    def test_run_gh_pr_files_reports_missing_cli_as_poll_error(self) -> None:
+        def raise_missing_gh(*_args: object, **_kwargs: object) -> None:
+            raise FileNotFoundError(2, "No such file or directory", "gh")
+
+        with patch.object(poll_pr_checks.subprocess, "run", side_effect=raise_missing_gh):
+            with self.assertRaises(poll_pr_checks.PollError) as caught:
+                poll_pr_checks.runGhPrFiles("1", None)
+
+        self.assertIn("gh CLI not found on PATH", str(caught.exception))
+
+    def test_main_exits_cleanly_when_gh_cli_is_missing(self) -> None:
+        def raise_missing_gh(*_args: object, **_kwargs: object) -> None:
+            raise FileNotFoundError(2, "No such file or directory", "gh")
+
+        stderr = io.StringIO()
+        with patch.object(poll_pr_checks.subprocess, "run", side_effect=raise_missing_gh):
+            with redirect_stderr(stderr):
+                exit_code = poll_pr_checks.main(["1"])
+
+        self.assertEqual(3, exit_code)
+        self.assertIn("gh CLI not found on PATH", stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Root cause

`scripts/poll_pr_checks.py` exec'd `gh` via `subprocess.run` in `runGhJson` and `runGhPrFiles` without guarding the exec call. When the `gh` CLI is not on PATH (the case in the remote execution environment), `subprocess.run` raises `FileNotFoundError`, crashing the whole poller with an uncaught traceback instead of the graceful `PollError` path that `main()` already catches (prints `poll_pr_checks: <message>` to stderr, returns exit 3).

This is the **same class of defect** fixed in `controller_resource_audit.runGhApiJson` (PR #875). These two scripts are the only ones in `scripts/` that invoke `gh`, so the missing-`gh` crash class is now closed across the workflow tooling.

## Changes

- `scripts/poll_pr_checks.py`: wrap both `subprocess.run` calls (`runGhJson`, `runGhPrFiles`) in `try/except`, catching `FileNotFoundError` → `PollError("gh CLI not found on PATH; cannot poll GitHub checks")` and a generic `OSError` → `PollError(... could not be executed ...)`. `FileNotFoundError` is caught before the generic `OSError`. The `returncode != 0` and JSON-decode paths are unchanged (outside the `try`). `runGhPrView`/`runGhRunList`/`runGhRunView` all route through `runGhJson`, so they inherit the guard.
- `tests/test_poll_pr_checks.py`: add regressions for `runGhJson`, `runGhPrFiles`, and an end-to-end `main(["1"])` test asserting exit code 3 and the stderr message when `gh` is missing. Added `redirect_stderr` import.

## Evidence

- `python3 -m unittest tests.test_poll_pr_checks` → Ran 30 tests, OK (+3 new)
- Before: `python3 scripts/poll_pr_checks.py 875` aborted with `FileNotFoundError: 'gh'`. After: prints `poll_pr_checks: gh CLI not found on PATH; cannot poll GitHub checks` and exits 3.

## Risks

Low. The `try` wraps only the `subprocess.run` invocation; the `gh`-present success path and the existing non-zero-exit `PollError` path are unchanged. Read-only poller; no Git-safety or gameplay impact.

## Manual review items

None outstanding. Independently reviewed (same reviewer as PR #875): confirmed exception ordering, backward compatibility, real (not over-mocked) leaf-only test mocking, and that no other unguarded `gh` `subprocess.run` site remains in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016D8Ra7XE7j7cBsVqzKfbou)_