### PR TITLE
Inventory map-local creature overrides via validate_content (E01/S01/SS02)

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -107,6 +107,31 @@ CREATURE_ARCHETYPE_ID_SUFFIXES = {
     CREATURE_CLASSES_CONFIG: CREATURE_CLASS_ID_SUFFIX,
 }
 
+# Map-local creature override inventory (EPIC_01/STORY_01/SUBSTORY_02).
+# Map config files reference creature templates via "ref" plus a "properties" block
+# that overrides template behavior.  Any override touching one of these properties
+# carries map-local behavior (Pritz controllers, quest-item carriers, npc dressing)
+# that a later template migration must preserve rather than flatten.  The native
+# CCreature template spells "stats" as the baseStats/levelStats pair and "labels"
+# as the singular "label" key, so both spellings are watched here.
+CREATURE_BASE_CLASS = "CCreature"
+CREATURE_OVERRIDE_PROPERTIES = (
+    "baseStats",
+    "levelStats",
+    "stats",
+    "actions",
+    "controller",
+    "fightController",
+    "affiliation",
+    "items",
+    "equipped",
+    "sw",
+    "animation",
+    "npc",
+    "label",
+    "labels",
+)
+
 
 @dataclass(frozen=True)
 class ValidationIssue:
@@ -123,6 +148,27 @@ class ConfigEntry:
     key: str
     data: Any
     path: Path
+
+
+@dataclass(frozen=True)
+class CreatureOverride:
+    path: str
+    key: str
+    location: str
+    template: str
+    properties: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "key": self.key,
+            "location": self.location,
+            "template": self.template,
+            "properties": list(self.properties),
+        }
+
+    def __str__(self) -> str:
+        return f"{self.path}: {self.location}: ref \"{self.template}\" overrides {', '.join(self.properties)}"
 
 
 @dataclass(frozen=True)
@@ -727,6 +773,64 @@ class ContentValidator:
         for context in self.map_contexts:
             self._validate_map_context(context)
         return sorted(self.issues, key=lambda issue: (issue.path, issue.location, issue.message))
+
+    def inventory_creature_overrides(self) -> list[CreatureOverride]:
+        """Enumerate every map-local creature reference that overrides template behavior.
+
+        This shares the class-resolution machinery used by validation but does not
+        emit validation issues or affect exit status; it is a read-only report used
+        to guard a later creature-template migration against losing map-local
+        behavior (controllers, quest-item carriers, npc dressing).
+        """
+        self._collect_engine_classes()
+        self._collect_plugin_classes()
+        self._load_global_configs()
+        self._load_maps()
+        overrides: list[CreatureOverride] = []
+        for context in self.map_contexts:
+            visible = self._visible_entries(context)
+            for entry in context.config_entries.values():
+                self._collect_creature_overrides(entry.path, entry.key, entry.key, entry.data, visible, overrides)
+        return sorted(overrides, key=lambda override: (override.path, override.location))
+
+    def _collect_creature_overrides(
+        self,
+        path: Path,
+        key: str,
+        location: str,
+        value: Any,
+        visible: dict[str, ConfigEntry],
+        overrides: list[CreatureOverride],
+    ) -> None:
+        if isinstance(value, dict):
+            properties = value.get("properties")
+            if isinstance(value.get("ref"), str) and isinstance(properties, dict) and self._is_creature_node(value, visible):
+                overridden = tuple(name for name in CREATURE_OVERRIDE_PROPERTIES if name in properties)
+                if overridden:
+                    overrides.append(
+                        CreatureOverride(
+                            path=self._rel(path),
+                            key=key,
+                            location=location,
+                            template=value["ref"],
+                            properties=overridden,
+                        )
+                    )
+            for child_key, child in value.items():
+                self._collect_creature_overrides(
+                    path, key, append_field(location, child_key), child, visible, overrides
+                )
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                self._collect_creature_overrides(path, key, append_index(location, index), child, visible, overrides)
+
+    def _is_creature_node(self, value: dict[str, Any], visible: dict[str, ConfigEntry]) -> bool:
+        class_name = self._effective_object_class(value, visible)
+        if not isinstance(class_name, str):
+            return False
+        if class_name == CREATURE_BASE_CLASS:
+            return True
+        return self._class_inherits_from(class_name, CREATURE_BASE_CLASS)
 
     def _collect_engine_classes(self) -> None:
         source_roots = [self.repo_root / "src"]
@@ -2227,10 +2331,25 @@ def validate_repo(repo_root: Path | str) -> list[ValidationIssue]:
     return ContentValidator(Path(repo_root)).validate()
 
 
+def inventory_creature_overrides(repo_root: Path | str) -> list[CreatureOverride]:
+    return ContentValidator(Path(repo_root)).inventory_creature_overrides()
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Validate game JSON resources and literal script refs.")
     parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument(
+        "--report-creature-overrides",
+        action="store_true",
+        help="Print the map-local creature override inventory as JSON and exit without validating.",
+    )
     args = parser.parse_args(argv)
+
+    if args.report_creature_overrides:
+        overrides = inventory_creature_overrides(args.repo_root)
+        json.dump([override.as_dict() for override in overrides], sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
 
     issues = validate_repo(args.repo_root)
     if issues:

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -24,7 +24,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.validate_content import ContentValidator, ScriptPropertyHygieneAllowance, validate_repo
+from scripts.validate_content import (
+    ContentValidator,
+    ScriptPropertyHygieneAllowance,
+    inventory_creature_overrides,
+    validate_repo,
+)
 
 
 class ContentValidatorTest(unittest.TestCase):
@@ -1351,6 +1356,94 @@ def read_json(path):
 
 def write_json(path, data):
     path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+class CreatureOverrideInventoryTest(unittest.TestCase):
+    def test_repo_inventory_lists_known_map_local_overrides(self):
+        overrides = {
+            (override.path, override.location): override for override in inventory_creature_overrides(REPO_ROOT)
+        }
+
+        siege_mage = overrides[("res/maps/siege/config.json", "siegePritzMage")]
+        self.assertEqual("PritzMage", siege_mage.template)
+        self.assertEqual(("controller", "affiliation", "items"), siege_mage.properties)
+
+        nested_pritz = overrides[("res/maps/nouraajd/config.json", "cave1.properties.monster")]
+        self.assertEqual("cave1", nested_pritz.key)
+        self.assertEqual("Pritz", nested_pritz.template)
+        self.assertEqual(("controller", "affiliation"), nested_pritz.properties)
+
+        anchor = overrides[("res/maps/ritual/config.json", "ritualAnchorNorth.properties.monster")]
+        self.assertEqual("Cultist", anchor.template)
+        self.assertEqual(("controller",), anchor.properties)
+
+    def test_inventory_detects_nested_overrides_and_ignores_non_creatures(self):
+        root = self.make_creature_fixture()
+
+        overrides = inventory_creature_overrides(root)
+        by_location = {override.location: override for override in overrides}
+
+        self.assertIn("townGuard", by_location)
+        self.assertEqual("Soldier", by_location["townGuard"].template)
+        self.assertEqual(("controller", "items"), by_location["townGuard"].properties)
+
+        self.assertIn("spawner.properties.monster", by_location)
+        self.assertEqual(("affiliation",), by_location["spawner.properties.monster"].properties)
+
+        # A creature ref that overrides no watched property and a non-creature ref are excluded.
+        self.assertNotIn("plainSoldier", by_location)
+        self.assertNotIn("loot", by_location)
+
+    def make_creature_fixture(self):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        root = Path(temp_dir.name)
+        (root / "res/config").mkdir(parents=True)
+        (root / "res/plugins").mkdir(parents=True)
+        (root / "res/maps/keep").mkdir(parents=True)
+
+        write_json(
+            root / "res/config/monsters.json",
+            {"Soldier": {"class": "CCreature", "properties": {"animation": "images/monsters/soldier"}}},
+        )
+        write_json(
+            root / "res/config/items.json",
+            {"Sword": {"class": "CItem"}},
+        )
+        write_json(
+            root / "res/config/buildings.json",
+            {"Spawner": {"class": "CBuilding"}},
+        )
+        write_json(
+            root / "res/maps/keep/map.json",
+            {
+                "type": "map",
+                "width": 1,
+                "height": 1,
+                "layers": [{"type": "tilelayer", "width": 1, "height": 1, "data": [0]}],
+                "tilesets": [{"firstgid": 1, "tileproperties": {}}],
+                "nextobjectid": 1,
+            },
+        )
+        write_json(
+            root / "res/maps/keep/config.json",
+            {
+                "townGuard": {
+                    "ref": "Soldier",
+                    "properties": {
+                        "controller": {"class": "CTargetController", "properties": {"target": "player"}},
+                        "items": [{"ref": "Sword"}],
+                    },
+                },
+                "plainSoldier": {"ref": "Soldier", "properties": {"message": "Just passing through."}},
+                "loot": {"ref": "Sword", "properties": {"animation": "images/item"}},
+                "spawner": {
+                    "ref": "Spawner",
+                    "properties": {"monster": {"ref": "Soldier", "properties": {"affiliation": "keep"}}},
+                },
+            },
+        )
+        return root
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue
`[EPIC_01][STORY_01][SUBSTORY_02]Inventory map-specific creature overrides` (claim `e88905d9-dda5-4ba8-b4ae-315b489f3df8`, owner `controller/ctrl-vm-4026-9b5a29b5/subagent-2`).

## What changed
Adds a **reproducible** map-local creature-override inventory to `scripts/validate_content.py` (preferred over a static file so it stays correct as configs change):
- New `ContentValidator.inventory_creature_overrides()` + recursive `_collect_creature_overrides` (catches nested `properties.monster` spawner refs) + `_is_creature_node` reusing the existing `_effective_object_class`/`_class_inherits_from` resolution.
- New `CreatureOverride` dataclass and public `inventory_creature_overrides(repo_root)`.
- New `--report-creature-overrides` CLI flag that prints the JSON inventory and exits **before** validation, so existing validation behavior and exit codes are untouched.
- Watches override properties: `baseStats/levelStats/stats/actions/controller/fightController/affiliation/items/equipped/sw/animation/npc/label(s)`.

## Result
Enumerates all **18** current overrides across `res/maps/{nouraajd,siege,ritual}/config.json` with exact path / key / location / template / overridden-properties (e.g. siege `siegePritzMage` quest-item carrier; nested `cave1.properties.monster` Pritz controller; ritual anchors). Satisfies the acceptance criterion that every map-local override is identified with exact path/key/property context, and guards a future creature-template migration from flattening map-local behavior.

## Files changed
`scripts/validate_content.py`, `tests/test_content_validator.py`.

## Validation
- `python3 -m unittest tests.test_content_validator` → **42 passed** (40 prior + 2 new).
- `python3 scripts/validate_content.py` → exit 0 (unchanged semantics).
- `python3 scripts/validate_content.py --report-creature-overrides` → 18-entry JSON inventory.
- `git diff --check` clean; no `planning/` files. Remaining CI evidence via GitHub Actions polling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_