### PR TITLE
Validate CCreature.creatureClass resolves to a CCreatureClass definition (E06/S01/SS02)

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -157,6 +157,18 @@ CREATURE_CLASS_BASE_CLASS = "CCreatureClass"
 CREATURE_ARCHETYPE_BASE_CLASSES = (CREATURE_RACE_BASE_CLASS, CREATURE_CLASS_BASE_CLASS)
 CREATURE_ARCHETYPE_DEFINITION_CONFIGS = (CREATURE_RACES_CONFIG, CREATURE_CLASSES_CONFIG)
 
+# CCreature.creatureClass reference resolution policy (EPIC_06/STORY_01/SUBSTORY_02).
+# A CCreature config carries its class template through the JSON *property*
+# "creatureClass" (CREATURE_CLASS_REFERENCE_PROPERTY) -- never the top-level object
+# constructor key "class".  That property value is itself an object node (a ref or
+# inline class) that the runtime loader resolves late; it must resolve, through any
+# ref/config chain, to a definition whose effective engine class is or inherits
+# CCreatureClass.  A value that is not an object node (a wrong-typed scalar/array), a
+# ref that does not resolve to a known config (missing), and an object that resolves
+# to a non-CCreatureClass class (wrong type) are each reported distinctly with the
+# exact "...properties.creatureClass" path.  No creature on current content sets this
+# property, so the check is forward-guarding and vacuously satisfied until authored.
+
 # Map-local creature override inventory (EPIC_01/STORY_01/SUBSTORY_02).
 # Map config files reference creature templates via "ref" plus a "properties" block
 # that overrides template behavior.  Any override touching one of these properties
@@ -1392,6 +1404,7 @@ class ContentValidator:
         self._validate_object_classes(entry.path, entry.key, entry.data, known_classes)
         self._validate_object_properties(entry.path, entry.key, entry.data, visible, known_classes)
         self._validate_creature_class_actions_levelling(entry.path, entry.key, entry.data, visible)
+        self._validate_creature_class_property(entry.path, entry.key, entry.data, visible)
 
     def _validate_object_shape(self, path: Path, location: str, value: Any) -> None:
         if isinstance(value, dict):
@@ -2495,6 +2508,67 @@ class ContentValidator:
 
     def _class_resolves_to_interaction(self, class_name: str) -> bool:
         return class_name == INTERACTION_BASE_CLASS or self._class_inherits_from(class_name, INTERACTION_BASE_CLASS)
+
+    def _validate_creature_class_property(
+        self, path: Path, location: str, value: Any, visible: dict[str, ConfigEntry]
+    ) -> None:
+        """Validate a CCreature's "creatureClass" property resolves to a CCreatureClass.
+
+        Recurses through the config tree so a creature node nested under a ref chain
+        or another object is still checked.  For every node whose effective class is or
+        inherits ``CCreature`` it inspects the *property* ``properties.creatureClass``
+        (never the top-level object-constructor key ``class``) and verifies that its
+        value is an object node resolving, through any ref/config chain, to a definition
+        whose effective class is or inherits ``CCreatureClass``.  Wrong-typed values,
+        unresolvable/missing references, and resolved-but-wrong-class targets are each
+        reported distinctly at the exact ``properties.creatureClass`` path.
+        """
+        if isinstance(value, dict):
+            if self._is_creature_node(value, visible):
+                self._validate_creature_class_reference_target(path, location, value, visible)
+            for key, child in value.items():
+                self._validate_creature_class_property(path, append_field(location, key), child, visible)
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                self._validate_creature_class_property(path, append_index(location, index), child, visible)
+
+    def _validate_creature_class_reference_target(
+        self, path: Path, location: str, value: dict[str, Any], visible: dict[str, ConfigEntry]
+    ) -> None:
+        properties = value.get("properties")
+        if not isinstance(properties, dict) or CREATURE_CLASS_REFERENCE_PROPERTY not in properties:
+            return
+        reference = properties[CREATURE_CLASS_REFERENCE_PROPERTY]
+        reference_location = append_field(append_field(location, "properties"), CREATURE_CLASS_REFERENCE_PROPERTY)
+        if not isinstance(reference, dict):
+            self._issue(
+                path,
+                reference_location,
+                f'property "{CREATURE_CLASS_REFERENCE_PROPERTY}" expected an object resolving to '
+                f'"{CREATURE_CLASS_BASE_CLASS}"; got {json_value_kind(reference)}',
+            )
+            return
+        resolved_class = self._effective_object_class(reference, visible)
+        if resolved_class is None:
+            self._issue(
+                path,
+                reference_location,
+                f'property "{CREATURE_CLASS_REFERENCE_PROPERTY}" expected an object resolving to '
+                f'"{CREATURE_CLASS_BASE_CLASS}"; reference does not resolve to a known config',
+            )
+            return
+        if not self._class_resolves_to_creature_class(resolved_class):
+            self._issue(
+                path,
+                reference_location,
+                f'property "{CREATURE_CLASS_REFERENCE_PROPERTY}" expected an object resolving to '
+                f'"{CREATURE_CLASS_BASE_CLASS}"; got "{resolved_class}"',
+            )
+
+    def _class_resolves_to_creature_class(self, class_name: str) -> bool:
+        return class_name == CREATURE_CLASS_BASE_CLASS or self._class_inherits_from(
+            class_name, CREATURE_CLASS_BASE_CLASS
+        )
 
     def _record_effective_action_id(
         self, path: Path, location: str, action: Any, seen_action_ids: dict[str, str]

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -960,6 +960,124 @@ class ContentValidatorTest(unittest.TestCase):
             'duplicate action id "Attack", previously granted at warriorClass.properties.actions[0]',
         )
 
+    def _write_creature_with_creature_class(self, root, creature_class_value):
+        # A concrete CCreature carrying its class template through the "creatureClass"
+        # *property* (never the top-level constructor key "class").  CCreatureClass is
+        # registered statically so the definition is constructible.
+        self._register_creature_class_type(root)
+        write_json(
+            root / "res/config/creature_classes.json",
+            {"warriorClass": {"class": "CCreatureClass", "properties": {"label": "Warrior"}}},
+        )
+        write_json(
+            root / "res/config/monsters.json",
+            {
+                "Goblin": {
+                    "class": "CCreature",
+                    "properties": {"creatureClass": creature_class_value, "label": "Goblin"},
+                }
+            },
+        )
+
+    def test_creature_class_property_resolving_to_creature_class_passes(self):
+        root = self.make_fixture()
+        self._write_creature_with_creature_class(root, {"ref": "warriorClass"})
+
+        issues = validate_repo(root)
+
+        creature_class_issues = [
+            str(issue) for issue in issues if "creatureClass" in str(issue) and "Goblin" in str(issue)
+        ]
+        self.assertEqual([], creature_class_issues)
+
+    def test_creature_class_property_inline_creature_class_passes(self):
+        root = self.make_fixture()
+        self._register_creature_class_type(root)
+        write_json(
+            root / "res/config/monsters.json",
+            {
+                "Goblin": {
+                    "class": "CCreature",
+                    "properties": {
+                        "creatureClass": {"class": "CCreatureClass", "properties": {"label": "Warrior"}},
+                        "label": "Goblin",
+                    },
+                }
+            },
+        )
+
+        issues = validate_repo(root)
+
+        creature_class_issues = [
+            str(issue) for issue in issues if "creatureClass" in str(issue) and "Goblin" in str(issue)
+        ]
+        self.assertEqual([], creature_class_issues)
+
+    def test_creature_class_property_missing_reference_is_reported(self):
+        root = self.make_fixture()
+        self._register_creature_class_type(root)
+        write_json(
+            root / "res/config/monsters.json",
+            {
+                "Goblin": {
+                    "class": "CCreature",
+                    "properties": {"creatureClass": {"ref": "ghostClass"}, "label": "Goblin"},
+                }
+            },
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/monsters.json",
+            "Goblin.properties.creatureClass",
+            'property "creatureClass" expected an object resolving to "CCreatureClass"; '
+            "reference does not resolve to a known config",
+        )
+
+    def test_creature_class_property_wrong_target_class_is_reported(self):
+        root = self.make_fixture()
+        self._write_creature_with_creature_class(root, {"ref": "LifePotion"})
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/monsters.json",
+            "Goblin.properties.creatureClass",
+            'property "creatureClass" expected an object resolving to "CCreatureClass"; got "CPotion"',
+        )
+
+    def test_creature_class_property_wrong_typed_value_is_reported(self):
+        root = self.make_fixture()
+        self._write_creature_with_creature_class(root, "warriorClass")
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/monsters.json",
+            "Goblin.properties.creatureClass",
+            'property "creatureClass" expected an object resolving to "CCreatureClass"; got string',
+        )
+
+    def test_creature_top_level_class_key_is_not_mistaken_for_creature_class_property(self):
+        root = self.make_fixture()
+        self._register_creature_class_type(root)
+        # The creature's top-level "class": "CCreature" constructor key must never be
+        # treated as the "creatureClass" reference property: a creature that omits the
+        # property is vacuously satisfied and emits no creatureClass diagnostic.
+        write_json(
+            root / "res/config/monsters.json",
+            {"Goblin": {"class": "CCreature", "properties": {"label": "Goblin"}}},
+        )
+
+        issues = validate_repo(root)
+
+        creature_class_issues = [str(issue) for issue in issues if "creatureClass" in str(issue)]
+        self.assertEqual([], creature_class_issues)
+
     def test_archetype_id_as_map_object_type_is_rejected(self):
         root = self.make_fixture()
         write_json(


### PR DESCRIPTION
## Issue
`[EPIC_06][STORY_01][SUBSTORY_02]Validate creatureClass resolves to CCreatureClass` (P1; claim `94158e2f…`, owner `controller/ctrl-vm-18621-2e420b9b/subagent-w2`).

## What changed (pure-Python content validation)
- `scripts/validate_content.py` (+74): `_validate_creature_class_property(...)` — for any `CCreature`-resolving node, validates the **property** `properties.creatureClass` (never the top-level `class` constructor key) resolves to a `CCreatureClass` definition; reports wrong-typed value, missing/unresolvable reference, and resolved-but-wrong-class distinctly at the exact `…properties.creatureClass` path. Registered in `_validate_config_entry` after the sibling actions/levelling validator; reuses `_is_creature_node`/`_effective_object_class`/`_class_inherits_from`/`json_value_kind`.
- `tests/test_content_validator.py` (+118): 6 synthetic cases (ref/inline pass; missing ref; non-`CCreatureClass` target; wrong-typed value; and a guard that the top-level `class` key isn't mistaken for the property).

Forward-guard — vacuously satisfied on real content.

## Validation
`python3 scripts/validate_content.py --repo-root .` → "Content validation passed"; `python3 -m unittest tests.test_content_validator` → 81 tests OK; `black -l 120` clean; `git diff --check` clean; no `planning/` files.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_