### PR TITLE
Validate quest state transitions and script-granted quest ids (E07/S01/SS02)

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -1364,6 +1364,7 @@ class ContentValidator:
         self._validate_dialogs(context, visible)
         self._validate_script_refs(context, visible, known_classes, archetype_ids)
         self._validate_script_property_hygiene(context)
+        self._validate_quest_state_transitions(context)
 
     def _visible_entries(self, context: MapContext) -> dict[str, ConfigEntry]:
         visible = dict(self.global_entries)
@@ -2212,6 +2213,67 @@ class ContentValidator:
                 continue
             valid_flags.add(flag.name)
         return valid_flags
+
+    def _validate_quest_state_transitions(self, context: MapContext) -> None:
+        """Validate the state machine declared by a map script's quest-state usage.
+
+        Builds on the quest-state collection produced by ScriptAnalyzer (QUEST_KEYS,
+        QUEST_DEFAULTS, _set_state/state_in writes and reads, and terminal completion
+        checks). A quest key is "declared" when QUEST_KEYS maps it to a storage key.
+        The rules enforced are:
+
+        * every QUEST_DEFAULTS default references a declared quest key;
+        * every transition target (a _set_state write) belongs to a declared quest key;
+        * every state read (a get_state comparison or state_in) belongs to a declared
+          quest key;
+        * every terminal completion state is reachable from a default -- i.e. it is the
+          default state itself or a state assigned by some transition write. A terminal
+          state that is never the default and never written can never be entered, so the
+          completion check it guards can never fire.
+
+        Undeclared keys are detected because any get_state/_set_state/state_in reference
+        records a ScriptQuestStateUsage entry whose storage_key stays None when the key
+        is absent from QUEST_KEYS.
+        """
+        info = context.script_info
+        if not info:
+            return
+        for quest_key in sorted(info.quest_states):
+            usage = info.quest_states[quest_key]
+            declared = bool(usage.storage_key)
+            location = f'quest "{quest_key}"'
+            if usage.default_state is not None and not declared:
+                self._issue(
+                    info.path,
+                    location,
+                    f'quest default "{usage.default_state}" references undeclared quest key "{quest_key}" '
+                    "(missing from QUEST_KEYS)",
+                )
+            if not declared:
+                for state in sorted(usage.written_states):
+                    self._issue(
+                        info.path,
+                        location,
+                        f'transition target "{state}" writes undeclared quest key "{quest_key}" '
+                        "(missing from QUEST_KEYS)",
+                    )
+                for state in sorted(usage.read_states):
+                    self._issue(
+                        info.path,
+                        location,
+                        f'state read "{state}" references undeclared quest key "{quest_key}" '
+                        "(missing from QUEST_KEYS)",
+                    )
+                continue
+            reachable = set(usage.written_states)
+            if usage.default_state is not None:
+                reachable.add(usage.default_state)
+            for state in sorted(usage.terminal_check_states - reachable):
+                self._issue(
+                    info.path,
+                    location,
+                    f'terminal state "{state}" is unreachable: it is neither the default nor a transition target',
+                )
 
     def _first_property_access(self, info: ScriptInfo, property_name: str) -> ScriptPropertyAccess | None:
         accesses = [

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -601,6 +601,189 @@ class ContentValidatorTest(unittest.TestCase):
 
         self.assertEqual([], [str(issue) for issue in issues])
 
+    def test_given_default_for_undeclared_quest_key_when_validating_then_reports_missing_declaration(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            class QuestSystem(QuestStateStore):
+                QUEST_KEYS = {"main": "quest_state_main"}
+                QUEST_DEFAULTS = {"main": "locked", "ghost": "not_started"}
+
+            @register(context)
+            class StartEvent(CEvent):
+                pass
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'quest "ghost"',
+            'quest default "not_started" references undeclared quest key "ghost" (missing from QUEST_KEYS)',
+        )
+
+    def test_given_transition_target_for_undeclared_quest_key_when_validating_then_reports_missing_declaration(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            class QuestSystem(QuestStateStore):
+                QUEST_KEYS = {"main": "quest_state_main"}
+                QUEST_DEFAULTS = {"main": "locked"}
+
+                def advance(self):
+                    self._set_state("ghost", "active")
+
+            @register(context)
+            class StartEvent(CEvent):
+                pass
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'quest "ghost"',
+            'transition target "active" writes undeclared quest key "ghost" (missing from QUEST_KEYS)',
+        )
+
+    def test_given_state_read_for_undeclared_quest_key_when_validating_then_reports_missing_declaration(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            class QuestSystem(QuestStateStore):
+                QUEST_KEYS = {"main": "quest_state_main"}
+                QUEST_DEFAULTS = {"main": "locked"}
+
+                def check(self):
+                    return self.get_state("ghost") == "active"
+
+            @register(context)
+            class StartEvent(CEvent):
+                pass
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'quest "ghost"',
+            'state read "active" references undeclared quest key "ghost" (missing from QUEST_KEYS)',
+        )
+
+    def test_given_unreachable_terminal_state_when_validating_then_reports_unreachable_terminal(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            class QuestSystem(QuestStateStore):
+                QUEST_KEYS = {"main": "quest_state_main"}
+                QUEST_DEFAULTS = {"main": "locked"}
+
+                def advance(self):
+                    self._set_state("main", "active")
+
+                def isCompleted(self):
+                    return self.get_state("main") == "finished"
+
+            @register(context)
+            class StartEvent(CEvent):
+                pass
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'quest "main"',
+            'terminal state "finished" is unreachable: it is neither the default nor a transition target',
+        )
+
+    def test_given_reachable_quest_state_machine_when_validating_then_accepts_transitions(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            class QuestSystem(QuestStateStore):
+                QUEST_KEYS = {"main": "quest_state_main"}
+                QUEST_DEFAULTS = {"main": "locked"}
+
+                def advance(self):
+                    if self.get_state("main") == "locked":
+                        self._set_state("main", "active")
+                    if self.get_state("main") == "active":
+                        self._set_state("main", "finished")
+
+                def isCompleted(self):
+                    return self.get_state("main") == "finished"
+
+            @register(context)
+            class StartEvent(CEvent):
+                pass
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
+    def test_given_default_terminal_state_when_validating_then_treats_default_as_reachable(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            class QuestSystem(QuestStateStore):
+                QUEST_KEYS = {"main": "quest_state_main"}
+                QUEST_DEFAULTS = {"main": "resolved"}
+
+                def isCompleted(self):
+                    return self.get_state("main") == "resolved"
+
+            @register(context)
+            class StartEvent(CEvent):
+                pass
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
+    def test_given_script_granted_quest_id_missing_from_config_when_validating_then_reports_unknown_quest(self):
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            class QuestSystem(QuestStateStore):
+                QUEST_KEYS = {"main": "quest_state_main"}
+                QUEST_DEFAULTS = {"main": "locked"}
+
+            @register(context)
+            class StartEvent(CEvent):
+                def onEnter(self, event):
+                    event.getCause().addQuest("phantomQuest")
+            """,
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'addQuest("phantomQuest")',
+            'unknown quest id "phantomQuest"',
+        )
+
     def test_creature_archetype_naming_policy_accepts_conforming_ids(self):
         root = self.make_fixture()
         write_json(


### PR DESCRIPTION
## Issue
`[EPIC_07][STORY_01][SUBSTORY_02]Validate quest state transitions` (P1; claim `804930ac…`, owner `controller/ctrl-vm-21731-06a89ce0/subagent-v4`).

## What changed (pure-Python content validation)
- `scripts/validate_content.py` (+62): `_validate_quest_state_transitions(context)` (registered in `_validate_map_context`), building on the SS01 `ScriptQuestStateUsage` collection. Flags quest `default`s, `_set_state` transition targets, and `get_state`/`state_in` reads that reference a quest key never declared in `QUEST_KEYS`, and reports terminal completion states that are unreachable (neither the default nor any transition target). Script-granted quest ids are already covered by `_validate_script_refs` and now have a regression test.
- `tests/test_content_validator.py` (+183): 7 synthetic-fixture cases (declared-vs-undeclared key/target/read, unreachable terminal, script-granted quest id missing, plus the reachable/default-terminal accept paths).

This validates **existing** quest content (not archetype-gated). Worker confirmed the shipped Nouraajd quests (6 keys) satisfy all rules — no rule loosened to fit; no real-content findings. Rebased onto main with the three sibling validators (no conflict).

## Validation
`python3 scripts/validate_content.py --repo-root .` → "Content validation passed"; `python3 -m unittest tests.test_content_validator` → 75 tests OK; `black -l 120` clean; `git diff --check` clean; no `planning/` files.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_