### PR TITLE
Require explicit authorization for implementation-PR auto-merge (#676)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,25 @@ For ordinary implementation or workflow-optimization PRs, run focused local vali
 Actions polling when the workflow covers the required evidence. If CI polling supplies the full validation evidence, run
 `python3 scripts/poll_pr_checks.py <PR_NUMBER>` to success before enabling auto-merge; it selects `linux` for
 lightweight PRs and `linux`, `windows-deps`, and `windows` for native validation PRs. Add `--require-step coverage` for
-coverage-relevant changes when you need to force that step. After the required evidence is present, run
-`gh pr merge <PR_NUMBER> --auto --squash` unless the user explicitly asks not to, GitHub reports that auto-merge is
-unavailable, or branch protection/check state prevents it. If validation or auto-merge is blocked, report the exact
-blocker and leave the PR intact.
+coverage-relevant changes when you need to force that step.
+
+Auto-merge for implementation PRs is not an unconditional default; it requires explicit, repo-verified authorization
+before you run `gh pr merge <PR_NUMBER> --auto --squash`. After the required validation evidence is present, resolve the
+authorization state from the repository merge policy and branch protection — for example with
+`python3 scripts/controller_resource_audit.py` (`mergePolicy.allowAutoMerge`, branch protection required checks) and the
+`pr_review_audit.py` `merge_policy_blocked` signal — and act on one of four states:
+
+- allowed: the repository reports `allow_auto_merge=true` and branch protection/check state permits it, so enable
+  squash auto-merge.
+- user-authorized: the user or a newer system instruction explicitly directs this merge even though the default probe
+  is not conclusive, so enable squash auto-merge per that explicit authorization.
+- disallowed: the repository reports auto-merge disabled or branch protection/check state blocks it, so leave the PR
+  open, request the repository setting change or explicit alternate merge authorization, and report the exact blocker.
+- unknown: authorization cannot be verified from the repository, so leave the PR open and report a blocker; do NOT
+  auto-merge on an unverified default.
+
+If validation or auto-merge is blocked, or the authorization state is disallowed or unknown, report the exact blocker
+and leave the PR intact.
 
 For workbook-only queue-state PRs that update only `planning/fall_of_nouraajd_issue_proposals.xlsx`, first confirm the
 diff is XLSX-only and `python3 scripts/issue_queue.py validate` passed. Then merge the claim, terminal-status,
@@ -663,9 +678,10 @@ After finishing a change, always complete the repository delivery workflow:
 5. Open a pull request targeting `main`.
 6. For implementation PRs, poll the selected GitHub Actions evidence to success before auto-merge when CI polling is
    replacing local heavy validation.
-7. Run `gh pr merge <PR_NUMBER> --auto --squash` after required evidence is present unless the user explicitly asks not
-   to, GitHub reports that auto-merge is unavailable, or branch protection/check state blocks it. Replace `<PR_NUMBER>`
-   with the pull request just opened.
+7. After required evidence is present, resolve the implementation-PR auto-merge authorization state per the pull request
+   merge policy (allowed / user-authorized / disallowed / unknown). Run `gh pr merge <PR_NUMBER> --auto --squash` only
+   when the state is allowed or user-authorized; when it is disallowed or unknown, leave the PR open and report the
+   blocker instead of auto-merging. Replace `<PR_NUMBER>` with the pull request just opened.
 8. For workbook-only queue-state PRs, use the immediate squash-merge rule in the pull request merge policy after
    confirming the diff is XLSX-only and queue validation passed.
 9. If GitHub queues auto-merge, do not wait for checks to finish unless those checks are the selected CI-polled

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -384,7 +384,12 @@ its `coverage` step somewhere in the selected build workflow run, currently in t
 poller auto-adds this step for coverage-relevant PR paths. Additional release, MCP gameplay, manual, or issue-specific
 validation is needed only when the task targets that surface or the user
 requests it.
-Do not enable auto-merge until CI-polled validation passes when it is the only full-validation evidence.
+Do not enable auto-merge until CI-polled validation passes when it is the only full-validation evidence. Auto-merge for
+implementation PRs is not an unconditional default: after the required evidence is present, resolve the authorization
+state per the `AGENTS.md` pull request merge policy (allowed / user-authorized / disallowed / unknown) using the
+repository merge policy and branch protection signals, and enable `gh pr merge --auto --squash` only when the state is
+allowed or user-authorized. When it is disallowed or unknown, leave the implementation PR open and report the blocker
+instead of auto-merging.
 
 Workbook-only queue-state PRs that update only `planning/fall_of_nouraajd_issue_proposals.xlsx` are different from
 implementation PRs. After reviewing that the diff is XLSX-only and running `python3 scripts/issue_queue.py validate`,

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -599,13 +599,20 @@ IMPL_PR_URL=$(gh pr create \
   --body-file "$IMPL_PR_BODY")
 IMPL_PR_NUMBER=$(gh pr view "$IMPL_PR_URL" --json number --jq .number)
 python3 scripts/poll_pr_checks.py "$IMPL_PR_NUMBER"
-gh pr merge "$IMPL_PR_NUMBER" --auto --squash
+# Implementation-PR auto-merge is not an unconditional default. Resolve the authorization state per AGENTS.md
+# (allowed / user-authorized / disallowed / unknown) before enabling auto-merge.
+gh pr merge "$IMPL_PR_NUMBER" --auto --squash  # only when authorization is allowed or user-authorized
 ```
 
 Run the polling command before enabling auto-merge when CI supplies the full validation evidence. This is the normal PR
 delivery path for Linux compilation and testing. For coverage-relevant changes, add `--require-step coverage`. Local
 native-build validation is a fallback only when CI cannot provide the needed evidence or a focused local reproduction is
-necessary.
+necessary. Implementation-PR auto-merge requires explicit, repo-verified authorization per the `AGENTS.md` pull request
+merge policy: resolve the merge policy and branch protection (for example with `scripts/controller_resource_audit.py`
+and the `pr_review_audit.py` `merge_policy_blocked` signal) into one of four states, and run `gh pr merge --auto
+--squash` only when the state is allowed or user-authorized. When it is disallowed or unknown, leave the
+implementation PR open and report the blocker instead of auto-merging. This conditional gate applies to implementation
+PRs only; it does not change the bounded workbook-only queue-state-PR immediate-merge exception.
 
 Do not mark the task `DONE` when auto-merge is merely queued. Record the issue as awaiting implementation merge,
 continue other safe controller work, and re-check later. If the implementation PR is already `MERGED`, stop waiting for

--- a/tests/test_prompt_inventory.py
+++ b/tests/test_prompt_inventory.py
@@ -72,6 +72,37 @@ class PromptInventoryTest(unittest.TestCase):
         self.assertIn("merge_policy_blocked", combined)
         self.assertIn("explicit alternate merge authorization", combined)
 
+    def test_implementation_pr_auto_merge_is_not_an_unconditional_default(self) -> None:
+        # Implementation-PR auto-merge must require explicit, repo-verified authorization. Guard against
+        # regression to the old opt-out wording that forced auto-merge unless the user opted out, and require
+        # the four-state authorization vocabulary to remain documented somewhere in the workflow text.
+        banned_patterns = {
+            r"--auto\s+--squash`?\s+unless\s+the\s+user\s+explicitly\s+asks\s+not\s+to": (
+                "implementation-PR auto-merge must not be framed as an opt-out default"
+            ),
+            r"run\s+`gh\s+pr\s+merge\s+<pr_number>\s+--auto\s+--squash`\s+unless": (
+                "implementation-PR auto-merge must not be framed as an opt-out default"
+            ),
+        }
+        for path in WORKFLOW_TEXT_PATHS:
+            text = path.read_text(encoding="utf-8").lower()
+            for pattern, reason in banned_patterns.items():
+                with self.subTest(path=path.relative_to(REPO_ROOT), pattern=pattern):
+                    self.assertIsNone(re.search(pattern, text), reason)
+
+        combined = "\n".join(path.read_text(encoding="utf-8") for path in WORKFLOW_TEXT_PATHS).lower()
+        self.assertIn(
+            "auto-merge for implementation prs is not an unconditional default",
+            combined,
+            "implementation-PR auto-merge must be documented as requiring explicit, repo-verified authorization",
+        )
+        for state in ("allowed", "user-authorized", "disallowed", "unknown"):
+            self.assertIn(
+                state,
+                combined,
+                f"the implementation-PR auto-merge authorization state '{state}' must remain documented",
+            )
+
     def test_queue_controller_observation_policy_is_direct_and_append_only(self) -> None:
         combined = "\n".join(path.read_text(encoding="utf-8") for path in OBSERVATION_POLICY_TEXT_PATHS).lower()
 


### PR DESCRIPTION
## Issue
`[EPIC_05][STORY_04][SUBSTORY_01] #676 Restore explicit authorization for agent auto-merge` (claim `fc03292a-02c4-44df-b1d5-5602832f0e6f`, owner `controller/ctrl-vm-4026-9b5a29b5/subagent-3`).

## Root cause
Agent/controller instructions framed implementation-PR auto-merge as an opt-out default (`gh pr merge --auto --squash` *unless the user explicitly asks not to*), risking unreviewed automated merges without explicit authorization evidence.

## What changed
- **AGENTS.md** (merge-policy section + delivery step 7): implementation-PR auto-merge is now explicitly *not* an unconditional default. After validation evidence, resolve a four-state authorization — **allowed / user-authorized / disallowed / unknown** — from the repository merge policy + branch protection (`controller_resource_audit.py` `mergePolicy.allowAutoMerge`/required checks, and the `pr_review_audit.py` `merge_policy_blocked` signal). `--auto --squash` runs only when allowed or user-authorized; **unknown/disallowed → leave PR open and report the blocker**.
- **prompts/codex-queue-controller.md** (Phase 3): added the authorization gate, scoped to implementation PRs only, with an explicit note that it does **not** change the bounded workbook-only queue-state immediate-merge exception.
- **docs/codex-agent-queue.md**: same four-state gate documented next to the (unchanged) bounded workbook-only exception.
- Integrates with the existing `#619/#620`-style merge-policy/branch-protection probing already in `controller_resource_audit.py` / `pr_review_audit.py` rather than inventing a new probe.

## Impact
Controllers no longer auto-merge implementation PRs on an unverified default; the workbook-only queue-state immediate-merge path is preserved and remains bounded.

## Files changed
`AGENTS.md`, `prompts/codex-queue-controller.md`, `docs/codex-agent-queue.md`, `tests/test_prompt_inventory.py`.

## Validation
- `python3 -m unittest tests.test_prompt_inventory -v` → 6 passed (incl. new `test_implementation_pr_auto_merge_is_not_an_unconditional_default`).
- `git diff --check` clean; no `planning/` files touched.
- Workflow-only change (docs/prompts/tests); remaining native CI evidence via GitHub Actions polling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_