### PR TITLE
Add CCreatureRace archetype definition (E02/S01/SS01–SS05)

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -2385,13 +2385,13 @@ class ContentValidator:
         archetype migration cannot quietly drop them:
 
         * The carrier still carries AMULET_QUEST_ITEM as quest-instance inventory --
-          i.e. its effective "items" (resolving ``ref`` inheritance) reference the
-          quest item by ref or by a node whose resolved "name" is the quest item.
-          Reported against ``<carrier>.properties.items`` so the migration can see the
-          item must stay on the instance rather than move to a race/class template.
+            i.e. its effective "items" (resolving ``ref`` inheritance) reference the
+            quest item by ref or by a node whose resolved "name" is the quest item.
+            Reported against ``<carrier>.properties.items`` so the migration can see the
+            item must stay on the instance rather than move to a race/class template.
         * The map script spawns the carrier under AMULET_RUNTIME_ACTOR_NAME and that
-          name is recognized as a resolvable map object (the completion path resolves
-          it via getObjectByName).  Reported against the spawning script.
+            name is recognized as a resolvable map object (the completion path resolves
+            it via getObjectByName).  Reported against the spawning script.
         """
         carrier_entry = context.config_entries.get(AMULET_CARRIER_CONFIG)
         if carrier_entry is None:
@@ -2602,11 +2602,11 @@ class ContentValidator:
         * every QUEST_DEFAULTS default references a declared quest key;
         * every transition target (a _set_state write) belongs to a declared quest key;
         * every state read (a get_state comparison or state_in) belongs to a declared
-          quest key;
+            quest key;
         * every terminal completion state is reachable from a default -- i.e. it is the
-          default state itself or a state assigned by some transition write. A terminal
-          state that is never the default and never written can never be entered, so the
-          completion check it guards can never fire.
+            default state itself or a state assigned by some transition write. A terminal
+            state that is never the default and never written can never be entered, so the
+            completion check it guards can never fire.
 
         Undeclared keys are detected because any get_state/_set_state/state_in reference
         records a ScriptQuestStateUsage entry whose storage_key stays None when the key

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -43,6 +43,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "../handler/CHandler.h"
 #include "../handler/CRngHandler.h"
 #include "../object/CCreature.h"
+#include "../object/CCreatureRace.h"
 #include "../object/CDialog.h"
 #include "../object/CEffect.h"
 #include "../object/CInteraction.h"
@@ -351,6 +352,7 @@ void register_python_binding_type_metadata() {
     CTypes::register_type_metadata<CWrapper<CEffect>, CEffect, CGameObject>();
     CTypes::register_type_metadata<CInteraction, CGameObject>();
     CTypes::register_type_metadata<CWrapper<CInteraction>, CInteraction, CGameObject>();
+    CTypes::register_type_metadata<CCreatureRace, CGameObject>();
     CTypes::register_type_metadata<CTile, CGameObject>();
     CTypes::register_type_metadata<CWrapper<CTile>, CTile, CGameObject>();
 
@@ -775,6 +777,21 @@ void init_game_module(py::module_ &m) {
         .def("addBonus", &CStats::addBonus, "Add all numeric stats from another CStats object.")
         .def("removeBonus", &CStats::removeBonus, "Remove all numeric stats from another CStats object.")
         .def("getText", &CStats::getText, "Return formatted stat summary text.");
+
+    py::class_<CCreatureRace, CGameObject, std::shared_ptr<CCreatureRace>>(
+        m, "CCreatureRace", "Creature race archetype definition (metadata only; not a spawnable creature).")
+        .def(py::init<>())
+        .def("getBaseStats", &CCreatureRace::getBaseStats, "Return the race's innate base stats.")
+        .def("setBaseStats", &CCreatureRace::setBaseStats, "Set the race's innate base stats (null becomes empty).")
+        .def("getActions", &CCreatureRace::getActions, "Return the race's innate actions.")
+        .def("setActions", &CCreatureRace::setActions, "Set the race's innate actions (nulls are dropped).")
+        .def("getCreatureType", &CCreatureRace::getCreatureType, "Return the coarse creature type string.")
+        .def("setCreatureType", &CCreatureRace::setCreatureType, "Set the coarse creature type string.")
+        .def("getSubtypes", &CCreatureRace::getSubtypes, "Return the race's subtype tags.")
+        .def("setSubtypes", &CCreatureRace::setSubtypes, "Set the race's subtype tags.")
+        .def("isPlayerSelectable", &CCreatureRace::isPlayerSelectable,
+             "Whether the race is offered at character creation.")
+        .def("setPlayerSelectable", &CCreatureRace::setPlayerSelectable, "Set whether the race is player-selectable.");
 
     auto ctile =
         py::class_<CTile, CWrapper<CTile>, std::shared_ptr<CTile>, CGameObject>(m, "CTile", "Base tile class.");

--- a/src/object/CCreatureRace.cpp
+++ b/src/object/CCreatureRace.cpp
@@ -1,0 +1,58 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "CCreatureRace.h"
+#include "core/CStats.h"
+#include "object/CInteraction.h"
+
+CCreatureRace::CCreatureRace() {}
+
+CCreatureRace::~CCreatureRace() {}
+
+std::shared_ptr<CStats> CCreatureRace::getBaseStats() { return baseStats; }
+
+// Null-safe: a missing baseStats normalizes to an empty CStats so stat
+// aggregation (race + class + creature) never dereferences a null definition.
+void CCreatureRace::setBaseStats(std::shared_ptr<CStats> value) {
+    baseStats = value ? value : std::make_shared<CStats>();
+}
+
+std::set<std::shared_ptr<CInteraction>> CCreatureRace::getActions() { return actions; }
+
+// Null-safe: drop null interactions so action composition over a race definition
+// stays well-formed and serialization remains deterministic.
+void CCreatureRace::setActions(std::set<std::shared_ptr<CInteraction>> value) {
+    std::set<std::shared_ptr<CInteraction>> filtered;
+    for (const auto &action : value) {
+        if (action) {
+            filtered.insert(action);
+        }
+    }
+    actions = filtered;
+}
+
+std::string CCreatureRace::getCreatureType() { return creatureType; }
+
+void CCreatureRace::setCreatureType(std::string value) { creatureType = value; }
+
+std::set<std::string> CCreatureRace::getSubtypes() { return subtypes; }
+
+void CCreatureRace::setSubtypes(std::set<std::string> value) { subtypes = value; }
+
+bool CCreatureRace::isPlayerSelectable() { return playerSelectable; }
+
+void CCreatureRace::setPlayerSelectable(bool value) { playerSelectable = value; }

--- a/src/object/CCreatureRace.h
+++ b/src/object/CCreatureRace.h
@@ -1,0 +1,75 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "core/CStats.h"
+#include "object/CGameObject.h"
+
+#include <set>
+#include <string>
+
+class CInteraction;
+
+// CCreatureRace is a CGameObject-derived *metadata definition*, not a CCreature
+// subtype: it is a referenced template (carried by CCreature.race) describing the
+// innate baseline a race contributes to a creature -- base stats, innate actions,
+// a coarse creatureType and finer subtypes, and whether the race is offered at
+// character creation. It is deliberately NOT a CMapObject/CCreature, so it can
+// never be spawned onto a map or appear in getAllSubTypes("CCreature") / random
+// encounter tables; it only carries data that the composition layer reads.
+class CCreatureRace : public CGameObject {
+
+    V_META(CCreatureRace, CGameObject,
+           V_PROPERTY(CCreatureRace, std::shared_ptr<CStats>, baseStats, getBaseStats, setBaseStats),
+           V_PROPERTY(CCreatureRace, std::set<std::shared_ptr<CInteraction>>, actions, getActions, setActions),
+           V_PROPERTY(CCreatureRace, std::string, creatureType, getCreatureType, setCreatureType),
+           V_PROPERTY(CCreatureRace, std::set<std::string>, subtypes, getSubtypes, setSubtypes),
+           V_PROPERTY(CCreatureRace, bool, playerSelectable, isPlayerSelectable, setPlayerSelectable))
+
+  public:
+    CCreatureRace();
+
+    virtual ~CCreatureRace();
+
+    std::shared_ptr<CStats> getBaseStats();
+
+    void setBaseStats(std::shared_ptr<CStats> value);
+
+    std::set<std::shared_ptr<CInteraction>> getActions();
+
+    void setActions(std::set<std::shared_ptr<CInteraction>> value);
+
+    std::string getCreatureType();
+
+    void setCreatureType(std::string value);
+
+    std::set<std::string> getSubtypes();
+
+    void setSubtypes(std::set<std::string> value);
+
+    bool isPlayerSelectable();
+
+    void setPlayerSelectable(bool value);
+
+  private:
+    std::shared_ptr<CStats> baseStats = std::make_shared<CStats>();
+    std::set<std::shared_ptr<CInteraction>> actions;
+    std::string creatureType;
+    std::set<std::string> subtypes;
+    bool playerSelectable = false;
+};

--- a/src/plugin/NativePlugin.cpp
+++ b/src/plugin/NativePlugin.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CTypes.h"
 #include "core/CWrapper.h"
 #include "handler/CObjectHandler.h"
+#include "object/CCreatureRace.h"
 #include "object/CDialog.h"
 #include "object/CMarket.h"
 #include "object/CObject.h"
@@ -153,6 +154,11 @@ bool register_controllers(const NativePluginHostV1 *host) {
 bool register_creatures(const NativePluginHostV1 *host) {
     auto *game = host_game(host);
     bool registered = true;
+    // Register the race archetype definition before the concrete creatures. It
+    // derives from CGameObject (not CCreature), so configured race IDs are
+    // constructible while the class stays out of CCreature inheritance and the
+    // random-encounter / getAllSubTypes("CCreature") enumeration.
+    registered = register_type<CCreatureRace, CGameObject>(game) && registered;
     registered = register_type<CCreature, CMapObject, CGameObject>(game) && registered;
     registered = register_type<CPlayer, CCreature, CMapObject, CGameObject>(game) && registered;
     if (registered) {

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -34,6 +34,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CUtil.h"
 #include "gui/CSdlResources.h"
 #include "object/CCreature.h"
+#include "object/CCreatureRace.h"
 #include "object/CEffect.h"
 #include "object/CGameObject.h"
 #include "object/CInteraction.h"
@@ -1775,6 +1776,73 @@ void test_creature_effective_actions_baseline_capture() {
     std::cout << "creature-actions-baseline-levelling-unlocks-observed\t" << templatesWithLevellingUnlock << '\n';
 }
 
+// CCreatureRace is a CGameObject-derived metadata definition. This pins that it
+// round-trips through CSerialization with all of its metadata (base stats, innate
+// actions, creatureType, subtypes, playerSelectable, plus inherited label/
+// description) intact, deserializes back into a CCreatureRace (not a creature/map
+// object), and that its setters are null-safe.
+void test_creature_race_metadata_round_trip() {
+    CTypes::register_type_metadata<CCreatureRace, CGameObject>();
+    CTypes::register_type_metadata<CStats, CGameObject>();
+    CTypes::register_type_metadata<CInteraction, CGameObject>();
+
+    auto game = std::make_shared<CGame>();
+    game->getObjectHandler()->registerType(CCreatureRace::static_meta()->name(),
+                                           []() { return std::make_shared<CCreatureRace>(); });
+    game->getObjectHandler()->registerType(CStats::static_meta()->name(), []() { return std::make_shared<CStats>(); });
+    game->getObjectHandler()->registerType(CInteraction::static_meta()->name(),
+                                           []() { return std::make_shared<CInteraction>(); });
+
+    auto baseStats = std::make_shared<CStats>();
+    baseStats->setStrength(7);
+    auto action = std::make_shared<CInteraction>();
+    action->setTypeId("raceStrike");
+
+    auto race = std::make_shared<CCreatureRace>();
+    race->setGame(game);
+    race->setBaseStats(baseStats);
+    race->setActions({action});
+    race->setCreatureType("humanoid");
+    race->setSubtypes({"human", "northerner"});
+    race->setPlayerSelectable(true);
+    race->setLabel("Human");
+    race->setDescription("The common folk of Nouraajd.");
+
+    auto serialized = CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::serialize(race);
+    expect_true((*serialized)["class"].get<std::string>() == CCreatureRace::static_meta()->name(),
+                "a serialized CCreatureRace should keep its metadata class identity");
+
+    auto round_trip = std::dynamic_pointer_cast<CCreatureRace>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game, serialized));
+
+    expect_true(round_trip != nullptr,
+                "a CCreatureRace should deserialize back into a CCreatureRace, not a creature or map object");
+    expect_true(round_trip->getCreatureType() == "humanoid", "creatureType should survive the round-trip");
+    expect_true(round_trip->getSubtypes() == std::set<std::string>({"human", "northerner"}),
+                "subtypes should survive the round-trip");
+    expect_true(round_trip->isPlayerSelectable(), "playerSelectable should survive the round-trip");
+    expect_true(round_trip->getLabel() == "Human", "inherited label should survive the round-trip");
+    expect_true(round_trip->getDescription() == "The common folk of Nouraajd.",
+                "inherited description should survive the round-trip");
+    expect_true(round_trip->getBaseStats() && round_trip->getBaseStats()->getStrength() == 7,
+                "base stats should survive the round-trip");
+    expect_true(round_trip->getActions().size() == 1, "innate actions should survive the round-trip");
+
+    // Null-safety: empty/null stats and null actions must not crash aggregation.
+    auto bare = std::make_shared<CCreatureRace>();
+    bare->setBaseStats(nullptr);
+    expect_true(bare->getBaseStats() != nullptr, "null baseStats should normalize to an empty CStats");
+    bare->setActions({nullptr});
+    expect_true(bare->getActions().empty(), "null actions should be filtered out");
+
+    // A race definition is not a creature subtype, so it must never appear in the
+    // CCreature subtype enumeration.
+    auto creatureSubtypes = game->getObjectHandler()->getAllSubTypes("CCreature");
+    expect_true(std::find(creatureSubtypes.begin(), creatureSubtypes.end(), CCreatureRace::static_meta()->name()) ==
+                    creatureSubtypes.end(),
+                "CCreatureRace must not be enumerated as a CCreature subtype");
+}
+
 } // namespace
 
 int main() {
@@ -1823,6 +1891,7 @@ int main() {
     test_serialization_collection_and_error_helpers();
     test_creature_effective_stats_baseline_capture();
     test_creature_effective_actions_baseline_capture();
+    test_creature_race_metadata_round_trip();
 
     return finish_tests();
 }


### PR DESCRIPTION
## Issue
The `CCreatureRace` archetype foundation — `[EPIC_02][STORY_01][SUBSTORY_01–05]` (P0; claims `846b0f24…`/`5baf0e8a…`/`e7f5102a…`/`2eae3b4e…`/`3a694472…`). Implemented directly by the controller; native CI is the compiler (build submodules aren't available locally).

## What changed
- **`src/object/CCreatureRace.{h,cpp}`** (new): a `CGameObject`-derived **metadata definition** (not a `CCreature`/`CMapObject`), with `V_META` properties `baseStats`, `actions`, `creatureType`, `subtypes`, `playerSelectable` (+ inherited `label`/`description`/`tags`/`typeId`). Mirrors `CInteraction`/`CStats`. **Null-safe setters**: `setBaseStats(null)` → empty `CStats`; `setActions` drops null interactions.
- **`src/plugin/NativePlugin.cpp`**: `register_type<CCreatureRace, CGameObject>(game)` in `register_creatures`, **before** `CCreature`/`CPlayer` — so configured race IDs are constructible while the type stays out of `CCreature` inheritance and the `getAllSubTypes("CCreature")` / encounter enumeration.
- **`src/core/CModule.cpp`**: `register_type_metadata<CCreatureRace, CGameObject>()` + a `py::class_<CCreatureRace, CGameObject, shared_ptr<CCreatureRace>>` with read/write metadata accessors (no gameplay mutation).
- **`tests/unit/test_core.cpp`**: `test_creature_race_metadata_round_trip` — serializes/deserializes a fully-populated race through `CSerialization`, asserts every field (incl. nested base stats + actions and inherited label/description) survives and it deserializes back to a `CCreatureRace`; asserts null-safety; and asserts `CCreatureRace` is **not** in `getAllSubTypes("CCreature")`.

Covers SS01 (class) → SS02 (null-safe setters) → SS03 (native registration) → SS04 (pybind) → SS05 (round-trip test) as one cohesive, self-validating unit. `CCreatureClass` will follow the same shape.

## Validation
`clang-format` applied; `git diff --check` clean; no `planning/` files. Local build unavailable (vstd/random-dungeon-generator submodules absent) — native compile + `core_unit_tests` round-trip delegated to GitHub Actions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_