### PR TITLE
Add coverage_report regression tests and lightweight CI routing

### DIFF
--- a/scripts/ci_change_classifier.py
+++ b/scripts/ci_change_classifier.py
@@ -63,6 +63,7 @@ LIGHTWEIGHT_PATH_PATTERNS = (
     "tests/test_ci_change_classifier.py",
     "tests/test_content_validator.py",
     "tests/test_controller_resource_audit.py",
+    "tests/test_coverage_report.py",
     "tests/test_issue_queue.py",
     "tests/test_poll_pr_checks.py",
     "tests/test_pr_review_audit.py",

--- a/tests/test_ci_change_classifier.py
+++ b/tests/test_ci_change_classifier.py
@@ -31,6 +31,13 @@ class CiChangeClassifierTest(unittest.TestCase):
         self.assertEqual((), classification.nativeReasons)
         self.assertIn(".github/workflows/build.yml", classification.paths)
 
+    def test_coverage_report_unit_test_routes_as_lightweight(self) -> None:
+        classification = self.classify("tests/test_coverage_report.py")
+
+        self.assertFalse(classification.nativeNeeded)
+        self.assertFalse(classification.coverageNeeded)
+        self.assertEqual((), classification.nativeReasons)
+
     def test_workflow_observation_ledger_json_does_not_need_native_validation(self) -> None:
         classification = self.classify(
             "planning/workflow_observations/records/20260621T120000Z-controller-example-1234abcd.json",

--- a/tests/test_coverage_report.py
+++ b/tests/test_coverage_report.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import argparse
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import coverage_report
+
+
+class CoverageReportTest(unittest.TestCase):
+    def test_positive_int_rejects_non_integer_and_below_one(self) -> None:
+        self.assertEqual(4, coverage_report.positive_int("4"))
+        with self.assertRaises(argparse.ArgumentTypeError):
+            coverage_report.positive_int("0")
+        with self.assertRaises(argparse.ArgumentTypeError):
+            coverage_report.positive_int("nope")
+
+    def test_positive_float_rejects_non_number_and_non_positive(self) -> None:
+        self.assertEqual(1.5, coverage_report.positive_float("1.5"))
+        with self.assertRaises(argparse.ArgumentTypeError):
+            coverage_report.positive_float("0")
+        with self.assertRaises(argparse.ArgumentTypeError):
+            coverage_report.positive_float("-3")
+        with self.assertRaises(argparse.ArgumentTypeError):
+            coverage_report.positive_float("x")
+
+    def test_normalize_path_resolves_relative_against_cwd(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir).resolve()
+            self.assertEqual(root / "src" / "a.cpp", coverage_report.normalize_path("src/a.cpp", root))
+            self.assertEqual(root / "src" / "a.cpp", coverage_report.normalize_path(str(root / "src/a.cpp"), root))
+
+    def test_filesystem_relative_path_uses_matching_ancestor_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir).resolve()
+            nested = root / "src" / "core"
+            nested.mkdir(parents=True)
+            self.assertEqual(Path("src/core"), coverage_report.filesystem_relative_path(root, nested))
+            self.assertEqual(Path("."), coverage_report.filesystem_relative_path(root, root))
+
+    def test_filesystem_relative_path_raises_for_unrelated_path(self) -> None:
+        with tempfile.TemporaryDirectory() as a_dir, tempfile.TemporaryDirectory() as b_dir:
+            with self.assertRaises(ValueError):
+                coverage_report.filesystem_relative_path(Path(a_dir).resolve(), Path(b_dir).resolve())
+
+    def test_is_included_respects_root_and_prefixes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir).resolve()
+            (root / "src").mkdir()
+            (root / "third_party").mkdir()
+            in_src = root / "src" / "a.cpp"
+            in_tp = root / "third_party" / "b.cpp"
+            outside = Path(tempfile.gettempdir()).resolve() / "definitely-not-under-root.cpp"
+
+            self.assertTrue(coverage_report.is_included(root, in_src))
+            self.assertFalse(coverage_report.is_included(root, outside))
+
+            prefixes = coverage_report.load_include_prefixes(root, ["src"])
+            self.assertTrue(coverage_report.is_included(root, in_src, prefixes))
+            self.assertFalse(coverage_report.is_included(root, in_tp, prefixes))
+
+    def test_validate_include_prefix_rejects_bad_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir).resolve()
+            (root / "src").mkdir()
+            self.assertEqual(root / "src", coverage_report.validate_include_prefix(root, "src"))
+            for bad in ["", "/abs/path", "../escape", "src/*", "missing_dir"]:
+                with self.assertRaises(ValueError):
+                    coverage_report.validate_include_prefix(root, bad)
+
+    def test_merge_line_counts_takes_max_count_per_line_and_filters(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir).resolve()
+            (root / "src").mkdir()
+            (root / "other").mkdir()
+            reports = [
+                {
+                    "current_working_directory": str(root),
+                    "files": [
+                        {
+                            "file": "src/a.cpp",
+                            "lines": [
+                                {"line_number": 1, "count": 0},
+                                {"line_number": 2, "count": 3},
+                            ],
+                        },
+                        {
+                            "file": "other/b.cpp",
+                            "lines": [{"line_number": 1, "count": 5}],
+                        },
+                    ],
+                },
+                {
+                    "current_working_directory": str(root),
+                    "files": [
+                        {
+                            "file": "src/a.cpp",
+                            "lines": [
+                                {"line_number": 1, "count": 4},  # higher count wins
+                                {"line_number": 2, "count": 1},  # lower count loses
+                            ],
+                        }
+                    ],
+                },
+            ]
+            prefixes = coverage_report.load_include_prefixes(root, ["src"])
+            merged = coverage_report.merge_line_counts(root, reports, prefixes)
+
+            self.assertEqual({root / "src" / "a.cpp"}, set(merged))  # other/ filtered out
+            self.assertEqual({1: 4, 2: 3}, merged[root / "src" / "a.cpp"])
+
+    def test_summarize_computes_percentages_and_missing_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir).resolve()
+            merged = {
+                root / "src" / "a.cpp": {1: 4, 2: 0, 3: 7},
+                root / "src" / "b.cpp": {10: 0, 11: 0},
+            }
+            summary, covered, total, pct = coverage_report.summarize(root, merged)
+
+            # a.cpp instrumented=3 covered=2 (lines 1,3); b.cpp instrumented=2 covered=0
+            self.assertEqual(5, total)
+            self.assertEqual(2, covered)
+            self.assertAlmostEqual(40.0, pct)
+            by_path = {str(item["path"]): item for item in summary}
+            self.assertEqual([2], by_path["src/a.cpp"]["missing"])
+            self.assertEqual([10, 11], by_path["src/b.cpp"]["missing"])
+            self.assertAlmostEqual(100.0 * 2 / 3, by_path["src/a.cpp"]["percentage"])
+
+    def test_summarize_treats_empty_file_as_full_coverage(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir).resolve()
+            summary, covered, total, pct = coverage_report.summarize(root, {root / "src" / "empty.cpp": {}})
+            self.assertEqual(0, total)
+            self.assertEqual(0, covered)
+            self.assertAlmostEqual(100.0, pct)
+            self.assertAlmostEqual(100.0, summary[0]["percentage"])
+
+    def test_preview_lines_truncates_after_twenty(self) -> None:
+        self.assertEqual("-", coverage_report.preview_lines([]))
+        self.assertEqual("1, 2, 3", coverage_report.preview_lines([1, 2, 3]))
+        many = coverage_report.preview_lines(list(range(1, 30)))
+        self.assertTrue(many.endswith(", ..."))
+        self.assertEqual("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, ...", many)
+
+    def test_write_text_report_emits_total_and_per_file_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report_path = Path(temp_dir) / "coverage.txt"
+            summary = [{"path": Path("src/a.cpp"), "lines": 3, "covered": 2, "missing": [2], "percentage": 66.67}]
+            coverage_report.write_text_report(report_path, summary, 2, 3, 66.67)
+            text = report_path.read_text(encoding="utf-8")
+            self.assertIn("TOTAL 2/3 eligible lines covered (66.67%)", text)
+            self.assertIn("src/a.cpp: 2/3 (66.67%) missing [2]", text)
+
+    def test_write_html_report_escapes_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report_path = Path(temp_dir) / "coverage.html"
+            summary = [{"path": Path("src/<x>.cpp"), "lines": 1, "covered": 1, "missing": [], "percentage": 100.0}]
+            coverage_report.write_html_report(report_path, summary, 1, 1, 100.0)
+            html_text = report_path.read_text(encoding="utf-8")
+            self.assertIn("src/&lt;x&gt;.cpp", html_text)
+            self.assertNotIn("<x>.cpp", html_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`scripts/coverage_report.py` backs the coverage CI gate but had **no unit tests**, so a regression in its summarize/merge math or path handling would only surface in the heavyweight native coverage job (if at all). An independent audit of the workflow tooling found no remaining code defect; this checkpoint closes the one named gap it surfaced — deterministic regression coverage for a gate-critical script.

## Changes

- **New `tests/test_coverage_report.py`** (13 deterministic, hermetic tests) characterizing the pure functions: `positive_int`/`positive_float` validators, `normalize_path`, `filesystem_relative_path` + the matching-ancestor fallback, `validate_include_prefix`/`load_include_prefixes`, `is_included` (root + include-prefix filtering), `merge_line_counts` (max-count-per-line merge + include filtering across multiple reports), `summarize` (instrumented/covered/percentage/missing math + empty-file = 100%), `preview_lines` (truncation at 20), and `write_text_report`/`write_html_report` (format + HTML escaping). The gcov-dependent collectors are intentionally excluded rather than mocked into meaningless tests.
- **`scripts/ci_change_classifier.py`**: register `tests/test_coverage_report.py` in `LIGHTWEIGHT_PATH_PATTERNS` so the new pure-Python test routes as lightweight CI (consistent with all ten sibling `tests/test_*.py` entries), instead of falling into the `unclassified:` fail-safe-native branch. Changes to the actual `coverage_report.py` script remain coverage/native classified — gating is not weakened.
- **`tests/test_ci_change_classifier.py`**: regression asserting the new test file routes lightweight.

## Evidence

- `python3 -m unittest tests.test_coverage_report` → 13 OK
- `python3 -m unittest tests.test_ci_change_classifier` → 12 OK (+1)
- Focused baseline (issue_queue + controller_resource_audit + pr_review_audit + workflow_observations + poll_pr_checks + ci_change_classifier + coverage_report) → 179 OK
- Verified routing: `classifyPaths(["tests/test_coverage_report.py"])` → `nativeNeeded=False, coverageNeeded=False`; `classifyPaths(["scripts/coverage_report.py"])` → `nativeNeeded=True, coverageNeeded=True` (unchanged).

## Risks

Very low. Test-only addition plus a single classifier allow-list entry mirroring existing siblings. No production code path changes; no weakening of coverage/native gating for actual `coverage_report.py` edits.

## Manual review items

None outstanding. Independently reviewed: all test math confirmed against source and live execution, determinism/hermeticity confirmed (tempdirs, no gcov/network), and the routing change confirmed not to weaken coverage gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016D8Ra7XE7j7cBsVqzKfbou)_