### PR TITLE
Integrate quest-state validator into the standard content-validation path (E07/S01/SS04)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,6 +34,36 @@ standard library and do not require the compiled `_game` module. They are run
 early in CI before the native build so broken map/config/dialog refs fail before
 expensive gameplay tests.
 
+### Quest-state-transition validation
+Content validation also checks each map's quest state machine. The check is wired
+into the standard `scripts/validate_content.py` path: it lives in
+`ContentValidator._validate_quest_state_transitions(context)`, which
+`ContentValidator._validate_map_context(context)` invokes after that map's config
+JSON, dialog JSON, `map.json`, and `script.py` are loaded and after the other
+per-map checks run. Because `_validate_map_context` is called from
+`ContentValidator.validate()` (the entry point behind `validate_repo()` and the
+`scripts/validate_content.py` CLI), the quest check runs on every normal
+validation, not as a later runtime-only test, and its findings are reported as
+ordinary `ValidationIssue` errors that fail the run.
+
+For each quest key a map script declares (via `QUEST_KEYS`, `QUEST_DEFAULTS`, and
+`_set_state`/`state_in`/`get_state` usage parsed by `ScriptAnalyzer`), the check
+reports: defaults, transition writes, or state reads that reference an undeclared
+quest key (missing from `QUEST_KEYS`), and terminal completion states that are
+unreachable because they are neither the quest default nor any transition target.
+Run it the same way as the rest of content validation:
+
+```bash
+python3 scripts/validate_content.py --repo-root .
+python3 -m unittest tests.test_content_validator
+```
+
+`tests/test_content_validator.py` covers the quest-transition rules through the
+end-to-end `validate_repo()` run, including
+`test_given_bad_quest_transition_when_running_standard_validation_path_then_reported_as_error`,
+which pins that the quest validator runs inside the standard
+`ContentValidator.validate()` path rather than only via a direct helper call.
+
 For Windows Visual Studio Release builds, use the same target and CTest label with the active configuration:
 
 ```bat

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -834,6 +834,61 @@ class ContentValidatorTest(unittest.TestCase):
 
         self.assertEqual([], [str(issue) for issue in issues])
 
+    def test_given_bad_quest_transition_when_running_standard_validation_path_then_reported_as_error(self):
+        # Regression for E07/S01/SS04: the quest-state-transition validator must run in
+        # the NORMAL validation path (validate_repo -> ContentValidator.validate ->
+        # _validate_map_context), not only via a direct helper call. A synthetic map with
+        # an unreachable terminal state must be caught by the default end-to-end run and
+        # surfaced as a standard ValidationIssue error.
+        root = self.make_fixture()
+        write_property_hygiene_script(
+            root / "res/maps/broken/script.py",
+            """
+            class QuestSystem(QuestStateStore):
+                QUEST_KEYS = {"main": "quest_state_main"}
+                QUEST_DEFAULTS = {"main": "locked"}
+
+                def advance(self):
+                    self._set_state("main", "active")
+
+                def isCompleted(self):
+                    return self.get_state("main") == "unreachable"
+
+            @register(context)
+            class StartEvent(CEvent):
+                pass
+            """,
+        )
+
+        unreachable_message = (
+            'terminal state "unreachable" is unreachable: it is neither the default nor a transition target'
+        )
+
+        # The default end-to-end run (the exact entrypoint scripts/validate_content.py
+        # invokes) must report the bad transition; it is not gated behind a runtime-only test.
+        end_to_end_issues = validate_repo(root)
+        self.assertIssueContains(end_to_end_issues, "res/maps/broken/script.py", 'quest "main"', unreachable_message)
+
+        # ContentValidator.validate() (which main()/validate_repo() call) must produce the
+        # same error, and the quest validator must stay wired into _validate_map_context so
+        # a future refactor cannot silently drop it from the standard path.
+        validate_issues = ContentValidator(root).validate()
+        self.assertTrue(
+            any(unreachable_message in str(issue) for issue in validate_issues),
+            "quest-state-transition validator did not run inside ContentValidator.validate()",
+        )
+        self.assertTrue(
+            hasattr(ContentValidator, "_validate_quest_state_transitions"),
+            "quest-state-transition validator helper is missing",
+        )
+
+        # Pin the wiring: _validate_map_context must invoke the quest-state validator so it
+        # always runs after map config, dialog JSON, map.json, and script.py are loaded.
+        import inspect
+
+        map_context_source = inspect.getsource(ContentValidator._validate_map_context)
+        self.assertIn("_validate_quest_state_transitions", map_context_source)
+
     def test_given_script_granted_quest_id_missing_from_config_when_validating_then_reports_unknown_quest(self):
         root = self.make_fixture()
         write_property_hygiene_script(


### PR DESCRIPTION
## Issue
`[EPIC_07][STORY_01][SUBSTORY_04]Integrate quest validator into CI path` (P1; claim `2f946c68…`, owner `controller/ctrl-vm-16740-1bd35272/subagent-p4`).

## What changed (test + docs; validator already wired)
The quest-state validator is **already fully in the standard path** (added by the merged E07/S01/SS02): `validate_repo` → `ContentValidator.validate()` → `_validate_map_context` → `_validate_quest_state_transitions` (reports standard `ValidationIssue` errors, only early-returns when a map has no `script.py`). So this delivers the honest remaining work — pin it and document it:
- `tests/test_content_validator.py` (+55): `test_given_bad_quest_transition_when_running_standard_validation_path_then_reported_as_error` — a synthetic map with an unreachable terminal state is caught by the default `validate_repo(root)` run (not only a direct call), and the wiring is pinned via `inspect.getsource(_validate_map_context)` referencing the validator, so a future refactor that drops it fails the suite.
- `docs/testing.md` (+30): "Quest-state-transition validation" section documenting where the checks live, what they report, and how to run them.

No production validator code changed.

## Validation
`validate_content.py --repo-root .` → "Content validation passed"; `python3 -m unittest tests.test_content_validator` → green; `black -l 120` clean; `git diff --check` clean; no `planning/` files.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_