### PR TITLE
Guard git subprocess calls against a missing git executable

### DIFF
--- a/scripts/ci_change_classifier.py
+++ b/scripts/ci_change_classifier.py
@@ -159,6 +159,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         except subprocess.CalledProcessError as exc:
             print(f"ci_change_classifier: git diff failed: {exc.stderr.strip()}", file=sys.stderr)
             return 2
+        except FileNotFoundError:
+            print("ci_change_classifier: git executable not found on PATH", file=sys.stderr)
+            return 2
+        except OSError as exc:
+            print(f"ci_change_classifier: git diff could not be executed: {exc}", file=sys.stderr)
+            return 2
     if args.paths_from_stdin:
         paths.extend(sys.stdin.read().splitlines())
 

--- a/scripts/workflow_observations.py
+++ b/scripts/workflow_observations.py
@@ -497,13 +497,18 @@ def validatePrChanges(root: Path, baseRef: str) -> list[str]:
         return ["--base must be a non-empty git ref"]
 
     rootPath = gitPathForRoot(root)
-    result = subprocess.run(
-        ["git", "diff", "--name-status", "--no-renames", baseRef],
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-status", "--no-renames", baseRef],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise ObservationError("git executable not found on PATH; cannot inspect ledger diff") from exc
+    except OSError as exc:
+        raise ObservationError(f"could not execute git diff for ledger inspection: {exc}") from exc
     if result.returncode != 0:
         message = result.stderr.strip() or result.stdout.strip() or "unknown git diff failure"
         raise ObservationError(f"could not inspect ledger diff from {baseRef}: {message}")
@@ -568,13 +573,16 @@ def validateDuplicateCycles(resolutions: dict[str, LoadedResolution]) -> list[st
 
 
 def currentCommit() -> str:
-    result = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError as exc:
+        raise ObservationError("could not determine source commit; pass --source-commit") from exc
     text = result.stdout.strip().lower()
     if result.returncode == 0 and COMMIT_PATTERN.match(text):
         return text

--- a/tests/test_ci_change_classifier.py
+++ b/tests/test_ci_change_classifier.py
@@ -4,8 +4,9 @@ import io
 import json
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest.mock import patch
 
 from scripts import ci_change_classifier
 
@@ -106,6 +107,18 @@ class CiChangeClassifierTest(unittest.TestCase):
             self.assertFalse(payload["nativeNeeded"])
             values = dict(line.split("=", 1) for line in output.read_text(encoding="utf-8").splitlines())
             self.assertEqual({"coverage-needed": "false", "native-needed": "false"}, values)
+
+    def test_main_returns_clean_error_when_git_executable_is_missing(self) -> None:
+        def raise_missing_git(*_args: object, **_kwargs: object) -> None:
+            raise FileNotFoundError(2, "No such file or directory", "git")
+
+        stderr = io.StringIO()
+        with patch.object(ci_change_classifier.subprocess, "run", side_effect=raise_missing_git):
+            with redirect_stderr(stderr):
+                exitCode = ci_change_classifier.main(["--base", "a", "--head", "b"])
+
+        self.assertEqual(2, exitCode)
+        self.assertIn("git executable not found on PATH", stderr.getvalue())
 
     def test_build_workflow_uses_classifier_outputs_for_native_routing(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/build.yml").read_text(encoding="utf-8")

--- a/tests/test_workflow_observations.py
+++ b/tests/test_workflow_observations.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest.mock import patch
 
 from scripts import issue_queue, workflow_observations
 
@@ -747,6 +748,26 @@ class WorkflowObservationsTest(unittest.TestCase):
             issue_queue.loadQueue(workbook)
 
         self.assertEqual(before, workbook.read_bytes())
+
+    def test_current_commit_raises_observation_error_when_git_is_missing(self) -> None:
+        def raise_missing_git(*_args: object, **_kwargs: object) -> None:
+            raise FileNotFoundError(2, "No such file or directory", "git")
+
+        with patch.object(workflow_observations.subprocess, "run", side_effect=raise_missing_git):
+            with self.assertRaises(workflow_observations.ObservationError) as caught:
+                workflow_observations.currentCommit()
+
+        self.assertIn("pass --source-commit", str(caught.exception))
+
+    def test_validate_pr_changes_raises_observation_error_when_git_is_missing(self) -> None:
+        def raise_missing_git(*_args: object, **_kwargs: object) -> None:
+            raise FileNotFoundError(2, "No such file or directory", "git")
+
+        with patch.object(workflow_observations.subprocess, "run", side_effect=raise_missing_git):
+            with self.assertRaises(workflow_observations.ObservationError) as caught:
+                workflow_observations.validatePrChanges(Path("planning/workflow_observations"), "main")
+
+        self.assertIn("git executable not found on PATH", str(caught.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Root cause

`ci_change_classifier.changedPaths` and `workflow_observations`' `validatePrChanges` / `currentCommit` shell out to `git` via `subprocess.run`, but a missing or unexecutable `git` raises `FileNotFoundError` (an `OSError`, **not** `subprocess.CalledProcessError`). The classifier's `main()` only caught `CalledProcessError`, and the observation helpers caught nothing, so an absent `git` escaped as an uncaught traceback instead of each tool's existing graceful path. All three sites were reproduced via `unittest.mock` before fixing.

This is the same robustness class as the `gh`-CLI hardening already merged for `runGhApiJson` (#875) and the PR-check poller (#884), now applied to the `git` call sites. A full scan confirms these are the only three `subprocess.run` `git` sites in the two files.

## Changes

- `scripts/ci_change_classifier.py` `main()`: catch `FileNotFoundError`/`OSError` around the `changedPaths()` call and return exit `2` with a clear stderr message, alongside the existing `CalledProcessError` handling (kept first because its handler reads the type-specific `exc.stderr`).
- `scripts/workflow_observations.py` `validatePrChanges()`: convert `FileNotFoundError`/`OSError` from `git diff` into `ObservationError`, which `main()` already maps to a clean exit.
- `scripts/workflow_observations.py` `currentCommit()`: convert `OSError` from `git rev-parse` into the existing `"could not determine source commit; pass --source-commit"` `ObservationError`, preserving its contract.

## Evidence

- `python3 -m unittest tests.test_ci_change_classifier` → 11 OK (+1)
- `python3 -m unittest tests.test_workflow_observations` → 21 OK (+2)
- Focused baseline `tests.test_issue_queue tests.test_controller_resource_audit tests.test_pr_review_audit tests.test_workflow_observations tests.test_poll_pr_checks tests.test_ci_change_classifier` → 163 OK
- `python3 scripts/issue_queue.py validate` / `workflow_observations.py validate` → OK
- Before: each site raised a raw `FileNotFoundError` traceback when `git` was absent. After: classifier exits `2` with `git executable not found on PATH`; `currentCommit`/`validatePrChanges` raise `ObservationError` → clean exit.

## Risks

Low. Each `try` wraps only the `subprocess.run` invocation; success paths and the existing `CalledProcessError` / `returncode != 0` / commit-pattern validation paths are unchanged. In `build.yml`, `git` is guaranteed by `actions/checkout`, so the production blast radius is the local/manual controller path; CI behavior is unchanged.

## Manual review items

None outstanding. Independently reviewed: confirmed exception ordering (`FileNotFoundError` before generic `OSError`), backward compatibility, the deliberate `currentCommit` message reuse, leaf-only mocking in tests, and that no other unguarded `git`/`gh` subprocess site remains in these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016D8Ra7XE7j7cBsVqzKfbou)_