### PR TITLE
Commit deterministic config-derived creature baseline fixture (E01/S02/SS05)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           python3 scripts/validate_content.py --repo-root .
           python3 -m unittest tests.test_content_validator
+          python3 -m unittest tests.test_creature_stat_scale_baseline
       - name: test (python fast)
         run: python3 test.py --suite fast
       - name: classify changed paths
@@ -370,6 +371,7 @@ jobs:
         run: |
           python scripts/validate_content.py --repo-root .
           python -m unittest tests.test_content_validator
+          python -m unittest tests.test_creature_stat_scale_baseline
       - name: test (python fast)
         run: python test.py --suite fast
       - &setup-msvc
@@ -633,6 +635,7 @@ jobs:
         run: |
           python scripts/validate_content.py --repo-root .
           python -m unittest tests.test_content_validator
+          python -m unittest tests.test_creature_stat_scale_baseline
       - name: test (python fast)
         run: python test.py --suite fast
       - *setup-msvc

--- a/tests/fixtures/creature_stat_scale_baseline.json
+++ b/tests/fixtures/creature_stat_scale_baseline.json
@@ -1,0 +1,366 @@
+{
+  "_description": "Config-derived balance baseline for every creature/player template in res/config/monsters.json. For each template it pins the declared class, the baseStats (spawn-scale stat map), the levelStats (per-level growth increments), the levelling (level -> skill ref unlock map), and sw (spawn weight, when declared). All values are read straight from the authoritative config; runtime object names, memory addresses, order-sensitive set iteration, and runtime coordinates are normalized out. This is a balance-neutral contract reviewed before migration PRs. Regenerated and verified by tests/test_creature_stat_scale_baseline.py.",
+  "_source": "res/config/monsters.json",
+  "templates": {
+    "Assasin": {
+      "baseStats": {
+        "agility": 5,
+        "crit": 10,
+        "dmgMax": 12,
+        "dmgMin": 10,
+        "hit": 75,
+        "intelligence": 5,
+        "mainStat": "agility",
+        "stamina": 5,
+        "strength": 5
+      },
+      "class": "CPlayer",
+      "levelStats": {
+        "agility": 3,
+        "crit": 2,
+        "dmgMax": 2,
+        "dmgMin": 1,
+        "hit": 3,
+        "intelligence": 2,
+        "stamina": 1,
+        "strength": 1
+      },
+      "levelling": {
+        "1": "SneakAttack",
+        "2": "Mutilation",
+        "3": "LethalPoison",
+        "4": "Chloroform",
+        "5": "Stunner",
+        "6": "Backstab"
+      }
+    },
+    "CultLeader": {
+      "baseStats": {
+        "agility": 8,
+        "crit": 15,
+        "dmgMax": 8,
+        "dmgMin": 6,
+        "hit": 80,
+        "intelligence": 8,
+        "mainStat": "strength",
+        "stamina": 7,
+        "strength": 7
+      },
+      "class": "CCreature",
+      "levelStats": {
+        "agility": 3,
+        "crit": 2,
+        "dmgMax": 4,
+        "dmgMin": 3,
+        "hit": 4,
+        "intelligence": 3,
+        "stamina": 4,
+        "strength": 4
+      },
+      "levelling": {},
+      "sw": 2
+    },
+    "Cultist": {
+      "baseStats": {
+        "agility": 5,
+        "crit": 10,
+        "dmgMax": 3,
+        "dmgMin": 2,
+        "hit": 75,
+        "intelligence": 5,
+        "mainStat": "strength",
+        "stamina": 3,
+        "strength": 5
+      },
+      "class": "CCreature",
+      "levelStats": {
+        "agility": 2,
+        "crit": 1,
+        "dmgMax": 1,
+        "dmgMin": 1,
+        "hit": 3,
+        "intelligence": 1,
+        "stamina": 1,
+        "strength": 2
+      },
+      "levelling": {},
+      "sw": 1
+    },
+    "GoblinThief": {
+      "baseStats": {
+        "agility": 5,
+        "crit": 10,
+        "dmgMax": 3,
+        "dmgMin": 2,
+        "hit": 75,
+        "intelligence": 5,
+        "mainStat": "strength",
+        "stamina": 3,
+        "strength": 5
+      },
+      "class": "CCreature",
+      "levelStats": {
+        "agility": 2,
+        "crit": 1,
+        "dmgMax": 1,
+        "dmgMin": 1,
+        "hit": 3,
+        "intelligence": 1,
+        "normalResist": 5,
+        "stamina": 1,
+        "strength": 2
+      },
+      "levelling": {
+        "4": "DoubleAttack"
+      },
+      "sw": 1
+    },
+    "Gooby": {
+      "baseStats": {
+        "agility": 5,
+        "crit": 10,
+        "dmgMax": 12,
+        "dmgMin": 10,
+        "hit": 75,
+        "intelligence": 5,
+        "mainStat": "strength",
+        "stamina": 5,
+        "strength": 5
+      },
+      "class": "CCreature",
+      "levelStats": {
+        "agility": 2,
+        "crit": 1,
+        "dmgMax": 3,
+        "dmgMin": 2,
+        "hit": 3,
+        "intelligence": 1,
+        "normalResist": 5,
+        "stamina": 2,
+        "strength": 3
+      },
+      "levelling": {
+        "4": "DoubleAttack"
+      },
+      "sw": 1
+    },
+    "Inquisitor": {
+      "baseStats": {
+        "agility": 5,
+        "crit": 8,
+        "dmgMax": 11,
+        "dmgMin": 9,
+        "hit": 78,
+        "intelligence": 7,
+        "mainStat": "intelligence",
+        "stamina": 6,
+        "strength": 6
+      },
+      "class": "CPlayer",
+      "levelStats": {
+        "agility": 1,
+        "crit": 1,
+        "dmgMax": 2,
+        "dmgMin": 1,
+        "hit": 2,
+        "intelligence": 2,
+        "stamina": 2,
+        "strength": 2
+      },
+      "levelling": {
+        "1": "ExposeCorruption",
+        "2": "Strike",
+        "3": "SanctifiedWard",
+        "4": "FrostBolt",
+        "5": "Barrier",
+        "6": "EndlessPain"
+      }
+    },
+    "OctoBogz": {
+      "baseStats": {
+        "agility": 10,
+        "crit": 20,
+        "dmgMax": 21,
+        "dmgMin": 17,
+        "hit": 80,
+        "intelligence": 10,
+        "mainStat": "strength",
+        "stamina": 10,
+        "strength": 10
+      },
+      "class": "CCreature",
+      "levelStats": {
+        "agility": 3,
+        "crit": 2,
+        "dmgMax": 5,
+        "dmgMin": 4,
+        "hit": 4,
+        "intelligence": 2,
+        "normalResist": 7,
+        "stamina": 3,
+        "strength": 5
+      },
+      "levelling": {
+        "2": "AbyssalShadows"
+      },
+      "sw": 2
+    },
+    "Pritz": {
+      "baseStats": {
+        "agility": 5,
+        "crit": 10,
+        "dmgMax": 3,
+        "dmgMin": 2,
+        "hit": 75,
+        "intelligence": 5,
+        "mainStat": "strength",
+        "stamina": 3,
+        "strength": 5
+      },
+      "class": "CCreature",
+      "levelStats": {
+        "agility": 2,
+        "crit": 1,
+        "dmgMax": 1,
+        "dmgMin": 1,
+        "hit": 3,
+        "intelligence": 1,
+        "normalResist": 5,
+        "stamina": 1,
+        "strength": 2
+      },
+      "levelling": {
+        "4": "DoubleAttack"
+      },
+      "sw": 1
+    },
+    "PritzMage": {
+      "baseStats": {
+        "agility": 5,
+        "crit": 10,
+        "dmgMax": 12,
+        "dmgMin": 10,
+        "hit": 75,
+        "intelligence": 5,
+        "mainStat": "intelligence",
+        "stamina": 5,
+        "strength": 5
+      },
+      "class": "CCreature",
+      "levelStats": {
+        "agility": 2,
+        "crit": 1,
+        "dmgMax": 3,
+        "dmgMin": 2,
+        "hit": 3,
+        "intelligence": 3,
+        "normalResist": 5,
+        "stamina": 2,
+        "strength": 3
+      },
+      "levelling": {
+        "2": "MagicMissile",
+        "3": "FrostBolt"
+      },
+      "sw": 2
+    },
+    "Sorcerer": {
+      "baseStats": {
+        "agility": 5,
+        "crit": 10,
+        "dmgMax": 12,
+        "dmgMin": 10,
+        "hit": 75,
+        "intelligence": 5,
+        "mainStat": "intelligence",
+        "stamina": 5,
+        "strength": 5
+      },
+      "class": "CPlayer",
+      "levelStats": {
+        "agility": 2,
+        "crit": 1,
+        "dmgMax": 1,
+        "dmgMin": 1,
+        "hit": 1,
+        "intelligence": 3,
+        "stamina": 1,
+        "strength": 1
+      },
+      "levelling": {
+        "1": "MagicMissile",
+        "10": "ChaosBlast",
+        "2": "AbyssalShadows",
+        "3": "FrostBolt",
+        "4": "EndlessPain",
+        "5": "ArmorOfEndlessWinter",
+        "7": "ShadowBolt",
+        "8": "Devour"
+      }
+    },
+    "Warrior": {
+      "baseStats": {
+        "agility": 5,
+        "crit": 10,
+        "dmgMax": 12,
+        "dmgMin": 10,
+        "hit": 75,
+        "intelligence": 5,
+        "mainStat": "strength",
+        "stamina": 5,
+        "strength": 5
+      },
+      "class": "CPlayer",
+      "levelStats": {
+        "agility": 2,
+        "crit": 1,
+        "dmgMax": 3,
+        "dmgMin": 2,
+        "hit": 3,
+        "intelligence": 1,
+        "stamina": 2,
+        "strength": 3
+      },
+      "levelling": {
+        "1": "Strike",
+        "2": "Barrier",
+        "3": "BloodThirst",
+        "4": "Bloodlash",
+        "5": "DeathStrike",
+        "6": "DoubleAttack"
+      }
+    },
+    "Wayfarer": {
+      "baseStats": {
+        "agility": 8,
+        "crit": 12,
+        "dmgMax": 11,
+        "dmgMin": 9,
+        "hit": 82,
+        "intelligence": 5,
+        "mainStat": "agility",
+        "stamina": 5,
+        "strength": 6
+      },
+      "class": "CPlayer",
+      "levelStats": {
+        "agility": 3,
+        "crit": 1,
+        "dmgMax": 2,
+        "dmgMin": 1,
+        "hit": 3,
+        "intelligence": 1,
+        "stamina": 1,
+        "strength": 2
+      },
+      "levelling": {
+        "1": "WayfarersStride",
+        "2": "SneakAttack",
+        "3": "SmugglersMark",
+        "4": "DoubleAttack",
+        "5": "Backstab",
+        "6": "BloodThirst"
+      }
+    }
+  }
+}

--- a/tests/test_creature_stat_scale_baseline.py
+++ b/tests/test_creature_stat_scale_baseline.py
@@ -1,0 +1,162 @@
+# fall-of-nouraajd c++ dark fantasy game
+# Copyright (C) 2026  Andrzej Lis
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Characterization baseline for creature stat scaling and levelling.
+
+This test pins, for every concrete creature/player template in
+``res/config/monsters.json``, the config-declared per-template balance fields that
+are deterministic from configuration alone:
+
+* ``class`` (CCreature / CPlayer),
+* ``sw`` (spawn weight, when declared),
+* ``baseStats`` (the absolute combat scale a creature spawns with),
+* ``levelStats`` (the per-level stat growth increments), and
+* ``levelling`` (the level -> skill reference unlock map).
+
+These values drive creature balance and are read straight from the authoritative
+JSON config by the object loader; none of them require the native ``_game`` engine.
+Anything that can only be produced by a runtime engine pass (e.g. computed effective
+stat totals, generated object names, memory addresses, runtime spawn coordinates, or
+order-sensitive set iteration) is deliberately excluded so the fixture is stable
+across repeated runs. The baseline is a balance-neutral contract: a migration PR that
+reshapes how these templates are defined must regenerate it deliberately, and an
+accidental balance change fails this test with a useful diff.
+
+The baseline is derived purely from config, so this test runs in the same lightweight
+CI step as the other content-config checks; no native ``_game`` module is required.
+"""
+
+import json
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MONSTERS_PATH = REPO_ROOT / "res" / "config" / "monsters.json"
+BASELINE_PATH = REPO_ROOT / "tests" / "fixtures" / "creature_stat_scale_baseline.json"
+
+
+def _ref(value):
+    """Return the typeId referenced by a ``{"ref": ...}`` config entry."""
+    if isinstance(value, dict):
+        return value.get("ref")
+    return value
+
+
+def _normalize_stats(block):
+    """Return the declared stat map for a ``CStats`` property node, sorted by key.
+
+    Only the declared ``properties`` payload is kept; the ``class`` wrapper is dropped
+    because it is a constant loader detail, not a balance value. Values are returned as
+    a plain dict; JSON serialization with ``sort_keys=True`` provides the canonical,
+    order-insensitive ordering.
+    """
+    if not isinstance(block, dict):
+        return {}
+    return dict(block.get("properties", {}) or {})
+
+
+def _normalize_levelling(levelling):
+    """Return the level -> skill-ref unlock map, keyed by string level.
+
+    Levels are JSON object keys (strings); each value is normalized to the referenced
+    skill typeId. Iteration order of the source object is irrelevant because the result
+    is compared as a dict and serialized with ``sort_keys=True``.
+    """
+    result = {}
+    for level, entry in (levelling or {}).items():
+        result[str(level)] = _ref(entry)
+    return result
+
+
+def _derive_template_record(body):
+    """Derive the config-declared balance fields for a single creature template."""
+    properties = body.get("properties", {}) or {}
+
+    record = {
+        "class": body.get("class"),
+        "baseStats": _normalize_stats(properties.get("baseStats")),
+        "levelStats": _normalize_stats(properties.get("levelStats")),
+        "levelling": _normalize_levelling(properties.get("levelling")),
+    }
+    if "sw" in properties:
+        record["sw"] = properties["sw"]
+    return record
+
+
+def derive_baseline_from_config():
+    """Build the normalized baseline mapping straight from the monsters config."""
+    monsters = json.loads(MONSTERS_PATH.read_text(encoding="utf-8"))
+    return {name: _derive_template_record(body) for name, body in monsters.items()}
+
+
+class CreatureStatScaleBaselineTest(unittest.TestCase):
+    def setUp(self):
+        self.derived = derive_baseline_from_config()
+        fixture = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+        self.baseline = fixture["templates"]
+
+    def test_derived_baseline_matches_committed_fixture(self):
+        """Every template's stat-scale identities match the committed baseline."""
+        self.assertEqual(
+            self.baseline,
+            self.derived,
+            "Creature stat scaling/levelling drifted from the committed baseline. "
+            "If this change is intentional and design-approved, regenerate "
+            "tests/fixtures/creature_stat_scale_baseline.json to match.",
+        )
+
+    def test_baseline_covers_every_template_exactly_once(self):
+        """The fixture covers exactly the templates present in monsters.json."""
+        self.assertEqual(
+            sorted(self.baseline.keys()),
+            sorted(self.derived.keys()),
+            "Baseline template set differs from monsters.json template set.",
+        )
+
+    def test_baseline_is_stable_across_repeated_derivations(self):
+        """Re-deriving the baseline yields an identical canonical serialization.
+
+        This guards the normalization: object-key order in the source config must not
+        leak into the result, so two independent derivations must serialize byte-for-byte
+        identically under ``sort_keys=True``.
+        """
+        first = json.dumps(derive_baseline_from_config(), sort_keys=True)
+        second = json.dumps(derive_baseline_from_config(), sort_keys=True)
+        self.assertEqual(first, second)
+
+    def test_intentional_balance_change_is_detected(self):
+        """A mutated stat value is detected against the committed baseline.
+
+        This is the drift sanity check: perturbing any baseline number in memory must
+        make the fixture comparison fail, proving the contract catches balance changes.
+        """
+        mutated = json.loads(json.dumps(self.baseline))
+        name = sorted(mutated.keys())[0]
+        base_stats = mutated[name]["baseStats"]
+        if base_stats:
+            key = sorted(base_stats.keys())[0]
+            value = base_stats[key]
+            base_stats[key] = (value + 1) if isinstance(value, (int, float)) else "DRIFTED"
+        else:
+            mutated[name]["class"] = "DRIFTED"
+        self.assertNotEqual(
+            mutated,
+            self.derived,
+            "Mutating a baseline value must be detectable as drift.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue
`[EPIC_01][STORY_02][SUBSTORY_05]Commit deterministic baseline fixture` (P0; claim `859e5cdd…`, owner `controller/ctrl-vm-27121-3e657616/subagent-10a`).

## What changed
A deterministic pre-migration baseline derived **purely from config** (no native `_game`), mirroring the established pattern of `tests/test_creature_equipment_inventory_baseline.py`:

- `tests/fixtures/creature_stat_scale_baseline.json` (new, +366): canonical sorted/normalized fixture for all 12 templates capturing config-declared `class`, `baseStats`, `levelStats`, `levelling` (level→skill-ref map), and `sw` when declared.
- `tests/test_creature_stat_scale_baseline.py` (new, +162): pure-Python test (4 tests) that recomputes the normalized structure from `res/config/monsters.json` and asserts equality, plus a stability check and a drift sanity check.
- `.github/workflows/build.yml` (+3): appends `... -m unittest tests.test_creature_stat_scale_baseline` to the three existing "Validate content JSON" steps, mirroring how `tests.test_content_validator` is wired (so CI actually runs it). YAML validated.

Runtime object names, addresses, set-iteration order, and coordinates are normalized out. **Deferred (noted honestly):** runtime-computed *effective* stat totals (engine-applied base+equipment+effects) are excluded — they require a native run and cannot be derived from config alone; PR #1004 / the SS01 native test cover the runtime layering.

## Validation
`python3 -m unittest tests.test_creature_stat_scale_baseline` → 4 tests OK, identical across two runs; drift check (mutating `Gooby.baseStats.strength`) correctly fails. `black -l 120` clean; `git diff --check` clean; no `planning/` files.

> Note: this PR touches `.github/workflows/build.yml` (adds one content-test invocation per existing validate step). If repo policy classifies workflow edits as requiring human review, treat accordingly — it changes no build/native logic, only wires the new content test in.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_