### PR TITLE
Separate dynamic property notifications from typed engine signals (#671)

### DIFF
--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -671,7 +671,7 @@ void CListView::disconnectRefreshSubscriptions() {
     }
     if (!subscribedRefreshOnPropertyChanged) {
         for (const auto &propertyName : subscribedRefreshProperties) {
-            if (!propertyName.empty()) {
+            if (!propertyName.empty() && !isCollidingRefreshProperty(propertyName)) {
                 refreshTarget->disconnect(propertyName + "Changed", self, "refreshFromPropertySpecificChanged");
             }
         }
@@ -695,11 +695,26 @@ void CListView::connectRefreshSubscriptions(const std::shared_ptr<CGameObject> &
     }
     if (!refreshOnPropertyChanged) {
         for (const auto &propertyName : refreshProperties) {
-            if (!propertyName.empty()) {
-                refreshTarget->connect(propertyName + "Changed", self, "refreshFromPropertySpecificChanged");
+            if (propertyName.empty()) {
+                continue;
             }
+            // Fail closed: a configured property whose "<name>Changed" channel collides
+            // with a typed engine signal must NOT be wired through the property-specific
+            // reflective dispatch, otherwise a benign list refresh config would subscribe
+            // to (and could spoof / be spoofed by) a typed engine event. Skip + log; valid
+            // configured properties still subscribe and refresh normally.
+            if (isCollidingRefreshProperty(propertyName)) {
+                vstd::logger::warning("Ignoring list refreshProperty colliding with typed engine signal:",
+                                      propertyName + "Changed");
+                continue;
+            }
+            refreshTarget->connect(propertyName + "Changed", self, "refreshFromPropertySpecificChanged");
         }
     }
+}
+
+bool CListView::isCollidingRefreshProperty(const std::string &propertyName) {
+    return CGameObject::isReservedTypedSignalName(propertyName + "Changed");
 }
 
 void CListView::refreshFromSubscription() {
@@ -727,7 +742,13 @@ void CListView::refreshFromSubscription() {
 }
 
 bool CListView::shouldRefreshForProperty(const std::string &propertyName) const {
-    return refreshOnPropertyChanged || refreshProperties.contains(propertyName);
+    if (refreshOnPropertyChanged) {
+        return true;
+    }
+    // A configured property that collides with a typed engine signal name is rejected
+    // fail-closed (it is never subscribed); do not let it drive a refresh via the
+    // generic propertiesChanged path either.
+    return refreshProperties.contains(propertyName) && !isCollidingRefreshProperty(propertyName);
 }
 
 int CListView::getXPrefferedSize() const { return xPrefferedSize; }

--- a/src/gui/panel/CListView.h
+++ b/src/gui/panel/CListView.h
@@ -296,4 +296,8 @@ class CListView : public CProxyTargetGraphicsObject {
     void refreshFromSubscription();
 
     bool shouldRefreshForProperty(const std::string &propertyName) const;
+
+    // True when a configured refreshProperty's derived "<name>Changed" channel collides
+    // with a reserved typed engine signal name (must be rejected fail-closed).
+    static bool isCollidingRefreshProperty(const std::string &propertyName);
 };

--- a/src/object/CGameObject.cpp
+++ b/src/object/CGameObject.cpp
@@ -136,6 +136,24 @@ bool equivalentValueInternal(const std::shared_ptr<CGameObject> &a, const std::s
 
 } // namespace
 
+bool CGameObject::isReservedTypedSignalName(const std::string &signalName) {
+    // Engine-owned signal names emitted directly via signal(...) with a hardcoded
+    // string. A dynamic property whose "<name>Changed" derived signal would equal
+    // one of these must NOT be dispatched on the typed channel, otherwise a
+    // config/runtime property named e.g. "inventory"/"equipped"/"items" could fire
+    // a typed engine slot (mismatched reflective dispatch / spoofed engine event).
+    static const std::set<std::string> reserved = {// CGameObject property-notification channel
+                                                   "propertyChanged", "propertiesChanged",
+                                                   // CCreature typed signals
+                                                   "inventoryChanged", "equippedChanged", "effectsChanged",
+                                                   "interactionsChanged",
+                                                   // CMarket typed signal
+                                                   "itemsChanged",
+                                                   // CMap typed signals
+                                                   "tileChanged", "objectChanged", "turnPassed"};
+    return reserved.contains(signalName);
+}
+
 std::function<bool(std::shared_ptr<CGameObject>, std::shared_ptr<CGameObject>)> CGameObject::name_comparator =
     [](std::shared_ptr<CGameObject> a, std::shared_ptr<CGameObject> b) {
         return CGameObject::sameConfiguredType(a, b);
@@ -339,8 +357,21 @@ void CGameObject::notifyPropertyChanged(const std::string &name) {
 }
 
 void CGameObject::notifyPropertyChangedWithoutInvalidation(const std::string &name) {
+    // Generic notification: always safe, this is the dynamic property channel that
+    // GUI/refresh subscribers (propertyChanged / propertySpecific) rely on.
     signal("propertyChanged", name);
-    signal(name + "Changed");
+    // Per-property typed-style notification lives in the SAME flat string channel as
+    // the engine's typed signals. Keep dynamic property notifications namespaced away
+    // from typed engine signal names: if "<name>Changed" collides with a reserved
+    // typed signal, fail closed (drop it + log) so a dynamic/runtime property cannot
+    // spoof a typed engine event or hit a typed slot with a mismatched signature.
+    const std::string perPropertySignal = name + "Changed";
+    if (isReservedTypedSignalName(perPropertySignal)) {
+        vstd::logger::warning("Ignoring dynamic property notification colliding with typed engine signal:",
+                              perPropertySignal);
+        return;
+    }
+    signal(perPropertySignal);
 }
 
 void CGameObject::notifyPropertiesChanged(const std::set<std::string> &names) {

--- a/src/object/CGameObject.h
+++ b/src/object/CGameObject.h
@@ -48,6 +48,15 @@ class CGameObject : public vstd::stringable, public std::enable_shared_from_this
   public:
     static std::function<bool(std::shared_ptr<CGameObject>, std::shared_ptr<CGameObject>)> name_comparator;
 
+    // Typed engine signals share the same flat string channel as the dynamic
+    // per-property "<name>Changed" notifications emitted from setProperty. To stop
+    // an arbitrary (config/runtime) property from spoofing a typed engine event,
+    // a dynamic property notification whose derived signal name lands in this
+    // reserved set is dropped fail-closed (the generic propertyChanged channel
+    // still fires). The set lists every name emitted directly via signal(...) with
+    // a hardcoded engine name across the codebase.
+    static bool isReservedTypedSignalName(const std::string &signalName);
+
     static bool sameInstance(const std::shared_ptr<CGameObject> &a, const std::shared_ptr<CGameObject> &b);
 
     static bool sameRuntimeIdentity(const std::shared_ptr<CGameObject> &a, const std::shared_ptr<CGameObject> &b);

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -676,6 +676,48 @@ void test_list_view_property_subscriptions_follow_resolved_target_and_null() {
                 "previous refresh target should be disconnected when the refresh script resolves to null");
 }
 
+void test_list_view_refresh_property_collision_fails_closed() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto game = create_gui_game(gui);
+    auto refresh_target = std::make_shared<CGameObject>();
+    auto list = std::make_shared<RefreshCountingListView>();
+    gui->pushChild(list);
+    list->setResolvedRefreshTarget(refresh_target);
+
+    // "inventory" derives the "inventoryChanged" channel, which collides with the
+    // typed engine signal CCreature emits. Configuring it as a refreshProperty must
+    // fail closed: the list must NOT wire a property-specific reflective subscription
+    // on the typed channel (no spoofing in either direction) while a valid configured
+    // property ("label") still refreshes normally.
+    list->setRefreshProperties({"inventory", "label"});
+
+    list->refresh();
+    const int after_initial_refresh = list->refresh_count;
+
+    // A direct typed-engine emission on the colliding channel must NOT refresh the list
+    // (the colliding property was never subscribed) and must not crash.
+    refresh_target->signal("inventoryChanged");
+    drain_event_loop();
+    expect_true(list->refresh_count == after_initial_refresh,
+                "a refreshProperty colliding with a typed engine signal must not be subscribed (fail closed)");
+
+    // A dynamic property literally named "inventory" must not refresh the list either:
+    // its per-property notification is dropped fail-closed and the name is rejected.
+    refresh_target->setStringProperty("inventory", "spoofed");
+    drain_event_loop();
+    expect_true(list->refresh_count == after_initial_refresh,
+                "a colliding dynamic property change must not drive a fail-closed refreshProperty");
+
+    // The valid configured property still refreshes.
+    refresh_target->setStringProperty("label", "ok");
+    drain_event_loop();
+    expect_true(list->refresh_count == after_initial_refresh + 1,
+                "a non-colliding configured refreshProperty must still refresh the list");
+}
+
 std::shared_ptr<CStats> player_stats() {
     auto stats = std::make_shared<CStats>();
     stats->setMainStat("stamina");
@@ -1345,6 +1387,7 @@ int main() {
     test_list_view_skips_queued_property_refresh_after_detach();
     test_list_view_refresh_event_compatibility();
     test_list_view_property_subscriptions_follow_resolved_target_and_null();
+    test_list_view_refresh_property_collision_fails_closed();
     test_inventory_double_select_uses_selected_item_and_clears_selection();
     test_fight_panel_enemy_selection_uses_exact_instance();
     test_gui_window_is_resizable_and_guard_paths_fail_closed();

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -1010,6 +1010,66 @@ void test_game_object_named_comparison_helpers_cover_explicit_semantics() {
                 "equivalentValue should reject unsupported cyclic object-reference graphs safely");
 }
 
+class TypedSignalProbe : public CGameObject {
+    V_META(TypedSignalProbe, CGameObject, V_METHOD(TypedSignalProbe, onPropertyChanged, void, std::string),
+           V_METHOD(TypedSignalProbe, onInventoryChanged))
+
+  public:
+    void onPropertyChanged(std::string property_name) { changedProperties.insert(std::move(property_name)); }
+
+    void onInventoryChanged() { ++inventoryChangedCalls; }
+
+    std::set<std::string> changedProperties;
+    int inventoryChangedCalls = 0;
+};
+
+void test_dynamic_property_cannot_spoof_typed_engine_signal() {
+    CTypes::register_type_metadata<TypedSignalProbe, CGameObject>();
+
+    auto object = std::make_shared<CGameObject>();
+    auto probe = std::make_shared<TypedSignalProbe>();
+
+    // A subscriber to the typed engine signal "inventoryChanged" (as CCreature emits
+    // it). A dynamic/runtime property literally named "inventory" derives the same
+    // "inventoryChanged" channel name in notifyPropertyChanged -> must be dropped fail
+    // closed so the dynamic property cannot fire (spoof) the typed engine slot.
+    object->connect("inventoryChanged", probe, "onInventoryChanged");
+    object->connect("propertyChanged", probe, "onPropertyChanged");
+
+    object->setStringProperty("inventory", "spoofed");
+    drain_event_loop();
+
+    expect_true(probe->inventoryChangedCalls == 0,
+                "a dynamic property named like a typed engine signal must not fire the typed signal's slot");
+    expect_true(probe->changedProperties.contains("inventory"),
+                "the generic propertyChanged channel must still report the dynamic property change");
+
+    // A non-colliding dynamic property still reaches its per-property "<name>Changed"
+    // subscriber (the namespace guard only suppresses reserved typed-signal names).
+    auto specific_probe = std::make_shared<TypedSignalProbe>();
+    object->connect("threatChanged", specific_probe, "onInventoryChanged");
+    object->setNumericProperty("threat", 1);
+    drain_event_loop();
+    expect_true(specific_probe->inventoryChangedCalls == 1,
+                "a non-colliding dynamic property must still fire its per-property notification slot");
+}
+
+void test_typed_engine_signal_still_fires_directly() {
+    CTypes::register_type_metadata<TypedSignalProbe, CGameObject>();
+    auto creature = std::make_shared<CCreature>();
+    auto probe = std::make_shared<TypedSignalProbe>();
+
+    // The real typed engine signal (emitted directly via signal("inventoryChanged"))
+    // must still reach its slot; the reserved-name guard only blocks the dynamic
+    // property channel, never direct typed emission.
+    creature->connect("inventoryChanged", probe, "onInventoryChanged");
+    creature->addItem(std::make_shared<CItem>());
+    drain_event_loop();
+
+    expect_true(probe->inventoryChangedCalls >= 1,
+                "directly emitted typed engine signals must still reach their slots");
+}
+
 void test_signal_slots_fail_closed_on_bad_config() {
     CTypes::register_type_metadata<PropertyChangeProbe, CGameObject>();
 
@@ -1039,6 +1099,8 @@ void test_signal_slots_fail_closed_on_bad_config() {
 
 int main() {
     test_signal_slots_fail_closed_on_bad_config();
+    test_dynamic_property_cannot_spoof_typed_engine_signal();
+    test_typed_engine_signal_still_fires_directly();
     test_tooltip_handler_builds_labels_descriptions_and_item_bonuses();
     test_market_guard_paths_and_item_transfers();
     test_market_prices_are_bounded_and_non_exploitable();


### PR DESCRIPTION
## Issue
`[EPIC_05][STORY_01][SUBSTORY_02] #671 Separate dynamic property notifications from typed engine signals` (claim `2829d4f9…`, owner `controller/ctrl-vm-4026-9b5a29b5/subagent-11`). Builds on the merged #678.

## Root cause (collision vector)
Dynamic property notifications and typed engine signals share one flat string namespace via `CGameObject::signal<>(std::string, …)`. `notifyPropertyChangedWithoutInvalidation` emitted `signal(name + "Changed")` for **any** property, so a config/runtime property literally named `inventory`/`equipped`/`items`/`tile`/… derived a channel (`inventoryChanged`, …) identical to a typed engine signal (`CCreature`/`CMap`/`CMarket`), letting a benign property write spoof a typed engine event. `CListView::refreshProperties` had the parallel vector (`connect(propertyName + "Changed", …)`).

## Fix (fail closed, no namespace refactor)
- `CGameObject::isReservedTypedSignalName` — registry of the engine's hardcoded `signal("…")` names (the 10 found by grep).
- `notifyPropertyChangedWithoutInvalidation`: keep the generic `signal("propertyChanged", name)`; **drop + log** the per-property `<name>Changed` emission when it collides with a reserved typed name.
- `CListView`: `connectRefreshSubscriptions`/`disconnectRefreshSubscriptions`/`shouldRefreshForProperty` skip+log colliding `refreshProperties` names.
- The legitimate typed `refreshEvent` subscription path (used by bundled `panels.json`) is unchanged, so valid list refresh still works — no compat alias needed.

## Files changed
`src/object/CGameObject.{h,cpp}`, `src/gui/panel/CListView.{h,cpp}`, `tests/unit/test_object.cpp`, `tests/unit/test_gui.cpp` (3 regressions: dynamic property cannot spoof typed signal; typed signal still fires directly; refreshProperty collision fails closed while valid property refreshes).

## Validation
`clang-format -i` applied; `git diff --check` clean; no `planning/` files. Native gui/object regressions + full gameplay suite via GitHub Actions on green `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_