### PR TITLE
[observation] ci_change_classifier over-classifies PRs as native when the base branch advances

### DIFF
--- a/planning/workflow_observations/records/20260630T115959Z-ctrl-vm-17796-c8464bae-2a044064.json
+++ b/planning/workflow_observations/records/20260630T115959Z-ctrl-vm-17796-c8464bae-2a044064.json
@@ -1,0 +1,27 @@
+{
+  "affectedPaths": [
+    ".github/workflows/build.yml",
+    "scripts/ci_change_classifier.py"
+  ],
+  "category": "ci",
+  "controllerId": "ctrl-vm-17796-c8464bae",
+  "createdAtUtc": "2026-06-30T11:59:59Z",
+  "details": "The build.yml 'classify changed paths' step passes --base \"${{ github.event.pull_request.base.sha }}\" --head \"${{ github.event.pull_request.head.sha }}\" to ci_change_classifier.py, whose changedPaths() runs a two-dot 'git diff --name-only <base> <head>'. When the base branch (main) advances past the PR branch point because other controllers merge concurrently, the two-dot diff sweeps in every file changed on main after the branch point. A lightweight Python-only PR then sees concurrently-merged C++/coverage paths as changed and is misclassified native-needed/coverage-needed, triggering unnecessary native + windows + coverage CI. This is the same root cause as the ledger-validation two-dot bug fixed in PR #943 (resolveLedgerDiffBase). NOTE: ci_change_classifier.py is being actively reworked by open PR #934 (held for human authority review), so this was not fixed inline to avoid overlapping that PR.",
+  "evidence": [
+    {
+      "command": "git diff --name-only <advanced_main_base> <pr_head> vs <base>...<pr_head>",
+      "reproduction": "two-dot diff returns scripts/tool.py + src/core/CGame.cpp (concurrently merged) -> nativeNeeded=true coverageNeeded=true; three-dot/merge-base returns only scripts/tool.py",
+      "result": "over-classified native+coverage"
+    }
+  ],
+  "fingerprint": "ci-change-classifier-two-dot-base-overclassification",
+  "id": "20260630T115959Z-ctrl-vm-17796-c8464bae-2a044064",
+  "impact": "Lightweight workflow PRs incur unnecessary heavy native/windows/coverage CI runs (wasted runner time and slower feedback) whenever main advances with native or coverage-relevant changes while the PR is open; the misclassification fails safe toward more validation, so it wastes resources rather than skipping required checks.",
+  "phase": "validation",
+  "role": "optimizer",
+  "schemaVersion": 1,
+  "severity": "medium",
+  "sourceCommit": "81dc19f97a9c0f0f2d488e154ac5e5443df1abe1",
+  "suggestedImprovement": "Compute the changed-path diff against the merge-base of base and head (three-dot 'git diff base...head' in changedPaths, or compute merge-base in the build.yml PR branch the way the push branch already does at lines 79-87), so only the PR's own changes drive classification. Defer until PR #934's classifier rework merges to avoid overlapping writers.",
+  "summary": "ci_change_classifier over-classifies PRs as native when the base branch advances"
+}


### PR DESCRIPTION
## Workflow observation (record-only)

Adds one append-only record under `planning/workflow_observations/records/`. No source, workbook, or workflow-code change.

- **ID:** `20260630T115959Z-ctrl-vm-17796-c8464bae-2a044064`
- **Category:** ci · **Severity:** medium · **Phase:** validation · **Role:** optimizer
- **Fingerprint:** `ci-change-classifier-two-dot-base-overclassification`

### Problem

`build.yml`'s "classify changed paths" step passes `--base "${{ github.event.pull_request.base.sha }}" --head "${{ github.event.pull_request.head.sha }}"` to `ci_change_classifier.py`, whose `changedPaths()` runs a **two-dot** `git diff --name-only <base> <head>`. When the base branch (`main`) advances past the PR branch point because other controllers merge concurrently, the two-dot diff sweeps in every file changed on `main` after the branch point. A lightweight Python-only PR then sees concurrently-merged C++/coverage paths as changed and is misclassified `native-needed`/`coverage-needed`, triggering unnecessary native + windows + coverage CI.

This is the **same root cause** as the ledger-validation two-dot bug fixed in PR #943 (`resolveLedgerDiffBase`).

### Evidence (reproduced)

In a scratch repo: branch a lightweight `scripts/tool.py` PR, then advance `main` with `src/core/CGame.cpp`. `git diff --name-only <advanced_base> <pr_head>` → `scripts/tool.py` **+** `src/core/CGame.cpp` → classifier reports `nativeNeeded=true, coverageNeeded=true`. The three-dot/merge-base diff `<base>...<pr_head>` → only `scripts/tool.py`.

### Impact

Lightweight workflow PRs incur unnecessary heavy native/windows/coverage CI (wasted runner time, slower feedback) whenever `main` advances with native/coverage-relevant changes while the PR is open. The misclassification fails safe toward *more* validation, so it wastes resources rather than skipping required checks.

### Suggested fix

Compute the changed-path diff against the merge-base of base and head — either three-dot `git diff <base>...<head>` inside `changedPaths`, or compute the merge-base in `build.yml`'s PR branch the way the push branch already does (lines 79-87). **Deferred** until open PR #934's `ci_change_classifier.py` rework merges, to avoid overlapping writers on the classifier machinery.

Append-only; unique record path; no existing record or receipt modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016D8Ra7XE7j7cBsVqzKfbou)_