### PR TITLE
Validate amulet quest item/runtime actor are preserved (E05/S02/SS02)

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -257,6 +257,25 @@ CREATURE_OVERRIDE_PROPERTIES = (
     "labels",
 )
 
+# Amulet quest item/runtime actor preservation (EPIC_05/STORY_02/SUBSTORY_02).
+# The amulet quest's thief carrier ("goblinThief") owns the quest item as
+# *quest-instance inventory*: the map config attaches "preciousAmulet" through the
+# carrier's "items" override, and the map script spawns that carrier at runtime
+# (createObject("goblinThief")) under the fixed object name "amuletGoblin", which the
+# completion path resolves via getObjectByName("amuletGoblin") to despawn the thief.
+# A later archetype migration must keep "preciousAmulet" as instance inventory on the
+# thief carrier rather than relocate it onto a shared GoblinRace/thief class template,
+# and must keep the runtime actor name resolvable.  This guard therefore asserts, on
+# any map that declares the AMULET_CARRIER_CONFIG, that the carrier's effective items
+# still include AMULET_QUEST_ITEM (following ref inheritance) and that the script
+# spawns the carrier under AMULET_RUNTIME_ACTOR_NAME as a name that getObjectByName can
+# resolve.  Maps that do not declare the carrier are vacuously satisfied.  Identifiers
+# are matched structurally against config/script content, never inferred from prose.
+AMULET_CARRIER_CONFIG = "goblinThief"
+AMULET_QUEST_ITEM = "preciousAmulet"
+AMULET_RUNTIME_ACTOR_NAME = "amuletGoblin"
+CREATURE_ITEMS_PROPERTY = "items"
+
 
 @dataclass(frozen=True)
 class ValidationIssue:
@@ -1498,6 +1517,7 @@ class ContentValidator:
         self._validate_script_refs(context, visible, known_classes, archetype_ids)
         self._validate_script_property_hygiene(context)
         self._validate_quest_state_transitions(context)
+        self._validate_amulet_quest_actor(context, visible)
 
     def _visible_entries(self, context: MapContext) -> dict[str, ConfigEntry]:
         visible = dict(self.global_entries)
@@ -2340,6 +2360,75 @@ class ContentValidator:
                     self._issue(context.script_info.path, trigger.location, f'unknown trigger event "{trigger.value}"')
             elif trigger.name == "trigger target" and trigger.value not in object_names:
                 self._issue(context.script_info.path, trigger.location, f'unknown trigger target "{trigger.value}"')
+
+    def _validate_amulet_quest_actor(self, context: MapContext, visible: dict[str, ConfigEntry]) -> None:
+        """Guard that the amulet quest keeps its item carrier and runtime actor name.
+
+        Vacuous unless this map declares the amulet thief carrier
+        (AMULET_CARRIER_CONFIG).  When it does, two invariants are enforced so an
+        archetype migration cannot quietly drop them:
+
+        * The carrier still carries AMULET_QUEST_ITEM as quest-instance inventory --
+          i.e. its effective "items" (resolving ``ref`` inheritance) reference the
+          quest item by ref or by a node whose resolved "name" is the quest item.
+          Reported against ``<carrier>.properties.items`` so the migration can see the
+          item must stay on the instance rather than move to a race/class template.
+        * The map script spawns the carrier under AMULET_RUNTIME_ACTOR_NAME and that
+          name is recognized as a resolvable map object (the completion path resolves
+          it via getObjectByName).  Reported against the spawning script.
+        """
+        carrier_entry = context.config_entries.get(AMULET_CARRIER_CONFIG)
+        if carrier_entry is None:
+            return
+        if isinstance(carrier_entry.data, dict):
+            items = self._effective_property_value(carrier_entry.data, CREATURE_ITEMS_PROPERTY, visible)
+            if not self._items_reference(items, AMULET_QUEST_ITEM, visible):
+                self._issue(
+                    carrier_entry.path,
+                    f"{append_field(AMULET_CARRIER_CONFIG, 'properties')}.{CREATURE_ITEMS_PROPERTY}",
+                    f'amulet quest carrier "{AMULET_CARRIER_CONFIG}" must carry quest item '
+                    f'"{AMULET_QUEST_ITEM}" as instance inventory; it must not be moved to a '
+                    f"shared race/class template during the archetype migration",
+                )
+
+        info = context.script_info
+        if info is None:
+            return
+        spawns_runtime_actor = any(
+            spawn.template == AMULET_CARRIER_CONFIG and spawn.runtime_name == AMULET_RUNTIME_ACTOR_NAME
+            for spawn in info.spawned_creatures
+        )
+        if not spawns_runtime_actor:
+            self._issue(
+                info.path,
+                f'createObject("{AMULET_CARRIER_CONFIG}")',
+                f'amulet quest runtime actor name "{AMULET_RUNTIME_ACTOR_NAME}" must be assigned to a '
+                f'spawned "{AMULET_CARRIER_CONFIG}"; the completion path resolves it via '
+                f"getObjectByName and would otherwise break",
+            )
+            return
+        recognized_names = context.placed_names | info.named_objects | {"player"}
+        if AMULET_RUNTIME_ACTOR_NAME not in recognized_names:
+            self._issue(
+                info.path,
+                f'getObjectByName("{AMULET_RUNTIME_ACTOR_NAME}")',
+                f'amulet quest runtime actor name "{AMULET_RUNTIME_ACTOR_NAME}" is not resolvable as a '
+                f"map object name",
+            )
+
+    def _items_reference(self, items: Any, item_id: str, visible: dict[str, ConfigEntry]) -> bool:
+        """Whether an "items" value references ``item_id`` by ref or resolved name."""
+        if not isinstance(items, list):
+            return False
+        for entry in items:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("ref") == item_id:
+                return True
+            name = self._effective_property_value(entry, "name", visible)
+            if name == item_id:
+                return True
+        return False
 
     def _validate_script_property_hygiene(self, context: MapContext) -> None:
         info = context.script_info

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -2330,6 +2330,116 @@ class ContentValidatorTest(unittest.TestCase):
             "expected a non-empty string; got string",
         )
 
+    def test_amulet_quest_carrier_and_runtime_actor_pass_validation(self):
+        root = self.make_amulet_fixture()
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
+    def test_amulet_quest_item_removed_from_carrier_is_reported(self):
+        root = self.make_amulet_fixture()
+        config_path = root / "res/maps/amulet/config.json"
+        config = read_json(config_path)
+        # Simulate the migration moving the quest item off the thief carrier (e.g. onto a
+        # shared GoblinRace/thief class template) by dropping it from the carrier items.
+        config["goblinThief"]["properties"]["items"] = []
+        write_json(config_path, config)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/amulet/config.json",
+            "goblinThief.properties.items",
+            'must carry quest item "preciousAmulet" as instance inventory',
+        )
+
+    def test_amulet_quest_runtime_actor_name_broken_is_reported(self):
+        root = self.make_amulet_fixture()
+        script_path = root / "res/maps/amulet/script.py"
+        # Break only the runtime name assigned to the spawned carrier.
+        script_path.write_text(
+            script_path.read_text(encoding="utf-8").replace('"amuletGoblin"', '"strayGoblin"'),
+            encoding="utf-8",
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/amulet/script.py",
+            'createObject("goblinThief")',
+            'runtime actor name "amuletGoblin" must be assigned to a spawned "goblinThief"',
+        )
+
+    def test_amulet_quest_guard_is_load_bearing(self):
+        # Removing the registration must make the broken-item fixture stop being rejected,
+        # proving the guard (not some sibling rule) is what catches the violation.
+        root = self.make_amulet_fixture()
+        config_path = root / "res/maps/amulet/config.json"
+        config = read_json(config_path)
+        config["goblinThief"]["properties"]["items"] = []
+        write_json(config_path, config)
+
+        validator = ContentValidator(root)
+        validator._validate_amulet_quest_actor = lambda *args, **kwargs: None
+        issue_text = "\n".join(str(issue) for issue in validator.validate())
+
+        self.assertNotIn('must carry quest item "preciousAmulet"', issue_text)
+
+    def make_amulet_fixture(self):
+        root = self.make_fixture()
+        (root / "res/maps/amulet").mkdir(parents=True)
+        write_json(
+            root / "res/config/items.json",
+            {
+                "LifePotion": {"class": "CPotion"},
+                "HitEffect": {"class": "CEffect"},
+                "Attack": {"class": "CInteraction", "properties": {"effect": {"ref": "HitEffect"}}},
+                "GoblinThief": {"class": "CCreature"},
+                "preciousAmulet": {"class": "CItem", "properties": {"name": "preciousAmulet"}},
+            },
+        )
+        write_json(
+            root / "res/maps/amulet/map.json",
+            {
+                "type": "map",
+                "width": 2,
+                "height": 2,
+                "layers": [
+                    {"type": "tilelayer", "width": 2, "height": 2, "data": [0, 0, 0, 0]},
+                    {
+                        "type": "objectgroup",
+                        "objects": [
+                            {
+                                "id": 1,
+                                "name": "start",
+                                "type": "AmuletEvent",
+                                "x": 0,
+                                "y": 0,
+                                "width": 1,
+                                "height": 1,
+                            }
+                        ],
+                    },
+                ],
+                "tilesets": [{"firstgid": 1, "tileproperties": {}}],
+                "nextobjectid": 2,
+            },
+        )
+        write_json(
+            root / "res/maps/amulet/config.json",
+            {
+                "goblinThief": {
+                    "ref": "GoblinThief",
+                    "properties": {"items": [{"ref": "preciousAmulet"}]},
+                },
+            },
+        )
+        write_amulet_script(root / "res/maps/amulet/script.py")
+        return root
+
     def assertIssueContains(self, issues, *substrings):
         issue_text = "\n".join(str(issue) for issue in issues)
         for substring in substrings:
@@ -2476,6 +2586,31 @@ def write_script(path, script_quest, script_map):
                 @trigger(context, "onEnter", "start")
                 class StartTrigger(CEvent):
                     pass
+            """).lstrip(),
+        encoding="utf-8",
+    )
+
+
+def write_amulet_script(path):
+    path.write_text(
+        textwrap.dedent("""
+            def load(self, context):
+                from game import CEvent
+                from game import register
+
+                @register(context)
+                class AmuletEvent(CEvent):
+                    def onEnter(self, event):
+                        game = self.getGame()
+                        game_map = game.getMap()
+                        goblin = game.createObject("goblinThief")
+                        goblin.setStringProperty("name", "amuletGoblin")
+                        game_map.addObject(goblin)
+
+                    def complete(self):
+                        amulet_goblin = self.getMap().getObjectByName("amuletGoblin")
+                        if amulet_goblin:
+                            self.getMap().removeObject(amulet_goblin)
             """).lstrip(),
         encoding="utf-8",
     )


### PR DESCRIPTION
## Issue
`[EPIC_05][STORY_02][SUBSTORY_02]Preserve amulet quest item/runtime actor` (P1; claim `c72d9668…`, owner `controller/ctrl-vm-16338-70309130/subagent-p1`).

## What changed (pure-Python content validation; no game-content edits)
- `scripts/validate_content.py` (+89): `_validate_amulet_quest_actor(...)` (registered in `_validate_map_context`) — for any map declaring the `goblinThief` carrier, asserts it still carries `preciousAmulet` as quest-instance inventory (`goblinThief.properties.items`, following ref inheritance) rather than relocating it onto a shared race/class, and that the script spawns it under runtime name `amuletGoblin` kept resolvable for the completion path's `getObjectByName`. Reuses existing spawn/name-tracking machinery; vacuous on maps without the carrier.
- `tests/test_content_validator.py` (+135): 4 cases (carrier+runtime pass; item removed rejected; broken runtime name rejected; load-bearing check).

## Validation
`validate_content.py --repo-root .` → "Content validation passed"; `python3 -m unittest tests.test_content_validator` → green; `black -l 120` clean; `git diff --check` clean; no `planning/` or `res/maps/nouraajd/*` edits.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_