### PR TITLE
Migrate save/load primary path off the resources singleton (EPIC_02/STORY_01/SUBSTORY_03)

### DIFF
--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -649,7 +649,7 @@ restore_save_document(const std::shared_ptr<CGame> &game, const CSaveFormat::Dec
 
 std::expected<std::shared_ptr<CMap>, std::string>
 load_save_candidate(const std::shared_ptr<CGame> &game, const std::string &slotName, const std::string &path) {
-    auto raw = CResourcesProvider::getInstance()->loadJson(path);
+    auto raw = game->getResourcesProvider()->loadJson(path);
     if (!raw) {
         return std::unexpected("save file could not be read or parsed");
     }
@@ -1059,7 +1059,11 @@ void CMapLoader::save(const std::shared_ptr<CMap> &map, const std::string &name)
         return;
     }
 
-    CResourcesProvider::getInstance()->save(CSaveFormat::primaryPath(name), CJsonUtil::to_string(*envelope, -1));
+    // Persist through the saved map's per-session resources provider; fall back to the process
+    // singleton only when the map has already been detached from its game (compatibility path).
+    auto game = map->getGame();
+    auto resources = game ? game->getResourcesProvider() : CResourcesProvider::getInstance();
+    resources->save(CSaveFormat::primaryPath(name), CJsonUtil::to_string(*envelope, -1));
 }
 
 void CMapLoader::handleTileLayer(const std::shared_ptr<CMap> &map, const std::vector<std::string> &tileTypes,


### PR DESCRIPTION
## Summary

Continues **[EPIC_02][STORY_01][SUBSTORY_03] Migrate engine loading call sites**, extending the prior plugin/animation migration to the **save/load** primary path.

Routes the saved-map read and write through the per-session resources provider instead of the process-wide `CResourcesProvider::getInstance()` singleton:

- **`load_save_candidate()`** — reads the save document via the loading game's provider (`game` is a guaranteed non-null parameter on the load path).
- **`CMapLoader::save()`** — persists through the saved map's game provider when the map is still attached, falling back to the singleton only when the map has been detached from its game (a compatibility path).

### Why this is behavior-preserving
`CResourcesProvider` carries no per-instance mutable state — only a static search path — so resolving through the context instance is identical to the singleton.

### Remaining (intentionally deferred)
The configuration-provider call sites (`CConfigurationProvider::getConfig` in map load) still use the static instance because that helper has a per-instance config cache, making its migration a caching-semantics change rather than a pure delegation swap — deferred to its own change so it can be validated against the native load/save tests. No-game free functions and GUI consumers remain on the singleton as the compatibility paths the substory allows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgwwEuSehxkjEsvFNu9fS)_