### PR TITLE
Align holyRelic description with OctoBogz contract mechanics (EPIC_60/STORY_01/SUBSTORY_01)

### DIFF
--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -536,7 +536,7 @@
     "properties": {
       "name": "holyRelic",
       "animation": "images/skull",
-      "description": "A sanctified shard taken from the ruined chapel, the only tool that can cleanse the OctoBogz lair.",
+      "description": "A sanctified shard taken from the ruined chapel, blessed to purify the OctoBogz lair once the brood has fallen.",
       "tags": [
         "quest"
       ]


### PR DESCRIPTION
## Issue
`[EPIC_60][STORY_01][SUBSTORY_01]Holy relic description claims exclusive cleanse but OctoBogz contract completes without it` — claim `dc279ef7-4836-4771-9134-4dda3295c944`, owner `controller/ctrl-vm-4078-31cf30b5/subagent-9`. Level-design backlog finding.

## Root cause (verified against source)
The `holyRelic` description (`res/maps/nouraajd/config.json`) claimed it was "the only tool that can cleanse the OctoBogz lair", but `OctoBogzCaveTrigger` (`res/maps/nouraajd/script.py:621-636`) calls `mark_octobogz_slain()` + `complete_octobogz_contract()` **unconditionally**; `RELIC_RETURNED` only gates the `OCTOBOGZ_CLEARED` flag and a purification flavor message. The "killed without relic" path is intended and tested (`test.py:12982-12993`).

## What changed (description only — option b)
- `res/maps/nouraajd/config.json` (1 line): `"…the only tool that can cleanse the OctoBogz lair."` → `"…blessed to purify the OctoBogz lair once the brood has fallen."`

Chose the description fix (acceptance option b) over gating the contract on `RELIC_RETURNED` (option a), which would alter intended, test-covered quest behavior. The new wording accurately reflects the relic's real role (post-clear purification / `OCTOBOGZ_CLEARED` flavor gate). No behavior changed.

## Validation
- JSON parses; `python3 scripts/validate_content.py` → Content validation passed; `git diff --check` clean.
- No test asserts the description string (verified); the `cleanse the OctoBogz` reference at `test.py:1572` is the separate `cleanseCaveQuest` description, untouched.

## Files changed
- `res/maps/nouraajd/config.json`

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_