### PR TITLE
Approve creature action precedence and dedupe by typeId (E01/S04/SS02)

### DIFF
--- a/docs/design/creature_archetypes.md
+++ b/docs/design/creature_archetypes.md
@@ -277,3 +277,63 @@ authoring. The id itself is policy-valid; only the lore label is pending.
   untracked/uncopied resource.
 - Classes (roles) and races (species) are independent axes. A future template
   may carry both a race family id and a `creatureClass` id.
+
+---
+
+# Creature action merge contract
+
+Status: Approved (design + engine). Scope: pins the order in which a creature's
+actions are composed from its archetype sources and how duplicate actions are
+deduplicated, so the upcoming race/class archetype authoring (EPIC_02) and the
+existing concrete monster templates compose a single, stable action set instead
+of accumulating duplicates.
+
+## Precedence order
+
+A creature's available actions are composed by merging, in this order, from
+least specific to most specific:
+
+1. **Race innate actions** — actions every member of the race always has.
+2. **Class starting actions** — actions granted by the creature's class at
+   creation.
+3. **Class level unlocks** — actions unlocked as the creature gains levels
+   (today expressed by the `levelling` map, applied via `levelUp`).
+4. **Concrete-template actions** — actions declared on the concrete template /
+   spawn (the most specific source).
+
+Sources are applied in that sequence, so a later (more specific) source is the
+"winner" when two sources contribute the same action.
+
+## Deduplication key (last/most-specific wins)
+
+Actions are deduplicated by configured identity:
+
+- the dedupe key is the action **`typeId`**;
+- when `typeId` is empty, it falls back to the action **`name`**.
+
+When a later source contributes an action whose key matches one already present,
+the earlier action is replaced by the later one (last/most-specific wins). The
+relative order of unrelated, surviving actions is otherwise preserved
+(stable merge). Consequences:
+
+- duplicate generic actions (e.g. two `Attack` definitions arriving from a race
+  source and again from a concrete template, common after archetype migration)
+  collapse to a **single** `Attack` entry rather than accumulating;
+- a unique concrete override (an action a more specific source defines that no
+  earlier source provided) is **preserved**;
+- an action redefined by a more specific source replaces the earlier definition
+  rather than coexisting with it.
+
+This key matches the engine's existing configured-identity semantics
+(`CGameObject::sameConfiguredType` / `name_comparator`, which prefer a matching
+`typeId` and fall back to type/name only when `typeId` is empty).
+
+## Where this is enforced and tested
+
+The merge primitive every source funnels through is
+`CCreature::addAction` (`src/object/CCreature.cpp`): `setActions` composes the
+set by calling `addAction` per entry, and level unlocks call it via `levelUp`.
+`addAction` deduplicates by the key above and keeps the last-added (more
+specific) action. This contract is pinned by the native regression test
+`test_creature_action_merge_dedupes_by_type_id` in
+`tests/unit/test_object.cpp`.

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -297,6 +297,30 @@ void CCreature::addAction(std::shared_ptr<CInteraction> action) {
     if (!action) {
         return;
     }
+    // Action merge contract (docs/design/creature_archetypes.md, "Creature action
+    // merge contract"): actions are composed in precedence order and deduplicated by
+    // configured identity. The identity key is the action `typeId`, falling back to
+    // `name` only when `typeId` is empty. A later (more specific) source overrides an
+    // earlier one, so duplicate actions (e.g. a second `Attack`) collapse to a single
+    // entry and do not accumulate, while unique concrete overrides are preserved.
+    auto sameAction = [&action](const std::shared_ptr<CInteraction> &candidate) {
+        if (!candidate) {
+            return false;
+        }
+        const std::string &candidateTypeId = candidate->getTypeId();
+        const std::string &actionTypeId = action->getTypeId();
+        if (!candidateTypeId.empty() || !actionTypeId.empty()) {
+            return candidateTypeId == actionTypeId;
+        }
+        return candidate->getName() == action->getName();
+    };
+    auto existing = std::find_if(actions.begin(), actions.end(), sameAction);
+    if (existing != actions.end()) {
+        if (CGameObject::sameInstance(*existing, action)) {
+            return;
+        }
+        actions.erase(existing);
+    }
     actions.insert(action);
     signal("interactionsChanged");
 }

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -26,6 +26,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CDialog.h"
 #include "object/CEffect.h"
 #include "object/CGameObject.h"
+#include "object/CInteraction.h"
 #include "object/CItem.h"
 #include "object/CMapObject.h"
 #include "object/CMarket.h"
@@ -653,6 +654,81 @@ void test_creature_archetype_identity_accessors_use_fallbacks() {
                 "archetype class label should fall back through archetype class id to name when nothing else is set");
 }
 
+void test_creature_action_merge_dedupes_by_type_id() {
+    // Pins the approved creature action merge contract
+    // (docs/design/creature_archetypes.md, "Creature action merge contract"):
+    // actions are composed in precedence order (race innate -> class starting ->
+    // class level unlocks -> concrete template) and deduplicated by `typeId`
+    // (falling back to `name` only when `typeId` is empty), last/most-specific wins.
+    auto creature = std::make_shared<CCreature>();
+
+    auto interaction = [](const std::string &typeId, const std::string &name) {
+        auto action = std::make_shared<CInteraction>();
+        action->setType("CInteraction");
+        action->setTypeId(typeId);
+        action->setName(name);
+        return action;
+    };
+
+    // (1) race innate: a generic Attack and a race-only ability.
+    auto raceAttack = interaction("Attack", "raceAttack");
+    auto raceClaw = interaction("Claw", "raceClaw");
+    // (2) class starting: a duplicate Attack (same typeId, different instance/name).
+    auto classAttack = interaction("Attack", "classAttack");
+    // (3) class level unlock: a unique unlock.
+    auto levelStrike = interaction("Strike", "levelStrike");
+    // (4) concrete template: the most specific Attack override plus a unique action.
+    auto concreteAttack = interaction("Attack", "concreteAttack");
+    auto concreteFinisher = interaction("Finisher", "concreteFinisher");
+
+    creature->addAction(raceAttack);
+    creature->addAction(raceClaw);
+    creature->addAction(classAttack);
+    creature->addAction(levelStrike);
+    creature->addAction(concreteAttack);
+    creature->addAction(concreteFinisher);
+
+    const auto actions = creature->getActions();
+
+    auto withTypeId = [&actions](const std::string &typeId) {
+        std::vector<std::shared_ptr<CInteraction>> matches;
+        for (const auto &action : actions) {
+            if (action && action->getTypeId() == typeId) {
+                matches.push_back(action);
+            }
+        }
+        return matches;
+    };
+
+    expect_true(withTypeId("Attack").size() == 1,
+                "duplicate Attack actions from race/class/concrete sources should collapse to a single entry");
+    expect_true(!withTypeId("Attack").empty() && withTypeId("Attack").front() == concreteAttack,
+                "the last/most-specific source should win for a deduplicated action typeId");
+    expect_true(actions.contains(raceClaw) && actions.contains(levelStrike) && actions.contains(concreteFinisher),
+                "unique actions from each source should be preserved through the merge");
+    expect_true(!actions.contains(raceAttack) && !actions.contains(classAttack),
+                "earlier Attack definitions should be replaced by the more specific source");
+    expect_true(actions.size() == 4, "the merged action set should keep one Attack plus the three unique actions");
+
+    // Re-adding the exact same instance is idempotent and does not duplicate.
+    creature->addAction(concreteAttack);
+    expect_true(creature->getActions().size() == 4, "re-adding the same action instance should be idempotent");
+
+    // typeId-empty actions fall back to name for dedupe.
+    auto namedCreature = std::make_shared<CCreature>();
+    auto firstWander = interaction("", "Wander");
+    auto secondWander = interaction("", "Wander");
+    auto patrol = interaction("", "Patrol");
+    namedCreature->addAction(firstWander);
+    namedCreature->addAction(secondWander);
+    namedCreature->addAction(patrol);
+    const auto namedActions = namedCreature->getActions();
+    expect_true(namedActions.size() == 2,
+                "actions without a typeId should deduplicate by name (last wins) and keep distinct names");
+    expect_true(namedActions.contains(secondWander) && !namedActions.contains(firstWander),
+                "the later name-keyed action should replace the earlier one when typeId is empty");
+}
+
 void test_game_object_comparator_and_identity_sets_document_current_semantics() {
     std::shared_ptr<CGameObject> null_object;
     auto object = std::make_shared<CGameObject>();
@@ -890,6 +966,7 @@ int main() {
     test_animation_property_events_invalidate_cached_graphics_object();
     test_creature_inventory_equipment_and_ratio_helpers();
     test_creature_archetype_identity_accessors_use_fallbacks();
+    test_creature_action_merge_dedupes_by_type_id();
     test_game_object_comparator_and_identity_sets_document_current_semantics();
     test_game_object_named_comparison_helpers_cover_explicit_semantics();
 


### PR DESCRIPTION
## Issue
`[EPIC_01][STORY_04][SUBSTORY_02]Approve action precedence and dedupe` (claim `89f59ce4…`, owner `controller/ctrl-vm-4026-9b5a29b5/subagent-7`).

## What changed
Enforces the approved **action merge contract** at the real aggregation choke point `CCreature::addAction` (the single method all sources — `setActions`, `levelUp` level unlocks, concrete actions — funnel through):
- Dedupe by action `typeId` (fallback `name` only when `typeId` empty), reusing the codebase's configured-identity semantics.
- Later/more-specific source wins, so duplicate generic actions (e.g. a second `Attack` after archetype migration) collapse to one entry; unique concrete overrides preserved; re-adding the same instance is idempotent.
- Documents the precedence (race innate → class starting → class level unlocks → concrete) + dedupe contract in `docs/design/creature_archetypes.md`.

The four named archetype sources are EPIC_02 work not yet implemented; enforcing dedupe at `addAction` makes the contract hold regardless of which sources feed it (no fabricated race/class objects).

## Files changed
`src/object/CCreature.cpp`, `docs/design/creature_archetypes.md`, `tests/unit/test_object.cpp` (new `test_creature_action_merge_dedupes_by_type_id`).

## Validation
`clang-format -i` applied; `git diff --check` clean; no `planning/` files. Native `object_unit_tests` + full suite via GitHub Actions on the (now-green) `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_