### PR TITLE
Resolve object-shaped check rollups in pr_review_audit

### DIFF
--- a/scripts/pr_review_audit.py
+++ b/scripts/pr_review_audit.py
@@ -297,7 +297,15 @@ def checkSummary(record: dict[str, Any]) -> CheckSummary:
         return summary or CheckSummary(state="unknown")
 
     if isinstance(rawChecks, dict):
-        rawChecks = firstValue(rawChecks, "nodes", "items", "checks", default=())
+        nested = firstValue(rawChecks, "nodes", "items", "checks", default=None)
+        if nested is None:
+            # An object-shaped rollup with no nested check collection may carry the
+            # aggregate state directly (e.g. {"state": "SUCCESS"}); interpret it the
+            # same way as the checkRollup fallback instead of dropping it to unknown.
+            summary = summaryFromRollup(rawChecks)
+            if summary is not None:
+                return summary
+        rawChecks = nested if nested is not None else ()
     if isinstance(rawChecks, str) or not isinstance(rawChecks, Iterable):
         rawChecks = [rawChecks]
 

--- a/tests/test_pr_review_audit.py
+++ b/tests/test_pr_review_audit.py
@@ -245,6 +245,33 @@ class PrReviewAuditTest(unittest.TestCase):
         self.assertEqual("success", review["checkState"])
         self.assertEqual([], review["failedChecks"])
 
+    def test_object_shaped_status_check_rollup_resolves_aggregate_state(self) -> None:
+        review = self.classify(
+            {
+                "number": 121,
+                "files": ["scripts/pr_review_audit.py"],
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": {"state": "SUCCESS"},
+            }
+        )
+
+        self.assertEqual("success", review["checkState"])
+        self.assertEqual([], review["failedChecks"])
+        self.assertNotIn("check rollup is missing or unrecognized", review.get("blockers", []))
+
+    def test_object_shaped_status_check_rollup_reports_failure(self) -> None:
+        review = self.classify(
+            {
+                "number": 122,
+                "files": ["scripts/pr_review_audit.py"],
+                "mergeStateStatus": "UNKNOWN",
+                "statusCheckRollup": {"state": "FAILURE"},
+            }
+        )
+
+        self.assertEqual("failure", review["checkState"])
+        self.assertEqual("failing_ci", review["actionCategory"])
+
     def test_newer_duplicate_check_success_replaces_older_cancelled_attempt(self) -> None:
         review = self.classify(
             {


### PR DESCRIPTION
## Root cause

`scripts/pr_review_audit.py` `checkSummary()` reduced an object-shaped `statusCheckRollup` that carries its aggregate state directly (e.g. `{"state": "SUCCESS"}`) to an empty collection via `firstValue(rawChecks, "nodes", "items", "checks", default=())`, yielding `checkState="unknown"` and a false `"check rollup is missing or unrecognized"` blocker that flagged healthy PRs for human review.

This was inconsistent with the sibling `summaryFromRollup` helper, which the `checkRollup` fallback path already uses to read state from a dict. Reproduced: `{"checkRollup": {"state": "SUCCESS"}}` resolved to `success` while `{"statusCheckRollup": {"state": "SUCCESS"}}` resolved to `unknown` — identical semantic input, different result.

## Changes

- `scripts/pr_review_audit.py` `checkSummary()`: when the primary rollup value is a dict with no nested `nodes`/`items`/`checks` collection, interpret it through `summaryFromRollup` so the aggregate state (success/failure/pending) is honored. Genuinely unrecognized objects still degrade to the existing `unknown` blocker, and the nested-collection (list) path is unchanged.

## Evidence

- `python3 -m unittest tests.test_pr_review_audit` → 36 OK (+2)
- Focused baseline (`test_issue_queue` + `test_controller_resource_audit` + `test_pr_review_audit` + `test_workflow_observations` + `test_poll_pr_checks` + `test_ci_change_classifier`) → 165 OK
- Before → after (live): `{"statusCheckRollup": {"state": "SUCCESS"}}` `unknown` → `success` (ready_to_merge, no blocker); `{"state": "FAILURE"}` → `failure` (failing_ci); `{"state": "PENDING"}` → `pending`. Regression-safe: `{"foo": "bar"}` still `unknown` + "check rollup is missing or unrecognized"; list/nodes rollups and bare lists unchanged.

## Risks

Low. The fix only adds a recovery branch for object dicts lacking a nested collection; the list/nodes path and the unrecognized-object path are behaviorally unchanged. No CLI, schema, or output-contract changes.

## Manual review items

None outstanding. Independently reviewed: confirmed the list path is byte-for-byte unchanged, unrecognized objects still block, `{"nodes": None}` and `{"nodes": None, "state": ...}` edges degrade/resolve sanely, failure/pending detection is not weakened, and `nested is None` is the correct sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016D8Ra7XE7j7cBsVqzKfbou)_