### PR TITLE
Preserve source map across scene transitions (restore #804 regression, unblock main build)

### DIFF
--- a/src/core/CSceneManager.cpp
+++ b/src/core/CSceneManager.cpp
@@ -164,7 +164,12 @@ void CSceneManager::performMapChange(const std::shared_ptr<CGame> &game, const s
         std::shared_ptr<CMap> map = CMapLoader::loadNewMap(game, mapName);
         game->setMap(map);
         if (oldMap && game->getMap()) {
-            std::shared_ptr<CPlayer> player = oldMap->detachPlayer();
+            // Preserve the source map's object list across the transition so it remains a stable
+            // historical snapshot (see the *_preserves_source_map regressions): read the player
+            // without stripping it from the old map, and transfer active ownership to the
+            // destination via attachPlayer (which sets owningMap, controllers, and the canonical
+            // player on the new map). detachPlayer() remains available as an explicit API.
+            std::shared_ptr<CPlayer> player = oldMap->getPlayer();
             if (player) {
                 game->getMap()->attachPlayer(player);
             }

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -177,9 +177,10 @@ void test_scene_manager_state_duplicate_and_player_transfer() {
     expect_true(new_map->getTurn() == 17, "scene transition should preserve the old map turn");
     expect_true(new_map->getPlayer() == player, "scene transition should transfer the same player object");
     expect_true(player->getCoords() == new_map->getEntry(), "transferred player should land at the target map entry");
-    expect_true(old_map->getObjectByName("player") == nullptr,
-                "scene transition should detach the transferred player from the old map");
-    expect_true(count_players_on_map(old_map) == 0, "old map should not retain a stale player object after transfer");
+    expect_true(old_map->getObjectByName("player") == player,
+                "scene transition should preserve the source map's player object for snapshot stability");
+    expect_true(count_players_on_map(old_map) == 1, "source map should retain its player object after the transition");
+    expect_true(player->getMap() == new_map, "transferred player's owning map should be the destination");
     expect_true(count_players_on_map(new_map) == 1, "new map should contain exactly one player after transfer");
     expect_true(manager->getTransitionState() == CSceneManager::TransitionState::Idle,
                 "scene manager should return to idle after transition completion");


### PR DESCRIPTION
Closing as redundant — the scene-manager source-map regression this fixed was independently resolved on `main` by #945 ("Fix two main-build gameplay regressions … unblocks main", commit `76f0e078`) and refined by #966. Same root cause and the `*_preserves_source_map` invariant is restored on `main`; no need for this duplicate. Superseded.