### PR TITLE
Add path-stop regression coverage after encounter (EPIC_01/STORY_02/SUBSTORY_05)

### DIFF
--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -1839,6 +1839,51 @@ void test_post_combat_cancellation_keeps_object_cache_at_origin_with_foe_present
                 "a cancelled encounter should leave both combatants alive and correctly indexed");
 }
 
+// Drives a full map move cycle for a player whose CPlayerController path steps directly into a
+// hostile cell. After the encounter resolves the post-combat policy returns the player to its
+// pre-step origin and the commit loop must interrupt the path controller, so a subsequent move
+// cycle does not automatically retarget the same enemy cell.
+void test_post_combat_player_path_stops_after_encounter() {
+    auto game = CGameLoader::loadGame();
+    CGameLoader::startGameWithPlayer(game, "test", "Warrior");
+    auto map = game->getMap();
+    auto player = map->getPlayer();
+
+    Coords origin = ZERO;
+    Coords delta = ZERO;
+    expect_true(find_walkable_step(map, origin, delta), "post-combat path-stop fixture should find a walkable step");
+    const Coords hostile_cell = map->normalizeCoords(origin + delta);
+
+    player->relocateWithoutMoveHooks(origin);
+    player->setFightController(std::make_shared<PostCombatKillingFightController>());
+    auto hostile = add_post_combat_hostile(game, "postCombatPathStopFoe", hostile_cell);
+
+    auto controller = std::dynamic_pointer_cast<CPlayerController>(player->getController());
+    expect_true(controller != nullptr, "the loaded player should be driven by a CPlayerController");
+    controller->setTarget(player, hostile_cell);
+    expect_true(!controller->isCompleted(player),
+                "pathing into the hostile cell should leave the controller with a pending path");
+
+    map->move();
+
+    expect_true(map->normalizeCoords(player->getCoords()) == origin,
+                "a player path that hits combat should leave the player at the pre-step origin");
+    expect_true(map->normalizeCoords(player->getCoords()) != hostile_cell,
+                "a player path that hits combat must not leave the player inside the hostile cell");
+    expect_true(!hostile->isAlive(), "the path-stop encounter should resolve the hostile occupant");
+    expect_true(controller->isCompleted(player),
+                "the encounter should interrupt the path controller so no pending path remains");
+
+    // A second movement cycle must not automatically step the player back into the enemy cell
+    // from the now-cleared path.
+    map->move();
+
+    expect_true(map->normalizeCoords(player->getCoords()) == origin,
+                "an interrupted path must not auto-retry stepping into the resolved enemy cell");
+    expect_true(map->normalizeCoords(player->getCoords()) != hostile_cell,
+                "the player must not re-enter the hostile cell after the path is interrupted");
+}
+
 } // namespace
 
 int main() {
@@ -1881,5 +1926,6 @@ int main() {
     test_post_combat_victory_keeps_object_cache_at_origin_not_hostile_cell();
     test_post_combat_cancellation_keeps_object_cache_at_origin_with_foe_present();
 
+    test_post_combat_player_path_stops_after_encounter();
     return finish_tests();
 }


### PR DESCRIPTION
## Issue
`[EPIC_01][STORY_02][SUBSTORY_05]Interrupt path controllers after encounter` — claim `afd9d088-a852-4631-9d47-b68e5909c5c0`, owner `controller/ctrl-vm-4078-31cf30b5/subagent-2`.

## Root cause / finding (verified against source)
The acceptance behavior is **already structurally guaranteed** by pre-existing code, so the smallest safe change is to lock it in with regression coverage rather than add redundant interrupt logic:
- `CMap.cpp` commit loop interrupts the mover's controller via **two** independent guards: the post-move position check `normalizeCoords(getCoords()) != target → interrupt()` (CMap.cpp:683-686) and `interrupt_after_step` captured before the step (CMap.cpp:689-691). Both predate this story (#674/#898).
- `CPlayerController::interrupt()` → `clearPath()` resets target/path/currentStep; `control()` only returns a path step while `hasPendingPath`, so after interruption the player returns its own coords and does not re-step.
- Combined with the SUBSTORY_04 post-combat relocation (player returns to pre-step origin), a player path that hits combat stops after resolution.

## What changed
- **Test-only.** `tests/unit/test_map.cpp` (+46): `test_post_combat_player_path_stops_after_encounter()`, wired into `main()`. Drives a full `map->move()` cycle with a real `CPlayerController` targeting a hostile-occupied adjacent cell and asserts: pending path before move; after move → player back at origin, not in hostile cell, hostile dead, `controller->isCompleted()` (path interrupted); after a **second** move cycle → player still at origin, never re-enters the hostile cell.

## User/developer impact
Locks the "pathing into combat stops after the encounter" contract with executed CI evidence; guards against regressions in the interrupt/relocation interaction. No behavior change.

## Files changed
- `tests/unit/test_map.cpp`

## Validation
- `clang-format -i` applied; `git diff --check` clean.
- Native compile + `test_map` execution delegated to GitHub Actions (submodules unfetchable locally). Reuses SUBSTORY_04 fixtures (`find_walkable_step`, `add_post_combat_hostile`, `PostCombatKillingFightController`) and the existing `setTarget`+`map->move()` pattern.

## Manual review items
- If a literal new `interrupt()` call site was expected: one already exists in the `CMap.cpp` commit loop (lines 684, 690); adding another would be redundant. Flagging for reviewer awareness.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_