### PR TITLE
Add CCreatureClass archetype definition (E02/S02/SS01–SS04)

### DIFF
--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -43,6 +43,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "../handler/CHandler.h"
 #include "../handler/CRngHandler.h"
 #include "../object/CCreature.h"
+#include "../object/CCreatureClass.h"
 #include "../object/CCreatureRace.h"
 #include "../object/CDialog.h"
 #include "../object/CEffect.h"
@@ -353,6 +354,7 @@ void register_python_binding_type_metadata() {
     CTypes::register_type_metadata<CInteraction, CGameObject>();
     CTypes::register_type_metadata<CWrapper<CInteraction>, CInteraction, CGameObject>();
     CTypes::register_type_metadata<CCreatureRace, CGameObject>();
+    CTypes::register_type_metadata<CCreatureClass, CGameObject>();
     CTypes::register_type_metadata<CTile, CGameObject>();
     CTypes::register_type_metadata<CWrapper<CTile>, CTile, CGameObject>();
 
@@ -792,6 +794,22 @@ void init_game_module(py::module_ &m) {
         .def("isPlayerSelectable", &CCreatureRace::isPlayerSelectable,
              "Whether the race is offered at character creation.")
         .def("setPlayerSelectable", &CCreatureRace::setPlayerSelectable, "Set whether the race is player-selectable.");
+
+    py::class_<CCreatureClass, CGameObject, std::shared_ptr<CCreatureClass>>(
+        m, "CCreatureClass", "Creature class archetype definition (metadata only; not a spawnable creature).")
+        .def(py::init<>())
+        .def("getBaseStats", &CCreatureClass::getBaseStats, "Return the class's base stats.")
+        .def("setBaseStats", &CCreatureClass::setBaseStats, "Set the class's base stats (null becomes empty).")
+        .def("getLevelStats", &CCreatureClass::getLevelStats, "Return the class's per-level stat growth.")
+        .def("setLevelStats", &CCreatureClass::setLevelStats,
+             "Set the class's per-level stat growth (null becomes empty).")
+        .def("getActions", &CCreatureClass::getActions, "Return the class's starting actions.")
+        .def("setActions", &CCreatureClass::setActions, "Set the class's starting actions (nulls are dropped).")
+        .def("getLevelling", &CCreatureClass::getLevelling, "Return the level-keyed unlock map.")
+        .def("setLevelling", &CCreatureClass::setLevelling,
+             "Set the level-keyed unlock map (null entries are dropped).")
+        .def("getMainStat", &CCreatureClass::getMainStat, "Return the name of the class's main stat.")
+        .def("setMainStat", &CCreatureClass::setMainStat, "Set the name of the class's main stat.");
 
     auto ctile =
         py::class_<CTile, CWrapper<CTile>, std::shared_ptr<CTile>, CGameObject>(m, "CTile", "Base tile class.");

--- a/src/object/CCreatureClass.cpp
+++ b/src/object/CCreatureClass.cpp
@@ -1,0 +1,74 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "CCreatureClass.h"
+#include "core/CStats.h"
+#include "object/CInteraction.h"
+
+CCreatureClass::CCreatureClass() {}
+
+CCreatureClass::~CCreatureClass() {}
+
+std::shared_ptr<CStats> CCreatureClass::getBaseStats() { return baseStats; }
+
+// Null-safe: a missing baseStats normalizes to an empty CStats so composed stat
+// aggregation never dereferences a null definition.
+void CCreatureClass::setBaseStats(std::shared_ptr<CStats> value) {
+    baseStats = value ? value : std::make_shared<CStats>();
+}
+
+std::shared_ptr<CStats> CCreatureClass::getLevelStats() { return levelStats; }
+
+// Null-safe: a missing levelStats normalizes to an empty CStats so per-level
+// growth aggregation stays well-formed.
+void CCreatureClass::setLevelStats(std::shared_ptr<CStats> value) {
+    levelStats = value ? value : std::make_shared<CStats>();
+}
+
+std::set<std::shared_ptr<CInteraction>> CCreatureClass::getActions() { return actions; }
+
+// Null-safe: drop null interactions from the starting-action set.
+void CCreatureClass::setActions(std::set<std::shared_ptr<CInteraction>> value) {
+    std::set<std::shared_ptr<CInteraction>> filtered;
+    for (const auto &action : value) {
+        if (action) {
+            filtered.insert(action);
+        }
+    }
+    actions = filtered;
+}
+
+CInteractionMap CCreatureClass::getLevelling() { return levelling; }
+
+// Null-safe: drop entries whose unlock interaction is null, but preserve the
+// configured level-string keys for every non-null entry so progression data
+// deserializes deterministically.
+void CCreatureClass::setLevelling(CInteractionMap value) {
+    CInteractionMap filtered;
+    for (const auto &entry : value) {
+        if (entry.second) {
+            filtered[entry.first] = entry.second;
+        }
+    }
+    levelling = filtered;
+}
+
+std::string CCreatureClass::getMainStat() { return mainStat; }
+
+// mainStat is stored as a plain string; validating that it names a real CStats
+// property belongs to the content validator, not runtime construction.
+void CCreatureClass::setMainStat(std::string value) { mainStat = value; }

--- a/src/object/CCreatureClass.h
+++ b/src/object/CCreatureClass.h
@@ -1,0 +1,80 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "core/CStats.h"
+#include "object/CGameObject.h"
+
+#include <map>
+#include <set>
+#include <string>
+
+class CInteraction;
+
+// Map of level-string -> unlocked interaction, identical in type to CCreature's
+// CInteractionMap. Redeclaring the typedef with the same underlying type is well
+// formed, so CCreatureClass does not need to pull in the heavy CCreature.h.
+typedef std::map<std::string, std::shared_ptr<CInteraction>> CInteractionMap;
+
+// CCreatureClass is a CGameObject-derived *metadata definition* (a learned role:
+// the class a creature is, e.g. Warrior/Sorcerer), not a CCreature subtype. It
+// carries the class contribution to a composed creature -- base stats, per-level
+// stat growth, innate actions, a level-keyed unlock map, and the name of its main
+// stat. Like CCreatureRace it is never spawnable and never enumerated as a
+// CCreature subtype; it is only referenced via CCreature.creatureClass.
+class CCreatureClass : public CGameObject {
+
+    V_META(CCreatureClass, CGameObject,
+           V_PROPERTY(CCreatureClass, std::shared_ptr<CStats>, baseStats, getBaseStats, setBaseStats),
+           V_PROPERTY(CCreatureClass, std::shared_ptr<CStats>, levelStats, getLevelStats, setLevelStats),
+           V_PROPERTY(CCreatureClass, std::set<std::shared_ptr<CInteraction>>, actions, getActions, setActions),
+           V_PROPERTY(CCreatureClass, CInteractionMap, levelling, getLevelling, setLevelling),
+           V_PROPERTY(CCreatureClass, std::string, mainStat, getMainStat, setMainStat))
+
+  public:
+    CCreatureClass();
+
+    virtual ~CCreatureClass();
+
+    std::shared_ptr<CStats> getBaseStats();
+
+    void setBaseStats(std::shared_ptr<CStats> value);
+
+    std::shared_ptr<CStats> getLevelStats();
+
+    void setLevelStats(std::shared_ptr<CStats> value);
+
+    std::set<std::shared_ptr<CInteraction>> getActions();
+
+    void setActions(std::set<std::shared_ptr<CInteraction>> value);
+
+    CInteractionMap getLevelling();
+
+    void setLevelling(CInteractionMap value);
+
+    std::string getMainStat();
+
+    void setMainStat(std::string value);
+
+  private:
+    std::shared_ptr<CStats> baseStats = std::make_shared<CStats>();
+    std::shared_ptr<CStats> levelStats = std::make_shared<CStats>();
+    std::set<std::shared_ptr<CInteraction>> actions;
+    CInteractionMap levelling;
+    std::string mainStat;
+};

--- a/src/plugin/NativePlugin.cpp
+++ b/src/plugin/NativePlugin.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CTypes.h"
 #include "core/CWrapper.h"
 #include "handler/CObjectHandler.h"
+#include "object/CCreatureClass.h"
 #include "object/CCreatureRace.h"
 #include "object/CDialog.h"
 #include "object/CMarket.h"
@@ -159,6 +160,9 @@ bool register_creatures(const NativePluginHostV1 *host) {
     // constructible while the class stays out of CCreature inheritance and the
     // random-encounter / getAllSubTypes("CCreature") enumeration.
     registered = register_type<CCreatureRace, CGameObject>(game) && registered;
+    // The creature class definition is likewise a CGameObject-derived archetype,
+    // not a CCreature, so it stays out of the encounter / subtype enumeration.
+    registered = register_type<CCreatureClass, CGameObject>(game) && registered;
     registered = register_type<CCreature, CMapObject, CGameObject>(game) && registered;
     registered = register_type<CPlayer, CCreature, CMapObject, CGameObject>(game) && registered;
     if (registered) {

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -34,6 +34,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CUtil.h"
 #include "gui/CSdlResources.h"
 #include "object/CCreature.h"
+#include "object/CCreatureClass.h"
 #include "object/CCreatureRace.h"
 #include "object/CEffect.h"
 #include "object/CGameObject.h"
@@ -1843,6 +1844,80 @@ void test_creature_race_metadata_round_trip() {
                 "CCreatureRace must not be enumerated as a CCreature subtype");
 }
 
+// CCreatureClass mirrors CCreatureRace: a CGameObject-derived metadata definition.
+// This pins that it round-trips through CSerialization with base stats, per-level
+// stats, starting actions, the level-keyed unlock map, mainStat, and inherited
+// label/description intact (incl. the original level keys), deserializes back into
+// a CCreatureClass, that its setters are null-safe, and that it is not a CCreature
+// subtype.
+void test_creature_class_metadata_round_trip() {
+    CTypes::register_type_metadata<CCreatureClass, CGameObject>();
+    CTypes::register_type_metadata<CStats, CGameObject>();
+    CTypes::register_type_metadata<CInteraction, CGameObject>();
+
+    auto game = std::make_shared<CGame>();
+    game->getObjectHandler()->registerType(CCreatureClass::static_meta()->name(),
+                                           []() { return std::make_shared<CCreatureClass>(); });
+    game->getObjectHandler()->registerType(CStats::static_meta()->name(), []() { return std::make_shared<CStats>(); });
+    game->getObjectHandler()->registerType(CInteraction::static_meta()->name(),
+                                           []() { return std::make_shared<CInteraction>(); });
+
+    auto baseStats = std::make_shared<CStats>();
+    baseStats->setStrength(9);
+    auto levelStats = std::make_shared<CStats>();
+    levelStats->setStrength(2);
+    auto startAction = std::make_shared<CInteraction>();
+    startAction->setTypeId("classStrike");
+    auto unlock = std::make_shared<CInteraction>();
+    unlock->setTypeId("classCleave");
+
+    auto klass = std::make_shared<CCreatureClass>();
+    klass->setGame(game);
+    klass->setBaseStats(baseStats);
+    klass->setLevelStats(levelStats);
+    klass->setActions({startAction});
+    klass->setLevelling({{"3", unlock}});
+    klass->setMainStat("strength");
+    klass->setLabel("Warrior");
+    klass->setDescription("Front-line martial role.");
+
+    auto serialized = CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::serialize(klass);
+    expect_true((*serialized)["class"].get<std::string>() == CCreatureClass::static_meta()->name(),
+                "a serialized CCreatureClass should keep its metadata class identity");
+
+    auto round_trip = std::dynamic_pointer_cast<CCreatureClass>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game, serialized));
+
+    expect_true(round_trip != nullptr,
+                "a CCreatureClass should deserialize back into a CCreatureClass, not a creature or map object");
+    expect_true(round_trip->getMainStat() == "strength", "mainStat should survive the round-trip");
+    expect_true(round_trip->getLabel() == "Warrior", "inherited label should survive the round-trip");
+    expect_true(round_trip->getBaseStats() && round_trip->getBaseStats()->getStrength() == 9,
+                "base stats should survive the round-trip");
+    expect_true(round_trip->getLevelStats() && round_trip->getLevelStats()->getStrength() == 2,
+                "per-level stats should survive the round-trip");
+    expect_true(round_trip->getActions().size() == 1, "starting actions should survive the round-trip");
+    auto levelling = round_trip->getLevelling();
+    expect_true(levelling.size() == 1 && levelling.count("3") == 1 && levelling["3"] != nullptr,
+                "the levelling map should round-trip with its original level key and unlock");
+
+    // Null-safety: empty/null stats, null actions, and null-valued levelling entries.
+    auto bare = std::make_shared<CCreatureClass>();
+    bare->setBaseStats(nullptr);
+    bare->setLevelStats(nullptr);
+    expect_true(bare->getBaseStats() != nullptr && bare->getLevelStats() != nullptr,
+                "null baseStats/levelStats should normalize to empty CStats");
+    bare->setActions({nullptr});
+    expect_true(bare->getActions().empty(), "null actions should be filtered out");
+    bare->setLevelling({{"1", nullptr}});
+    expect_true(bare->getLevelling().empty(), "null-valued levelling entries should be filtered out");
+
+    auto creatureSubtypes = game->getObjectHandler()->getAllSubTypes("CCreature");
+    expect_true(std::find(creatureSubtypes.begin(), creatureSubtypes.end(), CCreatureClass::static_meta()->name()) ==
+                    creatureSubtypes.end(),
+                "CCreatureClass must not be enumerated as a CCreature subtype");
+}
+
 } // namespace
 
 int main() {
@@ -1892,6 +1967,7 @@ int main() {
     test_creature_effective_stats_baseline_capture();
     test_creature_effective_actions_baseline_capture();
     test_creature_race_metadata_round_trip();
+    test_creature_class_metadata_round_trip();
 
     return finish_tests();
 }


### PR DESCRIPTION
## Issue
The `CCreatureClass` archetype foundation — `[EPIC_02][STORY_02][SUBSTORY_01–04]` (P0; claims `5b8ee55f…`/`e41a407b…`/`c96a5680…`/`a03ba15f…`). Mirrors the merged `CCreatureRace` (#1039); SS03 was unblocked (#1041) now that the class exists.

## What changed
- **`src/object/CCreatureClass.{h,cpp}`** (new): a `CGameObject`-derived **metadata definition** (a learned role, not a `CCreature`), with `V_META` properties `baseStats`, `levelStats`, `actions`, `levelling` (level-keyed unlock map), `mainStat` (+ inherited `label`/`description`/`tags`/`typeId`). Reuses the `CInteractionMap` type via an identical (legal) typedef so it avoids pulling in the heavy `CCreature.h`. **Null-safe setters**: `baseStats`/`levelStats` null → empty `CStats`; `actions` drops nulls; `levelling` drops null-valued entries while preserving the configured level keys; `mainStat` is a plain string (name validation belongs to the content validator).
- **`src/plugin/NativePlugin.cpp`**: `register_type<CCreatureClass, CGameObject>(game)` in `register_creatures` (after `CCreatureRace`, before `CCreature`) — stays out of `CCreature` inheritance / `getAllSubTypes("CCreature")` / encounters.
- **`src/core/CModule.cpp`**: `register_type_metadata` + `py::class_<CCreatureClass, …>` with read/write metadata accessors.
- **`tests/unit/test_core.cpp`**: `test_creature_class_metadata_round_trip` — serializes/deserializes a fully-populated class through `CSerialization`, asserts every field survives (incl. `levelStats`, the `levelling` map's original level keys, and inherited label), null-safety (incl. null-valued levelling entries), and that it is **not** a `CCreature` subtype.

Covers SS01 (class) → SS02 (null-safe setters) → SS03 (register + bind) → SS04 (round-trip test) as one cohesive unit.

## Validation
`clang-format` applied; `git diff --check` clean; no `planning/` files. Native compile + `core_unit_tests` round-trip delegated to GitHub Actions (build submodules absent locally).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_