### PR TITLE
Validate CCreatureClass.mainStat names a numeric CStats property (E06/S02/SS01)

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -115,6 +115,21 @@ CREATURE_ARCHETYPE_ID_SUFFIXES = {
     CREATURE_CLASSES_CONFIG: CREATURE_CLASS_ID_SUFFIX,
 }
 
+# CCreatureClass.mainStat validation (EPIC_06/STORY_02/SUBSTORY_01).
+# A creature class archetype names the stat it scales from via the "mainStat"
+# property, which the engine resolves at runtime through CStats::getMainValue ->
+# CStats::getNumericProperty(mainStat).  That lookup only succeeds when the value
+# names one of CStats' numeric (int) metadata properties; a typo such as
+# "strenght" would silently resolve to 0 main value at runtime.  The allowed names
+# are derived from the live CStats metadata schema (the int-typed properties), never
+# hard-coded, so the check stays in lockstep with src/core/CStats.h.  CCreatureClass
+# configs do not exist on the current content, so this validator is forward-guarding
+# and vacuously satisfied until such archetypes are authored.
+CREATURE_CLASS_OBJECT_CLASS = "CCreatureClass"
+CREATURE_CLASS_MAIN_STAT_PROPERTY = "mainStat"
+MAIN_STAT_SCHEMA_CLASS = "CStats"
+MAIN_STAT_NUMERIC_TYPE_TOKEN = "int"
+
 # Map-local creature override inventory (EPIC_01/STORY_01/SUBSTORY_02).
 # Map config files reference creature templates via "ref" plus a "properties" block
 # that overrides template behavior.  Any override touching one of these properties
@@ -1456,6 +1471,72 @@ class ContentValidator:
                     append_field(properties_location, property_name),
                     f'unknown property "{property_name}" for class "{class_name}"',
                 )
+        self._validate_creature_class_main_stat(path, properties_location, class_name, properties)
+
+    def _validate_creature_class_main_stat(
+        self,
+        path: Path,
+        properties_location: str,
+        class_name: str,
+        properties: dict[str, Any],
+    ) -> None:
+        """Verify a CCreatureClass.mainStat names a numeric CStats property.
+
+        The engine resolves a creature class's main stat through
+        ``CStats::getNumericProperty(mainStat)`` (CStats::getMainValue), so a
+        non-empty ``mainStat`` must name one of CStats' numeric (int) metadata
+        properties.  Empty, non-string, or typo values (e.g. "strenght") would
+        resolve to a zero main value at runtime, so they are rejected here with the
+        exact class config location.  The allowed names are derived from the live
+        CStats metadata schema, so this stays in lockstep with src/core/CStats.h.
+        ``CCreatureClass`` archetypes do not exist on current content, so this check
+        is vacuously satisfied (forward-guarding) until they are authored.
+        """
+        if class_name != CREATURE_CLASS_OBJECT_CLASS and not self._class_inherits_from(
+            class_name, CREATURE_CLASS_OBJECT_CLASS
+        ):
+            return
+        if CREATURE_CLASS_MAIN_STAT_PROPERTY not in properties:
+            return
+        main_stat = properties[CREATURE_CLASS_MAIN_STAT_PROPERTY]
+        main_stat_location = append_field(properties_location, CREATURE_CLASS_MAIN_STAT_PROPERTY)
+        if not isinstance(main_stat, str) or not main_stat:
+            self._issue(
+                path,
+                main_stat_location,
+                f'property "{CREATURE_CLASS_MAIN_STAT_PROPERTY}" for class "{class_name}" '
+                f"expected a non-empty numeric {MAIN_STAT_SCHEMA_CLASS} property name; "
+                f"got {json_value_kind(main_stat)}",
+            )
+            return
+        allowed_stats = self._numeric_main_stat_names()
+        if allowed_stats is None:
+            return
+        if main_stat not in allowed_stats:
+            self._issue(
+                path,
+                main_stat_location,
+                f'property "{CREATURE_CLASS_MAIN_STAT_PROPERTY}" for class "{class_name}" '
+                f'value "{main_stat}" is not a numeric {MAIN_STAT_SCHEMA_CLASS} property; '
+                f"expected one of {', '.join(sorted(allowed_stats))}",
+            )
+
+    def _numeric_main_stat_names(self) -> set[str] | None:
+        """Return CStats' numeric (int) metadata property names, or None if absent.
+
+        Derived from the live CStats metadata schema so the allowed set never drifts
+        from src/core/CStats.h.  Returns None when CStats metadata is unavailable
+        (e.g. before the native sources exist), leaving the check inert rather than
+        guessing a stat set.
+        """
+        property_schema = self._metadata_property_schema(MAIN_STAT_SCHEMA_CLASS)
+        if not property_schema:
+            return None
+        return {
+            cpp_property.name
+            for cpp_property in property_schema.values()
+            if cpp_property.type_token == MAIN_STAT_NUMERIC_TYPE_TOKEN
+        }
 
     def _effective_object_class(
         self, value: dict[str, Any], visible: dict[str, ConfigEntry], seen_refs: set[str] | None = None

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -775,6 +775,86 @@ class ContentValidatorTest(unittest.TestCase):
             'unknown property "bogus" for class "CPropertyDerived"',
         )
 
+    def test_creature_class_main_stat_numeric_stat_passes(self):
+        root = self.make_fixture()
+        self.write_creature_class_main_stat_fixture(root)
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["WarriorClass"] = {
+            "class": "CCreatureClass",
+            "properties": {"mainStat": "strength"},
+        }
+        write_json(config_path, config)
+
+        validator = ContentValidator(root)
+        validator._collect_engine_classes()
+
+        self.assertEqual({"strength", "agility", "intelligence"}, validator._numeric_main_stat_names())
+        self.assertEqual([], [str(issue) for issue in validate_repo(root)])
+
+    def test_creature_class_main_stat_typo_reports_class_path(self):
+        root = self.make_fixture()
+        self.write_creature_class_main_stat_fixture(root)
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["WarriorClass"] = {
+            "class": "CCreatureClass",
+            "properties": {"mainStat": "strenght"},
+        }
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "WarriorClass.properties.mainStat",
+            'property "mainStat" for class "CCreatureClass" value "strenght" is not a numeric CStats property',
+            "expected one of agility, intelligence, strength",
+        )
+
+    def test_creature_class_main_stat_non_numeric_stat_reports_class_path(self):
+        root = self.make_fixture()
+        self.write_creature_class_main_stat_fixture(root)
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        # "mainStat" itself is a std::string CStats property -- present but non-numeric.
+        config["MageClass"] = {
+            "class": "CCreatureClass",
+            "properties": {"mainStat": "mainStat"},
+        }
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "MageClass.properties.mainStat",
+            'property "mainStat" for class "CCreatureClass" value "mainStat" is not a numeric CStats property',
+        )
+
+    def test_creature_class_main_stat_empty_reports_class_path(self):
+        root = self.make_fixture()
+        self.write_creature_class_main_stat_fixture(root)
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["EmptyClass"] = {
+            "class": "CCreatureClass",
+            "properties": {"mainStat": ""},
+        }
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "EmptyClass.properties.mainStat",
+            'property "mainStat" for class "CCreatureClass" expected a non-empty numeric CStats property name; '
+            "got string",
+        )
+
     def test_cpp_property_schema_reports_scalar_type_mismatches(self):
         root = self.make_fixture()
         self.write_property_schema_fixture(root)
@@ -1304,6 +1384,49 @@ class ContentValidatorTest(unittest.TestCase):
         manifest = root / "scripts/type_registration_exclusions.json"
         manifest.parent.mkdir(parents=True, exist_ok=True)
         write_json(manifest, {"exclusions": exclusions})
+
+    def write_creature_class_main_stat_fixture(self, root):
+        """Declare synthetic CStats + CCreatureClass metadata for mainStat checks.
+
+        CCreatureClass does not exist on real content, so the validator is vacuously
+        satisfied there; these synthetic headers let the test exercise the forward
+        guard.  CStats mirrors src/core/CStats.h closely enough to drive the numeric
+        property derivation: a couple of int stats plus the std::string mainStat.
+        """
+        header = root / "src/object/CCreatureClassFixture.h"
+        header.parent.mkdir(parents=True, exist_ok=True)
+        header.write_text(
+            textwrap.dedent("""
+                class CGameObject {
+                    V_META(CGameObject, vstd::meta::empty,
+                        V_PROPERTY(CGameObject, std::string, name, getName, setName))
+                };
+
+                class CStats {
+                    V_META(CStats, CGameObject,
+                        V_PROPERTY(CStats, int, strength, getStrength, setStrength),
+                        V_PROPERTY(CStats, int, agility, getAgility, setAgility),
+                        V_PROPERTY(CStats, int, intelligence, getIntelligence, setIntelligence),
+                        V_PROPERTY(CStats, std::string, mainStat, getMainStat, setMainStat))
+                };
+
+                class CCreatureClass {
+                    V_META(CCreatureClass, CGameObject,
+                        V_PROPERTY(CCreatureClass, std::string, mainStat, getMainStat, setMainStat))
+                };
+            """).lstrip(),
+            encoding="utf-8",
+        )
+        type_registration = root / "src/object/CCreatureClassTypeRegistration.cpp"
+        type_registration.write_text(
+            textwrap.dedent("""
+                void registerCreatureClassTypes() {
+                    CTypes::register_type<CStats, CGameObject>();
+                    CTypes::register_type<CCreatureClass, CGameObject>();
+                }
+            """).lstrip(),
+            encoding="utf-8",
+        )
 
     def assertIssueContains(self, issues, *substrings):
         issue_text = "\n".join(str(issue) for issue in issues)


### PR DESCRIPTION
## Issue
`[EPIC_06][STORY_02][SUBSTORY_01]Validate class mainStat` (P1; claim `f29da59f…`, owner `controller/ctrl-vm-21329-d93e25a1/subagent-v1`).

## What changed (pure-Python content validation)
- `scripts/validate_content.py` (+81): `ContentValidator._validate_creature_class_main_stat(...)` — for a `CCreatureClass` config (or a class inheriting it), verifies a present `mainStat` is a non-empty string naming a numeric (`int`) `CStats` property; reports the exact `…properties.mainStat` path otherwise. Allowed names are derived from the **live** `CStats` metadata schema (`_metadata_property_schema("CStats")`, filtered to `int`) via `_numeric_main_stat_names()`, so they track `src/core/CStats.h` automatically rather than being hard-coded. Wired into the existing `_validate_object_node_properties` loop.
- `tests/test_content_validator.py` (+123): 4 cases (numeric stat passes; typo `"strenght"`, non-numeric, and empty rejected with path) using synthetic `CStats`/`CCreatureClass` fixtures.

`CCreatureClass` configs don't exist on `main` yet, so the check is vacuously satisfied today (forward-guard) and real-content validation still passes.

## Validation (run locally by worker + controller)
`python3 scripts/validate_content.py --repo-root .` → "Content validation passed"; `python3 -m unittest tests.test_content_validator` → 57 tests OK. `black -l 120` clean; `git diff --check` clean; no `planning/` files.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_