### PR TITLE
Migrate Victor and amulet reward paths to claim-first guards (EPIC_07/STORY_02/SUBSTORY_02)

### DIFF
--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -955,6 +955,12 @@ def load(self, context):
                 return
             if game_map.getBoolProperty("VICTOR_REWARD_CLAIMED") or game_map.getBoolProperty("VICTOR_GOOD_END"):
                 return
+            # Claim-first: claim the Victor payout before handing out gold, healing, the reward dialog
+            # and the one-time vendor panel so a re-entered trigger cannot grant the reward twice.
+            # VICTOR_REWARD_CLAIMED is a state-derived legacy flag, so a dedicated non-derived key is
+            # used for the claim to avoid sync_legacy_flags overwriting the guard.
+            if not claim_once(game_map, "VICTOR_REWARD_GRANTED"):
+                return
             player = game.getMap().getPlayer()
             player.addGold(500)
             player.healProc(100)
@@ -1009,6 +1015,11 @@ def load(self, context):
             if quest_system.get_state("amulet") != "active":
                 return
             if player.hasItem(lambda it: it.getName() == "preciousAmulet"):
+                # Claim-first: claim the amulet return reward before consuming the amulet, paying the
+                # gold and cleaning up the quest actors so a re-run cannot grant it twice. AMULET_RETURNED
+                # is a state-derived legacy flag, so a dedicated non-derived key backs the claim.
+                if not claim_once(game_map, "AMULET_REWARD_CLAIMED"):
+                    return
                 player.removeItem(lambda it: it.getName() == "preciousAmulet", True)
                 player.addGold(50)
                 quest_system.finish_amulet()

--- a/test.py
+++ b/test.py
@@ -2870,6 +2870,7 @@ NOURAAJD_MAP_BOOL_FLAGS = (
     "OCTOBOGZ_REWARD_CLAIMED",
     "AMULET_QUEST_STARTED",
     "AMULET_RETURNED",
+    "AMULET_REWARD_CLAIMED",
     "VICTOR_QUEST_STARTED",
     "VICTOR_COURTYARD_FOUND",
     "VICTOR_CULTISTS_SPAWNED",
@@ -2877,6 +2878,7 @@ NOURAAJD_MAP_BOOL_FLAGS = (
     "VICTOR_BAD_END",
     "VICTOR_HELP",
     "VICTOR_REWARD_CLAIMED",
+    "VICTOR_REWARD_GRANTED",
 )
 
 NOURAAJD_PLAYER_BOOL_FLAGS = (
@@ -12390,6 +12392,8 @@ class GameTest(unittest.TestCase):
             "victor_reward_once_guard": (
                 "player.addGold(500)" in script and 'getBoolProperty("VICTOR_REWARD_CLAIMED")' in script
             ),
+            "victor_reward_claim_first": 'claim_once(game_map, "VICTOR_REWARD_GRANTED")' in script,
+            "amulet_reward_claim_first": 'claim_once(game_map, "AMULET_REWARD_CLAIMED")' in script,
             "victor_dialog_coherent": (
                 courtyard_state is not None
                 and "already sacrificed" not in courtyard_state.get("properties", {}).get("text", "").lower()
@@ -13220,6 +13224,7 @@ class GameTest(unittest.TestCase):
             self.assertTrue(game_map.getBoolProperty("VICTOR_GOOD_END"))
             self.assertFalse(game_map.getBoolProperty("VICTOR_BAD_END"))
             self.assertTrue(game_map.getBoolProperty("VICTOR_REWARD_CLAIMED"))
+            self.assertTrue(game_map.getBoolProperty("VICTOR_REWARD_GRANTED"))
             self.assertEqual(game_map.getNumericProperty("VICTOR_COURTYARD_TURN"), -1)
             self.assertIn("victorRewardDialog", captured["dialogs"])
             self.assertIn("victorMarket", captured["trades"])
@@ -13250,6 +13255,7 @@ class GameTest(unittest.TestCase):
             self.assertEqual(heal_amounts, [100])
             self.assertEqual(captured["dialogs"].count("victorRewardDialog"), 1)
             self.assertEqual(captured["trades"].count("victorMarket"), 1)
+            self.assertTrue(game_map.getBoolProperty("VICTOR_REWARD_GRANTED"))
 
             return True, json.dumps(
                 {
@@ -13379,6 +13385,7 @@ class GameTest(unittest.TestCase):
         self.assertEqual(player.getGold() - start_gold, 50)
         self.assertFalse(player.hasItem(lambda it: it.getName() == "preciousAmulet"))
         self.assertTrue(game_map.getBoolProperty("AMULET_RETURNED"))
+        self.assertTrue(game_map.getBoolProperty("AMULET_REWARD_CLAIMED"))
         self.assertIsNone(game_map.getObjectByName("amuletGoblin"))
         self.assertIsNone(game_map.getObjectByName("oldWoman"))
         assert_player_quest_state(self, player, "amuletQuest", completed=True)
@@ -13392,6 +13399,7 @@ class GameTest(unittest.TestCase):
         self.assertEqual(player.getGold() - start_gold, 50)
         self.assertEqual(game_map.getStringProperty("quest_state_amulet"), "returned")
         self.assertTrue(player.hasItem(lambda it: it.getName() == "preciousAmulet"))
+        self.assertTrue(game_map.getBoolProperty("AMULET_REWARD_CLAIMED"))
 
         return True, json.dumps(
             {


### PR DESCRIPTION
## Issue
`[EPIC_07][STORY_02][SUBSTORY_02]Migrate reward paths to claim-first` — claim `1806262f-29ff-44de-9f60-ab2ab75142ef`, owner `controller/ctrl-vm-4078-31cf30b5/subagent-5`.

## Root cause / scope (verified against source)
`claim_once(owner, prop)` (`res/game.py:40`) sets a persistent bool flag and returns `False` on repeat. Some rewards already use it (Gooby `:437`, OctoBogz `:568`, siege `:66`), but the **Victor cult-leader payout** and **amulet return** lacked a claim-first guard, so a re-entered trigger could grant them twice.

## What changed
- `res/maps/nouraajd/script.py` (+11): claim-first guards before the grants.
  - Victor reward (`CultLeaderQuestTrigger`, ~:960): `if not claim_once(game_map, "VICTOR_REWARD_GRANTED"): return` before 500 gold + `healProc(100)` + reward dialog + one-time vendor panel.
  - Amulet return (`QuestReturnDialog.complete_amulet_quest`, ~:1018): `if not claim_once(game_map, "AMULET_REWARD_CLAIMED"): return` before consuming `preciousAmulet` + 50 gold + actor cleanup.
  - **Dedicated non-derived keys** are used deliberately: `VICTOR_REWARD_CLAIMED`/`AMULET_RETURNED` are `LegacyBoolFlag`s recomputed by `sync_legacy_flags()`, so reusing them would let a state sync overwrite the guard. This mirrors how the existing Gooby/OctoBogz keys are free-standing.
- `test.py` (+8): static-contract substring checks + `VICTOR_REWARD_GRANTED`/`AMULET_REWARD_CLAIMED` single-grant regression tests + added both keys to the save/load snapshot bool-flag set.

## Deliberately left unchanged (with reason)
- Siege completion (already claim-guarded), Gooby/OctoBogz (already guarded).
- `completedQuests`/`onComplete` quest paths — no concrete unprotected duplicate-granting path found; the only value-granting onCompletes (Gooby, OctoBogz) are already guarded.
- Item-grant triggers (skullOfRolf, holyRelic) and cleanup-only paths — out of named scope, protected by existing per-object/quest-state guards.

## Validation
- `python3 -m py_compile` on the scripts + `res/game.py` → OK; `git diff --check` clean.
- `python3 -m unittest tests.test_claim_once_helper` → 2 tests OK.
- Engine-backed `test.py` regressions delegated to GitHub Actions (no native `_game` module locally).

## Files changed
- `res/maps/nouraajd/script.py`
- `test.py`

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_