### PR TITLE
Diff ledger PR changes against the merge-base

### DIFF
--- a/scripts/workflow_observations.py
+++ b/scripts/workflow_observations.py
@@ -492,14 +492,47 @@ def gitPathForRoot(root: Path) -> str:
     return PurePosixPath(str(root)).as_posix()
 
 
+def resolveLedgerDiffBase(baseRef: str) -> str:
+    """Resolve the diff base to the merge-base of ``baseRef`` and ``HEAD``.
+
+    The ledger-mixing check must inspect only the pull request's own changes.
+    Diffing directly against ``baseRef`` is a two-dot diff against the current
+    base tip, so when the base branch advances past the branch point (for
+    example a concurrently merged ledger record from another controller) those
+    unrelated files are swept into the diff and a ledger-only PR is falsely
+    rejected. Diffing against the merge-base instead restricts the comparison to
+    the branch point. When ``baseRef`` already is the merge-base (for example
+    ``--base HEAD`` against a working tree) this is a no-op. Falls back to
+    ``baseRef`` when no merge-base can be computed.
+    """
+
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", baseRef, "HEAD"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise ObservationError("git executable not found on PATH; cannot inspect ledger diff") from exc
+    except OSError as exc:
+        raise ObservationError(f"could not execute git merge-base for ledger inspection: {exc}") from exc
+    mergeBase = result.stdout.strip()
+    if result.returncode == 0 and mergeBase:
+        return mergeBase
+    return baseRef
+
+
 def validatePrChanges(root: Path, baseRef: str) -> list[str]:
     if not baseRef or not baseRef.strip():
         return ["--base must be a non-empty git ref"]
 
     rootPath = gitPathForRoot(root)
+    diffBase = resolveLedgerDiffBase(baseRef)
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-status", "--no-renames", baseRef],
+            ["git", "diff", "--name-status", "--no-renames", diffBase],
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/tests/test_workflow_observations.py
+++ b/tests/test_workflow_observations.py
@@ -708,6 +708,54 @@ class WorkflowObservationsTest(unittest.TestCase):
         self.assertEqual(0, exitCode, stderr)
         self.assertEqual([], json.loads(stdout)["errors"])
 
+    def test_validate_base_ignores_files_merged_after_branch_point(self) -> None:
+        def rev_parse(repo: Path, ref: str) -> str:
+            return subprocess.run(
+                ["git", "rev-parse", ref], cwd=repo, check=True, stdout=subprocess.PIPE, text=True
+            ).stdout.strip()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir) / "repo"
+            repo.mkdir()
+            self.run_git(repo, ["init"])
+            self.run_git(repo, ["config", "user.email", "test@example.invalid"])
+            self.run_git(repo, ["config", "user.name", "Workflow Test"])
+            (repo / "scripts").mkdir()
+            (repo / "scripts" / "placeholder.py").write_text("print('base')\n", encoding="utf-8")
+            self.run_git(repo, ["add", "scripts/placeholder.py"])
+            self.run_git(repo, ["commit", "-m", "base"])
+            base_sha = rev_parse(repo, "HEAD")
+
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(repo)
+                # The PR branch adds a single ledger-only record.
+                self.run_git(repo, ["checkout", "-b", "pr"])
+                added = self.observation_payload("20260620T150300Z-ctrl-test-44444444")
+                self.write_record(Path("planning/workflow_observations"), added)
+                self.run_git(
+                    repo, ["add", f"planning/workflow_observations/records/{added['id']}.json"]
+                )
+                self.run_git(repo, ["commit", "-m", "ledger record"])
+
+                # The base branch advances with an unrelated file merged after the branch point.
+                self.run_git(repo, ["checkout", base_sha])
+                (repo / "scripts" / "other.py").write_text("print('concurrent')\n", encoding="utf-8")
+                self.run_git(repo, ["add", "scripts/other.py"])
+                self.run_git(repo, ["commit", "-m", "concurrent merge on base"])
+                advanced_base = rev_parse(repo, "HEAD")
+
+                self.run_git(repo, ["checkout", "pr"])
+                exitCode, stdout, stderr = self.run_cli(
+                    ["validate", "--root", "planning/workflow_observations", "--base", advanced_base]
+                )
+            finally:
+                os.chdir(old_cwd)
+
+        # The concurrently merged scripts/other.py must not be swept into the ledger diff.
+        self.assertEqual(0, exitCode, stderr)
+        self.assertEqual([], json.loads(stdout)["errors"])
+
     def test_workflow_ledger_operations_preserve_xlsx_bytes_and_queue_compatibility(self) -> None:
         workbook = REPO_ROOT / issue_queue.DEFAULT_WORKBOOK
         before = workbook.read_bytes()


### PR DESCRIPTION
## Root cause

The CI "Validate workflow observation ledger" step runs `python3 scripts/workflow_observations.py validate --base "${{ github.event.pull_request.base.sha }}"` (`build.yml:51`), and `validatePrChanges` diffed directly against that base ref with a **two-dot** `git diff --name-status --no-renames <baseRef>`. When the base branch advances past the branch point — another controller merges to `main` while the PR is open — the two-dot diff against the advanced base tip sweeps in those concurrently-merged files (they appear as deletions on the PR branch), so a ledger-only PR is falsely flagged `"… : ledger PR changes must not be mixed with non-ledger changes"` and the step exits 1 before the native build runs.

Source-backed by open observation PR #938: PR #920 (only real change `tests/unit/test_handler.cpp`) had its build runs fail the ledger step with 12 swept-in paths, including another controller's ledger record.

## Fix

Add `resolveLedgerDiffBase(baseRef)` which computes `git merge-base <baseRef> HEAD` and has `validatePrChanges` diff against that merge-base, restricting the comparison to the PR's own changes regardless of how far the base has advanced. When the base ref already **is** the merge-base (e.g. the existing `--base HEAD` against a staged working tree, or `build.yml`'s second invocation which passes its own computed merge-base), `merge-base` returns that same ref — a no-op, so existing behavior is preserved. It falls back to the raw base ref when no merge-base can be computed (unrelated histories / shallow clone), reusing the existing `FileNotFoundError`/`OSError` → `ObservationError` handling.

## Evidence

- `python3 -m unittest tests.test_workflow_observations` → 22 OK (+1)
- Focused baseline (issue_queue + controller_resource_audit + pr_review_audit + workflow_observations + poll_pr_checks + ci_change_classifier + coverage_report + prompt_inventory) → 193 OK
- Reproduced in a scratch repo: two-dot `git diff <advanced_base>` yields `A record.json` **+** `D scripts/other.py` (false sweep-in); merge-base diff yields only `A record.json`.
- New regression `test_validate_base_ignores_files_merged_after_branch_point` branches a ledger-only PR, advances the base with an unrelated file, and asserts `validate --base <advanced>` does not flag it — it **fails without the fix** (failures=1) and **passes with it**.

## Risks

Low. The ledger-mixing rule is unchanged — only the comparison base is corrected. `validatePrChanges` is reached only via the `validate --base` CLI path; the `record` path passes no base and is unaffected. The merge-base failure fallback preserves today's behavior exactly.

## Manual review items

None outstanding. Independently reviewed: merge-base semantics, the `--base HEAD` no-op, fallback/exception handling, no `record`-path impact, real fails-without/passes-with regression, and edge cases (detached HEAD, shallow clone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016D8Ra7XE7j7cBsVqzKfbou)_