### PR TITLE
Add reusable runtime actor cleanup helper for Nouraajd quests (EPIC_07/STORY_02/SUBSTORY_03)

### DIFF
--- a/res/game.py
+++ b/res/game.py
@@ -44,6 +44,35 @@ def claim_once(owner, property_name):
     return True
 
 
+def remove_runtime_actors(game_map, names=(), prefixes=()):
+    """Idempotently remove runtime actor objects from a map.
+
+    Objects are matched by exact name (``names``) or by an explicitly reviewed
+    name prefix (``prefixes``). Objects whose names merely overlap a target name
+    are preserved unless a prefix that matches them was explicitly passed, so a
+    similar but non-matching actor is never collateral. The helper tolerates
+    actors that are already gone and returns the number of objects removed.
+    """
+    name_set = frozenset(name for name in names if name)
+    prefix_tuple = tuple(prefix for prefix in prefixes if prefix)
+    if not name_set and not prefix_tuple:
+        return 0
+
+    def _matches(obj):
+        name = obj.getName()
+        if not name:
+            return False
+        if name in name_set:
+            return True
+        return bool(prefix_tuple) and name.startswith(prefix_tuple)
+
+    doomed = []
+    game_map.forObjects(doomed.append, _matches)
+    for obj in doomed:
+        game_map.removeObject(obj)
+    return len(doomed)
+
+
 def playtest_object_ref(obj):
     if obj is None:
         return None

--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -9,6 +9,7 @@ def load(self, context):
     from game import PlayerQuestRegistry
     from game import QuestStateStore
     from game import claim_once
+    from game import remove_runtime_actors
     from game import ensure_quest
     from game import register, trigger
 
@@ -20,11 +21,7 @@ def load(self, context):
     MAIN_QUEST_GOLD_REWARD = 200
 
     def _clear_victor_encounter(game_map):
-        def should_remove(obj):
-            name = obj.getName()
-            return bool(name) and (name == "cultLeaderQuest" or name.startswith(VICTOR_CULTIST_PREFIX))
-
-        game_map.removeAll(should_remove)
+        remove_runtime_actors(game_map, names=("cultLeaderQuest",), prefixes=(VICTOR_CULTIST_PREFIX,))
         game_map.setNumericProperty("VICTOR_COURTYARD_TURN", -1)
         game_map.setNumericProperty("VICTOR_CULTISTS_PLACED", 0)
 
@@ -978,7 +975,7 @@ def load(self, context):
                 quest_system = _quest_system_from(obj)
                 amulet_state = quest_system.get_state("amulet")
                 if amulet_state == "returned":
-                    game_map.removeObject(obj)
+                    remove_runtime_actors(game_map, names=("oldWoman",))
                     return
                 player = game_map.getPlayer()
                 if player.hasItem(lambda it: it.getName() == "preciousAmulet"):
@@ -1023,12 +1020,7 @@ def load(self, context):
                 player.removeItem(lambda it: it.getName() == "preciousAmulet", True)
                 player.addGold(50)
                 quest_system.finish_amulet()
-                amulet_goblin = game_map.getObjectByName("amuletGoblin")
-                if amulet_goblin:
-                    game_map.removeObject(amulet_goblin)
-                old_woman = game_map.getObjectByName("oldWoman")
-                if old_woman:
-                    game_map.removeObject(old_woman)
+                remove_runtime_actors(game_map, names=("amuletGoblin", "oldWoman"))
                 game.getGuiHandler().showMessage(
                     "The old woman presses 50 gold upon you, tears streaking her dust-caked cheeks."
                 )

--- a/test.py
+++ b/test.py
@@ -12401,6 +12401,23 @@ class GameTest(unittest.TestCase):
             ),
             "catacombs_uses_catacombs_image": config["catacombs"]["properties"].get("animation")
             == "images/buildings/catacombs",
+            "actor_cleanup_helper_imported": "from game import remove_runtime_actors" in script,
+            "victor_cleanup_uses_helper": (
+                'remove_runtime_actors(game_map, names=("cultLeaderQuest",), prefixes=(VICTOR_CULTIST_PREFIX,))'
+                in script
+            ),
+            "amulet_cleanup_uses_helper": (
+                'remove_runtime_actors(game_map, names=("amuletGoblin", "oldWoman"))' in script
+            ),
+            "old_woman_cleanup_uses_helper": 'remove_runtime_actors(game_map, names=("oldWoman",))' in script,
+            "actor_cleanup_dedupes_removal": (
+                'game_map.getObjectByName("amuletGoblin")' not in script
+                and "game_map.removeObject(amulet_goblin)" not in script
+                and "game_map.removeObject(old_woman)" not in script
+            ),
+            "actor_cleanup_preserves_public_names": all(
+                token in script for token in ("cultLeaderQuest", "amuletGoblin", "oldWoman", "victorCultist")
+            ),
         }
 
         failed = sorted([name for name, ok in checks.items() if not ok])
@@ -12513,6 +12530,69 @@ class GameTest(unittest.TestCase):
                         lambda it: it.getName() == "holyRelic"
                     ),
                 },
+            }
+            return True, json.dumps(log, sort_keys=True)
+        finally:
+            game.CGuiHandler.showMessage = original_show_message
+
+    @game_test
+    def test_nouraajd_remove_runtime_actors_helper(self):
+        from game import remove_runtime_actors
+
+        game = load_game_module()
+        original_show_message = game.CGuiHandler.showMessage
+        try:
+            game.CGuiHandler.showMessage = lambda self, message: None
+            g, game_map, player = load_game_map_with_player("nouraajd")
+
+            def spawn(name):
+                obj = g.createObject("goblinThief")
+                obj.setStringProperty("name", name)
+                game_map.addObject(obj)
+                return obj
+
+            # Synthetic runtime actors so the scenario does not depend on map content:
+            # exact-name target, two prefix targets, plus deliberately overlapping names
+            # that must survive because they are neither exact matches nor prefix targets.
+            spawn("questBossActor")
+            spawn("questMinionAlpha")
+            spawn("questMinionBravo")
+            spawn("questBossActorEcho")
+            spawn("questAlly")
+
+            self.assertIsNotNone(game_map.getObjectByName("questBossActor"))
+
+            # Cleanup with actors present: exact name plus a reviewed prefix.
+            removed = remove_runtime_actors(game_map, names=("questBossActor",), prefixes=("questMinion",))
+            self.assertEqual(removed, 3)
+            self.assertIsNone(game_map.getObjectByName("questBossActor"))
+            self.assertIsNone(game_map.getObjectByName("questMinionAlpha"))
+            self.assertIsNone(game_map.getObjectByName("questMinionBravo"))
+            # Overlapping-but-non-matching names survive (exact match only, no matching prefix).
+            self.assertIsNotNone(game_map.getObjectByName("questBossActorEcho"))
+            self.assertIsNotNone(game_map.getObjectByName("questAlly"))
+
+            # Cleanup after the actors were already removed is an idempotent no-op.
+            removed_again = remove_runtime_actors(game_map, names=("questBossActor",), prefixes=("questMinion",))
+            self.assertEqual(removed_again, 0)
+
+            # An exact-name removal with no prefix must not touch an overlapping name.
+            spawn("loneActor")
+            spawn("loneActorTwin")
+            removed_lone = remove_runtime_actors(game_map, names=("loneActor",))
+            self.assertEqual(removed_lone, 1)
+            self.assertIsNone(game_map.getObjectByName("loneActor"))
+            self.assertIsNotNone(game_map.getObjectByName("loneActorTwin"))
+
+            # No targets requested is a no-op.
+            self.assertEqual(remove_runtime_actors(game_map), 0)
+
+            log = {
+                "removed": removed,
+                "removed_again": removed_again,
+                "removed_lone": removed_lone,
+                "echo_survives": game_map.getObjectByName("questBossActorEcho") is not None,
+                "twin_survives": game_map.getObjectByName("loneActorTwin") is not None,
             }
             return True, json.dumps(log, sort_keys=True)
         finally:


### PR DESCRIPTION
## Summary

Implements **[EPIC_07][STORY_02][SUBSTORY_03] Add runtime actor cleanup helpers**.

Introduces `remove_runtime_actors(game_map, names=(), prefixes=())` in `res/game.py` and uses it to replace the duplicated actor-cleanup logic scattered across the Nouraajd map script.

### The helper
- Removes runtime actors by **exact name** (`names`) or by an **explicitly reviewed prefix** (`prefixes`).
- **Idempotent** — tolerates actors that are already gone; a repeat call is a no-op.
- **Overlap-safe** — an object whose name merely overlaps a target is preserved unless a matching prefix was explicitly passed, so a similar-but-non-matching actor is never collateral.
- Returns the number of objects removed.

### Call sites migrated
- `_clear_victor_encounter()` — `cultLeaderQuest` + `victorCultist*`
- `OldWomanTrigger.trigger()` — `oldWoman`
- `QuestReturnDialog.complete_amulet_quest()` — `amuletGoblin` + `oldWoman`
- `CultLeaderQuestTrigger.trigger()` — covered transitively via `_clear_victor_encounter()`

Public object names, quest ids, dialog ids, and trigger targets are unchanged.

### Tests
- `test_nouraajd_remove_runtime_actors_helper` — cleanup with actors present, an idempotent repeat call, exact-name and prefix gating, and overlapping-name preservation.
- Added static-source assertions to `test_nouraajd_quest_integrity_regression` confirming the helper is used at each site and the old per-object removal logic is gone.
- The existing `walkthrough_nouraajd_map` integration path already exercises the Victor good-end and amulet cleanup behavior.

### Local validation
- `python3 scripts/validate_content.py --repo-root .` → passes (trigger-target exceptions remain valid).
- Helper logic verified against all acceptance-criteria scenarios via a mock map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgwwEuSehxkjEsvFNu9fS)_