### PR TITLE
Define and enforce creature-archetype naming and compatibility policy

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -93,6 +93,20 @@ REVIEWED_DYNAMIC_PROPERTY_PREFIXES = {
 PYTHON_REGISTRATION_DECORATORS = {"register", "trigger"}
 TYPE_REGISTRATION_EXCLUSIONS_PATH = Path("scripts/type_registration_exclusions.json")
 
+# Creature archetype naming and compatibility policy (EPIC_01/STORY_03/SUBSTORY_04).
+# Race template ids end with "Race", class template ids end with "Class", and the
+# class reference is carried by the JSON property "creatureClass" -- never the bare
+# "class" key, which is reserved as the object-constructor key.
+CREATURE_RACES_CONFIG = "creature_races.json"
+CREATURE_CLASSES_CONFIG = "creature_classes.json"
+CREATURE_RACE_ID_SUFFIX = "Race"
+CREATURE_CLASS_ID_SUFFIX = "Class"
+CREATURE_CLASS_REFERENCE_PROPERTY = "creatureClass"
+CREATURE_ARCHETYPE_ID_SUFFIXES = {
+    CREATURE_RACES_CONFIG: CREATURE_RACE_ID_SUFFIX,
+    CREATURE_CLASSES_CONFIG: CREATURE_CLASS_ID_SUFFIX,
+}
+
 
 @dataclass(frozen=True)
 class ValidationIssue:
@@ -998,6 +1012,7 @@ class ContentValidator:
         for entry in self.global_entries.values():
             self._validate_config_entry(entry, visible, known_classes)
         self._validate_crafting_refs()
+        self._validate_creature_archetype_naming()
 
     def _validate_map_context(self, context: MapContext) -> None:
         visible = self._visible_entries(context)
@@ -1821,6 +1836,38 @@ class ContentValidator:
             if isinstance(station_id, str):
                 station_ids.add(station_id)
         return station_ids
+
+    def _validate_creature_archetype_naming(self) -> None:
+        config_dir = self.repo_root / "res" / "config"
+        for filename, suffix in CREATURE_ARCHETYPE_ID_SUFFIXES.items():
+            path = config_dir / filename
+            data = self.global_files.get(path)
+            if not isinstance(data, dict):
+                continue
+            for template_id, entry in data.items():
+                if isinstance(template_id, str) and not template_id.endswith(suffix):
+                    self._issue(
+                        path,
+                        template_id,
+                        f'{filename} template id "{template_id}" must end with "{suffix}"',
+                    )
+                self._validate_creature_class_reference(path, template_id, entry)
+
+    def _validate_creature_class_reference(self, path: Path, location: str, value: Any) -> None:
+        if isinstance(value, dict):
+            properties = value.get("properties")
+            if isinstance(properties, dict) and "class" in properties:
+                self._issue(
+                    path,
+                    f"{append_field(location, 'properties')}.class",
+                    f'class reference must use property "{CREATURE_CLASS_REFERENCE_PROPERTY}", '
+                    f'never the reserved object-constructor key "class"',
+                )
+            for key, child in value.items():
+                self._validate_creature_class_reference(path, append_field(location, key), child)
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                self._validate_creature_class_reference(path, append_index(location, index), child)
 
     def _issue(self, path: Path, location: str, message: str) -> None:
         self.issues.append(ValidationIssue(path=self._rel(path), location=location, message=message))

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -460,6 +460,74 @@ class ContentValidatorTest(unittest.TestCase):
 
         self.assertEqual([], [str(issue) for issue in issues])
 
+    def test_creature_archetype_naming_policy_accepts_conforming_ids(self):
+        root = self.make_fixture()
+        write_json(
+            root / "res/config/creature_races.json",
+            {"humanRace": {"properties": {"creatureClass": {"ref": "warriorClass"}}}},
+        )
+        write_json(
+            root / "res/config/creature_classes.json",
+            {"warriorClass": {"properties": {"label": "Warrior"}}},
+        )
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
+    def test_creature_race_id_without_race_suffix_is_reported(self):
+        root = self.make_fixture()
+        write_json(
+            root / "res/config/creature_races.json",
+            {"human": {"properties": {"label": "Human"}}},
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/creature_races.json",
+            "human",
+            'creature_races.json template id "human" must end with "Race"',
+        )
+
+    def test_creature_class_id_without_class_suffix_is_reported(self):
+        root = self.make_fixture()
+        write_json(
+            root / "res/config/creature_classes.json",
+            {"warrior": {"properties": {"label": "Warrior"}}},
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/creature_classes.json",
+            "warrior",
+            'creature_classes.json template id "warrior" must end with "Class"',
+        )
+
+    def test_creature_class_reference_via_reserved_class_key_is_reported(self):
+        root = self.make_fixture()
+        write_json(
+            root / "res/config/creature_races.json",
+            {"humanRace": {"properties": {"class": {"ref": "warriorClass"}}}},
+        )
+        write_json(
+            root / "res/config/creature_classes.json",
+            {"warriorClass": {"properties": {"label": "Warrior"}}},
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/creature_races.json",
+            "humanRace.properties.class",
+            'class reference must use property "creatureClass"',
+            'never the reserved object-constructor key "class"',
+        )
+
     def test_invalid_transition_targets_report_map_name(self):
         root = self.make_fixture(script_map="missingMap")
 


### PR DESCRIPTION
## Issue
`[EPIC_01][STORY_03][SUBSTORY_04]Define naming and compatibility policy` (creature-archetype plan)
Claim ID: `d5d90a3b-1a6c-4ba5-83b7-a67f9d89c2a9`

## Root cause / current state
The archetype naming policy was undocumented and unenforced. `res/config/creature_races.json` and `creature_classes.json` do not exist yet, and there is no `creatureClass` property or `CRace`/`CCreatureClass` engine type — this substory is forward-looking. The `class` collision the issue describes is real and already latent: `res/config/monsters.json` (`PritzMage`) uses `properties.class = "CStats"`, and `REVIEWED_DYNAMIC_PROPERTIES` whitelists `class` on `CCreature`, so a blanket rule would have broken `test_current_content_passes_validation`.

## What changed
- `scripts/validate_content.py`: added archetype policy constants (race IDs end with `Race`, class IDs end with `Class`, class reference property is `creatureClass`) and two file-scoped rules — `_validate_creature_archetype_naming()` and `_validate_creature_class_reference()` — invoked from `_validate_global_configs()`. They run only when the designated archetype config files exist, so they are a no-op for all current content while mechanically enforcing the policy once content is added. Scoped to the two archetype files to preserve the whitelisted `properties.class` usage elsewhere.
- `tests/test_content_validator.py`: 4 narrow, additive regression tests (conforming IDs pass; missing `Race`/`Class` suffix reported; reserved `class` reference reported). No refactor of the shared file.

## Impact
Establishes a mechanically enforceable naming/compatibility contract for the upcoming creature-archetype migration without changing any current behavior or content.

## Files changed
- `scripts/validate_content.py`
- `tests/test_content_validator.py`

## Validation
- `python3 -m unittest tests.test_content_validator` → **Ran 40 tests, OK** (36 pre-existing + 4 new)
- `black -l 120 --check` on both files → clean
- `git diff --cached --check` → clean
- `scripts/ci_change_classifier.py` → `nativeNeeded: false`, `coverageNeeded: false` (lightweight; Python tooling + tests only)
- No native build / ctest / full suite / coverage run locally — not required for this Python-only change; Linux CI provides PR evidence.

## Manual review items
- ID example shapes (`humanRace`, `warriorClass`) are inferred from the issue text since no archetype content/schema exists yet; the enforced rules (suffix + forbidden `properties.class` in archetype files) match the issue policy exactly and do not presuppose a `creatureClass` value shape.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_016u5uW4rast2aU7xGx5yyLe)_