### PR TITLE
Define and validate optional map.json assets schema (EPIC_04/STORY_03/SUBSTORY_01)

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -1,0 +1,69 @@
+# Content schema
+
+Reference for author-facing content declarations validated by
+`scripts/validate_content.py`. Run the validator locally with:
+
+```
+python3 scripts/validate_content.py --repo-root .
+```
+
+## Map assets (`map.json` → `assets`)
+
+Each map lives in `res/maps/<name>/` and is described by a Tiled-style
+`map.json`. A map may additionally declare the local assets it owns through an
+**optional** top-level `assets` array. The declaration is descriptive metadata:
+it documents and validates which files, directories, and logical resources a map
+depends on. Undeclared assets are not loaded or staged differently yet — engine
+loading and CMake staging rules are introduced separately — so adding `assets`
+is safe and purely additive for existing maps.
+
+### Shape
+
+```json
+{
+  "width": 64,
+  "height": 64,
+  "layers": [ /* ... */ ],
+  "assets": [
+    { "path": "images/portrait.png", "kind": "file" },
+    { "path": "frames", "kind": "directory" },
+    { "path": "anim/walk", "kind": "animationRoot" },
+    { "path": "hero.combat.idle", "kind": "logicalId", "description": "combat idle pose" }
+  ]
+}
+```
+
+`assets`, when present, must be a JSON array. Each entry is an object with:
+
+| Field         | Required | Description |
+| ------------- | -------- | ----------- |
+| `path`        | yes      | A safe POSIX-style relative path (or logical id) — see **Path safety**. |
+| `kind`        | yes      | One of the kinds below. |
+| `description` | no       | Free-form note for authors and reviewers. |
+
+### Kinds
+
+- **`file`** — a single asset file under the map directory
+  (for example `images/portrait.png`). The file must exist.
+- **`directory`** — a directory of assets under the map directory. The
+  directory must exist.
+- **`animationRoot`** — an animation base path under the map directory. It
+  resolves either to a directory (multi-frame animation) or to a sibling
+  `<path>.png` file (single-frame animation), mirroring how the engine resolves
+  animations. One of the two must exist.
+- **`logicalId`** — a logical asset identifier rather than a filesystem path.
+  It is constrained to the same safe-path character rules but is **not** checked
+  against the filesystem.
+
+### Path safety
+
+`path` is always interpreted relative to the map's own directory and must stay
+within it. The validator rejects a declaration when its `path`:
+
+- is absolute or begins with `/`;
+- contains a `..` traversal segment, a `.` segment, or an empty segment;
+- contains a backslash (`\`) or a colon (`:`), including Windows drive letters;
+- is empty or has surrounding whitespace.
+
+A `path` may not be declared more than once within a single map's `assets`
+array.

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -19,6 +19,9 @@ from pathlib import Path
 from typing import Any
 
 OBJECT_SCHEMA_KEYS = {"class", "ref", "properties"}
+# Recognised kinds for an optional map.json top-level "assets" declaration. Each declared asset
+# is a safe relative path under its own map directory; the kind documents how the entry resolves.
+MAP_ASSET_KINDS = {"file", "directory", "animationRoot", "logicalId"}
 SCRIPT_REF_CALLS = {"createObject", "addObjectByName"}
 SCRIPT_ITEM_CALLS = {"addItem"}
 SCRIPT_QUEST_CALLS = {"addQuest", "ensure_quest", "_grant_quest", "grant_quest"}
@@ -1096,6 +1099,19 @@ class TriggerAnalyzer(ast.NodeVisitor):
             )
 
 
+def is_safe_map_relative_path(path: str) -> bool:
+    """Return True when ``path`` is a safe POSIX-style relative path under a map directory.
+
+    Rejects absolute paths, Windows-style separators or drive letters, leading slashes, and any
+    ``.``/``..``/empty path segment so a declared asset can never escape its own map directory.
+    """
+    if not isinstance(path, str) or not path or path != path.strip():
+        return False
+    if "\\" in path or ":" in path or path.startswith("/"):
+        return False
+    return all(segment not in ("", ".", "..") for segment in path.split("/"))
+
+
 class ContentValidator:
     def __init__(
         self,
@@ -1583,6 +1599,7 @@ class ContentValidator:
             self._validate_config_entry(entry, visible, known_classes)
         self._validate_top_level_ref_cycles(context, visible)
         self._validate_map_json(context, visible, known_classes, archetype_ids)
+        self._validate_map_assets(context)
         self._validate_dialogs(context, visible)
         self._validate_script_refs(context, visible, known_classes, archetype_ids)
         self._validate_gooby_runtime_names(context)
@@ -2104,6 +2121,63 @@ class ContentValidator:
                 )
             elif layer_type == "objectgroup":
                 self._validate_object_layer(context, layer, layer_location, visible, known_classes, archetype_ids)
+
+    def _validate_map_assets(self, context: MapContext) -> None:
+        data = context.map_data
+        if not isinstance(data, dict) or "assets" not in data:
+            return
+        assets = data.get("assets")
+        if not isinstance(assets, list):
+            self._issue(context.map_path, "assets", "expected array")
+            return
+        seen_paths: set[str] = set()
+        for index, entry in enumerate(assets):
+            location = f"assets[{index}]"
+            if not isinstance(entry, dict):
+                self._issue(context.map_path, location, "expected object with 'path' and 'kind'")
+                continue
+            path_value = entry.get("path")
+            if not isinstance(path_value, str) or not path_value:
+                self._issue(context.map_path, f"{location}.path", "expected non-empty string")
+                continue
+            if not is_safe_map_relative_path(path_value):
+                self._issue(
+                    context.map_path,
+                    f"{location}.path",
+                    "must be a safe relative path under the map directory (no absolute paths, '..' traversal, "
+                    "backslashes, drive letters, or empty segments)",
+                )
+                continue
+            if path_value in seen_paths:
+                self._issue(context.map_path, f"{location}.path", f"duplicate asset declaration: {path_value}")
+            seen_paths.add(path_value)
+            kind = entry.get("kind")
+            if not isinstance(kind, str) or kind not in MAP_ASSET_KINDS:
+                self._issue(
+                    context.map_path,
+                    f"{location}.kind",
+                    f"expected one of {sorted(MAP_ASSET_KINDS)}",
+                )
+                continue
+            self._validate_map_asset_target(context, location, path_value, kind)
+
+    def _validate_map_asset_target(self, context: MapContext, location: str, path_value: str, kind: str) -> None:
+        if kind == "logicalId":
+            return
+        target = context.directory / path_value
+        if kind == "file":
+            if not target.is_file():
+                self._issue(context.map_path, f"{location}.path", f"declared file asset not found: {path_value}")
+        elif kind == "directory":
+            if not target.is_dir():
+                self._issue(context.map_path, f"{location}.path", f"declared directory asset not found: {path_value}")
+        elif kind == "animationRoot":
+            if not target.is_dir() and not (context.directory / f"{path_value}.png").is_file():
+                self._issue(
+                    context.map_path,
+                    f"{location}.path",
+                    f"declared animation root resolves to neither a directory nor a '<path>.png' file: {path_value}",
+                )
 
     def _validate_tile_layer(
         self,

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -75,6 +75,107 @@ class ContentValidatorTest(unittest.TestCase):
             "previously defined at layers[1].objects[0]",
         )
 
+    def _declare_map_assets(self, root, assets):
+        map_path = root / "res/maps/broken/map.json"
+        map_data = read_json(map_path)
+        map_data["assets"] = assets
+        write_json(map_path, map_data)
+        return map_path
+
+    def _make_asset_files(self, root):
+        map_dir = root / "res/maps/broken"
+        (map_dir / "images").mkdir(parents=True, exist_ok=True)
+        (map_dir / "images/portrait.png").write_text("png")
+        (map_dir / "frames").mkdir(parents=True, exist_ok=True)
+        (map_dir / "frames/0.png").write_text("png")
+        (map_dir / "sprites").mkdir(parents=True, exist_ok=True)
+        (map_dir / "sprites/0.png").write_text("png")
+        (map_dir / "anim").mkdir(parents=True, exist_ok=True)
+        (map_dir / "anim/walk.png").write_text("png")
+
+    def test_map_assets_valid_declarations_pass_validation(self):
+        root = self.make_fixture()
+        self._make_asset_files(root)
+        self._declare_map_assets(
+            root,
+            [
+                {"path": "images/portrait.png", "kind": "file"},
+                {"path": "frames", "kind": "directory"},
+                {"path": "anim/walk", "kind": "animationRoot"},
+                {"path": "sprites", "kind": "animationRoot"},
+                {"path": "hero.combat.idle", "kind": "logicalId"},
+            ],
+        )
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
+    def test_map_assets_non_array_is_flagged(self):
+        root = self.make_fixture()
+        self._declare_map_assets(root, {"path": "images/portrait.png", "kind": "file"})
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(issues, "res/maps/broken/map.json", "assets", "expected array")
+
+    def test_map_assets_unsafe_path_is_flagged(self):
+        root = self.make_fixture()
+        self._declare_map_assets(root, [{"path": "../escape.png", "kind": "file"}])
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(issues, "res/maps/broken/map.json", "assets[0].path", "safe relative path")
+
+    def test_map_assets_missing_target_is_flagged(self):
+        root = self.make_fixture()
+        self._declare_map_assets(
+            root,
+            [
+                {"path": "images/missing.png", "kind": "file"},
+                {"path": "nodir", "kind": "directory"},
+                {"path": "anim/none", "kind": "animationRoot"},
+            ],
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(issues, "assets[0].path", "declared file asset not found: images/missing.png")
+        self.assertIssueContains(issues, "assets[1].path", "declared directory asset not found: nodir")
+        self.assertIssueContains(issues, "assets[2].path", "animation root resolves to neither")
+
+    def test_map_assets_invalid_entry_shape_is_flagged(self):
+        root = self.make_fixture()
+        self._make_asset_files(root)
+        self._declare_map_assets(
+            root,
+            [
+                "notanobject",
+                {"kind": "file"},
+                {"path": "images/portrait.png", "kind": "sprite"},
+            ],
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(issues, "assets[0]", "expected object with 'path' and 'kind'")
+        self.assertIssueContains(issues, "assets[1].path", "expected non-empty string")
+        self.assertIssueContains(issues, "assets[2].kind", "expected one of")
+
+    def test_map_assets_duplicate_path_is_flagged(self):
+        root = self.make_fixture()
+        self._declare_map_assets(
+            root,
+            [
+                {"path": "shared.id", "kind": "logicalId"},
+                {"path": "shared.id", "kind": "logicalId"},
+            ],
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(issues, "assets[1].path", "duplicate asset declaration: shared.id")
+
     def test_unreachable_dialog_state_reports_dialog_and_state(self):
         root = self.make_fixture()
         dialog_path = root / "res/maps/broken/dialog.json"


### PR DESCRIPTION
## Summary

Implements **[EPIC_04][STORY_03][SUBSTORY_01] Define map assets schema**.

Adds an **optional** top-level `assets` declaration to `map.json` so a map can document the local resources it owns, plus a validation target and author documentation. The declaration is purely additive — existing maps declare no assets and are unaffected — and nothing changes about how assets are loaded or staged (engine loading / CMake staging come separately, per the issue).

### Schema
Each `assets` entry is an object with:
- `path` — a safe POSIX-style relative path (or logical id) under the map's own directory.
- `kind` — one of `file`, `directory`, `animationRoot`, `logicalId`.
- `description` *(optional)* — free-form note.

### Validation (`scripts/validate_content.py`)
- Adds `MAP_ASSET_KINDS` and `is_safe_map_relative_path()`.
- Validates the optional `assets` array: must be a list of objects with a safe relative `path` (rejects absolute paths, `..`/`.`/empty segments, backslashes, colons/drive letters, surrounding whitespace) and a valid `kind`.
- `file`/`directory`/`animationRoot` targets are checked for existence (`animationRoot` resolves to a directory **or** a sibling `<path>.png`); `logicalId` is not filesystem-checked.
- Duplicate paths within a map are reported.

### Docs (`docs/content.md`)
New content-schema reference documenting the `assets` declaration, the four kinds, and the path-safety rules.

### Tests (`tests/test_content_validator.py`)
Fixtures for valid declarations and for each invalid case (non-array, unsafe path, missing target, bad entry shape/kind, duplicate path).

### Local validation
- `python3 scripts/validate_content.py --repo-root .` → passes (existing maps unaffected).
- `python3 -m unittest tests.test_content_validator.ContentValidatorTest` → 104 tests pass, including the new map-assets cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgwwEuSehxkjEsvFNu9fS)_