### PR TITLE
Add issue_queue propose command for filing new issues

### DIFF
--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -472,6 +472,37 @@ python3 scripts/issue_queue.py list --status BLOCKED --json
 python3 scripts/issue_queue.py show --issue "$ISSUE_NAME"
 ```
 
+## Proposing new issues
+
+`propose` appends a new `NOT_STARTED` issue (for example an autonomously
+discovered bug) directly into the canonical workbook under the same lock and
+atomic-save path as every other mutation. The `Epic #`, `Story #`, and
+`Substory #` columns are derived from the bracketed `Issue Name`, and the row
+is validated transactionally: it is only persisted when the resulting queue
+still passes `validate`, so a malformed proposal can never corrupt the backlog.
+Duplicate issue names and unknown dependencies are rejected without writing.
+
+```bash
+python3 scripts/issue_queue.py propose \
+  --issue-name "[EPIC_09][STORY_01][SUBSTORY_01]Fix null deref in CFightHandler when target dies mid-swing" \
+  --epic-title "Autonomously Discovered Bugs" \
+  --story-title "Combat crash bugs" \
+  --substory-title "Null deref when target dies mid-swing" \
+  --priority P1 \
+  --issue-type Bug \
+  --component Combat \
+  --target-file src/handler/CFightHandler.cpp \
+  --target-file src/handler/CFightHandler.h \
+  --description "CFightHandler::resolve dereferences target after onDeath may have freed it." \
+  --acceptance "No crash when the target dies mid-resolution; a regression test reproduces and guards it." \
+  --validation "ctest --test-dir cmake-build-release -R controller_unit_tests" \
+  --source-url "https://github.com/lisu188/fall-of-nouraajd/blob/main/src/handler/CFightHandler.cpp"
+```
+
+Pass `--dependencies` with one or more existing issue names (separated by `;`)
+when the fix must wait on other work; the `none` token and an empty value both
+mean "no dependencies". Real dependency names must already exist in the queue.
+
 ## Operating constraints
 
 - Do not keep the XLSX open in desktop Excel/LibreOffice while agents are mutating it, especially on Windows; those programs may prevent atomic replacement.

--- a/scripts/issue_queue.py
+++ b/scripts/issue_queue.py
@@ -98,7 +98,9 @@ WORKFLOW_HEADERS = (
 )
 ALL_HEADERS = REQUIRED_HEADERS + WORKFLOW_HEADERS
 ISSUE_NAME_PATTERN = re.compile(r"^\[EPIC_\d{2}\]\[STORY_\d{2}\]\[SUBSTORY_\d{2}\].+")
+ISSUE_NAME_TOKENS = re.compile(r"^\[(EPIC_\d{2})\]\[(STORY_\d{2})\]\[(SUBSTORY_\d{2})\](.+)$")
 PRIORITY_ORDER = {"P0": 0, "P1": 1, "P2": 2}
+VALID_PRIORITIES = ("P0", "P1", "P2")
 DEFAULT_RECLAIM_AGE_MINUTES = 240
 DEFAULT_HEARTBEAT_INTERVAL_MINUTES = DEFAULT_RECLAIM_AGE_MINUTES // 2
 DEFAULT_CONTROLLER_ACTIVE_ISSUE_FLOOR = 4
@@ -1514,6 +1516,128 @@ def claimTask(
             state.workbook.close()
 
 
+def proposeTask(
+    workbookPath: Path,
+    *,
+    issueName: str,
+    epicTitle: str,
+    storyTitle: str,
+    substoryTitle: str,
+    priority: str,
+    component: str,
+    targetFiles: Sequence[str],
+    issueType: str = "Bug",
+    dependencies: str = "None",
+    description: str = "",
+    acceptance: str = "",
+    validation: str = "",
+    sourceUrls: Sequence[str] = (),
+    sprint: str = "None",
+    lockTimeoutSeconds: float = 30.0,
+) -> dict[str, Any]:
+    """Append a new NOT_STARTED issue row to the canonical workbook.
+
+    The row is validated transactionally: it is only persisted when the
+    resulting queue still passes ``validateQueueState`` so a malformed proposal
+    can never corrupt the backlog.
+    """
+
+    issueName = issueName.strip()
+    tokens = ISSUE_NAME_TOKENS.match(issueName)
+    if not tokens:
+        raise QueueError(
+            "Issue name must match [EPIC_NN][STORY_NN][SUBSTORY_NN]<title>, got: " + (issueName or "<empty>")
+        )
+    priority = priority.strip().upper()
+    if priority not in VALID_PRIORITIES:
+        raise QueueError(f"--priority must be one of {', '.join(VALID_PRIORITIES)}, got {priority or '<empty>'}")
+    requiredText = {
+        "--epic-title": epicTitle,
+        "--story-title": storyTitle,
+        "--substory-title": substoryTitle,
+        "--component": component,
+    }
+    for label, value in requiredText.items():
+        if not str(value or "").strip():
+            raise QueueError(f"{label} must be non-empty")
+    targets = [line.strip() for line in targetFiles if str(line or "").strip()]
+    if not targets:
+        raise QueueError("--target-file must be provided at least once")
+    urls = [line.strip() for line in sourceUrls if str(line or "").strip()]
+    # The workbook stores "no dependencies" as an empty cell; the literal token
+    # "None" is normalized away so it is not treated as an unknown dependency.
+    deps = [
+        token.strip()
+        for token in re.split(r"[;\n]+", str(dependencies or ""))
+        if token.strip() and token.strip().lower() != "none"
+    ]
+
+    epicNumber, storyNumber, substoryNumber, _title = tokens.groups()
+
+    with WorkbookLock(workbookPath, lockTimeoutSeconds):
+        state = loadQueue(workbookPath, writable=True)
+        try:
+            ensureWorkflowSchema(state)
+            state = refreshTasks(state)
+            now = utcNow()
+            errors, _ = validateQueueState(state, now=now)
+            if errors:
+                raise QueueError("Queue validation failed before propose:\n- " + "\n- ".join(errors))
+
+            duplicate = next((task for task in state.tasks if task.issueName == issueName), None)
+            if duplicate is not None:
+                raise QueueError(f"Issue name already exists at row {duplicate.row}: {issueName}")
+
+            newRow = state.sheet.maxRow + 1
+            cells: dict[str, Any] = {
+                "Issue Name": issueName,
+                "Epic #": epicNumber,
+                "Epic Title": epicTitle.strip(),
+                "Story #": storyNumber,
+                "Story Title": storyTitle.strip(),
+                "Substory #": substoryNumber,
+                "Substory Title": substoryTitle.strip(),
+                "Priority": priority,
+                "Issue Type": (issueType or "Bug").strip() or "Bug",
+                "Component": component.strip(),
+                "Dependencies": "\n".join(deps) if deps else None,
+                "Target Files / Modules": "\n".join(targets),
+                "Technical Code-Level Description": (description or "").strip(),
+                "Acceptance Criteria": (acceptance or "").strip(),
+                "Validation / Tests": (validation or "").strip(),
+                "Source URLs": "\n".join(urls) if urls else None,
+                "Status": STATUS_NOT_STARTED,
+                "Owner": "",
+                "Sprint": (sprint or "").strip() or None,
+                "Claim ID": "",
+                "Claimed At UTC": None,
+                "Updated At UTC": None,
+                "Lease Until UTC": None,
+                "Completed At UTC": None,
+                "Progress %": 0,
+                "Last Note": "",
+                "Result Summary": "",
+                "Validation Results": "",
+                "Attempt": 0,
+            }
+            for header, value in cells.items():
+                setValue(state, newRow, header, value)
+
+            state = refreshTasks(state)
+            postErrors, postWarnings = validateQueueState(state, now=now)
+            if postErrors:
+                raise QueueError("Proposed row would invalidate the queue:\n- " + "\n- ".join(postErrors))
+
+            atomicSave(state, workbookPath)
+            state = refreshTasks(state)
+            proposed = taskByName(state, issueName)
+            payload = taskPayload(proposed, state=state, now=now)
+            payload.update({"proposed": True, "row": proposed.row, "warnings": postWarnings})
+            return payload
+        finally:
+            state.workbook.close()
+
+
 def requireClaim(state: QueueState, issueName: str, claimId: str, owner: str) -> TaskRecord:
     task = taskByName(state, issueName)
     actualClaim = str(task.values.get("Claim ID") or "").strip()
@@ -1836,6 +1960,34 @@ def buildParser() -> argparse.ArgumentParser:
     validateParser = subparsers.add_parser("validate", help="Validate queue schema and state invariants")
     addCommonArguments(validateParser)
 
+    proposeParser = subparsers.add_parser(
+        "propose", help="Append a new NOT_STARTED issue (e.g. an autonomously discovered bug)"
+    )
+    addCommonArguments(proposeParser)
+    proposeParser.add_argument(
+        "--issue-name", required=True, help="[EPIC_NN][STORY_NN][SUBSTORY_NN]<title>"
+    )
+    proposeParser.add_argument("--epic-title", required=True)
+    proposeParser.add_argument("--story-title", required=True)
+    proposeParser.add_argument("--substory-title", required=True)
+    proposeParser.add_argument("--priority", required=True, help="P0, P1, or P2")
+    proposeParser.add_argument("--component", required=True)
+    proposeParser.add_argument(
+        "--target-file", action="append", default=[], help="Target file/module; may be repeated"
+    )
+    proposeParser.add_argument("--issue-type", default="Bug")
+    proposeParser.add_argument("--dependencies", default="None")
+    proposeParser.add_argument("--description")
+    proposeParser.add_argument("--description-file")
+    proposeParser.add_argument("--acceptance")
+    proposeParser.add_argument("--acceptance-file")
+    proposeParser.add_argument("--validation")
+    proposeParser.add_argument("--validation-file")
+    proposeParser.add_argument(
+        "--source-url", action="append", default=[], help="Evidence/source URL; may be repeated"
+    )
+    proposeParser.add_argument("--sprint", default="None")
+
     listParser = subparsers.add_parser("list", help="List tasks")
     addCommonArguments(listParser)
     listParser.add_argument("--status", action="append", default=[])
@@ -2006,6 +2158,32 @@ def main(argv: Sequence[str] | None = None) -> int:
                 state.workbook.close()
             printJson({"workbook": str(workbookPath), "errors": errors, "warnings": warnings})
             return 1 if errors else 0
+
+        if args.command == "propose":
+            description = readTextOption(args.description, args.description_file, "description")
+            acceptance = readTextOption(args.acceptance, args.acceptance_file, "acceptance")
+            validation = readTextOption(args.validation, args.validation_file, "validation")
+            printJson(
+                proposeTask(
+                    workbookPath,
+                    issueName=args.issue_name,
+                    epicTitle=args.epic_title,
+                    storyTitle=args.story_title,
+                    substoryTitle=args.substory_title,
+                    priority=args.priority,
+                    component=args.component,
+                    targetFiles=args.target_file,
+                    issueType=args.issue_type,
+                    dependencies=args.dependencies,
+                    description=description,
+                    acceptance=acceptance,
+                    validation=validation,
+                    sourceUrls=args.source_url,
+                    sprint=args.sprint,
+                    lockTimeoutSeconds=args.lock_timeout_seconds,
+                )
+            )
+            return 0
 
         if args.command in {"list", "show", "next", "shortlist", "prompt"}:
             state = loadQueue(workbookPath, writable=False)

--- a/tests/test_issue_queue.py
+++ b/tests/test_issue_queue.py
@@ -1257,6 +1257,150 @@ class IssueQueueTest(unittest.TestCase):
         with zipfile.ZipFile(self.workbook_path, "r") as archive:
             self.assertEqual(marker_value, archive.read(marker_name))
 
+    def test_propose_appends_not_started_bug_row_and_validates(self) -> None:
+        issue_name = "[EPIC_02][STORY_01][SUBSTORY_01]Fix null deref in resolver"
+        result = issue_queue.proposeTask(
+            self.workbook_path,
+            issueName=issue_name,
+            epicTitle="Discovered Bugs",
+            storyTitle="Crashes",
+            substoryTitle="Null deref in resolver",
+            priority="p1",
+            component="Combat",
+            targetFiles=["src/handler/CFightHandler.cpp", "src/handler/CFightHandler.h"],
+            description="Deref after free.",
+            acceptance="No crash; regression added.",
+            validation="python3 -m unittest tests.test_issue_queue",
+            sourceUrls=["https://github.com/lisu188/fall-of-nouraajd"],
+        )
+
+        self.assertTrue(result["proposed"])
+        self.assertEqual(issue_name, result["Issue Name"])
+        self.assertEqual(issue_queue.STATUS_NOT_STARTED, result["Status"])
+        self.assertEqual("P1", result["Priority"])
+
+        state = issue_queue.loadQueue(self.workbook_path)
+        errors, _ = issue_queue.validateQueueState(state)
+        self.assertEqual([], errors)
+        task = issue_queue.taskByName(state, issue_name)
+        self.assertEqual("EPIC_02", task.values["Epic #"])
+        self.assertEqual("STORY_01", task.values["Story #"])
+        self.assertEqual("SUBSTORY_01", task.values["Substory #"])
+        self.assertEqual("Bug", task.values["Issue Type"])
+        self.assertEqual({"src/handler/CFightHandler.cpp", "src/handler/CFightHandler.h"}, task.targetFiles)
+        self.assertEqual([], task.dependencies)
+        # A freshly proposed bug is immediately claimable.
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", issueName=issue_name)
+        self.assertTrue(claim["claimed"])
+
+    def test_propose_records_real_dependency(self) -> None:
+        result = issue_queue.proposeTask(
+            self.workbook_path,
+            issueName="[EPIC_02][STORY_01][SUBSTORY_02]Depends on existing issue",
+            epicTitle="Discovered Bugs",
+            storyTitle="Crashes",
+            substoryTitle="Depends",
+            priority="P2",
+            component="Combat",
+            targetFiles=["src/x.cpp"],
+            dependencies=f"none;{self.issue_b}",
+        )
+        # The "none" token is normalized away; the real dependency is retained.
+        self.assertEqual(self.issue_b, result["Dependencies"])
+        state = issue_queue.loadQueue(self.workbook_path)
+        task = issue_queue.taskByName(state, result["Issue Name"])
+        self.assertEqual([self.issue_b], task.dependencies)
+
+    def test_propose_rejects_duplicate_issue_name_without_writing(self) -> None:
+        before = self.workbook_path.read_bytes()
+        with self.assertRaises(issue_queue.QueueError):
+            issue_queue.proposeTask(
+                self.workbook_path,
+                issueName=self.issue_a,
+                epicTitle="E",
+                storyTitle="S",
+                substoryTitle="SS",
+                priority="P1",
+                component="Combat",
+                targetFiles=["src/a.cpp"],
+            )
+        self.assertEqual(before, self.workbook_path.read_bytes())
+
+    def test_propose_rejects_unknown_dependency_transactionally(self) -> None:
+        before = self.workbook_path.read_bytes()
+        with self.assertRaises(issue_queue.QueueError):
+            issue_queue.proposeTask(
+                self.workbook_path,
+                issueName="[EPIC_02][STORY_09][SUBSTORY_09]Bad dependency",
+                epicTitle="E",
+                storyTitle="S",
+                substoryTitle="SS",
+                priority="P1",
+                component="Combat",
+                targetFiles=["src/a.cpp"],
+                dependencies="[EPIC_99][STORY_99][SUBSTORY_99]missing",
+            )
+        self.assertEqual(before, self.workbook_path.read_bytes())
+
+    def test_propose_rejects_bad_name_priority_and_missing_target(self) -> None:
+        common = {
+            "epicTitle": "E",
+            "storyTitle": "S",
+            "substoryTitle": "SS",
+            "component": "Combat",
+        }
+        with self.assertRaises(issue_queue.QueueError):
+            issue_queue.proposeTask(
+                self.workbook_path, issueName="not-a-pattern", priority="P1", targetFiles=["a.cpp"], **common
+            )
+        with self.assertRaises(issue_queue.QueueError):
+            issue_queue.proposeTask(
+                self.workbook_path,
+                issueName="[EPIC_02][STORY_02][SUBSTORY_01]Bad priority",
+                priority="HIGH",
+                targetFiles=["a.cpp"],
+                **common,
+            )
+        with self.assertRaises(issue_queue.QueueError):
+            issue_queue.proposeTask(
+                self.workbook_path,
+                issueName="[EPIC_02][STORY_02][SUBSTORY_02]No targets",
+                priority="P1",
+                targetFiles=[],
+                **common,
+            )
+
+    def test_propose_cli_appends_row(self) -> None:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = issue_queue.main(
+                [
+                    "propose",
+                    "--workbook",
+                    str(self.workbook_path),
+                    "--issue-name",
+                    "[EPIC_02][STORY_03][SUBSTORY_01]CLI proposed bug",
+                    "--epic-title",
+                    "Discovered Bugs",
+                    "--story-title",
+                    "Crashes",
+                    "--substory-title",
+                    "CLI proposed bug",
+                    "--priority",
+                    "P0",
+                    "--component",
+                    "Combat",
+                    "--target-file",
+                    "src/core/CGame.cpp",
+                ]
+            )
+        self.assertEqual(0, exit_code)
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["proposed"])
+        state = issue_queue.loadQueue(self.workbook_path)
+        errors, _ = issue_queue.validateQueueState(state)
+        self.assertEqual([], errors)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

This is the foundational piece of an autonomous bug-finder workflow: a way to file a discovered defect into the canonical issue workbook. `issue_queue.py` could claim and manage existing rows but had **no command to add one**, so a bug-finder had no safe path to record a new issue. A follow-up PR adds the `codex-bug-finder` prompt + goal that drives detection and calls this command.

## Changes

- **`scripts/issue_queue.py`**: new `propose` command (and `proposeTask` API) that appends a `NOT_STARTED` issue under the same `WorkbookLock` + atomic-save path as every other mutation. `Epic #`/`Story #`/`Substory #` are derived from the bracketed `Issue Name`.
  - **Transactional:** the row is written in-memory, then the queue is re-validated, and `atomicSave` runs **only if** the result still passes `validateQueueState` — a malformed proposal can never corrupt the backlog.
  - Rejects (without writing) a duplicate `Issue Name`, an unknown dependency, a non-conformant name, an invalid priority, and a missing target file; returns exit code 2 on rejection.
  - The `none`/empty dependency token normalizes to an empty cell, matching the existing no-dependency convention (the literal string `"None"` would otherwise be flagged as an unknown dependency).
- **`tests/test_issue_queue.py`**: 6 regressions — successful proposal (claimable afterwards), real-dependency recording + `none` normalization, duplicate rejection, transactional rejection of an unknown dependency (file byte-identical), input validation, and the CLI path.
- **`docs/codex-agent-queue.md`**: new "Proposing new issues" section.

## Evidence

- `python3 -m unittest tests.test_issue_queue` → 45 OK (+6)
- Focused baseline (issue_queue + controller_resource_audit + pr_review_audit + workflow_observations + poll_pr_checks + ci_change_classifier + coverage_report) → 185 OK
- Manual: proposing into a **copy** of the canonical workbook adds a valid claimable row and `validate` stays clean; 5 rejection cases (duplicate, bad name, bad priority, unknown dep, missing target) all leave the workbook byte-identical and exit 2. The canonical `planning/*.xlsx` is never touched by code or tests.

## Risks

Low. Purely additive — a new subparser and dispatch branch plus a new API function; no existing command, schema, or `validateQueueState` behavior is changed. The transactional save envelope protects the canonical backlog.

## Manual review items

None outstanding. Independently reviewed: confirmed the transactional guarantee (no path persists an invalid row or mutates disk on rejection), dependency normalization + validation, Issue-Name derivation consistency, faithful lock/save mirror of `claimTask`, real end-to-end tests, and edge cases (`maxRow` append, `setCell(None)` vs literal "None", numeric `Progress %`/`Attempt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016D8Ra7XE7j7cBsVqzKfbou)_