### PR TITLE
Make CPlayerFightController::end() idempotent and stale-safe (E01/S03/SS03)

### DIFF
--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -733,15 +733,19 @@ bool CPlayerFightController::control(std::shared_ptr<CCreature> me, std::shared_
 }
 
 void CPlayerFightController::end(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent) {
-    if (!me || !me->getMap() || !me->getMap()->getGame()) {
+    // Idempotent teardown: an already-closed/absent panel is a clean no-op.
+    auto panel = fightPanel;
+    fightPanel = nullptr;
+    if (!panel) {
         return;
     }
-    vstd::if_not_null(me->getMap()->getGame()->getGui(), [&](auto gui) {
-        if (fightPanel) {
-            fightPanel->close();
-            fightPanel = nullptr;
-        }
-    });
+    // close() detaches the panel from CGui through its own parent chain (getTopParent),
+    // not through me/opponent/map, so it stays safe when the player is gone, the map
+    // object was removed, the GUI was destroyed, or the active map has advanced past the
+    // encounter (the same staleness hasCancelledContext()/the deferred guards tolerate).
+    // Clearing fightPanel before this call keeps the member null on every path, including
+    // if close() throws.
+    panel->close();
 }
 
 bool CPlayerFightController::isCancelled(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent) {

--- a/tests/unit/test_controller.cpp
+++ b/tests/unit/test_controller.cpp
@@ -536,6 +536,74 @@ void test_player_fight_controller_start_is_idempotent_and_guards_invalid_encount
                 "fight controller should refuse to start without a GUI");
 }
 
+void test_player_fight_controller_end_is_idempotent_and_guards_invalid_encounters() {
+    auto gui = std::make_shared<CGui>();
+    auto game = fight_panel_game(gui);
+    auto map = game->getMap();
+
+    auto attacker = map_creature(game, "unitEndAttacker", Coords(0, 0, 0));
+    auto opponent = map_creature(game, "unitEndOpponent", Coords(1, 0, 0));
+
+    auto controller = std::make_shared<CPlayerFightController>();
+    attacker->setFightController(controller);
+
+    controller->start(attacker, opponent);
+    expect_true(count_fight_panels(gui) == 1, "starting a fight should add exactly one fight panel to the GUI");
+
+    controller->end(attacker, opponent);
+    expect_true(count_fight_panels(gui) == 0, "ending a fight should remove the fight panel from the GUI");
+
+    // A second end() must be a clean no-op: no panel remains and nothing crashes.
+    controller->end(attacker, opponent);
+    expect_true(count_fight_panels(gui) == 0, "ending a fight twice should leave no panel under the GUI");
+
+    // end() before any start() (no panel) is a no-op.
+    auto freshController = std::make_shared<CPlayerFightController>();
+    freshController->end(attacker, opponent);
+    expect_true(count_fight_panels(gui) == 0, "ending without a started fight should be a no-op");
+
+    // end() must clear the panel even when the player is missing.
+    controller->start(attacker, opponent);
+    expect_true(count_fight_panels(gui) == 1, "restarting a fight should re-add the panel");
+    controller->end(nullptr, opponent);
+    expect_true(count_fight_panels(gui) == 0,
+                "ending with a missing player should still remove the panel from the GUI");
+    controller->end(nullptr, opponent);
+    expect_true(count_fight_panels(gui) == 0, "ending twice with a missing player should leave no panel");
+
+    // end() must clear the panel even after the player's map object was removed.
+    controller->start(attacker, opponent);
+    expect_true(count_fight_panels(gui) == 1, "restarting a fight should re-add the panel");
+    map->removeObject(attacker);
+    controller->end(attacker, opponent);
+    expect_true(count_fight_panels(gui) == 0,
+                "ending after the player object was removed from the map should still remove the panel");
+    map->addObject(attacker);
+
+    // end() must clear the panel even when the active game map has advanced past the encounter.
+    controller->start(attacker, opponent);
+    expect_true(count_fight_panels(gui) == 1, "restarting a fight should re-add the panel");
+    auto pendingMap = std::make_shared<CMap>();
+    pendingMap->setGame(game);
+    game->setMap(pendingMap);
+    controller->end(attacker, opponent);
+    expect_true(count_fight_panels(gui) == 0,
+                "ending after the active map advanced past the encounter should still remove the panel");
+    game->setMap(map);
+
+    // end() must not crash when the GUI/game backing the controller is gone.
+    auto guiless = std::make_shared<CGame>();
+    auto guiless_map = std::make_shared<CMap>();
+    guiless->setMap(guiless_map);
+    guiless_map->setGame(guiless);
+    auto guiless_attacker = map_creature(guiless, "unitEndNoGuiAttacker", Coords(0, 0, 0));
+    auto guiless_opponent = map_creature(guiless, "unitEndNoGuiOpponent", Coords(1, 0, 0));
+    auto guiless_controller = std::make_shared<CPlayerFightController>();
+    guiless_controller->start(guiless_attacker, guiless_opponent);
+    guiless_controller->end(guiless_attacker, guiless_opponent);
+    guiless_controller->end(guiless_attacker, guiless_opponent);
+}
+
 void test_monster_fight_controller_uses_mana_item_when_mana_is_low() {
     auto game = std::make_shared<CGame>();
     auto map = std::make_shared<CMap>();
@@ -579,6 +647,7 @@ int main() {
     test_target_controller_flow_field_invalidates_when_cross_level_edge_is_added();
     test_fight_controller_guard_paths_and_fallbacks();
     test_player_fight_controller_start_is_idempotent_and_guards_invalid_encounters();
+    test_player_fight_controller_end_is_idempotent_and_guards_invalid_encounters();
     test_monster_fight_controller_uses_mana_item_when_mana_is_low();
 
     return finish_tests();


### PR DESCRIPTION
## Issue
`[EPIC_01][STORY_03][SUBSTORY_03]Make fight-panel end idempotent` (claim `fd232afd…`, owner `controller/ctrl-vm-4026-9b5a29b5/subagent-12`). Follows the merged `start()`-idempotent work (#919).

## Root cause
`CPlayerFightController::end()` cleared `fightPanel` only **inside** an `if_not_null(getGui())` block reached via `me->getMap()->getGame()->getGui()`. On the early return (missing player / removed-or-detached map object / destroyed game) or when the GUI was already null, `fightPanel` was left non-null and still attached to the GUI tree — `end()` was not idempotent, and the `me->getMap()->...` chain risked a stale-map deref.

## Fix (`end()` only)
Snapshot the panel, set the member to `nullptr` first, no-op when absent, then `panel->close()`. `close()` detaches via the panel's own CGui parent chain (`getTopParent`), never through `me`/opponent/map, so it's safe regardless of player/map/GUI state; the member stays null on every path including if `close()` throws. Staleness authority (`hasCancelledContext` / deferred-callback generation guards) is unchanged.

## Files changed
`src/core/CController.cpp`, `tests/unit/test_controller.cpp` (new `test_player_fight_controller_end_is_idempotent_and_guards_invalid_encounters`).

## Validation
`clang-format -i` applied; `git diff --check` clean; no `planning/` files. Native `controller_unit_tests` + full suite via GitHub Actions on green `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_