### PR TITLE
Add unmigrated-monster report mode to validate_content (E05/S06/SS01)

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -319,6 +319,33 @@ class CreatureClassification:
 
 
 @dataclass(frozen=True)
+class UnmigratedCreature:
+    """A production CCreature/CPlayer config still missing race/creatureClass migration.
+
+    ``config_id`` is the global config key and ``path`` the file that declares it.
+    ``missing`` is the sorted tuple of archetype reference properties absent from the
+    config's ``properties`` block -- a subset of {"race", "creatureClass"}.  This is a
+    purely informational report (it never emits validation issues or affects exit
+    status); it drives one migration ticket per remaining creature family so a partial
+    archetype migration cannot ship silently.
+    """
+
+    config_id: str
+    path: str
+    missing: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "configId": self.config_id,
+            "path": self.path,
+            "missing": list(self.missing),
+        }
+
+    def __str__(self) -> str:
+        return f"{self.path}: {self.config_id}: missing {', '.join(self.missing)}"
+
+
+@dataclass(frozen=True)
 class RegistrationExclusionUse:
     path: str
     location: str
@@ -1087,6 +1114,47 @@ class ContentValidator:
             # the CCreature subtype enumeration that random-encounter code relies on.
             players_in_creature_enumeration=tuple(players),
         )
+
+    def report_unmigrated_creatures(self) -> list[UnmigratedCreature]:
+        """List production CCreature/CPlayer configs missing race and/or creatureClass.
+
+        Resolves each global config's effective engine class (following ``ref`` chains)
+        and selects those whose class is, or inherits from, ``CCreature`` -- which also
+        covers ``CPlayer`` templates since CPlayer derives from CCreature.  For each such
+        config it inspects the ``properties`` block for the archetype reference
+        properties ``race`` (CREATURE_RACE_PROPERTY) and ``creatureClass``
+        (CREATURE_CLASS_REFERENCE_PROPERTY) and records whichever are absent.  This is a
+        read-only report: it shares the validation class-resolution machinery but never
+        emits validation issues or changes exit status, so the normal validation run --
+        which today would flag every still-unmigrated creature -- stays green.  Results
+        are sorted by config id for deterministic output, and each missing-property list
+        is itself sorted ("creatureClass" before "race").
+        """
+        self._collect_engine_classes()
+        self._collect_plugin_classes()
+        self._load_global_configs()
+        visible = dict(self.global_entries)
+        unmigrated: list[UnmigratedCreature] = []
+        for key, entry in self.global_entries.items():
+            if not isinstance(entry.data, dict):
+                continue
+            class_name = self._effective_object_class(entry.data, visible)
+            if not isinstance(class_name, str):
+                continue
+            if not (class_name == CREATURE_BASE_CLASS or self._class_inherits_from(class_name, CREATURE_BASE_CLASS)):
+                continue
+            properties = entry.data.get("properties")
+            properties = properties if isinstance(properties, dict) else {}
+            missing = tuple(
+                sorted(
+                    name
+                    for name in (CREATURE_CLASS_REFERENCE_PROPERTY, CREATURE_RACE_PROPERTY)
+                    if name not in properties
+                )
+            )
+            if missing:
+                unmigrated.append(UnmigratedCreature(config_id=key, path=self._rel(entry.path), missing=missing))
+        return sorted(unmigrated, key=lambda creature: (creature.config_id, creature.path))
 
     def _collect_creature_overrides(
         self,
@@ -3344,6 +3412,10 @@ def classify_creature_templates(repo_root: Path | str) -> CreatureClassification
     return ContentValidator(Path(repo_root)).classify_creature_templates()
 
 
+def report_unmigrated_creatures(repo_root: Path | str) -> list[UnmigratedCreature]:
+    return ContentValidator(Path(repo_root)).report_unmigrated_creatures()
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Validate game JSON resources and literal script refs.")
     parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
@@ -3357,6 +3429,14 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Print the metadata-derived player/monster classification as JSON and exit without validating.",
     )
+    parser.add_argument(
+        "--report-unmigrated",
+        action="store_true",
+        help=(
+            "Print the production CCreature/CPlayer configs still missing race and/or "
+            "creatureClass as JSON and exit without validating."
+        ),
+    )
     args = parser.parse_args(argv)
 
     if args.report_creature_overrides:
@@ -3368,6 +3448,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.report_creature_classification:
         classification = classify_creature_templates(args.repo_root)
         json.dump(classification.as_dict(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    if args.report_unmigrated:
+        unmigrated = report_unmigrated_creatures(args.repo_root)
+        json.dump([creature.as_dict() for creature in unmigrated], sys.stdout, indent=2)
         sys.stdout.write("\n")
         return 0
 

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -29,6 +29,7 @@ from scripts.validate_content import (
     ScriptPropertyHygieneAllowance,
     classify_creature_templates,
     inventory_creature_overrides,
+    report_unmigrated_creatures,
     validate_repo,
 )
 
@@ -2700,6 +2701,104 @@ class CreatureClassificationTest(unittest.TestCase):
             },
         )
         return root
+
+
+class UnmigratedCreatureReportTest(unittest.TestCase):
+    def make_unmigrated_fixture(self):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        root = Path(temp_dir.name)
+        (root / "res/config").mkdir(parents=True)
+        (root / "src/object").mkdir(parents=True)
+
+        # Engine metadata: CPlayer derives from CCreature, mirroring src/object/CPlayer.h.
+        (root / "src/object/CCreatures.h").write_text(
+            textwrap.dedent("""
+                class CMapObject {
+                    V_META(CMapObject, CGameObject, vstd::meta::empty())
+                };
+
+                class CCreature {
+                    V_META(CCreature, CMapObject, vstd::meta::empty())
+                };
+
+                class CPlayer {
+                    V_META(CPlayer, CCreature, vstd::meta::empty())
+                };
+            """).lstrip(),
+            encoding="utf-8",
+        )
+        write_json(
+            root / "res/config/monsters.json",
+            {
+                # Fully migrated creature: carries both archetype references.
+                "MigratedGoblin": {
+                    "class": "CCreature",
+                    "properties": {"race": {"ref": "GoblinRace"}, "creatureClass": {"ref": "BruteClass"}},
+                },
+                # Missing only the class reference.
+                "NoClassGoblin": {
+                    "class": "CCreature",
+                    "properties": {"race": {"ref": "GoblinRace"}},
+                },
+                # Missing only the race reference.
+                "NoRaceGoblin": {
+                    "class": "CCreature",
+                    "properties": {"creatureClass": {"ref": "BruteClass"}},
+                },
+                # Unmigrated creature: missing both (and no properties block at all path).
+                "LegacyGoblin": {"class": "CCreature", "properties": {"label": "Goblin"}},
+                # Player template (CPlayer inherits CCreature) -- also subject to migration.
+                "LegacyHero": {"class": "CPlayer", "properties": {"label": "Hero"}},
+                # Not a creature -- must never appear in the report.
+                "PlainItem": {"class": "CItem", "properties": {"label": "Sword"}},
+            },
+        )
+        return root
+
+    def test_report_lists_only_creatures_missing_archetype_references(self):
+        root = self.make_unmigrated_fixture()
+
+        report = report_unmigrated_creatures(root)
+        missing_by_id = {creature.config_id: creature.missing for creature in report}
+
+        self.assertEqual(
+            {
+                "NoClassGoblin": ("creatureClass",),
+                "NoRaceGoblin": ("race",),
+                "LegacyGoblin": ("creatureClass", "race"),
+                "LegacyHero": ("creatureClass", "race"),
+            },
+            missing_by_id,
+        )
+        # Fully migrated creatures and non-creatures never appear.
+        self.assertNotIn("MigratedGoblin", missing_by_id)
+        self.assertNotIn("PlainItem", missing_by_id)
+
+    def test_report_output_is_deterministically_sorted(self):
+        root = self.make_unmigrated_fixture()
+
+        report = report_unmigrated_creatures(root)
+
+        ids = [creature.config_id for creature in report]
+        self.assertEqual(sorted(ids), ids)
+        for creature in report:
+            self.assertEqual(sorted(creature.missing), list(creature.missing))
+            self.assertEqual("res/config/monsters.json", creature.path)
+
+    def test_report_does_not_affect_normal_validation(self):
+        # Every shipped creature is unmigrated today, yet the normal validation run
+        # must still pass -- the report is informational and shares no failing path.
+        self.assertEqual([], [str(issue) for issue in validate_repo(REPO_ROOT)])
+
+        report = report_unmigrated_creatures(REPO_ROOT)
+        # The report is non-empty on current content (nothing is migrated yet) and the
+        # production player templates surface as still needing migration.
+        self.assertTrue(report)
+        report_ids = {creature.config_id for creature in report}
+        for player in ("Assasin", "Inquisitor", "Sorcerer", "Warrior", "Wayfarer"):
+            self.assertIn(player, report_ids)
+            self.assertEqual(("creatureClass", "race"), next(c.missing for c in report if c.config_id == player))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue
`[EPIC_05][STORY_06][SUBSTORY_01]Generate unmigrated monster report` (P1; claim `5d2bfc12…`, owner `controller/ctrl-vm-16338-70309130/subagent-p3`).

## What changed (pure-Python, informational)
- `scripts/validate_content.py` (+86): `report_unmigrated_creatures()` / `--report-unmigrated` CLI flag + `UnmigratedCreature` dataclass — lists every production `CCreature`/`CPlayer` config still missing `race` and/or `creatureClass`, deterministically sorted, as JSON. Reuses the validator's class-resolution machinery but emits **no** validation issues and runs only when explicitly invoked, so the normal run stays green even though every creature is unmigrated today.
- `tests/test_content_validator.py` (+99): 3 cases (exact unmigrated set on a migrated/partial/unmigrated fixture; determinism; normal validation path unaffected).

## Validation
`validate_content.py --repo-root .` → "Content validation passed" (exit 0); `--report-unmigrated` lists today's 12 unmigrated creatures (each missing `creatureClass`+`race`); `python3 -m unittest tests.test_content_validator` → 97 tests OK; `black -l 120` clean; `git diff --check` clean; no `planning/`/`monsters.json` edits.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_