### PR TITLE
Add movement-cost edge and performance-guard regression tests (EPIC_04/STORY_02/SUBSTORY_05)

### DIFF
--- a/tests/unit/test_controller.cpp
+++ b/tests/unit/test_controller.cpp
@@ -334,6 +334,32 @@ void test_target_controller_flow_field_prefers_longer_lower_cost_route() {
     expect_true(chaser->getCoords() == target->getCoords(), "target weighted detour should reach the target");
 }
 
+void test_player_controller_prefers_cheap_navigation_edge_over_expensive_band() {
+    auto game = std::make_shared<CGame>();
+    auto map = weighted_detour_map(game);
+    // A bidirectional waypoint edge spans the expensive row-0 band. Its step cost is the destination
+    // tile cost (1), not the 30-cost band, so weighted pathing must cross the edge instead of taking
+    // the expensive direct row or the longer cheap detour.
+    add_navigation_edge(map, Coords(0, 0, 0), Coords(4, 0, 0), true);
+
+    const auto tiles_before = map->getTiles().size();
+
+    auto player = player_at(game, Coords(0, 0, 0));
+    auto controller = std::make_shared<CPlayerController>();
+    player->setController(controller);
+    controller->setTarget(player, Coords(4, 0, 0));
+
+    auto first_step = resolve_coords(controller->control(player));
+    expect_true(first_step == Coords(4, 0, 0),
+                "weighted pathing should cross the cheap waypoint edge rather than the expensive band or detour");
+    player->moveTo(first_step);
+    controller->onStepCommitted(player, first_step);
+
+    expect_true(player->getCoords() == Coords(4, 0, 0), "the weighted edge crossing should reach the target");
+    expect_true(controller->isCompleted(player), "reaching the target through the edge should complete the controller");
+    expect_true(map->getTiles().size() == tiles_before, "weighted edge pathing should not materialize extra tiles");
+}
+
 void test_player_controller_uses_navigation_neighbors_for_cross_level_route() {
     auto game = std::make_shared<CGame>();
     auto map = open_tile_map(game, 3, 1, 2);
@@ -731,6 +757,7 @@ int main() {
     test_player_controller_prefers_longer_lower_cost_route();
     test_npc_random_controller_prefers_longer_lower_cost_route();
     test_target_controller_flow_field_prefers_longer_lower_cost_route();
+    test_player_controller_prefers_cheap_navigation_edge_over_expensive_band();
     test_player_controller_uses_navigation_neighbors_for_cross_level_route();
     test_target_controller_flow_field_uses_navigation_neighbors_for_cross_level_pursuit();
     test_player_controller_respects_disabled_and_one_way_cross_level_edges();

--- a/tests/unit/test_engine_hotspot_performance.cpp
+++ b/tests/unit/test_engine_hotspot_performance.cpp
@@ -490,6 +490,52 @@ void test_bulk_inventory_property_notifications_are_count_bounded() {
                 "legacy inventoryChanged remains item-level until GUI refresh migrates to property notifications");
 }
 
+void test_weighted_target_flow_field_is_single_build_and_materialization_bounded() {
+    auto fixture = make_open_map(6, 3);
+    // Make the row-0 band between the chasers and the goal expensive so the weighted flow field has
+    // to route around it; this exercises movement-cost lookups during flow-field construction.
+    for (int x = 1; x <= 4; ++x) {
+        if (auto tile = fixture.map->getTile(Coords(x, 0, 0))) {
+            tile->setMovementCost(30);
+        }
+    }
+
+    const Coords goal_coords(5, 0, 0);
+    add_object(fixture, make_object(fixture, "weightedGoal", goal_coords));
+
+    std::vector<std::shared_ptr<CCreature>> chasers;
+    for (int y = 0; y < 3; ++y) {
+        auto chaser = make_actor(fixture, "weightedChaser" + std::to_string(y), Coords(0, y, 0), "weightedGoal");
+        add_object(fixture, chaser);
+        chasers.push_back(chaser);
+    }
+
+    const auto revision_before = fixture.map->getNavigationRevision();
+    const auto tiles_before = fixture.map->getTiles().size();
+    const auto objects_before = fixture.map->getObjects().size();
+
+    performance_guard::clearTargetFlowCache();
+    expect_true(performance_guard::targetFlowCacheSize() == 0, "weighted flow cache should start empty");
+    for (const auto &chaser : chasers) {
+        resolve_step(chaser);
+    }
+
+    expect_true(performance_guard::targetFlowCacheSize() == 1,
+                "weighted chasers sharing one goal should reuse a single target flow field");
+    expect_true(fixture.map->getNavigationRevision() == revision_before,
+                "weighted flow-field reads should not mutate the navigation revision");
+    expect_true(fixture.map->getTiles().size() == tiles_before,
+                "weighted flow-field reads should not materialize extra tiles");
+    expect_true(fixture.map->getObjects().size() == objects_before,
+                "weighted flow-field reads should not add or remove objects");
+
+    for (const auto &chaser : chasers) {
+        resolve_step(chaser);
+    }
+    expect_true(performance_guard::targetFlowCacheSize() == 1,
+                "repeated weighted reads should keep reusing the cached target flow field");
+}
+
 } // namespace
 
 void run_engine_hotspot_performance_tests() {
@@ -499,6 +545,7 @@ void run_engine_hotspot_performance_tests() {
     }
 
     test_many_target_controllers_share_one_goal_without_mutating_navigation();
+    test_weighted_target_flow_field_is_single_build_and_materialization_bounded();
     test_relevant_object_move_invalidates_target_navigation();
     test_relevant_tile_change_invalidates_target_navigation();
     test_navigation_edge_removal_invalidates_target_navigation();


### PR DESCRIPTION
Extends the weighted-movement coverage from the dependency (`[EPIC_04][STORY_02][SUBSTORY_04]` Pass movement costs to path consumers) with the two cases it did not yet exercise. Weighted direct-path and flow-field route choice are already covered by that dependency's tests.

## Changes

- **`tests/unit/test_controller.cpp`** (`controller_unit_tests`) — waypoint/edge movement with costs: a player on the weighted detour map with a bidirectional navigation edge spanning the expensive row-0 band. The edge's step cost is the destination tile cost (1), not the 30-cost band, so weighted pathing must cross the edge in a single step rather than take the expensive direct row or the longer cheap detour. Also asserts the weighted lookups don't materialize extra tiles.

- **`tests/unit/test_engine_hotspot_performance.cpp`** (`performance_guard_tests`) — deterministic guard for weighted target flow fields: several chasers sharing one goal across an expensive band must build exactly one target flow field and reuse it, without mutating the navigation revision, materializing tiles, or adding/removing objects — bounding the cost-aware flow-field work.

Both reuse the existing fixtures/helpers (`weighted_detour_map`, `set_tile_movement_cost`, `add_navigation_edge`, `resolve_coords`; `make_open_map`, `make_actor`, `resolve_step`, `performance_guard` probes).

## Validation

Additive C++ unit tests (no production code change), so they rely on this PR's CI — `controller_unit_tests` and `performance_guard_tests` under `ctest`, plus the Linux/Windows native builds and coverage. `ci_change_classifier` marks them native+coverage. Written against the exact existing helper signatures and probe APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgwwEuSehxkjEsvFNu9fS)_