### PR TITLE
Migrate plugin and animation loading off the resources singleton (EPIC_02/STORY_01/SUBSTORY_03)

### DIFF
--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -1305,7 +1305,7 @@ bool CPluginLoader::loadPlugin(const std::shared_ptr<CGame> &game, const std::st
         return false;
     }
     try {
-        std::string code = CResourcesProvider::getInstance()->load(path);
+        std::string code = game->getResourcesProvider()->load(path);
         pybind11::dict plugin_namespace;
         plugin_namespace["__builtins__"] = build_restricted_plugin_builtins();
         plugin_namespace["__file__"] = path;
@@ -1398,7 +1398,7 @@ bool CPluginLoader::loadGlobalPlugins(const std::shared_ptr<CGame> &game) {
         }
     }
 
-    for (const std::string &script : CResourcesProvider::getInstance()->getFiles(CResType::PLUGIN)) {
+    for (const std::string &script : game->getResourcesProvider()->getFiles(CResType::PLUGIN)) {
         if (!loadedPythonPlugins.contains(script)) {
             loadedAll = loadPlugin(game, script) && loadedAll;
         }

--- a/src/core/CProvider.cpp
+++ b/src/core/CProvider.cpp
@@ -525,10 +525,10 @@ std::shared_ptr<CAnimation> CAnimationProvider::getAnimation(const std::shared_p
     }
     auto animation = game->createObject<CAnimation>("CAnimation");
     auto animationPath = object->getAnimation();
-    const auto resolvedAnimationPath = CResourcesProvider::getInstance()->getPath(animationPath);
+    const auto resolvedAnimationPath = game->getResourcesProvider()->getPath(animationPath);
     if (!resolvedAnimationPath.empty() && std::filesystem::is_directory(resolvedAnimationPath)) {
         animation = game->createObject<CDynamicAnimation>("CDynamicAnimation");
-    } else if (std::filesystem::is_regular_file(CResourcesProvider::getInstance()->getPath(animationPath + ".png"))) {
+    } else if (std::filesystem::is_regular_file(game->getResourcesProvider()->getPath(animationPath + ".png"))) {
         animation = custom ? game->createObject<CAnimation>("CCustomAnimation")
                            : game->createObject<CStaticAnimation>("CStaticAnimation");
     } else {


### PR DESCRIPTION
## Summary

Incremental, behavior-preserving step of **[EPIC_02][STORY_01][SUBSTORY_03] Migrate engine loading call sites**.

Routes the **plugin-load** and **animation-load** primary paths through the per-session resources provider (`game->getResourcesProvider()`, which delegates to `CGameContext`) instead of the process-wide `CResourcesProvider::getInstance()` singleton.

### Call sites migrated
- `CPluginLoader::loadPlugin` — reads plugin source
- `CPluginLoader::loadGlobalPlugins` — enumerates plugin files
- `CAnimationProvider::getAnimation` — resolves animation resource path (×2)

All four hold a guaranteed non-null `game` instance.

### Why this is safe / behavior-preserving
`CResourcesProvider` carries **no per-instance mutable state** — only a static search path; every method hits the filesystem directly. So resolving resources through the context instance is identical to resolving through the singleton.

### Intentionally deferred (kept on the singleton as compatibility paths)
- Call sites with **no `game` in scope**: save-backup repair, plugin-manifest lookup, config-path enumeration.
- **GUI resource consumers** (`CTextureCache`, `CTextManager`, `CTextResource`) — no game instance available, which the substory explicitly allows.
- The **configuration-provider** migration: `CConfigurationProvider` has a per-instance config cache, so moving config reads to the context provider is a caching-semantics change (process-wide → per-session) rather than a pure delegation swap — deferred to its own change so it can be validated against the native load/save tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgwwEuSehxkjEsvFNu9fS)_