### PR TITLE
Add gated production-archetype requirement to content validator (EPIC_06/STORY_04/SUBSTORY_01)

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -291,6 +291,25 @@ AMULET_QUEST_ITEM = "preciousAmulet"
 AMULET_RUNTIME_ACTOR_NAME = "amuletGoblin"
 CREATURE_ITEMS_PROPERTY = "items"
 
+# Required production archetype enforcement (EPIC_06/STORY_04/SUBSTORY_01).
+# Once the archetype migration is declared complete, every production
+# CCreature/CPlayer config must declare BOTH its race (CREATURE_RACE_PROPERTY) and
+# its class (CREATURE_CLASS_REFERENCE_PROPERTY) reference properties so that no
+# production creature can silently remain on the legacy path -- with the only
+# permitted gaps being entries listed in an explicit reviewed exception manifest
+# (intended for low-level test fixtures, each exempted by exact config path + key
+# with a reason).  The migration is NOT complete on current content -- the archetype
+# config files do not exist and essentially no production creature declares
+# race/creatureClass yet -- so enforcement is gated behind ARCHETYPE_MIGRATION_COMPLETE
+# and is fully inert (emits nothing) while that switch is False.  The standalone
+# read-only report_unmigrated_creatures() inventory is unaffected and keeps working
+# regardless of this switch.
+ARCHETYPE_MIGRATION_COMPLETE = False
+CREATURE_REQUIRED_ARCHETYPE_PROPERTIES = (
+    CREATURE_RACE_PROPERTY,
+    CREATURE_CLASS_REFERENCE_PROPERTY,
+)
+
 
 @dataclass(frozen=True)
 class ValidationIssue:
@@ -476,6 +495,30 @@ class ScriptPropertyAccess:
     def location(self) -> str:
         call = f'{self.method}("{self.name}")'
         return f"{self.context}:{self.lineno} {call}" if self.context else f"line {self.lineno} {call}"
+
+
+@dataclass(frozen=True)
+class ArchetypeMigrationException:
+    """A reviewed exemption from the required-production-archetype rule.
+
+    ``path`` is the repo-relative config file (e.g. "res/config/test_fixtures.json")
+    and ``key`` the exact top-level config id within it that is allowed to remain on
+    the legacy path without declaring race/creatureClass.  ``reason`` documents why the
+    exemption is acceptable -- intended for low-level test fixtures, never production
+    creatures.  An entry only suppresses diagnostics for the creature whose path AND
+    key match exactly, so a manifest entry can never blanket-exempt real content.
+    """
+
+    path: str
+    key: str
+    reason: str
+
+
+# Reviewed exemptions from the required-production-archetype rule.  Empty by default:
+# no production creature is exempt, and low-level test fixtures are added here only
+# with an exact path/key and a reason.  Honored only while ARCHETYPE_MIGRATION_COMPLETE
+# is True (and even then, only for the exact path+key listed).
+ARCHETYPE_MIGRATION_EXCEPTIONS: tuple[ArchetypeMigrationException, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -1058,6 +1101,8 @@ class ContentValidator:
         self,
         repo_root: Path,
         property_hygiene_allowlist: tuple[ScriptPropertyHygieneAllowance, ...] | None = None,
+        archetype_migration_complete: bool | None = None,
+        archetype_migration_exceptions: tuple[ArchetypeMigrationException, ...] | None = None,
     ) -> None:
         self.repo_root = repo_root.resolve()
         self.issues: list[ValidationIssue] = []
@@ -1078,6 +1123,15 @@ class ContentValidator:
         self.registration_exclusions: dict[str, RegistrationExclusion] = {}
         self.property_hygiene_allowlist = (
             SCRIPT_PROPERTY_HYGIENE_ALLOWLIST if property_hygiene_allowlist is None else property_hygiene_allowlist
+        )
+        # Required-production-archetype enforcement is gated behind this switch so the
+        # rule stays fully inert on pre-migration content; defaults to the module-level
+        # ARCHETYPE_MIGRATION_COMPLETE (False today) and is overridable for fixture tests.
+        self.archetype_migration_complete = (
+            ARCHETYPE_MIGRATION_COMPLETE if archetype_migration_complete is None else archetype_migration_complete
+        )
+        self.archetype_migration_exceptions = (
+            ARCHETYPE_MIGRATION_EXCEPTIONS if archetype_migration_exceptions is None else archetype_migration_exceptions
         )
 
     def validate(self) -> list[ValidationIssue]:
@@ -1519,6 +1573,7 @@ class ContentValidator:
         self._validate_crafting_refs()
         self._validate_creature_archetype_naming()
         self._validate_duplicate_player_selectable_race_labels(visible)
+        self._validate_required_production_archetypes(visible)
 
     def _validate_map_context(self, context: MapContext) -> None:
         visible = self._visible_entries(context)
@@ -2807,6 +2862,52 @@ class ContentValidator:
                     f"it collides with {others} -- res/game.py maps a selected label back to a "
                     f"single race id, so duplicate labels make the selection ambiguous",
                 )
+
+    def _validate_required_production_archetypes(self, visible: dict[str, ConfigEntry]) -> None:
+        """Require every production creature to declare race AND creatureClass post-migration.
+
+        Once the archetype migration is declared complete, no production CCreature/CPlayer
+        config may silently remain on the legacy path: each must declare both its race
+        (CREATURE_RACE_PROPERTY) and its class (CREATURE_CLASS_REFERENCE_PROPERTY) reference
+        property in its ``properties`` block.  Production creatures are the global
+        res/config entries whose effective engine class is, or inherits from, CCreature
+        (which also covers CPlayer, since CPlayer derives from CCreature) -- the exact same
+        resolution the read-only report_unmigrated_creatures() inventory uses.  Every
+        missing archetype across all production creatures is reported in a single run, with
+        one issue per absent property naming the precise ``configId.properties.<prop>`` path.
+
+        Enforcement is gated behind ``self.archetype_migration_complete`` so the rule is
+        fully inert on pre-migration content: while the switch is False (the default today)
+        nothing is emitted, keeping the standard validation green.  When the switch is on, a
+        creature exempted in the reviewed exception manifest (by exact path AND key) is not
+        flagged -- the manifest is intended for low-level test fixtures only.
+        """
+        if not self.archetype_migration_complete:
+            return
+        exempt_keys = {(exception.path, exception.key) for exception in self.archetype_migration_exceptions}
+        for key, entry in self.global_entries.items():
+            if not isinstance(entry.data, dict):
+                continue
+            class_name = self._effective_object_class(entry.data, visible)
+            if not isinstance(class_name, str):
+                continue
+            if not (class_name == CREATURE_BASE_CLASS or self._class_inherits_from(class_name, CREATURE_BASE_CLASS)):
+                continue
+            if (self._rel(entry.path), key) in exempt_keys:
+                continue
+            properties = entry.data.get("properties")
+            properties = properties if isinstance(properties, dict) else {}
+            properties_location = append_field(key, "properties")
+            for property_name in CREATURE_REQUIRED_ARCHETYPE_PROPERTIES:
+                if property_name not in properties:
+                    self._issue(
+                        entry.path,
+                        append_field(properties_location, property_name),
+                        f'production creature "{key}" (class "{class_name}") must declare archetype '
+                        f'property "{property_name}" after archetype migration; legacy creatures without '
+                        f"race/creatureClass are no longer allowed unless listed in the reviewed archetype "
+                        f"exception manifest",
+                    )
 
     def _effective_property_value(
         self,

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -25,6 +25,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.validate_content import (
+    ArchetypeMigrationException,
     ContentValidator,
     ScriptPropertyHygieneAllowance,
     classify_creature_templates,
@@ -3118,6 +3119,160 @@ class UnmigratedCreatureReportTest(unittest.TestCase):
         for player in ("Assasin", "Inquisitor", "Sorcerer", "Warrior", "Wayfarer"):
             self.assertIn(player, report_ids)
             self.assertEqual(("creatureClass", "race"), next(c.missing for c in report if c.config_id == player))
+
+
+class RequiredProductionArchetypeTest(unittest.TestCase):
+    """EPIC_06/STORY_04/SUBSTORY_01 -- required production archetypes after migration.
+
+    The enforcement rule is gated behind the migration-complete switch.  These tests
+    drive it with the switch explicitly ON over synthetic in-memory content (never the
+    real monsters.json) to prove it flags every production creature missing race/class
+    in one run, honors the reviewed exception manifest, and stays inert with the switch
+    OFF (the default that keeps current full validation green).
+    """
+
+    def make_archetype_fixture(self):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        root = Path(temp_dir.name)
+        (root / "res/config").mkdir(parents=True)
+        (root / "src/object").mkdir(parents=True)
+
+        # Engine metadata: CPlayer derives from CCreature, mirroring src/object/CPlayer.h.
+        (root / "src/object/CCreatures.h").write_text(
+            textwrap.dedent("""
+                class CMapObject {
+                    V_META(CMapObject, CGameObject, vstd::meta::empty())
+                };
+
+                class CCreature {
+                    V_META(CCreature, CMapObject, vstd::meta::empty())
+                };
+
+                class CPlayer {
+                    V_META(CPlayer, CCreature, vstd::meta::empty())
+                };
+            """).lstrip(),
+            encoding="utf-8",
+        )
+        write_json(
+            root / "res/config/monsters.json",
+            {
+                # Fully migrated creature: declares both archetype references.
+                "MigratedGoblin": {
+                    "class": "CCreature",
+                    "properties": {"race": {"ref": "GoblinRace"}, "creatureClass": {"ref": "BruteClass"}},
+                },
+                # Missing only the class reference.
+                "NoClassGoblin": {
+                    "class": "CCreature",
+                    "properties": {"race": {"ref": "GoblinRace"}},
+                },
+                # Missing only the race reference.
+                "NoRaceGoblin": {
+                    "class": "CCreature",
+                    "properties": {"creatureClass": {"ref": "BruteClass"}},
+                },
+                # Unmigrated creature: missing both.
+                "LegacyGoblin": {"class": "CCreature", "properties": {"label": "Goblin"}},
+                # Player template (CPlayer inherits CCreature) -- also subject to the rule.
+                "LegacyHero": {"class": "CPlayer", "properties": {"label": "Hero"}},
+                # Not a creature -- must never be flagged.
+                "PlainItem": {"class": "CItem", "properties": {"label": "Sword"}},
+            },
+        )
+        return root
+
+    @staticmethod
+    def _archetype_locations(issues):
+        # Only the locations of this rule's diagnostics; the synthetic refs/labels in the
+        # fixture intentionally trip other validators (unknown ref/property), which are
+        # irrelevant to the required-archetype rule under test.
+        return {issue.location for issue in issues if "must declare archetype property" in str(issue)}
+
+    def test_switch_on_flags_all_production_creatures_missing_archetypes(self):
+        root = self.make_archetype_fixture()
+
+        issues = ContentValidator(root, archetype_migration_complete=True).validate()
+        flagged = self._archetype_locations(issues)
+
+        # Every missing archetype across every production creature is reported in ONE run,
+        # one issue per absent property at the exact "<id>.properties.<prop>" path.  The
+        # fully migrated creature and the non-creature never appear; CPlayer templates do
+        # (CPlayer inherits CCreature).
+        self.assertEqual(
+            {
+                "NoClassGoblin.properties.creatureClass",
+                "NoRaceGoblin.properties.race",
+                "LegacyGoblin.properties.race",
+                "LegacyGoblin.properties.creatureClass",
+                "LegacyHero.properties.race",
+                "LegacyHero.properties.creatureClass",
+            },
+            flagged,
+        )
+
+    def test_manifest_exempted_entry_is_not_flagged(self):
+        root = self.make_archetype_fixture()
+        exceptions = (
+            ArchetypeMigrationException(
+                path="res/config/monsters.json",
+                key="LegacyGoblin",
+                reason="Low-level test fixture exempted from archetype migration.",
+            ),
+        )
+
+        issues = ContentValidator(
+            root,
+            archetype_migration_complete=True,
+            archetype_migration_exceptions=exceptions,
+        ).validate()
+        flagged = self._archetype_locations(issues)
+
+        # The exact path+key exemption suppresses BOTH of LegacyGoblin's archetype
+        # diagnostics, while every other unmigrated creature is still flagged.
+        self.assertEqual(
+            {
+                "NoClassGoblin.properties.creatureClass",
+                "NoRaceGoblin.properties.race",
+                "LegacyHero.properties.race",
+                "LegacyHero.properties.creatureClass",
+            },
+            flagged,
+        )
+
+    def test_switch_off_is_inert_even_with_unmigrated_creatures(self):
+        root = self.make_archetype_fixture()
+
+        # Default constructor (switch defaults to ARCHETYPE_MIGRATION_COMPLETE == False).
+        default_issues = ContentValidator(root).validate()
+        explicit_off_issues = ContentValidator(root, archetype_migration_complete=False).validate()
+
+        for issues in (default_issues, explicit_off_issues):
+            archetype_issues = [str(issue) for issue in issues if "must declare archetype property" in str(issue)]
+            self.assertEqual([], archetype_issues)
+
+    def test_manifest_only_matches_exact_path_and_key(self):
+        root = self.make_archetype_fixture()
+        # A manifest entry whose key matches but whose path points at a different file
+        # must NOT suppress the diagnostic (exact path AND key are required).
+        exceptions = (
+            ArchetypeMigrationException(
+                path="res/config/other.json",
+                key="LegacyGoblin",
+                reason="Wrong file -- must not exempt the real LegacyGoblin.",
+            ),
+        )
+
+        issues = ContentValidator(
+            root,
+            archetype_migration_complete=True,
+            archetype_migration_exceptions=exceptions,
+        ).validate()
+        flagged = self._archetype_locations(issues)
+
+        self.assertIn("LegacyGoblin.properties.race", flagged)
+        self.assertIn("LegacyGoblin.properties.creatureClass", flagged)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Issue
`[EPIC_06][STORY_04][SUBSTORY_01]Require production creatures to declare archetypes` — claim `892f7429…`, owner `controller/ctrl-vm-4039-a70f65a5/subagent-21`.

## What changed (validator + tests only — 256 insertions, 0 deletions)
- `scripts/validate_content.py`: new `_validate_required_production_archetypes()` rule wired into `_validate_global_configs()`. When archetype migration is declared complete it emits one `ValidationIssue` per production `CCreature`/`CPlayer` config missing `race` or `creatureClass`, reporting **all** misses in a single run.
- `tests/test_content_validator.py`: `RequiredProductionArchetypeTest` (4 tests).

## Gated to stay inert today (critical)
Archetype migration is **not** complete (`creature_races.json`/`creature_classes.json` don't exist yet; no production creature declares archetypes). The rule is gated behind module constant `ARCHETYPE_MIGRATION_COMPLETE = False` (overridable via constructor) and returns immediately while off — so current content is unaffected and `python3 scripts/validate_content.py` still exits 0.

## Exception manifest
Frozen `ArchetypeMigrationException(path, key, reason)`; an entry suppresses a diagnostic only when **both** repo-relative path AND exact top-level config key match — never a blanket exemption. Default manifest empty.

## Reused existing machinery (no new conventions)
Property constants `CREATURE_RACE_PROPERTY="race"` / `CREATURE_CLASS_REFERENCE_PROPERTY="creatureClass"`; production classification via `_effective_object_class` + `_class_inherits_from(..., CREATURE_BASE_CLASS)` (same as the existing `report_unmigrated_creatures()`).

## Validation
- `python3 -m unittest tests.test_content_validator` → 111 OK (4 new + 107 existing).
- `python3 scripts/validate_content.py` → passed, **exit 0** (regression check).
- Tests assert: switch-on flags all 6 expected missing locations in one run; manifest exact path+key exemption suppresses only that entry; wrong-path manifest entry does not suppress; switch-off (default) is inert.
- `black -l 120` (repo line length) leaves both files unchanged; `git diff --check` clean.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_