### PR TITLE
Migrate audited reward paths to claim-first (EPIC_07/STORY_02/SUBSTORY_02)

### DIFF
--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -8,6 +8,7 @@ def load(self, context):
     from game import LegacyBoolFlag
     from game import PlayerQuestRegistry
     from game import QuestStateStore
+    from game import claim_once
     from game import ensure_quest
     from game import register, trigger
 
@@ -431,9 +432,10 @@ def load(self, context):
 
         def onComplete(self):
             game_map = self.getGame().getMap()
-            if not game_map.getBoolProperty("GOOBY_REWARD_CLAIMED"):
+            # Claim-first: set the claim flag before granting so a repeated dialog/trigger run cannot
+            # grant the gold twice.
+            if claim_once(game_map, "GOOBY_REWARD_CLAIMED"):
                 game_map.getPlayer().addGold(MAIN_QUEST_GOLD_REWARD)
-                game_map.setBoolProperty("GOOBY_REWARD_CLAIMED", True)
             self.getGame().getGuiHandler().showMessage("Gooby lies butchered, and weary townsfolk dare a ragged cheer.")
 
     @register(context)
@@ -561,12 +563,13 @@ def load(self, context):
         def onComplete(self):
             game = self.getGame()
             game_map = game.getMap()
-            if game_map.getBoolProperty("OCTOBOGZ_REWARD_CLAIMED"):
+            # Claim-first: claim the reward before handing out gold and the item so the payout
+            # cannot repeat if onComplete runs again.
+            if not claim_once(game_map, "OCTOBOGZ_REWARD_CLAIMED"):
                 return
             player = game_map.getPlayer()
             player.addGold(1000)
             player.addItem("ShadowBlade")
-            game_map.setBoolProperty("OCTOBOGZ_REWARD_CLAIMED", True)
             game.getGuiHandler().showMessage("The refugees press 1000 gold and the Shadow Blade into your hands.")
 
     @register(context)

--- a/res/maps/siege/script.py
+++ b/res/maps/siege/script.py
@@ -8,6 +8,7 @@ def load(self, context):
     from game import trigger
     from game import randint
     from game import logger
+    from game import claim_once
 
     SPAWN_POINTS = ("spawnPoint1", "spawnPoint2", "spawnPoint3", "spawnPoint4")
 
@@ -58,12 +59,14 @@ def load(self, context):
             return "Pritz mages carry extra wands; defeat them if you run out."
 
         def onComplete(self):
-            player = self.getGame().getMap().getPlayer()
-            if self.getGame().getMap().getBoolProperty("siege_reward_claimed"):
+            game_map = self.getGame().getMap()
+            player = game_map.getPlayer()
+            # Claim-first: claim the campaign reward before granting gold or marking completion so a
+            # repeated completion cannot pay the 500 gold twice.
+            if not claim_once(game_map, "siege_reward_claimed"):
                 return
             player.addGold(500)
-            self.getGame().getMap().setBoolProperty("siege_reward_claimed", True)
-            self.getGame().getMap().setBoolProperty("campaign_completed", True)
+            game_map.setBoolProperty("campaign_completed", True)
             self.getGame().getGuiHandler().showMessage("The last breach is sealed. Nouraajd survives the night.")
 
     @register(context)


### PR DESCRIPTION
The Gooby, Octobogz, and siege-completion rewards granted gold/items and *then* set their reward-claimed flag (grant-first), leaving a window where a repeated dialog/trigger run could pay out twice before the flag was set. Each is converted to the `claim_once(owner, flag)` helper so the claim flag is set **before** any payout.

## Changes

- **`res/maps/nouraajd/script.py`** — Gooby (`GOOBY_REWARD_CLAIMED`) and Octobogz (`OCTOBOGZ_REWARD_CLAIMED`) `onComplete` rewards.
- **`res/maps/siege/script.py`** — campaign completion (`siege_reward_claimed`).

`claim_once` returns `True` only on the first claim and persists the same boolean flag, so first-time payouts and the post-claim flag state are unchanged — only the ordering becomes claim-first. Both scripts now import `claim_once` from `game`.

## Scope (per the issue's caveat)

The **Victor** reward is intentionally left as-is: its `VICTOR_REWARD_CLAIMED` flag is overloaded as a good-end/bad-end state marker (reset on bad end) and the payout is already gated by the encounter quest state, so per *"do not migrate paths already protected … unless a duplicate path is verified"* it is not converted. The amulet/quest `onComplete` payouts protected by `completedQuests` are likewise left untouched.

## Validation

- `python3 scripts/validate_content.py` passes; 107 content-validator unit tests pass; both scripts parse.
- The existing double-invocation regressions already assert exact deltas and exercise the claim-first behavior: `test_nouraajd_octobogz_unique_reward_is_not_duplicated` (calls `onComplete()` twice → +1000 gold and one Shadow Blade only) and the Gooby main-quest test (calls `onComplete()` twice → +200 gold only). No new blind gameplay test was added since these already cover the regression. CI runs the native `test.py` suite (`ci_change_classifier`: native, no coverage gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgwwEuSehxkjEsvFNu9fS)_