### PR TITLE
Interrupt creatures removed during move planning (fix CI map_unit_tests)

### DIFF
--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -621,7 +621,12 @@ void CMap::move() {
         auto creature = vstd::cast<CCreature>(object);
         return creature->getController()->control(creature)->thenLater(
             [creature, coordinates, canApplyDeferredMoveWork, map](Coords coords) {
-                if (canApplyDeferredMoveWork() && creature && map->getObjectByName(creature->getName()) == creature) {
+                // Keep planned steps for creatures that are still on this map's transition
+                // generation, even if the controller removed the creature during planning.
+                // The commit loop below interrupts non-active creatures; dropping them here
+                // would skip that interrupt. Stale results from a map transition are filtered
+                // by canApplyDeferredMoveWork().
+                if (canApplyDeferredMoveWork() && creature) {
                     coordinates->push_back(std::make_pair(creature, coords));
                 }
             });


### PR DESCRIPTION
## Problem

CI was failing on every push to `main` (while PRs stayed green) on the native test `for_unit_tests.map_unit_tests`:

```
FAIL: move should interrupt creatures removed before their planned step is committed
```

Native C++ tests only run on `push` events (via `--force-native`), not on PRs, which is why PR builds passed while `main` was red.

## Root cause

PR #727 ("Guard deferred transition callbacks") added a `map->getObjectByName(creature->getName()) == creature` condition to the deferred move-planning callback in `CMap::move()`. That condition silently dropped the planned step of any creature that removed itself during planning, so it never reached the commit loop where `interrupt()` is invoked. This regressed the assertion added in #848.

## Fix

Removed the redundant name check from the planning callback. The map-transition case #727 actually targeted is already handled by `canApplyDeferredMoveWork()`, which returns `false` when a controller triggers a transition mid-planning. Keeping the planned step for removed-but-non-transitioned creatures lets the commit loop's existing `is_active_creature` check interrupt them as designed.

This satisfies both tests:
- #727 transition test → `canApplyDeferredMoveWork()` false → step dropped, `interruptCount == 0`
- #848 removal test → step pushed, commit loop sees inactive creature (`removeObject` clears the owning map) → `interruptCount == 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSqq8aAvq3PSdZQJfdvB5V)_