### PR TITLE
Tune cave2 OctoBogz early-fight difficulty (EPIC_60/STORY_02/SUBSTORY_03)

### DIFF
--- a/res/config/monsters.json
+++ b/res/config/monsters.json
@@ -156,12 +156,12 @@
         "properties": {
           "agility": 10,
           "crit": 20,
-          "dmgMax": 21,
-          "dmgMin": 17,
+          "dmgMax": 16,
+          "dmgMin": 12,
           "hit": 80,
           "intelligence": 10,
           "mainStat": "strength",
-          "stamina": 10,
+          "stamina": 7,
           "strength": 10
         }
       },

--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -423,7 +423,7 @@
           }
         }
       },
-      "monsters": "5"
+      "monsters": "3"
     }
   },
   "market1": {

--- a/tests/fixtures/creature_stat_scale_baseline.json
+++ b/tests/fixtures/creature_stat_scale_baseline.json
@@ -180,12 +180,12 @@
       "baseStats": {
         "agility": 10,
         "crit": 20,
-        "dmgMax": 21,
-        "dmgMin": 17,
+        "dmgMax": 16,
+        "dmgMin": 12,
         "hit": 80,
         "intelligence": 10,
         "mainStat": "strength",
-        "stamina": 10,
+        "stamina": 7,
         "strength": 10
       },
       "class": "CCreature",


### PR DESCRIPTION
## Issue
`[EPIC_60][STORY_02][SUBSTORY_03]Cave2 OctoBogz pack is a sharp early difficulty spike yet trivially skippable on cave entry` — claim `6d979ce2-bf9a-4641-a8b8-b9c1be61890c`, owner `controller/ctrl-vm-4078-31cf30b5/subagent-7`. Level-design backlog finding.

## Root cause (verified against source)
cave2 spawns 5 `OctoBogz`; each at load level 1 has effective stamina 13 → HP 91 (`stamina*7`, `CCreature.cpp:644`), damage 21–26, crit 22%, hit 84% — well above a fair early fight.

## What changed (balance only)
| File | Field | Before → After |
|---|---|---|
| `res/config/monsters.json` (OctoBogz baseStats) | dmgMin / dmgMax | 17/21 → **12/16** |
| | stamina | 10 → **7** |
| `res/maps/nouraajd/config.json` (cave2) | monsters | "5" → **"3"** |
| `tests/fixtures/creature_stat_scale_baseline.json` | OctoBogz baseStats | regenerated to match |

Net per OctoBogz at level 1: HP **91→70**, dmg **21–26→16–21**; pack **5→3** — within the acceptance's suggested ranges. Scoped to the **dedicated** OctoBogz template (confirmed not shared with other monsters) + cave2 spawn; crit/hit/strength/animation/IDs preserved.

## Skippable aspect — noted follow-up (not fixed)
"Trivially skippable" is structural engine behavior: `Cave.onEnter` (`res/plugins/object.py:116`) spawns the pack then `removeObjectByName("cave2")`, firing the `OctoBogzCaveTrigger` onDestroy that completes the contract **regardless of kills**. Proper kill-tracking is a non-trivial design change that would break authored contract regression tests (`test_nouraajd_octobogz_*`, `slay_octobogz` helper), so per the task guidance it is reported as a follow-up rather than over-reached here.

## Validation
- JSON parses OK (all 3 files); `git diff --check` clean.
- `python3 -m unittest tests.test_creature_stat_scale_baseline` → **4 tests OK** (fixture matches new config).
- `python3 scripts/validate_content.py` → **Content validation passed**.
- Native/full suite delegated to GitHub Actions.

## Files changed
- `res/config/monsters.json`
- `res/maps/nouraajd/config.json`
- `tests/fixtures/creature_stat_scale_baseline.json`

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_