### PR TITLE
Observation: eligible-but-prose-blocked queue row forces wasted claim+block round-trip

### DIFF
--- a/planning/workflow_observations/records/20260630T151424Z-ctrl-vm-12080-c05dba37-6a1264d0.json
+++ b/planning/workflow_observations/records/20260630T151424Z-ctrl-vm-12080-c05dba37-6a1264d0.json
@@ -1,0 +1,35 @@
+{
+  "affectedPaths": [
+    "planning/fall_of_nouraajd_creature_archetype_jira_plan.xlsx"
+  ],
+  "category": "other",
+  "controllerId": "ctrl-vm-12080-c05dba37",
+  "createdAtUtc": "2026-06-30T15:14:24Z",
+  "details": "The aggregate shortlist surfaced [EPIC_01][STORY_03][SUBSTORY_01]\"Approve player-selectable race IDs\"\nas an eligible P0 candidate (Status NOT_STARTED, empty Dependencies column, deps=[] in shortlist), so it\nwas selected and claimed during a normal refill. Only on reading the row's Technical Code-Level Description\ndid the hard blocker surface: \"This task is blocked until the content owner approves the playable race set...\nDo not infer Human, Pritz, Cultist, or any other species from art, labels, or assumptions.\" This is a human\ncontent-owner decision, not an implementable change, so it had to be claimed then immediately BLOCKED.\n\nThis is a recurrence of the same class of defect previously recorded for\n[EPIC_01]...Register CCreatureClass-style rows: a row whose real blocker lives in the prose\n(description/acceptance) but is NOT modeled in the Dependencies column, so capacity-based shortlisting treats\nit as eligible. The cost is a wasted claim+block round-trip (two extra workbook PRs) per occurrence and the\nrisk of a worker being dispatched to invent content the task explicitly forbids inferring.\n\nSuggested durable fix (for a later optimizer): give the queue a machine-checkable \"blocked-on\" / \"needs-approval\"\nsignal (e.g. a status of AWAITING_APPROVAL, or a structured Dependencies/gate field) for rows gated on\ncontent-owner or human sign-off, and have shortlist exclude them from the eligible set instead of relying on\nprose. Alternatively, validate that any row containing approval-gate language in its description is not eligible\nuntil a gate field is cleared.\n",
+  "evidence": [
+    {
+      "actualBlockerSource": "Technical Code-Level Description",
+      "blockerQuote": "This task is blocked until the content owner approves the playable race set ... Do not infer Human, Pritz, Cultist, or any other species from art, labels, or assumptions.",
+      "controllerAction": "claimed then immediately BLOCKED via workbook PR #1002",
+      "recurrenceClass": "eligible row whose real blocker is in prose, not modeled in Dependencies",
+      "selectedAsEligible": "[EPIC_01][STORY_03][SUBSTORY_01]Approve player-selectable race IDs",
+      "shortlistDependencies": [],
+      "wastedRoundTripPRs": [
+        "claim #1001 (partial)",
+        "block #1002"
+      ],
+      "workbookStatusAtSelection": "NOT_STARTED"
+    }
+  ],
+  "fingerprint": "eligible row blocked by description prose not modeled in dependencies column",
+  "id": "20260630T151424Z-ctrl-vm-12080-c05dba37-6a1264d0",
+  "impact": "Capacity-based shortlist selected an approval-gated row (race IDs) as eligible because the blocker is in the description, not the Dependencies column; controller spent two extra workbook PRs (claim then block) and risked dispatching a worker to invent content the task forbids inferring. Recurs across approval/prerequisite-gated rows.",
+  "phase": "claim",
+  "queueIssue": "[EPIC_01][STORY_03][SUBSTORY_01]Approve player-selectable race IDs",
+  "role": "controller",
+  "schemaVersion": 1,
+  "severity": "medium",
+  "sourceCommit": "76ac55ca18e81a7f6d8a4dd83082cbf6d3ef2619",
+  "suggestedImprovement": "Add a machine-checkable approval/prerequisite gate (e.g. AWAITING_APPROVAL status or a structured gate field) so shortlist excludes content-owner/human-gated rows from the eligible set instead of relying on prose; or validate that rows containing approval-gate language are ineligible until a gate field clears.",
+  "summary": "Eligible-but-prose-blocked queue row forced a wasted claim+block round-trip (recurring)"
+}


### PR DESCRIPTION
Observation-only PR — adds exactly one immutable record under `planning/workflow_observations/records/`.

Records a recurring queue-selection defect: `[EPIC_01][STORY_03][SUBSTORY_01]Approve player-selectable race IDs` was selected/claimed as eligible (NOT_STARTED, empty Dependencies) but its description mandates content-owner approval (*"blocked until the content owner approves… Do not infer… any other species"*), forcing an immediate block. The real blocker lived in prose, not the Dependencies column. Same class as the earlier CCreatureClass-style block. Suggested durable fix: a machine-checkable approval/prerequisite gate so shortlist excludes human-gated rows from the eligible set.

Ledger `validate` passes. No XLSX, source, or workflow-code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_