### PR TITLE
Validate CCreature.race resolves to a CCreatureRace definition (E06/S01/SS01)

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -83,7 +83,11 @@ BUILTIN_CLASSES = {
     "CWeapon",
 }
 REVIEWED_DYNAMIC_PROPERTIES = {
-    "CCreature": {"class"},
+    # "race" is the CCreatureRace archetype reference reviewed by
+    # _validate_creature_race_reference (EPIC_06/STORY_01/SUBSTORY_01); it is accepted
+    # as a known dynamic property so its resolution is checked rather than rejected as
+    # an unknown property.
+    "CCreature": {"class", "race"},
     "CDialogState": {"condition"},
     "CScroll": {"singleUse"},
 }
@@ -168,6 +172,18 @@ CREATURE_ARCHETYPE_DEFINITION_CONFIGS = (CREATURE_RACES_CONFIG, CREATURE_CLASSES
 # to a non-CCreatureClass class (wrong type) are each reported distinctly with the
 # exact "...properties.creatureClass" path.  No creature on current content sets this
 # property, so the check is forward-guarding and vacuously satisfied until authored.
+
+# CCreature.race resolution policy (EPIC_06/STORY_01/SUBSTORY_01).
+# A creature names its race archetype via the "race" property, which the runtime
+# loader resolves late through the same ref/config machinery as any object node: the
+# value is an object node ({"ref": "<raceId>"} or an inline {"class": ...}) whose
+# effective engine class must be -- or inherit from -- CCreatureRace.  A reference to
+# an unknown id, to a config whose class is not a CCreatureRace, or a wrong-typed
+# (non-object) "race" value would silently resolve to no/wrong race at load time, so
+# each is reported here against the exact path (e.g. configId.properties.race.ref).
+# CCreature configs do not declare a "race" property on current content, so this
+# check is forward-guarding and vacuously satisfied until such configs are authored.
+CREATURE_RACE_PROPERTY = "race"
 
 # Map-local creature override inventory (EPIC_01/STORY_01/SUBSTORY_02).
 # Map config files reference creature templates via "ref" plus a "properties" block
@@ -1515,6 +1531,82 @@ class ContentValidator:
                     f'unknown property "{property_name}" for class "{class_name}"',
                 )
         self._validate_creature_class_main_stat(path, properties_location, class_name, properties)
+        self._validate_creature_race_reference(
+            path, properties_location, class_name, properties, visible, known_classes
+        )
+
+    def _validate_creature_race_reference(
+        self,
+        path: Path,
+        properties_location: str,
+        class_name: str,
+        properties: dict[str, Any],
+        visible: dict[str, ConfigEntry],
+        known_classes: set[str],
+    ) -> None:
+        """Verify a CCreature.race resolves to a CCreatureRace definition.
+
+        A creature names its race archetype through the "race" property, which the
+        engine resolves through the same ref/config machinery as any object node.  The
+        value must be an object node ({"ref": "<raceId>"} or an inline {"class": ...})
+        whose effective engine class is -- or inherits from -- CCreatureRace.  An
+        unknown reference, a reference to a config whose class is not a CCreatureRace,
+        or a wrong-typed (non-object / class-less) "race" value would silently resolve
+        to no/wrong race at load time, so each is reported against the exact path
+        (e.g. configId.properties.race.ref).  CCreature configs do not declare a "race"
+        property on current content, so this check is vacuously satisfied (forward
+        guarding) until such configs are authored.
+        """
+        if class_name != CREATURE_BASE_CLASS and not self._class_inherits_from(class_name, CREATURE_BASE_CLASS):
+            return
+        if CREATURE_RACE_PROPERTY not in properties:
+            return
+        race_value = properties[CREATURE_RACE_PROPERTY]
+        race_location = append_field(properties_location, CREATURE_RACE_PROPERTY)
+        if not isinstance(race_value, dict):
+            self._issue(
+                path,
+                race_location,
+                f'property "{CREATURE_RACE_PROPERTY}" for class "{class_name}" expected object inheriting from '
+                f'"{CREATURE_RACE_BASE_CLASS}"; got {json_value_kind(race_value)}',
+            )
+            return
+        ref = race_value.get("ref")
+        declared_class = race_value.get("class")
+        if isinstance(ref, str):
+            reference_location = append_field(race_location, "ref")
+        elif isinstance(declared_class, str):
+            reference_location = append_field(race_location, "class")
+        else:
+            reference_location = race_location
+        if isinstance(ref, str) and ref not in visible:
+            self._issue(
+                path,
+                reference_location,
+                f'property "{CREATURE_RACE_PROPERTY}" for class "{class_name}" references unknown id "{ref}"; '
+                f'expected a "{CREATURE_RACE_BASE_CLASS}" definition',
+            )
+            return
+        actual_class = self._effective_object_class(race_value, visible)
+        if actual_class is None:
+            self._issue(
+                path,
+                reference_location,
+                f'property "{CREATURE_RACE_PROPERTY}" for class "{class_name}" expected object inheriting from '
+                f'"{CREATURE_RACE_BASE_CLASS}"; got object without class/ref',
+            )
+            return
+        if actual_class not in known_classes:
+            return
+        if actual_class != CREATURE_RACE_BASE_CLASS and not self._class_inherits_from(
+            actual_class, CREATURE_RACE_BASE_CLASS
+        ):
+            self._issue(
+                path,
+                reference_location,
+                f'property "{CREATURE_RACE_PROPERTY}" for class "{class_name}" expected object inheriting from '
+                f'"{CREATURE_RACE_BASE_CLASS}"; got "{actual_class}"',
+            )
 
     def _validate_creature_class_main_stat(
         self,

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -1963,6 +1963,130 @@ class ContentValidatorTest(unittest.TestCase):
             encoding="utf-8",
         )
 
+    def write_creature_race_fixture(self, root):
+        """Declare synthetic CCreature + CCreatureRace metadata for race checks.
+
+        CCreature configs do not declare a "race" property on real content, so the
+        validator is vacuously satisfied there; these synthetic headers let the test
+        exercise the forward guard.  CCreatureRace and a sibling non-race class are
+        registered statically (without V_META registration) so they are constructible
+        and the inheritance check can confirm the resolved race class lineage.
+        """
+        header = root / "src/object/CCreatureRaceFixture.h"
+        header.parent.mkdir(parents=True, exist_ok=True)
+        header.write_text(
+            textwrap.dedent("""
+                class CGameObject {
+                    V_META(CGameObject, vstd::meta::empty,
+                        V_PROPERTY(CGameObject, std::string, name, getName, setName))
+                };
+
+                class CCreature {
+                    V_META(CCreature, CGameObject,
+                        V_PROPERTY(CCreature, std::string, name, getName, setName))
+                };
+
+                class CCreatureRace {
+                    V_META(CCreatureRace, CGameObject,
+                        V_PROPERTY(CCreatureRace, std::string, label, getLabel, setLabel))
+                };
+
+                class CCreatureClass {
+                    V_META(CCreatureClass, CGameObject,
+                        V_PROPERTY(CCreatureClass, std::string, label, getLabel, setLabel))
+                };
+            """).lstrip(),
+            encoding="utf-8",
+        )
+        type_registration = root / "src/object/CCreatureRaceTypeRegistration.cpp"
+        type_registration.write_text(
+            textwrap.dedent("""
+                void registerCreatureRaceTypes() {
+                    CTypes::register_type<CCreatureRace, CGameObject>();
+                    CTypes::register_type<CCreatureClass, CGameObject>();
+                }
+            """).lstrip(),
+            encoding="utf-8",
+        )
+
+    def test_creature_race_ref_to_creature_race_passes(self):
+        root = self.make_fixture()
+        self.write_creature_race_fixture(root)
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["humanRace"] = {"class": "CCreatureRace", "properties": {"label": "Human"}}
+        config["Townsfolk"] = {
+            "class": "CCreature",
+            "properties": {"race": {"ref": "humanRace"}},
+        }
+        write_json(config_path, config)
+
+        self.assertEqual([], [str(issue) for issue in validate_repo(root)])
+
+    def test_creature_race_unknown_ref_reports_ref_path(self):
+        root = self.make_fixture()
+        self.write_creature_race_fixture(root)
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["Townsfolk"] = {
+            "class": "CCreature",
+            "properties": {"race": {"ref": "missingRace"}},
+        }
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "Townsfolk.properties.race.ref",
+            'property "race" for class "CCreature" references unknown id "missingRace"; '
+            'expected a "CCreatureRace" definition',
+        )
+
+    def test_creature_race_ref_to_non_race_reports_ref_path(self):
+        root = self.make_fixture()
+        self.write_creature_race_fixture(root)
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        # CCreatureClass is constructible but is not a CCreatureRace lineage.
+        config["warriorClass"] = {"class": "CCreatureClass", "properties": {"label": "Warrior"}}
+        config["Townsfolk"] = {
+            "class": "CCreature",
+            "properties": {"race": {"ref": "warriorClass"}},
+        }
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "Townsfolk.properties.race.ref",
+            'property "race" for class "CCreature" expected object inheriting from '
+            '"CCreatureRace"; got "CCreatureClass"',
+        )
+
+    def test_creature_race_wrong_typed_value_reports_race_path(self):
+        root = self.make_fixture()
+        self.write_creature_race_fixture(root)
+        config_path = root / "res/maps/broken/config.json"
+        config = read_json(config_path)
+        config["Townsfolk"] = {
+            "class": "CCreature",
+            "properties": {"race": "humanRace"},
+        }
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/config.json",
+            "Townsfolk.properties.race",
+            'property "race" for class "CCreature" expected object inheriting from ' '"CCreatureRace"; got string',
+        )
+
     def assertIssueContains(self, issues, *substrings):
         issue_text = "\n".join(str(issue) for issue in issues)
         for substring in substrings:


### PR DESCRIPTION
## Issue
`[EPIC_06][STORY_01][SUBSTORY_01]Validate race resolves to CCreatureRace` (P1; claim `1f6ad3b4…`, owner `controller/ctrl-vm-18621-2e420b9b/subagent-w1`).

## What changed (pure-Python content validation)
- `scripts/validate_content.py`: `_validate_creature_race_reference(...)` — for any `CCreature`-resolving node, validates the `race` property resolves through ref/config to a `CCreatureRace` definition; reports unknown ref (`…race.ref`), inline wrong class (`…race.class`), and wrong-typed value (`…race`). Registered in `_validate_object_node_properties`; reuses `_effective_object_class`/`_class_inherits_from`/`json_value_kind`. Adds `CREATURE_RACE_PROPERTY = "race"` and registers `race` in `REVIEWED_DYNAMIC_PROPERTIES["CCreature"]`.
- `tests/test_content_validator.py`: 4 synthetic cases (resolves pass; unknown ref; non-`CCreatureRace` target; wrong-typed value).

Forward-guard — vacuously satisfied on real content. Rebased over the sibling creatureClass validator (#1025); policy comments kept-both.

## Validation
`python3 scripts/validate_content.py --repo-root .` → "Content validation passed"; `python3 -m unittest tests.test_content_validator` → green (suite grows with each sibling); `black -l 120` clean; `git diff --check` clean; no `planning/` files.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_