### PR TITLE
Approve legacy fallback compatibility contract (E01/S04/SS03)

### DIFF
--- a/docs/design/creature_archetypes.md
+++ b/docs/design/creature_archetypes.md
@@ -413,3 +413,86 @@ regression tests `test_no_archetype_creature_stats_keep_legacy_composition`
 (full per-property composition) and
 `test_creature_stat_precedence_orders_sources_and_main_stat` (override ordering
 and the class-then-legacy main-stat fallback) in `tests/unit/test_object.cpp`.
+
+---
+
+# Legacy fallback compatibility contract
+
+Status: Approved (design + engine). Scope: pins, as a **hard forward-compatibility
+rule**, the behavior of a creature that has **neither a race nor a
+`creatureClass`**. Such a creature uses the **current legacy stat and level-up
+paths exactly**, with no behavioral change of any kind. This protects existing
+saves, existing test fixtures, and any partial-migration state in which only some
+creatures have been given an archetype. It is the compatibility counterpart of the
+stat-precedence and action-merge contracts above: those define how archetype
+sources compose *when present*; this one defines what must happen when they are
+**absent**.
+
+## Approved hard rule
+
+For a creature with no race and no `creatureClass` (the **legacy creature**):
+
+1. **Stats** are composed **exactly** as the legacy path composes them today —
+   `creature.baseStats` (seeding `mainStat`), then `creature.levelStats` applied
+   once per level, then equipment bonuses, then effect bonuses. No race/class base
+   stats, no class level growth, and no class-supplied main stat participate,
+   because there are no such sources. The composed block is bit-for-bit the
+   pre-archetype result.
+2. **Level-up** runs the legacy path **exactly** — incrementing `level` and
+   applying the concrete template's own `levelling` unlock for that level. No
+   race- or class-driven level action, growth, or progression is introduced.
+3. **Main stat** resolves to the legacy `creature.baseStats.mainStat`. The
+   class-first selection rule never engages because there is no class.
+
+Because the race / `creatureClass` archetype objects (`CCreatureRace`,
+`CCreatureClass`) do **not exist in the codebase yet**, **every** creature is a
+legacy creature today, and this rule pins that observed behavior so that landing
+the archetype foundation cannot silently alter it.
+
+## Deserialization assigns no default race or class
+
+Deserialization (loading a creature from JSON config or from a save) **must not**
+assign a default race or `creatureClass`. A creature is a legacy creature unless
+its source data explicitly provides an archetype reference. Concretely:
+
+- The serialization/property contract for a creature is the `V_META` property
+  list on `CCreature` (`src/object/CCreature.h`). It declares the legacy stat and
+  progression fields (`baseStats`, `levelStats`, `levelling`, `level`, `exp`,
+  `equipped`, `items`, `effects`, ...) and declares **no** `race` and **no**
+  `creatureClass` property. A loaded creature therefore acquires neither, and any
+  archetype keys that may appear in future data are simply not bound onto a
+  legacy-shaped object.
+- No constructor, loader, or post-load step seeds a fallback/default archetype.
+  An old save or an un-migrated fixture round-trips to a legacy creature
+  unchanged.
+
+A **later migration may opt in** to assigning a race/class — but only explicitly,
+guarded, and version-gated. Absent such an explicit opt-in, the deserialized
+result is a legacy creature. This is a hard rule: a default archetype must never
+be introduced implicitly as a side effect of adding the archetype foundation.
+
+## Where this is grounded and enforced
+
+Grounded in the current legacy paths in `src/object/CCreature.cpp`:
+
+- **Stat composition** — `CCreature::getStats` (`src/object/CCreature.cpp:834`).
+  Positions 1, 2, and 4 (race base, class base, class level growth) are documented
+  extension points that contribute nothing today, so the function already produces
+  the exact legacy composition for a creature with no archetype.
+- **Level-up** — `CCreature::levelUp` (`src/object/CCreature.cpp:572`) and the
+  per-level unlock it applies, `CCreature::getLevelAction`
+  (`src/object/CCreature.cpp:100`), which reads only the concrete template's
+  `levelling` map.
+- **Deserialization** — the `V_META` property declaration on `CCreature`
+  (`src/object/CCreature.h:50`), which binds only the legacy fields and **no**
+  race/class property, so loading assigns no default archetype.
+
+When the archetype foundation lands, it must preserve this rule: the
+race/`creatureClass` sources may only ever *add* to a creature that explicitly
+declares them, and the no-archetype path must remain identical to today's legacy
+behavior. The stat side of "identical to legacy" is already pinned by the native
+regression test `test_no_archetype_creature_stats_keep_legacy_composition` in
+`tests/unit/test_object.cpp` (a creature with no archetype composes to the legacy
+stat block); the level-up and no-default-archetype guarantees here are pinned by
+this approved contract and must be covered by a regression test alongside any
+change that introduces the archetype objects.

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -570,6 +570,13 @@ std::shared_ptr<CArmor> CCreature::getArmor() { return vstd::cast<CArmor>(getIte
 
 // TODO: get rid of this, calculate level automatically
 void CCreature::levelUp() {
+    // Legacy fallback compatibility contract (docs/design/creature_archetypes.md,
+    // "Legacy fallback compatibility contract"): a creature with no race and no
+    // creatureClass uses this legacy level-up path exactly -- increment level and
+    // apply the concrete template's own `levelling` unlock (getLevelAction). No
+    // race/class-driven growth or progression participates, because those archetype
+    // objects (CCreatureRace / CCreatureClass) do not exist yet. Any future
+    // archetype level growth must slot in without altering this no-archetype path.
     level++;
     // TODO: dynamic action calculation
     addAction(getLevelAction());
@@ -846,6 +853,9 @@ std::shared_ptr<CStats> CCreature::getStats() {
     // (CCreatureClass) do not exist yet, so positions 1, 2, 4 and the class-first main
     // stat are extension points that contribute nothing today; they slot in here
     // without disturbing the equipment-then-effects tail or the legacy fallback.
+    // Legacy fallback compatibility contract (same doc, "Legacy fallback
+    // compatibility contract"): for a creature with no race and no creatureClass
+    // (every creature today) this composes the legacy stat block exactly.
     std::shared_ptr<CStats> ret = std::make_shared<CStats>();
     // Main stat: creatureClass.baseStats.mainStat first (extension point), then the
     // legacy creature.baseStats.mainStat fallback below.


### PR DESCRIPTION
## Issue
`[EPIC_01][STORY_04][SUBSTORY_03]Approve legacy fallback contract` (P0; claim `e70a04f5…`, owner `controller/ctrl-vm-1228-ef48f962/subagent-11b`).

## What changed (docs + comment-only)
Approves, as a hard forward-compatibility rule, that a creature with neither a race nor a `creatureClass` uses the current legacy stat and level-up paths exactly — protecting old saves, fixtures, and partial-migration states.

- `docs/design/creature_archetypes.md` (+83): new "Legacy fallback compatibility contract" Approved section — legacy stat composition and level-up are bit-for-bit unchanged when no archetype is present; deserialization assigns no default race/class (the `CCreature` `V_META` list declares no such property); only an explicit, version-gated later migration may opt in.
- `src/object/CCreature.cpp` (+10): comment-only annotations on `getStats`/`levelUp` referencing the contract. **No logic change.**

Mirrors the merged stat-precedence approval #988. Grounded in `CCreature::getStats` (`:834`), `levelUp` (`:572`), `getLevelAction` (`:100`), and the `V_META` declaration (`CCreature.h:50`, which declares no `race`/`creatureClass`). The stat side is already pinned by `test_no_archetype_creature_stats_keep_legacy_composition`; the doc records the level-up / no-default-archetype guarantees for a future regression test.

## Validation
`clang-format` clean; `git diff --check` clean; no `planning/` files. Native suite via GitHub Actions (comment-only source change).

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_