### PR TITLE
Validate Gooby quest CaveTrigger spawn/rename chain is preserved (E05/S03/SS02)

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -221,6 +221,21 @@ CREATURE_RACE_PROPERTY = "race"
 CREATURE_RACE_PLAYER_SELECTABLE_PROPERTY = "playerSelectable"
 CREATURE_RACE_LABEL_PROPERTY = "label"
 
+# Gooby quest runtime-name preservation (EPIC_05/STORY_03/SUBSTORY_02).
+# The Gooby hunt depends on a fixed spawn/rename chain in the nouraajd map script:
+# CaveTrigger spawns the template named GOOBY_TEMPLATE_NAME ("gooby") and immediately
+# renames the runtime object to GOOBY_RUNTIME_NAME ("gooby1") via
+# setStringProperty("name", "gooby1"); GoobyTrigger then fires onDestroy against the
+# runtime name "gooby1" and marks the main quest "gooby_slain".  Both names are
+# load-bearing constants that a template migration must NOT rename: if the template id
+# changed, createObject would spawn nothing; if the runtime name changed, the onDestroy
+# trigger and quest-completion flow could never recognize the slain creature.  This
+# guard fires only on a map that participates in the chain -- one that spawns the
+# "gooby" template or wires a trigger against the "gooby1" runtime name -- so unrelated
+# maps and synthetic fixtures stay unaffected, but the real chain is asserted whole.
+GOOBY_TEMPLATE_NAME = "gooby"
+GOOBY_RUNTIME_NAME = "gooby1"
+
 # Map-local creature override inventory (EPIC_01/STORY_01/SUBSTORY_02).
 # Map config files reference creature templates via "ref" plus a "properties" block
 # that overrides template behavior.  Any override touching one of these properties
@@ -1515,6 +1530,7 @@ class ContentValidator:
         self._validate_map_json(context, visible, known_classes, archetype_ids)
         self._validate_dialogs(context, visible)
         self._validate_script_refs(context, visible, known_classes, archetype_ids)
+        self._validate_gooby_runtime_names(context)
         self._validate_script_property_hygiene(context)
         self._validate_quest_state_transitions(context)
         self._validate_amulet_quest_actor(context, visible)
@@ -2429,6 +2445,67 @@ class ContentValidator:
             if name == item_id:
                 return True
         return False
+
+    def _validate_gooby_runtime_names(self, context: MapContext) -> None:
+        """Assert the Gooby quest spawn/rename chain keeps its load-bearing names.
+
+        EPIC_05/STORY_03/SUBSTORY_02. The chain is: CaveTrigger
+        ``createObject("gooby")`` -> ``setStringProperty("name", "gooby1")``, and a
+        ``@trigger(..., "onDestroy", "gooby1")`` plus quest-completion flow that
+        recognizes the runtime name "gooby1".  A migration must preserve both the
+        template id "gooby" and the runtime name "gooby1"; renaming either silently
+        breaks the spawn, the onDestroy trigger, or quest completion.
+
+        The guard engages only on a map that already participates in the chain -- one
+        that spawns the "gooby" template, or that renames a spawn to "gooby1", or that
+        wires a trigger against the "gooby1" runtime name -- so unrelated maps and
+        synthetic fixtures stay unaffected.  Once engaged it requires the full chain:
+        a "gooby" template spawn that is renamed to "gooby1", and a trigger target
+        recognizing "gooby1".  Every diagnostic reports the script path so an author
+        sees exactly where the chain broke.
+        """
+        info = context.script_info
+        if not info:
+            return
+
+        gooby_template_spawns = [c for c in info.spawned_creatures if c.template == GOOBY_TEMPLATE_NAME]
+        renamed_to_runtime = [c for c in info.spawned_creatures if c.runtime_name == GOOBY_RUNTIME_NAME]
+        runtime_trigger_targets = [
+            t for t in info.trigger_targets if t.name == "trigger target" and t.value == GOOBY_RUNTIME_NAME
+        ]
+
+        # Engage only when this map participates in the Gooby chain in some form.
+        if not (gooby_template_spawns or renamed_to_runtime or runtime_trigger_targets):
+            return
+
+        chain_spawns = [c for c in gooby_template_spawns if c.runtime_name == GOOBY_RUNTIME_NAME]
+
+        if not gooby_template_spawns:
+            location = renamed_to_runtime[0].location if renamed_to_runtime else runtime_trigger_targets[0].location
+            self._issue(
+                info.path,
+                location,
+                f'Gooby quest chain references runtime name "{GOOBY_RUNTIME_NAME}" but no spawn of '
+                f'template "{GOOBY_TEMPLATE_NAME}" remains; the template name must not be renamed',
+            )
+            return
+
+        if not chain_spawns:
+            self._issue(
+                info.path,
+                gooby_template_spawns[0].location,
+                f'CaveTrigger spawns template "{GOOBY_TEMPLATE_NAME}" but does not rename the runtime '
+                f'object to "{GOOBY_RUNTIME_NAME}"; the runtime name must be preserved',
+            )
+            return
+
+        if not runtime_trigger_targets:
+            self._issue(
+                info.path,
+                chain_spawns[0].location,
+                f'runtime object "{GOOBY_RUNTIME_NAME}" is spawned from template "{GOOBY_TEMPLATE_NAME}" but no '
+                f'trigger recognizes "{GOOBY_RUNTIME_NAME}"; quest-completion flow must keep recognizing it',
+            )
 
     def _validate_script_property_hygiene(self, context: MapContext) -> None:
         info = context.script_info

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -405,6 +405,80 @@ class ContentValidatorTest(unittest.TestCase):
         self.assertEqual("gooby1", named.get("gooby"))
         self.assertEqual("amuletGoblin", named.get("goblinThief"))
 
+    def test_real_gooby_quest_runtime_names_preserved(self):
+        # The real nouraajd chain (createObject("gooby") -> name "gooby1", onDestroy
+        # trigger on "gooby1") must satisfy the runtime-name preservation guard.
+        issues = validate_repo(REPO_ROOT)
+        gooby_issues = [str(issue) for issue in issues if "gooby" in str(issue).lower()]
+        self.assertEqual([], gooby_issues)
+
+    def test_renamed_gooby_template_breaks_chain(self):
+        root = self.make_fixture()
+        write_gooby_chain_script(
+            root / "res/maps/broken/script.py",
+            template="goobyMonster",  # template renamed away from "gooby"
+            runtime="gooby1",
+            trigger_target="gooby1",
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'no spawn of template "gooby" remains',
+        )
+
+    def test_renamed_gooby_runtime_name_breaks_chain(self):
+        root = self.make_fixture()
+        write_gooby_chain_script(
+            root / "res/maps/broken/script.py",
+            template="gooby",
+            runtime="goobyAlive",  # runtime name renamed away from "gooby1"
+            trigger_target="goobyAlive",
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'does not rename the runtime object to "gooby1"',
+        )
+
+    def test_gooby_runtime_name_without_trigger_breaks_chain(self):
+        root = self.make_fixture()
+        write_gooby_chain_script(
+            root / "res/maps/broken/script.py",
+            template="gooby",
+            runtime="gooby1",
+            trigger_target=None,  # nothing recognizes "gooby1" anymore
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'no trigger recognizes "gooby1"',
+        )
+
+    def test_intact_gooby_chain_fixture_passes_guard(self):
+        # The synthetic chain, when intact, raises no Gooby preservation issue
+        # (proving the rule is load-bearing rather than always-failing).
+        root = self.make_fixture()
+        write_gooby_chain_script(
+            root / "res/maps/broken/script.py",
+            template="gooby",
+            runtime="gooby1",
+            trigger_target="gooby1",
+        )
+
+        issues = validate_repo(root)
+
+        gooby_issues = [str(issue) for issue in issues if "gooby" in str(issue).lower()]
+        self.assertEqual([], gooby_issues)
+
     def test_given_player_bool_read_without_default_when_validating_then_reports_uninitialized_property(self):
         root = self.make_fixture()
         write_property_hygiene_script(
@@ -2612,6 +2686,61 @@ def write_amulet_script(path):
                         if amulet_goblin:
                             self.getMap().removeObject(amulet_goblin)
             """).lstrip(),
+        encoding="utf-8",
+    )
+
+
+def write_gooby_chain_script(path, template, runtime, trigger_target):
+    """Write a script whose CaveTrigger spawns ``template`` and renames it to ``runtime``.
+
+    Mirrors the real nouraajd Gooby chain so the runtime-name preservation guard can be
+    exercised: a createObject spawn, a setStringProperty("name", ...) rename, and an
+    optional onDestroy trigger against ``trigger_target``.  The template config entry is
+    written alongside so unrelated ref checks stay quiet.  Pass ``trigger_target=None`` to
+    omit the recognizing trigger.
+    """
+    config_path = path.parent / "config.json"
+    config = read_json(config_path)
+    config[template] = {"class": "CCreature"}
+    write_json(config_path, config)
+
+    trigger_block = ""
+    if trigger_target is not None:
+        trigger_block = textwrap.dedent(f"""
+            @trigger(context, "onDestroy", "{trigger_target}")
+            class GoobyTrigger(CTrigger):
+                def trigger(self, obj, event):
+                    pass
+            """)
+    trigger_block = textwrap.indent(trigger_block.strip(), "    ")
+
+    path.write_text(
+        textwrap.dedent(f"""
+            def load(self, context):
+                from game import CEvent
+                from game import CQuest
+                from game import CTrigger
+                from game import register
+                from game import trigger
+
+                @register(context)
+                class StartEvent(CEvent):
+                    def onEnter(self, event):
+                        pass
+
+                @register(context)
+                class GoodQuest(CQuest):
+                    pass
+
+                @trigger(context, "onDestroy", "cave1")
+                class CaveTrigger(CTrigger):
+                    def trigger(self, obj, event):
+                        game = self.getGame()
+                        gooby = game.createObject("{template}")
+                        gooby.setStringProperty("name", "{runtime}")
+                        game.getMap().addObject(gooby)
+
+            """).lstrip() + trigger_block + "\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Issue
`[EPIC_05][STORY_03][SUBSTORY_02]Preserve Gooby quest runtime names` (P1; claim `9beab0f4…`, owner `controller/ctrl-vm-16338-70309130/subagent-p2`).

## What changed (pure-Python content validation; no game-content edits)
- `scripts/validate_content.py` (+77): `_validate_gooby_runtime_names(context)` (registered in `_validate_map_context`) — on any map participating in the chain, asserts `CaveTrigger` spawns template `gooby`, renames the runtime object to `gooby1`, and a trigger recognizes `gooby1` (so a migration can't silently rename the template id or runtime name). Reuses the analyzer's `spawned_creatures`/`trigger_targets`; vacuous on unrelated maps. Distinct diagnostics for each break point.
- `tests/test_content_validator.py` (+129): 5 cases (real chain passes; template renamed / runtime renamed / recognizing-trigger dropped each rejected; load-bearing check).

## Validation
`validate_content.py --repo-root .` → "Content validation passed"; `python3 -m unittest tests.test_content_validator` → green; `black -l 120` clean; `git diff --check` clean; no `planning/` or `res/maps/nouraajd/*` edits. Rebased over the sibling amulet/report validators (keep-both methods + helpers; controller re-ran the suite post-rebase).

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_