### PR TITLE
Classify player vs monster templates via metadata inheritance

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -123,6 +123,17 @@ CREATURE_ARCHETYPE_ID_SUFFIXES = {
 # CCreature template spells "stats" as the baseStats/levelStats pair and "labels"
 # as the singular "label" key, so both spellings are watched here.
 CREATURE_BASE_CLASS = "CCreature"
+# Player vs monster classification (EPIC_01/STORY_01/SUBSTORY_04).
+# CPlayer derives from CCreature in engine metadata (src/object/CPlayer.h:
+# V_META(CPlayer, CCreature, ...)), so getAllSubTypes("CCreature") -- used by
+# CRngHandler to build the random-encounter creature table -- enumerates player
+# templates alongside true monsters.  Classification below is derived purely from
+# that metadata inheritance lineage (never from template-id name strings): a
+# template is a player when its resolved class inherits CPlayer, and a monster
+# when it inherits CCreature but not CPlayer.  The player templates that leak into
+# the CCreature enumeration are flagged so random-encounter code can explicitly
+# exclude them.
+PLAYER_BASE_CLASS = "CPlayer"
 CREATURE_OVERRIDE_PROPERTIES = (
     "baseStats",
     "levelStats",
@@ -177,6 +188,28 @@ class CreatureOverride:
 
     def __str__(self) -> str:
         return f"{self.path}: {self.location}: ref \"{self.template}\" overrides {', '.join(self.properties)}"
+
+
+@dataclass(frozen=True)
+class CreatureClassification:
+    """Metadata-inheritance partition of CCreature templates into players vs monsters.
+
+    Derived solely from engine class lineage (CPlayer derives from CCreature), not
+    from template-id naming heuristics.  ``players_in_creature_enumeration`` lists the
+    player templates that getAllSubTypes("CCreature") returns, so random-encounter
+    code can explicitly exclude them.
+    """
+
+    player_templates: tuple[str, ...]
+    monster_templates: tuple[str, ...]
+    players_in_creature_enumeration: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "playerTemplates": list(self.player_templates),
+            "monsterTemplates": list(self.monster_templates),
+            "playersInCreatureEnumeration": list(self.players_in_creature_enumeration),
+        }
 
 
 @dataclass(frozen=True)
@@ -910,6 +943,45 @@ class ContentValidator:
                 self._collect_creature_overrides(entry.path, entry.key, entry.key, entry.data, visible, overrides)
         return sorted(overrides, key=lambda override: (override.path, override.location))
 
+    def classify_creature_templates(self) -> CreatureClassification:
+        """Partition global CCreature templates into players vs monsters by metadata.
+
+        A template is classified by resolving its effective engine class (following
+        ``ref`` chains) and walking the C++ metadata inheritance lineage: it is a
+        player when the class inherits ``CPlayer`` and a (non-player) monster when it
+        inherits ``CCreature`` but not ``CPlayer``.  No template-id name strings are
+        consulted.  Player templates that fall inside the broader CCreature lineage --
+        i.e. those that getAllSubTypes("CCreature") would enumerate for random
+        encounters -- are also reported separately so encounter code can exclude them.
+        """
+        self._collect_engine_classes()
+        self._collect_plugin_classes()
+        self._load_global_configs()
+        visible = dict(self.global_entries)
+        players: list[str] = []
+        monsters: list[str] = []
+        for key, entry in self.global_entries.items():
+            if not isinstance(entry.data, dict):
+                continue
+            class_name = self._effective_object_class(entry.data, visible)
+            if not isinstance(class_name, str):
+                continue
+            if not (class_name == CREATURE_BASE_CLASS or self._class_inherits_from(class_name, CREATURE_BASE_CLASS)):
+                continue
+            if self._class_inherits_from(class_name, PLAYER_BASE_CLASS):
+                players.append(key)
+            else:
+                monsters.append(key)
+        players.sort()
+        monsters.sort()
+        return CreatureClassification(
+            player_templates=tuple(players),
+            monster_templates=tuple(monsters),
+            # CPlayer inherits CCreature, so every player template is also returned by
+            # the CCreature subtype enumeration that random-encounter code relies on.
+            players_in_creature_enumeration=tuple(players),
+        )
+
     def _collect_creature_overrides(
         self,
         path: Path,
@@ -921,7 +993,11 @@ class ContentValidator:
     ) -> None:
         if isinstance(value, dict):
             properties = value.get("properties")
-            if isinstance(value.get("ref"), str) and isinstance(properties, dict) and self._is_creature_node(value, visible):
+            if (
+                isinstance(value.get("ref"), str)
+                and isinstance(properties, dict)
+                and self._is_creature_node(value, visible)
+            ):
                 overridden = tuple(name for name in CREATURE_OVERRIDE_PROPERTIES if name in properties)
                 if overridden:
                     overrides.append(
@@ -2476,6 +2552,10 @@ def inventory_creature_overrides(repo_root: Path | str) -> list[CreatureOverride
     return ContentValidator(Path(repo_root)).inventory_creature_overrides()
 
 
+def classify_creature_templates(repo_root: Path | str) -> CreatureClassification:
+    return ContentValidator(Path(repo_root)).classify_creature_templates()
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Validate game JSON resources and literal script refs.")
     parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
@@ -2484,11 +2564,22 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Print the map-local creature override inventory as JSON and exit without validating.",
     )
+    parser.add_argument(
+        "--report-creature-classification",
+        action="store_true",
+        help="Print the metadata-derived player/monster classification as JSON and exit without validating.",
+    )
     args = parser.parse_args(argv)
 
     if args.report_creature_overrides:
         overrides = inventory_creature_overrides(args.repo_root)
         json.dump([override.as_dict() for override in overrides], sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    if args.report_creature_classification:
+        classification = classify_creature_templates(args.repo_root)
+        json.dump(classification.as_dict(), sys.stdout, indent=2)
         sys.stdout.write("\n")
         return 0
 

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -27,6 +27,7 @@ if str(REPO_ROOT) not in sys.path:
 from scripts.validate_content import (
     ContentValidator,
     ScriptPropertyHygieneAllowance,
+    classify_creature_templates,
     inventory_creature_overrides,
     validate_repo,
 )
@@ -158,9 +159,7 @@ class ContentValidatorTest(unittest.TestCase):
 
         issues = validate_repo(root)
 
-        self.assertIssueContains(
-            issues, "properties.action", 'dialog action "valid action" is not a valid method name'
-        )
+        self.assertIssueContains(issues, "properties.action", 'dialog action "valid action" is not a valid method name')
         self.assertIssueContains(
             issues, "properties.condition", 'dialog condition "9condition" is not a valid method name'
         )
@@ -1578,6 +1577,102 @@ class CreatureOverrideInventoryTest(unittest.TestCase):
                     "ref": "Spawner",
                     "properties": {"monster": {"ref": "Soldier", "properties": {"affiliation": "keep"}}},
                 },
+            },
+        )
+        return root
+
+
+class CreatureClassificationTest(unittest.TestCase):
+    # Concrete player template ids shipped in res/config/monsters.json. These are
+    # the "class": "CPlayer" entries; the classification must derive playerhood from
+    # CPlayer metadata inheritance, never from these names.
+    EXPECTED_PLAYER_TEMPLATES = ("Assasin", "Inquisitor", "Sorcerer", "Warrior", "Wayfarer")
+
+    def test_repo_classification_lists_concrete_player_templates_as_players(self):
+        classification = classify_creature_templates(REPO_ROOT)
+
+        for player in self.EXPECTED_PLAYER_TEMPLATES:
+            with self.subTest(player=player):
+                self.assertIn(player, classification.player_templates)
+                # A player template must never be silently treated as a monster.
+                self.assertNotIn(player, classification.monster_templates)
+
+    def test_repo_classification_separates_monsters_from_players(self):
+        classification = classify_creature_templates(REPO_ROOT)
+
+        self.assertEqual(set(self.EXPECTED_PLAYER_TEMPLATES), set(classification.player_templates))
+        self.assertTrue(classification.monster_templates)
+        # Known non-player creatures must land in the monster partition.
+        self.assertIn("Cultist", classification.monster_templates)
+        self.assertIn("Pritz", classification.monster_templates)
+        # Player and monster partitions are disjoint.
+        self.assertEqual(
+            set(),
+            set(classification.player_templates) & set(classification.monster_templates),
+        )
+
+    def test_player_templates_are_flagged_in_creature_enumeration(self):
+        # CPlayer inherits CCreature, so getAllSubTypes("CCreature") (used by the
+        # random-encounter table builder) enumerates every player template. The
+        # classification must surface exactly these so encounter code can exclude them.
+        classification = classify_creature_templates(REPO_ROOT)
+
+        self.assertEqual(
+            set(self.EXPECTED_PLAYER_TEMPLATES),
+            set(classification.players_in_creature_enumeration),
+        )
+        self.assertEqual(
+            set(classification.player_templates),
+            set(classification.players_in_creature_enumeration),
+        )
+
+    def test_classification_is_derived_from_metadata_inheritance_not_names(self):
+        # A creature template whose id looks like a monster but whose class is a
+        # CPlayer subclass must classify as a player; a player-sounding id on a plain
+        # CCreature must classify as a monster. This proves lineage, not naming, drives
+        # the decision.
+        root = self.make_classification_fixture()
+
+        classification = classify_creature_templates(root)
+
+        self.assertIn("grumpyOgre", classification.player_templates)
+        self.assertNotIn("grumpyOgre", classification.monster_templates)
+        self.assertIn("heroLookalike", classification.monster_templates)
+        self.assertNotIn("heroLookalike", classification.player_templates)
+        self.assertIn("grumpyOgre", classification.players_in_creature_enumeration)
+        self.assertNotIn("heroLookalike", classification.players_in_creature_enumeration)
+
+    def make_classification_fixture(self):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        root = Path(temp_dir.name)
+        (root / "res/config").mkdir(parents=True)
+        (root / "src/object").mkdir(parents=True)
+
+        # Engine metadata: CPlayer derives from CCreature, mirroring src/object/CPlayer.h.
+        (root / "src/object/CCreatures.h").write_text(
+            textwrap.dedent("""
+                class CMapObject {
+                    V_META(CMapObject, CGameObject, vstd::meta::empty())
+                };
+
+                class CCreature {
+                    V_META(CCreature, CMapObject, vstd::meta::empty())
+                };
+
+                class CPlayer {
+                    V_META(CPlayer, CCreature, vstd::meta::empty())
+                };
+            """).lstrip(),
+            encoding="utf-8",
+        )
+        write_json(
+            root / "res/config/monsters.json",
+            {
+                # Monster-sounding id, but a CPlayer subtype -> classified as player.
+                "grumpyOgre": {"class": "CPlayer", "properties": {"label": "Ogre"}},
+                # Hero-sounding id, but a plain CCreature -> classified as monster.
+                "heroLookalike": {"class": "CCreature", "properties": {"label": "Hero"}},
             },
         )
         return root


### PR DESCRIPTION
## Issue
`[EPIC_01][STORY_01][SUBSTORY_04]Classify player templates versus monster templates` — Claim `d9181674…`, owner `controller/ctrl-vm-4039-a70f65a5/subagent-6`

## What changed
Classification is derived from **V_META lineage**, not naming:
- `scripts/validate_content.py`: `PLAYER_BASE_CLASS = "CPlayer"`; `CreatureClassification` dataclass; `ContentValidator.classify_creature_templates()` partitions templates by effective class via metadata inheritance (player iff inherits `CPlayer`; monster iff inherits `CCreature` and not `CPlayer`); `players_in_creature_enumeration` lists players that `getAllSubTypes("CCreature")` would return (the explicit hand-off for later encounter-exclusion work); `--report-creature-classification` CLI flag.
- `tests/test_content_validator.py`: `CreatureClassificationTest` (4 tests) — concrete player IDs (Assasin/Inquisitor/Sorcerer/Warrior/Wayfarer) classify as players; players/monsters disjoint; players flagged in creature enumeration; a fixture proving lineage—not naming—drives it (monster-named CPlayer → player; hero-named CCreature → monster).

Source evidence: `CPlayer:CCreature` (`src/object/CPlayer.h:24-25`); `getAllSubTypes` metadata inheritance (`src/handler/CObjectHandler.cpp:104-120`); `CRngHandler.cpp:63` enumerates `CCreature` subtypes (the leak this flags). No production C++ change.

## Validation
- `python3 -m unittest tests.test_content_validator` → **53 tests OK** (4 new). Mutation check (lump players into monsters) → 8 failures, confirming the guard.
- `--report-creature-classification` → correct partition. `black -l 120 --check` clean.
- `tests.test_player_class_options` requires native `_game` (CI); skips as pure-Python locally.

## Scope note
This substory is classification + flagging; the actual `CRngHandler` encounter-exclusion is a separate later substory, fed by the new `players_in_creature_enumeration` output.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_