### PR TITLE
Inventory runtime-spawned quest creatures in content validator

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -161,6 +161,31 @@ class ScriptCall:
 
 
 @dataclass
+class SpawnedCreature:
+    """A creature template spawned at runtime via createObject/addObjectByName.
+
+    ``template`` is the literal template id passed to the spawn call. ``runtime_name``
+    is the post-spawn object name assigned through ``setStringProperty("name", ...)``
+    when that name is a string literal, or ``None`` when the spawn stays anonymous or
+    the name is computed (e.g. an f-string). These are recorded separately so the
+    migration preserves both template ids and runtime names, which trigger validators
+    special-case for runtime-spawned quest actors. Nothing here is inferred from design
+    docs -- only literal values present in the script source are captured.
+    """
+
+    template: str
+    spawn_call: str
+    lineno: int
+    context: str
+    runtime_name: str | None = None
+
+    @property
+    def location(self) -> str:
+        call = f'{self.spawn_call}("{self.template}")'
+        return f"{self.context}:{self.lineno} {call}" if self.context else f"line {self.lineno} {call}"
+
+
+@dataclass
 class ScriptQuestStateUsage:
     storage_key: str | None = None
     default_state: str | None = None
@@ -268,6 +293,7 @@ class ScriptInfo:
     property_writes: list[ScriptPropertyAccess] = field(default_factory=list)
     trigger_targets: list[ScriptCall] = field(default_factory=list)
     named_objects: set[str] = field(default_factory=set)
+    spawned_creatures: list[SpawnedCreature] = field(default_factory=list)
 
 
 @dataclass
@@ -289,6 +315,10 @@ class ScriptAnalyzer(ast.NodeVisitor):
         self._function_stack: list[str] = []
         self._state_alias_stack: list[dict[str, str]] = []
         self._string_values_stack: list[dict[str, set[str]]] = []
+        # Maps a local variable name to the SpawnedCreature it was assigned from
+        # (via createObject) so a later setStringProperty("name", ...) on that
+        # variable can attach the runtime name. Scoped per function body.
+        self._spawn_vars_stack: list[dict[str, SpawnedCreature]] = []
 
     def visit_ClassDef(self, node: ast.ClassDef) -> Any:
         self.info.classes.add(node.name)
@@ -309,8 +339,10 @@ class ScriptAnalyzer(ast.NodeVisitor):
         self._function_stack.append(node.name)
         self._state_alias_stack.append({})
         self._string_values_stack.append({})
+        self._spawn_vars_stack.append({})
         for child in node.body:
             self.visit(child)
+        self._spawn_vars_stack.pop()
         self._string_values_stack.pop()
         self._state_alias_stack.pop()
         self._function_stack.pop()
@@ -321,12 +353,14 @@ class ScriptAnalyzer(ast.NodeVisitor):
     def visit_Assign(self, node: ast.Assign) -> Any:
         self._record_class_constant_assignment(node)
         self._record_local_assignment(node.targets, node.value)
+        self._record_spawn_assignment(node.targets, node.value)
         self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> Any:
         if node.value is not None:
             self._record_class_constant_assignment(node)
             self._record_local_assignment([node.target], node.value)
+            self._record_spawn_assignment([node.target], node.value)
         self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> Any:
@@ -334,6 +368,8 @@ class ScriptAnalyzer(ast.NodeVisitor):
         if name:
             self._record_script_call(name, node)
             self._record_named_object(name, node)
+            self._record_anonymous_spawn(name, node)
+            self._record_runtime_spawn_name(name, node)
             self._record_quest_state_call(name, node)
             self._record_property_access(name, node)
         self.generic_visit(node)
@@ -367,6 +403,79 @@ class ScriptAnalyzer(ast.NodeVisitor):
             value = string_literal(node.args[1])
             if key == "name" and value:
                 self.info.named_objects.add(value)
+
+    def _record_anonymous_spawn(self, name: str, node: ast.Call) -> None:
+        """Record addObjectByName("template", ...) spawns, which are anonymous.
+
+        addObjectByName instantiates a template directly on the map without binding
+        a Python variable, so there is never a runtime name to attach.
+        """
+        if name != "addObjectByName":
+            return
+        template = first_string_arg(node)
+        if template is None:
+            return
+        self.info.spawned_creatures.append(
+            SpawnedCreature(
+                template=template,
+                spawn_call=name,
+                lineno=node.lineno,
+                context=self._context,
+                runtime_name=None,
+            )
+        )
+
+    def _record_spawn_assignment(self, targets: list[ast.expr], value: ast.AST) -> None:
+        """Track ``var = ...createObject("template")`` so a later name write can attach.
+
+        Records the SpawnedCreature immediately (template id) and remembers the local
+        variable; the runtime name is filled in when a subsequent
+        ``var.setStringProperty("name", literal)`` is seen in the same function scope.
+        """
+        if not self._spawn_vars_stack:
+            return
+        spawn_vars = self._spawn_vars_stack[-1]
+        template = self._created_object_template(value)
+        for target in targets:
+            target_name = assigned_name(target)
+            if target_name is None:
+                continue
+            if template is None:
+                spawn_vars.pop(target_name, None)
+                continue
+            creature = SpawnedCreature(
+                template=template,
+                spawn_call="createObject",
+                lineno=getattr(value, "lineno", 0),
+                context=self._context,
+                runtime_name=None,
+            )
+            self.info.spawned_creatures.append(creature)
+            spawn_vars[target_name] = creature
+
+    def _record_runtime_spawn_name(self, name: str, node: ast.Call) -> None:
+        """Attach a literal runtime name to a tracked createObject spawn variable."""
+        if name != "setStringProperty" or len(node.args) < 2:
+            return
+        if string_literal(node.args[0]) != "name":
+            return
+        runtime_name = string_literal(node.args[1])
+        if runtime_name is None:
+            return
+        receiver = node.func.value if isinstance(node.func, ast.Attribute) else None
+        receiver_name = assigned_name(receiver) if receiver is not None else None
+        if receiver_name is None or not self._spawn_vars_stack:
+            return
+        for spawn_vars in reversed(self._spawn_vars_stack):
+            creature = spawn_vars.get(receiver_name)
+            if creature is not None and creature.runtime_name is None:
+                creature.runtime_name = runtime_name
+                return
+
+    def _created_object_template(self, node: ast.AST) -> str | None:
+        if isinstance(node, ast.Call) and call_name(node.func) == "createObject":
+            return first_string_arg(node)
+        return None
 
     def _record_class_constant_assignment(self, node: ast.Assign | ast.AnnAssign) -> None:
         if not self._class_stack:

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -263,6 +263,68 @@ class ContentValidatorTest(unittest.TestCase):
         self.assertIn(("map", "MAIN_TURN", "setNumericProperty"), property_writes)
         self.assertIn(("player", "skill_flag", "setBoolProperty"), property_writes)
 
+    def test_script_analyzer_inventories_runtime_spawned_creatures(self):
+        root = self.make_fixture()
+        script_path = root / "res/maps/broken/script.py"
+        script_path.write_text(
+            textwrap.dedent("""
+                def load(self, context):
+                    from game import CTrigger
+                    from game import register
+
+                    NAME_PREFIX = "wave"
+
+                    def spawn_quest_actors(game, game_map):
+                        leader = game.createObject("CultLeader")
+                        leader.setStringProperty("name", "cultLeaderQuest")
+                        game_map.addObject(leader)
+
+                        controller = game.createObject("CTargetController")
+                        controller.setTarget("player")
+
+                        for index in range(3):
+                            mob = game.createObject("Cultist")
+                            mob.setStringProperty("name", f"{NAME_PREFIX}{index}")
+                            game_map.addObject(mob)
+
+                        game_map.addObjectByName("siegePritz", game_map.getCoords())
+                """).lstrip(),
+            encoding="utf-8",
+        )
+        info = ContentValidator(root)._parse_script(script_path)
+        self.assertIsNotNone(info)
+        if info is None:
+            return
+
+        spawns = {(c.spawn_call, c.template, c.runtime_name) for c in info.spawned_creatures}
+
+        # createObject template ids are recorded with their literal post-spawn names.
+        self.assertIn(("createObject", "CultLeader", "cultLeaderQuest"), spawns)
+        # createObject without a name write stays anonymous (controllers, etc.).
+        self.assertIn(("createObject", "CTargetController", None), spawns)
+        # A computed (f-string) name is NOT inferred -- only literal names are kept.
+        self.assertIn(("createObject", "Cultist", None), spawns)
+        # addObjectByName spawns are anonymous: template preserved, no runtime name.
+        self.assertIn(("addObjectByName", "siegePritz", None), spawns)
+
+        # Template ids and runtime names are tracked separately so a migration can
+        # preserve both for the trigger validators that special-case quest actors.
+        templates = {c.template for c in info.spawned_creatures}
+        runtime_names = {c.runtime_name for c in info.spawned_creatures if c.runtime_name is not None}
+        self.assertEqual({"CultLeader", "CTargetController", "Cultist", "siegePritz"}, templates)
+        self.assertEqual({"cultLeaderQuest"}, runtime_names)
+
+    def test_script_analyzer_inventories_real_quest_creature_spawns(self):
+        # Names must come from real script source, never from design docs.
+        info = ContentValidator(REPO_ROOT)._parse_script(REPO_ROOT / "res/maps/nouraajd/script.py")
+        self.assertIsNotNone(info)
+        if info is None:
+            return
+        named = {c.template: c.runtime_name for c in info.spawned_creatures if c.runtime_name is not None}
+        self.assertEqual("cultLeaderQuest", named.get("CultLeader"))
+        self.assertEqual("gooby1", named.get("gooby"))
+        self.assertEqual("amuletGoblin", named.get("goblinThief"))
+
     def test_given_player_bool_read_without_default_when_validating_then_reports_uninitialized_property(self):
         root = self.make_fixture()
         write_property_hygiene_script(


### PR DESCRIPTION
## Issue
`[EPIC_01][STORY_01][SUBSTORY_03]Inventory runtime-spawned quest creatures` — Claim ID `808578e1-8cb9-47b6-aa7e-1de5c53fca25`
Owner `controller/ctrl-vm-4039-a70f65a5/subagent-2`

## Root cause / context
`createObject`/`addObjectByName` spawn calls were ref-validated generically but never inventoried as runtime-spawned creatures, and their literal post-spawn runtime names were not linked to their templates. The migration must preserve template IDs and runtime names because trigger validators special-case runtime-spawned quest actors.

Verified source evidence:
- Analyzer reused: `scripts/validate_content.py:285` `ScriptAnalyzer(ast.NodeVisitor)`; spawn calls `SCRIPT_REF_CALLS = {"createObject","addObjectByName"}` (line 22)
- Real spawn sites (literal): `res/maps/nouraajd/script.py:98-99` `createObject("CultLeader")`→name `cultLeaderQuest`, `:604-605` `gooby`→`gooby1`, `:992-993` `goblinThief`→`amuletGoblin`; `res/maps/siege/script.py:103,106` anonymous `addObjectByName`; `res/maps/ritual/script.py:45-47` `ritualLeaderTemplate`→`ritualLeader`

## What changed
- `scripts/validate_content.py` (+109): `SpawnedCreature` dataclass + `ScriptInfo.spawned_creatures`; `ScriptAnalyzer` now records anonymous `addObjectByName` spawns, tracks `var = createObject("tpl")` per function scope, and attaches a literal runtime name from a later `var.setStringProperty("name", literal)`. Template IDs and runtime names stored **separately**; computed (f-string) names yield `runtime_name=None` — nothing is inferred from design docs.
- `tests/test_content_validator.py` (+62): `test_script_analyzer_inventories_runtime_spawned_creatures` (synthetic literal/anonymous/f-string cases) and `test_script_analyzer_inventories_real_quest_creature_spawns` (asserts real names come from actual script source).

## Impact
Runtime-spawned quest actor templates and their literal names are now inventoried directly from script source, giving the migration a no-inference baseline. No runtime behavior changed.

## Files changed
`scripts/validate_content.py`, `tests/test_content_validator.py`

## Validation
- `python3 -m unittest tests.test_content_validator` → **Ran 42 tests … OK** (re-run by controller, passes).
- `black -l 120` on both files → unchanged (already compliant).
- Pure-Python change; native build not required for these paths. CI runs the workflow-classified validation lane.

## Manual review items
- Inventory lists every literal `createObject`/`addObjectByName` template (not only provable creatures) to avoid class-hierarchy inference, which the acceptance criteria forbid. Computed names are intentionally `None`.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_