### PR TITLE
Queue work: CMapSessionStore, transition movement guard, save round-trip harness

### DIFF
--- a/src/core/CGameContext.cpp
+++ b/src/core/CGameContext.cpp
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CGameContext.h"
 #include "core/CController.h"
 #include "core/CGame.h"
+#include "core/CMap.h"
 #include "core/CProvider.h"
 #include "core/CSceneManager.h"
 #include "core/CSlotConfig.h"
@@ -100,6 +101,51 @@ std::shared_ptr<CConfigurationProvider> CGameContext::getConfigurationProvider()
     return configurationProvider;
 }
 
+std::shared_ptr<CMapSessionStore> CGameContext::getMapSessionStore() {
+    requireActiveService("CMapSessionStore");
+    if (!mapSessionStore) {
+        mapSessionStore = std::make_shared<CMapSessionStore>();
+    }
+    return mapSessionStore;
+}
+
+std::string CMapSessionStore::makeKey(const std::string &mapName, const std::string &instanceId) {
+    // Length-prefix the map name so distinct (mapName, instanceId) pairs never collide.
+    return std::to_string(mapName.size()) + ":" + mapName + ":" + instanceId;
+}
+
+void CMapSessionStore::put(const std::string &mapName, const std::string &instanceId,
+                           const std::shared_ptr<CMap> &map) {
+    if (!map) {
+        return;
+    }
+    sessions[makeKey(mapName, instanceId)] = map;
+}
+
+void CMapSessionStore::put(const std::shared_ptr<CMap> &map, const std::string &instanceId) {
+    if (!map) {
+        return;
+    }
+    put(map->getMapName(), instanceId, map);
+}
+
+std::shared_ptr<CMap> CMapSessionStore::get(const std::string &mapName, const std::string &instanceId) const {
+    auto it = sessions.find(makeKey(mapName, instanceId));
+    return it != sessions.end() ? it->second : nullptr;
+}
+
+bool CMapSessionStore::contains(const std::string &mapName, const std::string &instanceId) const {
+    return sessions.find(makeKey(mapName, instanceId)) != sessions.end();
+}
+
+bool CMapSessionStore::evict(const std::string &mapName, const std::string &instanceId) {
+    return sessions.erase(makeKey(mapName, instanceId)) > 0;
+}
+
+void CMapSessionStore::clear() { sessions.clear(); }
+
+std::size_t CMapSessionStore::size() const { return sessions.size(); }
+
 bool CGameContext::isActive() const { return active.load(std::memory_order_acquire); }
 
 void CGameContext::shutdown() {
@@ -128,6 +174,10 @@ void CGameContext::shutdown(CGame *owner) {
         scriptHandler->releaseState();
     }
     slotConfiguration.clear();
+    if (mapSessionStore) {
+        mapSessionStore->clear();
+    }
+    mapSessionStore.reset();
     configurationProvider.reset();
     resourcesProvider.reset();
     scriptHandler.reset();

--- a/src/core/CGameContext.h
+++ b/src/core/CGameContext.h
@@ -18,19 +18,48 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string>
+#include <unordered_map>
 
 #include "core/CGlobal.h"
 
 class CGame;
 class CGuiHandler;
 class CConfigurationProvider;
+class CMap;
 class CObjectHandler;
 class CResourcesProvider;
 class CRngHandler;
 class CScriptHandler;
 class CSlotConfig;
+
+// Context-owned cache of loaded maps that should outlive a single transition. Sessions are keyed by
+// map name plus an optional instance id so multiple live copies of the same map can be retained. The
+// store only retains and hands back maps; it does not change transition semantics on its own.
+class CMapSessionStore {
+  public:
+    static std::string makeKey(const std::string &mapName, const std::string &instanceId = "");
+
+    void put(const std::string &mapName, const std::string &instanceId, const std::shared_ptr<CMap> &map);
+
+    void put(const std::shared_ptr<CMap> &map, const std::string &instanceId = "");
+
+    std::shared_ptr<CMap> get(const std::string &mapName, const std::string &instanceId = "") const;
+
+    bool contains(const std::string &mapName, const std::string &instanceId = "") const;
+
+    bool evict(const std::string &mapName, const std::string &instanceId = "");
+
+    void clear();
+
+    std::size_t size() const;
+
+  private:
+    std::unordered_map<std::string, std::shared_ptr<CMap>> sessions;
+};
 
 class CGameContext {
     friend class CGame;
@@ -53,6 +82,8 @@ class CGameContext {
     std::shared_ptr<CResourcesProvider> getResourcesProvider();
 
     std::shared_ptr<CConfigurationProvider> getConfigurationProvider();
+
+    std::shared_ptr<CMapSessionStore> getMapSessionStore();
 
     bool isActive() const;
 
@@ -78,6 +109,7 @@ class CGameContext {
     std::shared_ptr<CRngHandler> rngHandler;
     std::shared_ptr<CResourcesProvider> resourcesProvider;
     std::shared_ptr<CConfigurationProvider> configurationProvider;
+    std::shared_ptr<CMapSessionStore> mapSessionStore;
     vstd::lazy<CSlotConfig> slotConfiguration;
     std::atomic<bool> active = true;
     std::atomic<TransitionGeneration> transitionGeneration = 0;

--- a/src/core/CMap.cpp
+++ b/src/core/CMap.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CGame.h"
 #include "core/CGameContext.h"
 #include "core/CPlaytestTrace.h"
+#include "core/CSceneManager.h"
 #include "core/CSerialization.h"
 #include "object/CItem.h"
 #include "object/CTrigger.h"
@@ -569,11 +570,19 @@ void CMap::move() {
         vstd::logger::fatal("Invalid move request");
     }
 
+    auto game = map->getGame();
+    // Do not begin a new movement/controller cycle once a map transition has been queued. The
+    // pending transition will swap the active map, so running another turn on the old map would
+    // only schedule controller futures whose results must then be discarded as stale.
+    if (auto sceneManager = game ? game->getSceneManager() : nullptr;
+        sceneManager && sceneManager->isTransitionPending()) {
+        return;
+    }
+
     map->moving = true;
 
     vstd::logger::debug("Turn:", map->turn);
 
-    auto game = map->getGame();
     auto transitionContext = game ? game->getContext() : nullptr;
     const auto expectedGeneration =
         transitionContext ? transitionContext->captureTransitionGeneration() : CGameContext::TransitionGeneration{0};

--- a/test.py
+++ b/test.py
@@ -3003,6 +3003,66 @@ def assert_nouraajd_save_load_roundtrip(test_case, game, game_map, prefix, save_
     return loaded_game, loaded_map, loaded_player, after
 
 
+def save_state_summary(
+    game_map,
+    player,
+    *,
+    map_bool_flags=(),
+    map_numeric_flags=(),
+    inventory_items=(),
+    object_names=(),
+    object_prefixes=(),
+):
+    """Reusable normalized summary of the live state that must survive a save/reload unchanged.
+
+    Captures the stable fields shared by every save-affecting fixture -- map name and turn, the
+    scene transition state, player identity/position/gold, inventory counts, active and completed
+    quests, selected map flags, named-object presence, and spawned-name prefix counts -- so a new
+    fixture can round-trip with just the flag/item/object keys it cares about. The result is
+    normalized for order-independent comparison. The owning game instance (for the scene transition
+    state) is resolved from the map, so callers pass the live map and player rather than the module.
+    """
+    return normalize_save_snapshot(
+        {
+            "map": game_map.mapName,
+            "turn": game_map.getTurn(),
+            "transition_state": game_map.getGame().getSceneManager().getTransitionStateName(),
+            "player": {
+                "type": player.getType(),
+                "typeId": player.getTypeId(),
+                "coords": coords_tuple(player.getCoords()),
+                "gold": player.getGold(),
+            },
+            "items": player_item_counts(player, inventory_items),
+            "active_quests": quest_names(player),
+            "completed_quests": completed_quest_names(player),
+            "map_bool_flags": {flag: game_map.getBoolProperty(flag) for flag in map_bool_flags},
+            "map_numeric_flags": {flag: game_map.getNumericProperty(flag) for flag in map_numeric_flags},
+            "objects": named_object_presence(game_map, object_names),
+            "object_prefix_counts": named_object_prefix_counts(game_map, object_prefixes),
+        }
+    )
+
+
+def assert_save_load_roundtrip(test_case, game, game_map, prefix, save_paths=None, **summary_kwargs):
+    """Summarize live state, save, reload, and assert every stable field round-trips unchanged.
+
+    Appends the produced save path to ``save_paths`` (when given) so callers can clean it up, and
+    returns ``(loaded_game, loaded_map, loaded_player, summary)`` for fixture-specific assertions on
+    the reloaded state.
+    """
+    before = save_state_summary(game_map, game_map.getPlayer(), **summary_kwargs)
+    save_path, loaded_game, loaded_map, loaded_player = save_load_roundtrip(game, game_map, prefix)
+    if save_paths is not None:
+        save_paths.append(save_path)
+    after = save_state_summary(loaded_map, loaded_player, **summary_kwargs)
+
+    test_case.assertEqual(before, after)
+    test_case.assertIsNotNone(get_player_controller(loaded_player))
+    test_case.assertIsNotNone(loaded_player.getFightController())
+    return loaded_game, loaded_map, loaded_player, after
+
+
 def find_map_object_definition(map_name, object_name):
     map_data = load_map_data(map_name)
     for layer in map_data.get("layers", []):
@@ -15184,6 +15244,47 @@ class GameTest(unittest.TestCase):
                     "initial": initial["quest_states"],
                     "mid": mid["quest_states"],
                     "late": late["quest_states"],
+                    "save_count": len(save_paths),
+                },
+                sort_keys=True,
+            )
+        finally:
+            for save_path in save_paths:
+                save_path.unlink(missing_ok=True)
+
+    @game_test
+    def test_save_state_summary_round_trips_through_save_load(self):
+        game = load_game_module()
+        save_paths = []
+
+        try:
+            g, game_map, player = load_game_map_with_player("nouraajd")
+            player.addGold(250)
+            player.addItem("letterFromRolf")
+            player.addQuest("rolfQuest")
+
+            g, game_map, player, summary = assert_save_load_roundtrip(
+                self,
+                game,
+                game_map,
+                "save_state_summary_roundtrip",
+                save_paths,
+                inventory_items=("letterFromRolf",),
+                object_names=("cave1",),
+            )
+
+            self.assertEqual("nouraajd", summary["map"])
+            self.assertEqual("Warrior", summary["player"]["typeId"])
+            self.assertGreaterEqual(summary["player"]["gold"], 250)
+            self.assertGreaterEqual(summary["items"]["letterFromRolf"], 1)
+            self.assertIn("rolfQuest", summary["active_quests"])
+            self.assertTrue(summary["objects"]["cave1"])
+
+            return True, json.dumps(
+                {
+                    "map": summary["map"],
+                    "gold": summary["player"]["gold"],
+                    "active_quests": summary["active_quests"],
                     "save_count": len(save_paths),
                 },
                 sort_keys=True,

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -1416,6 +1416,67 @@ void test_animation_provider_uses_dynamic_animation_for_directory_resources() {
                 "animation provider should use dynamic animations for directory resources");
 }
 
+void test_map_session_store_put_get_evict_and_ownership() {
+    CMapSessionStore store;
+    expect_true(store.size() == 0, "a new session store should be empty");
+
+    auto first = std::make_shared<CMap>();
+    first->setMapName("alpha");
+    auto second = std::make_shared<CMap>();
+    second->setMapName("alpha");
+    auto beta = std::make_shared<CMap>();
+    beta->setMapName("beta");
+
+    store.put(first);                     // alpha / default instance, key derived from the map name
+    store.put("alpha", "second", second); // alpha / explicit instance id
+    store.put(beta, "");
+
+    expect_true(store.size() == 3, "store should hold three distinct sessions");
+    expect_true(store.get("alpha") == first, "default-instance get should return the stored map");
+    expect_true(store.get("alpha", "second") == second, "instance get should return the per-instance map");
+    expect_true(store.get("beta") == beta, "named get should return the stored map");
+    expect_true(store.get("missing") == nullptr, "an absent session should resolve to null");
+    expect_true(store.contains("alpha", "second"), "contains should report a stored instance session");
+    expect_true(!store.contains("alpha", "third"), "contains should reject an unstored instance id");
+
+    // The store owns its cached maps: dropping every external reference keeps the map alive.
+    std::weak_ptr<CMap> weakBeta = beta;
+    beta.reset();
+    expect_true(!weakBeta.expired(), "store should retain ownership of cached maps");
+    expect_true(store.get("beta") != nullptr, "a retained map should still be retrievable");
+
+    expect_true(store.evict("alpha", "second"), "evict should report removing an existing session");
+    expect_true(!store.evict("alpha", "second"), "evicting an absent session should report false");
+    expect_true(store.get("alpha", "second") == nullptr, "an evicted session should no longer resolve");
+    expect_true(store.get("alpha") == first, "evicting one instance should not affect the default session");
+
+    auto replacement = std::make_shared<CMap>();
+    replacement->setMapName("alpha");
+    store.put(replacement);
+    expect_true(store.get("alpha") == replacement, "putting the same key should replace the cached map");
+
+    store.put(std::shared_ptr<CMap>(), "ignored");
+    expect_true(!store.contains("", "ignored"), "putting a null map should be ignored");
+
+    store.clear();
+    expect_true(store.size() == 0, "clear should drop every session");
+    expect_true(store.get("alpha") == nullptr, "a cleared store should resolve nothing");
+}
+
+void test_game_context_owns_a_map_session_store() {
+    auto game = std::make_shared<CGame>();
+    auto context = game->getContext();
+    auto store = context->getMapSessionStore();
+    expect_true(store != nullptr, "context should expose a map session store");
+    expect_true(context->getMapSessionStore() == store, "context should return the same store instance on each call");
+
+    auto cached = std::make_shared<CMap>();
+    cached->setMapName("cached");
+    store->put(cached);
+    expect_true(context->getMapSessionStore()->get("cached") == cached,
+                "context-owned store should retain maps across accessor calls");
+}
+
 } // namespace
 
 int main() {
@@ -1446,6 +1507,8 @@ int main() {
     test_map_keeps_tiles_and_objects_separate_by_z();
     test_can_step_checks_default_tile_passability_without_materializing();
     test_animation_provider_uses_dynamic_animation_for_directory_resources();
+    test_map_session_store_put_get_evict_and_ownership();
+    test_game_context_owns_a_map_session_store();
 
     return finish_tests();
 }

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -1477,6 +1477,37 @@ void test_game_context_owns_a_map_session_store() {
                 "context-owned store should retain maps across accessor calls");
 }
 
+class TurnCountingController : public CController {
+  public:
+    std::shared_ptr<vstd::future<Coords, void>> control(std::shared_ptr<CCreature> creature) override {
+        controlCalls++;
+        return vstd::later([creature]() { return creature->getCoords(); });
+    }
+
+    int controlCalls = 0;
+};
+
+void test_map_move_blocks_new_turn_while_transition_pending() {
+    auto game = CGameLoader::loadGame();
+    CGameLoader::startGameWithPlayer(game, "test", "Warrior");
+    auto map = game->getMap();
+
+    auto controller = std::make_shared<TurnCountingController>();
+    auto creature = test_creature(game, "transitionPendingWalker", ZERO, controller);
+    map->addObject(creature);
+
+    expect_true(game->getSceneManager()->requestMapChange(game, "ritual"),
+                "requesting a map change should be accepted while the scene manager is idle");
+    expect_true(game->getSceneManager()->isTransitionPending(),
+                "the scene manager should report a pending transition after the request");
+
+    const int turn_before = map->getTurn();
+    map->move();
+
+    expect_true(controller->controlCalls == 0, "no controller cycle should start while a transition is pending");
+    expect_true(map->getTurn() == turn_before, "the old map should not advance a turn while a transition is pending");
+}
+
 } // namespace
 
 int main() {
@@ -1509,6 +1540,7 @@ int main() {
     test_animation_provider_uses_dynamic_animation_for_directory_resources();
     test_map_session_store_put_get_evict_and_ownership();
     test_game_context_owns_a_map_session_store();
+    test_map_move_blocks_new_turn_while_transition_pending();
 
     return finish_tests();
 }


### PR DESCRIPTION
Three independent queue issues, each its own commit on top of the latest `main`.

> Note: this branch originally carried two more commits — `[EPIC_01][STORY_03][SUBSTORY_02]` fight-panel **start** idempotence, `[EPIC_07][STORY_01][SUBSTORY_02]` quest-state validation, and `[EPIC_01][STORY_03][SUBSTORY_03]` fight-panel **end** idempotence — but `main` merged equivalent (and in places more thorough) implementations of those from other controllers, so they were dropped during rebase. The three below are the unique, surviving work.

## Commits

1. **`[EPIC_02][STORY_03][SUBSTORY_04]` Add CMapSessionStore** — `src/core/CGameContext.{h,cpp}`, `tests/unit/test_map.cpp`
   A context-owned cache of loaded maps keyed by map name + optional instance id, with put/get/contains/evict/clear/size, cleared on context shutdown. `CGame::changeMap` semantics are intentionally unchanged (persistent transitions stay opt-in). Unit tests cover put/get/evict/replace/clear and ownership retention.

2. **`[EPIC_02][STORY_04][SUBSTORY_03]` Block movement cycles while transition pending** — `src/core/CMap.cpp`, `tests/unit/test_map.cpp`
   `CMap::move()` now returns early (before setting `moving` or scheduling controllers) when the scene manager reports a pending transition, so no new turn begins on the old map. In-progress moves still finish and clear `moving`, which is what the deferred transition waits on. Regression: with a transition queued, `move()` runs no controller cycle and does not advance the turn.

3. **`[EPIC_03][STORY_05][SUBSTORY_05]` Add save round-trip comparison harness** — `test.py`
   Generic `save_state_summary(...)` + `assert_save_load_roundtrip(...)` so any save-affecting fixture can compare stable fields (map/turn, transition state, player identity/coords/gold, inventory, quests, map flags, named objects) across a save/reload with minimal boilerplate, reusing the existing field helpers (no serialization change). A demonstration test round-trips the nouraajd fixture.

## Validation

These touch native C++ and `test.py`, which can't be built or run in the authoring environment, so they rely on this PR's CI (Linux/Windows native build, unit tests, full `test.py`, coverage). Each was written against verified source APIs and mirrors existing test patterns; `ci_change_classifier` marks them native+coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)