### PR TITLE
Capture encounter power and scale baseline (E01/S02/SS04)

### DIFF
--- a/tests/unit/test_handler.cpp
+++ b/tests/unit/test_handler.cpp
@@ -44,10 +44,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <memory>
 #include <optional>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -1153,6 +1155,117 @@ void test_rng_handler_builds_encounters_from_concrete_creature_sw() {
     }
 }
 
+void test_rng_handler_captures_encounter_power_and_scale_baseline() {
+    // EPIC_01/STORY_02/SUBSTORY_04 pre-migration baseline.
+    //
+    // The random-encounter machinery enumerates creature templates with
+    // CObjectHandler::getAllSubTypes("CCreature") and keys its power table on the
+    // concrete creature's getSw() (src/handler/CRngHandler.cpp:63-69, :124-131).
+    // A later archetype migration must NOT let race/class *definition* types (which
+    // do not exist yet) leak into that enumeration, and it must keep a defined sw on
+    // every concrete monster template. This test records sw/level/getScale() and the
+    // power-table participation for every concrete template as a reviewable artifact
+    // and asserts only structural invariants the source guarantees today.
+    auto game = load_empty_game();
+    auto objectHandler = game->getObjectHandler();
+
+    // Reconstruct the exact enumeration the RNG handler scans
+    // (src/handler/CRngHandler.cpp:63). getAllSubTypes only returns a type when its
+    // resolved config "class" constructs and meta()->inherits("CCreature") holds
+    // (src/handler/CObjectHandler.cpp:104-119), which is the precise gate a migration
+    // must not loosen for definition-only race/class types.
+    const std::vector<std::string> creatureSubTypes = objectHandler->getAllSubTypes("CCreature");
+    expect_true(!creatureSubTypes.empty(),
+                "the normally-configured game should register at least one concrete CCreature template");
+
+    struct CreatureBaseline {
+        std::string type;
+        int sw = 0;
+        int level = 0;
+        int scale = 0;
+        bool inPowerTable = false;
+    };
+
+    // Deterministic ordering: getAllSubTypes already returns a sorted, de-duplicated
+    // list (src/handler/CObjectHandler.cpp:61-63), so iterate it directly so the
+    // emitted baseline table is stable across runs.
+    std::vector<CreatureBaseline> baseline;
+    for (const std::string &type : creatureSubTypes) {
+        auto creature = game->createObject<CCreature>(type);
+        // getAllSubTypes only yields constructible CCreature-inheriting templates, so
+        // every concrete monster template must materialize.
+        expect_true(creature != nullptr, "every concrete CCreature template should construct from the registry");
+        if (!creature) {
+            continue;
+        }
+
+        // Reject race/class-definition leakage structurally: anything the encounter
+        // enumeration returns must still be a real creature, mirroring the
+        // getAllSubTypes inherits gate (src/handler/CObjectHandler.cpp:115).
+        expect_true(creature->meta()->inherits("CCreature"),
+                    "encounter templates must inherit CCreature so race/class definitions cannot leak in");
+
+        CreatureBaseline entry;
+        entry.type = type;
+        entry.sw = creature->getSw();
+        entry.level = creature->getLevel();
+        entry.scale = creature->getScale();
+
+        // Every concrete monster must preserve a defined sw/level pair, and getScale()
+        // stays level + sw (src/object/CCreature.cpp:366), which the encounter power
+        // math relies on across the migration.
+        expect_true(entry.scale == entry.level + entry.sw,
+                    "concrete template getScale() should equal getLevel() + getSw()");
+
+        baseline.push_back(entry);
+    }
+
+    // Rebuild the creature power table the way CRngHandler's constructor does
+    // (src/handler/CRngHandler.cpp:63-69): one entry per concrete subtype keyed on
+    // getSw(). Mark which templates participate so the artifact records membership.
+    std::unordered_multimap<int, std::string> creaturePowerTable;
+    for (auto &entry : baseline) {
+        creaturePowerTable.insert(std::make_pair(entry.sw, entry.type));
+        entry.inPowerTable = true;
+    }
+    expect_true(!creaturePowerTable.empty(),
+                "the creature power table should be produced non-empty from concrete templates");
+    expect_true(creaturePowerTable.size() == baseline.size(),
+                "every concrete template should contribute exactly one power-table entry");
+
+    // Emit the deterministic, ordered baseline artifact for review.
+    std::cout << "[SS04] encounter power/scale baseline (type sw level scale inPowerTable)\n";
+    for (const auto &entry : baseline) {
+        std::cout << "[SS04] " << entry.type << " sw=" << entry.sw << " level=" << entry.level
+                  << " scale=" << entry.scale << " inPowerTable=" << (entry.inPowerTable ? "true" : "false") << "\n";
+    }
+    std::cout.flush();
+
+    // Building the live handler must ingest the same enumeration without crashing and
+    // must produce a usable, non-empty encounter source.
+    CRngHandler rng_handler(game);
+    std::set<int> baselineSw;
+    for (const auto &entry : baseline) {
+        baselineSw.insert(entry.sw);
+    }
+    bool producedEncounter = false;
+    for (int attempt = 0; attempt < 64 && !producedEncounter; attempt++) {
+        auto encounter = rng_handler.getRandomEncounter(40);
+        for (const auto &creature : encounter) {
+            if (!creature) {
+                continue;
+            }
+            producedEncounter = true;
+            // addExp scaling never mutates sw (src/handler/CRngHandler.cpp:135), so an
+            // encounter creature's getSw() must remain a recorded baseline power key.
+            expect_true(baselineSw.contains(creature->getSw()),
+                        "encounter creatures should retain a concrete baseline-template sw used as the power key");
+        }
+    }
+    expect_true(producedEncounter,
+                "the baseline power table should be able to assemble a non-empty encounter without crashing");
+}
+
 } // namespace
 
 int main() {
@@ -1162,6 +1275,7 @@ int main() {
     test_handler_constructors_are_covered_by_native_tests();
     test_creature_scale_preserves_level_plus_sw_invariant();
     test_rng_handler_builds_encounters_from_concrete_creature_sw();
+    test_rng_handler_captures_encounter_power_and_scale_baseline();
     test_event_handler_trigger_registration_uses_named_comparison_helpers();
     test_fight_handler_rejects_stale_and_cross_map_participants();
     test_fight_handler_attributes_lethal_effects_to_valid_casters();


### PR DESCRIPTION
## Issue
`[EPIC_01][STORY_02][SUBSTORY_04]Capture encounter power and scale` (P0; claim `82d16e49…`, owner `controller/ctrl-vm-27121-3e657616/subagent-9a`).

## What changed (test-only)
`tests/unit/test_handler.cpp` (+114): new `test_rng_handler_captures_encounter_power_and_scale_baseline()` (wired into `main()`). Loads the normally-configured game via the existing `load_empty_game()` helper, enumerates every concrete `CCreature` template exactly as the random-encounter code does (`getAllSubTypes("CCreature")` + `getSw()`), records `sw`/`level`/`getScale()`/power-table participation, and emits a deterministic ordered `[SS04]` table to stdout as the reviewable baseline artifact.

Structural assertions only (no balance magic numbers): enumeration non-empty; every concrete monster preserves a defined `sw` with `getScale() == level + sw`; the reconstructed power table is non-empty with exactly one entry per concrete template; only `CCreature`-inheriting templates appear (rejects future race/class definition-type leakage). So a later archetype migration cannot leak definition types into the power table or drop `sw` on concrete monsters.

Source grounding: `CRngHandler.cpp:63-69,124-135`; `CObjectHandler.cpp:104-119` (the `meta()->inherits` gate) `:61-63` (sorted/de-duped); `CCreature.cpp:366` (`getScale()==level+sw`), `:612`, `:500`.

## Validation
`clang-format` clean; `git diff --check` clean; no `planning/` files. Native `handler_unit_tests` + full suite via GitHub Actions (submodules unavailable locally).

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_