### PR TITLE
Validate CCreatureClass.actions/levelling resolve to CInteraction (E06/S02/SS02)

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -130,6 +130,20 @@ CREATURE_CLASS_MAIN_STAT_PROPERTY = "mainStat"
 MAIN_STAT_SCHEMA_CLASS = "CStats"
 MAIN_STAT_NUMERIC_TYPE_TOKEN = "int"
 
+# CCreatureClass action/levelling resolution policy (EPIC_06/STORY_02/SUBSTORY_02).
+# A CCreatureClass definition grants interactions through two property blocks that
+# the runtime loader resolves late: "actions" is a list of object nodes (each a
+# ref or inline class) that must each resolve to a CInteraction, and "levelling" is
+# a map keyed by the level at which an interaction is unlocked -- the keys must be
+# positive-integer strings and the values must each resolve to a CInteraction. The
+# same effective action id must not be granted twice within one class definition
+# (whether through "actions" or "levelling"), since a duplicate silently shadows the
+# earlier grant at load time instead of being reported.
+CREATURE_CLASS_CONSTRUCTOR_CLASS = "CCreatureClass"
+CREATURE_CLASS_ACTIONS_PROPERTY = "actions"
+CREATURE_CLASS_LEVELLING_PROPERTY = "levelling"
+INTERACTION_BASE_CLASS = "CInteraction"
+
 # Map-local creature override inventory (EPIC_01/STORY_01/SUBSTORY_02).
 # Map config files reference creature templates via "ref" plus a "properties" block
 # that overrides template behavior.  Any override touching one of these properties
@@ -1362,6 +1376,7 @@ class ContentValidator:
         self._validate_refs(entry.path, entry.key, entry.data, visible)
         self._validate_object_classes(entry.path, entry.key, entry.data, known_classes)
         self._validate_object_properties(entry.path, entry.key, entry.data, visible, known_classes)
+        self._validate_creature_class_actions_levelling(entry.path, entry.key, entry.data, visible)
 
     def _validate_object_shape(self, path: Path, location: str, value: Any) -> None:
         if isinstance(value, dict):
@@ -2271,6 +2286,134 @@ class ContentValidator:
             for index, child in enumerate(value):
                 self._validate_creature_class_reference(path, append_index(location, index), child)
 
+    def _validate_creature_class_actions_levelling(
+        self, path: Path, location: str, value: Any, visible: dict[str, ConfigEntry]
+    ) -> None:
+        """Validate CCreatureClass.actions / levelling resolve to CInteraction.
+
+        Recurses through the config tree so a CCreatureClass node nested under a ref
+        chain or another object is still checked.  For every node whose effective
+        class is ``CCreatureClass`` it verifies that each ``actions`` entry resolves
+        to a ``CInteraction``, that each ``levelling`` key is a positive-integer
+        string whose value resolves to a ``CInteraction``, and that no effective
+        action id (the ref target id) is granted more than once across both blocks.
+        """
+        if isinstance(value, dict):
+            if self._effective_object_class(value, visible) == CREATURE_CLASS_CONSTRUCTOR_CLASS:
+                self._validate_creature_class_grants(path, location, value, visible)
+            for key, child in value.items():
+                self._validate_creature_class_actions_levelling(path, append_field(location, key), child, visible)
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                self._validate_creature_class_actions_levelling(path, append_index(location, index), child, visible)
+
+    def _validate_creature_class_grants(
+        self, path: Path, location: str, value: dict[str, Any], visible: dict[str, ConfigEntry]
+    ) -> None:
+        properties = value.get("properties")
+        if not isinstance(properties, dict):
+            return
+        properties_location = append_field(location, "properties")
+        seen_action_ids: dict[str, str] = {}
+        self._validate_creature_class_actions(
+            path,
+            append_field(properties_location, CREATURE_CLASS_ACTIONS_PROPERTY),
+            properties.get(CREATURE_CLASS_ACTIONS_PROPERTY),
+            visible,
+            seen_action_ids,
+        )
+        self._validate_creature_class_levelling(
+            path,
+            append_field(properties_location, CREATURE_CLASS_LEVELLING_PROPERTY),
+            properties.get(CREATURE_CLASS_LEVELLING_PROPERTY),
+            visible,
+            seen_action_ids,
+        )
+
+    def _validate_creature_class_actions(
+        self,
+        path: Path,
+        location: str,
+        actions: Any,
+        visible: dict[str, ConfigEntry],
+        seen_action_ids: dict[str, str],
+    ) -> None:
+        if actions is None:
+            return
+        if not isinstance(actions, list):
+            self._issue(path, location, "expected array of CInteraction action entries")
+            return
+        for index, action in enumerate(actions):
+            entry_location = append_index(location, index)
+            self._validate_creature_class_interaction_entry(path, entry_location, action, visible)
+            self._record_effective_action_id(path, entry_location, action, seen_action_ids)
+
+    def _validate_creature_class_levelling(
+        self,
+        path: Path,
+        location: str,
+        levelling: Any,
+        visible: dict[str, ConfigEntry],
+        seen_action_ids: dict[str, str],
+    ) -> None:
+        if levelling is None:
+            return
+        if not isinstance(levelling, dict):
+            self._issue(path, location, "expected object keyed by positive-integer level")
+            return
+        for level_key, action in levelling.items():
+            entry_location = append_field(location, level_key)
+            if not is_positive_integer_string(level_key):
+                self._issue(
+                    path,
+                    entry_location,
+                    f'levelling key "{level_key}" must be a positive-integer string',
+                )
+            self._validate_creature_class_interaction_entry(path, entry_location, action, visible)
+            self._record_effective_action_id(path, entry_location, action, seen_action_ids)
+
+    def _validate_creature_class_interaction_entry(
+        self, path: Path, location: str, action: Any, visible: dict[str, ConfigEntry]
+    ) -> None:
+        if not isinstance(action, dict):
+            self._issue(path, location, f'expected object resolving to "{INTERACTION_BASE_CLASS}"')
+            return
+        class_name = self._effective_object_class(action, visible)
+        if class_name is None:
+            self._issue(
+                path,
+                location,
+                f'expected object resolving to "{INTERACTION_BASE_CLASS}"; got object without class/ref',
+            )
+            return
+        if not self._class_resolves_to_interaction(class_name):
+            self._issue(
+                path,
+                location,
+                f'expected object resolving to "{INTERACTION_BASE_CLASS}"; got "{class_name}"',
+            )
+
+    def _class_resolves_to_interaction(self, class_name: str) -> bool:
+        return class_name == INTERACTION_BASE_CLASS or self._class_inherits_from(class_name, INTERACTION_BASE_CLASS)
+
+    def _record_effective_action_id(
+        self, path: Path, location: str, action: Any, seen_action_ids: dict[str, str]
+    ) -> None:
+        if not isinstance(action, dict):
+            return
+        action_id = action.get("ref")
+        if not isinstance(action_id, str) or not action_id:
+            return
+        previous = seen_action_ids.get(action_id)
+        if previous is not None:
+            self._issue(
+                path,
+                location,
+                f'duplicate action id "{action_id}", previously granted at {previous}',
+            )
+            return
+        seen_action_ids[action_id] = location
+
     def _issue(self, path: Path, location: str, message: str) -> None:
         self.issues.append(ValidationIssue(path=self._rel(path), location=location, message=message))
 
@@ -2391,6 +2534,18 @@ def json_value_kind(value: Any) -> str:
     if value is None:
         return "null"
     return type(value).__name__
+
+
+def is_positive_integer_string(value: Any) -> bool:
+    """Return True when ``value`` is a canonical positive-integer string (1, 2, ...).
+
+    Rejects non-strings, non-digit strings, "0", and any leading-zero / signed /
+    whitespace-padded form so a levelling key always denotes a single unambiguous
+    positive level.
+    """
+    if not isinstance(value, str) or not value.isdigit():
+        return False
+    return value == str(int(value)) and int(value) > 0
 
 
 def normalize_cpp_type(raw: str) -> str:

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -669,6 +669,114 @@ class ContentValidatorTest(unittest.TestCase):
             'never the reserved object-constructor key "class"',
         )
 
+    def _register_creature_class_type(self, root):
+        # CCreatureClass is not a builtin; register it statically (without V_META) so
+        # the synthetic configs are constructible and carry no metadata property
+        # schema, leaving only the actions/levelling validator to fire.
+        type_registration = root / "src/object/CObjectTypeRegistration.cpp"
+        type_registration.parent.mkdir(parents=True, exist_ok=True)
+        type_registration.write_text(
+            "void registerObjectTypes() { CTypes::register_type<CCreatureClass, CGameObject>(); }\n",
+            encoding="utf-8",
+        )
+
+    def _write_creature_class(self, root, properties):
+        write_json(
+            root / "res/config/creature_classes.json",
+            {"warriorClass": {"class": "CCreatureClass", "properties": properties}},
+        )
+
+    def test_creature_class_actions_and_levelling_resolving_to_interaction_pass(self):
+        root = self.make_fixture()
+        self._register_creature_class_type(root)
+        self._write_creature_class(
+            root,
+            {
+                "actions": [
+                    {"ref": "Attack"},
+                    {"class": "CInteraction", "properties": {"effect": {"ref": "HitEffect"}}},
+                ],
+                "levelling": {"1": {"class": "CInteraction"}, "2": {"class": "CInteraction"}},
+            },
+        )
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
+    def test_creature_class_action_not_resolving_to_interaction_is_reported(self):
+        root = self.make_fixture()
+        self._register_creature_class_type(root)
+        self._write_creature_class(root, {"actions": [{"ref": "LifePotion"}]})
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/creature_classes.json",
+            "warriorClass.properties.actions[0]",
+            'expected object resolving to "CInteraction"; got "CPotion"',
+        )
+
+    def test_creature_class_levelling_value_not_resolving_to_interaction_is_reported(self):
+        root = self.make_fixture()
+        self._register_creature_class_type(root)
+        self._write_creature_class(root, {"levelling": {"1": {"ref": "LifePotion"}}})
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/creature_classes.json",
+            'warriorClass.properties.levelling["1"]',
+            'expected object resolving to "CInteraction"; got "CPotion"',
+        )
+
+    def test_creature_class_non_integer_levelling_key_is_reported(self):
+        root = self.make_fixture()
+        self._register_creature_class_type(root)
+        self._write_creature_class(root, {"levelling": {"one": {"ref": "Attack"}}})
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/creature_classes.json",
+            "warriorClass.properties.levelling.one",
+            'levelling key "one" must be a positive-integer string',
+        )
+
+    def test_creature_class_non_positive_levelling_key_is_reported(self):
+        root = self.make_fixture()
+        self._register_creature_class_type(root)
+        self._write_creature_class(root, {"levelling": {"0": {"ref": "Attack"}}})
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/creature_classes.json",
+            'warriorClass.properties.levelling["0"]',
+            'levelling key "0" must be a positive-integer string',
+        )
+
+    def test_creature_class_duplicate_action_id_is_reported(self):
+        root = self.make_fixture()
+        self._register_creature_class_type(root)
+        self._write_creature_class(
+            root,
+            {"actions": [{"ref": "Attack"}], "levelling": {"1": {"ref": "Attack"}}},
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/creature_classes.json",
+            'warriorClass.properties.levelling["1"]',
+            'duplicate action id "Attack", previously granted at warriorClass.properties.actions[0]',
+        )
+
     def test_invalid_transition_targets_report_map_name(self):
         root = self.make_fixture(script_map="missingMap")
 


### PR DESCRIPTION
## Issue
`[EPIC_06][STORY_02][SUBSTORY_02]Validate class actions and levelling` (P1; claim `230eb4bf…`, owner `controller/ctrl-vm-21329-d93e25a1/subagent-v2`).

## What changed (pure-Python content validation)
- `scripts/validate_content.py` (+155): `_validate_creature_class_actions_levelling(...)` (+ helpers) — for any config node resolving to `CCreatureClass`, each `actions[]` entry and each `levelling` value must resolve to a `CInteraction` (following ref chains and Python/metadata inheritance), `levelling` keys must be canonical positive-integer strings, and no effective action id may be granted twice within one class definition. Runs in `_validate_config_entry`, reusing the existing class-resolution machinery; reports exact JSON paths.
- `tests/test_content_validator.py` (+108): 6 synthetic-fixture cases (pass; action not interaction; levelling value not interaction; non-integer key; non-positive key; duplicate id).

Forward-guard (no `CCreatureClass` configs exist yet) — vacuously satisfied on real content. Rebased over the sibling mainStat validator (#1018); constants kept-both, no logic overlap.

## Validation (run by controller post-rebase)
`python3 scripts/validate_content.py --repo-root .` → "Content validation passed"; `python3 -m unittest tests.test_content_validator` → 63 tests OK; `black -l 120` clean; `git diff --check` clean; no `planning/` files.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_