### PR TITLE
Extract legacy CCreature::getStats into buildLegacyStats helper (E02/S04/SS01)

### DIFF
--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -838,7 +838,9 @@ void CCreature::removeQuestItem(std::shared_ptr<CItem> item) { removeItem(item, 
 
 void CCreature::removeQuestItem(std::function<bool(std::shared_ptr<CItem>)> item) { removeItem(item, true); }
 
-std::shared_ptr<CStats> CCreature::getStats() {
+std::shared_ptr<CStats> CCreature::getStats() { return buildLegacyStats(); }
+
+std::shared_ptr<CStats> CCreature::buildLegacyStats() {
     // Stat precedence contract (docs/design/creature_archetypes.md, "Creature stat
     // precedence contract"): effective stats are composed least- to most-specific:
     //   1. race.baseStats             -- extension point (no backing object yet)

--- a/src/object/CCreature.h
+++ b/src/object/CCreature.h
@@ -293,6 +293,8 @@ class CCreature : public CMapObject, public CMoveable, public CVisitable {
 
     void takeDamage(int i);
 
+    std::shared_ptr<CStats> buildLegacyStats();
+
     std::shared_ptr<CInteraction> getLevelAction();
 
     bool npc = false;


### PR DESCRIPTION
## Issue
`[EPIC_02][STORY_04][SUBSTORY_01]Extract legacy getStats helper` (P0; claim `4bc2821a…`, owner `controller/ctrl-vm-28315-49d5f302/subagent-s4a`).

## What changed (zero-logic-change refactor)
Extracts the existing `CCreature::getStats()` body **verbatim** into a new private `buildLegacyStats()`; `getStats()` now just `return buildLegacyStats();`.

- `src/object/CCreature.cpp` (+4/−1): `std::shared_ptr<CStats> CCreature::getStats() { return buildLegacyStats(); }` + `buildLegacyStats()` definition holding the moved body (all precedence comments, `make_shared`, `setMainStat`, the three `addBonus` loops, `return ret;`).
- `src/object/CCreature.h` (+2): private `std::shared_ptr<CStats> buildLegacyStats();` declaration.

Isolates the legacy stat composition so the upcoming race/creatureClass archetype logic can be layered and unit-tested independently, while keeping old saves/unmigrated content bit-for-bit compatible. `buildLegacyStats` is private and called only by `getStats`; includes unchanged; the moved body's `return ret;` returns from the helper which `getStats` returns directly — behavior identical.

## Validation
Diff confirms the body appears only as unchanged context (no `+`/`-` inside it); `clang-format` clean; `git diff --check` clean; no `planning/` files. Native build + full suite via GitHub Actions.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_