### PR TITLE
Add siege PritzMage wand/controller preservation test (EPIC_05/STORY_01/SUBSTORY_03)

### DIFF
--- a/test.py
+++ b/test.py
@@ -14346,8 +14346,11 @@ class GameTest(unittest.TestCase):
         self.assertEqual("player", config_controller.get("properties", {}).get("target"))
         self.assertIn("quest", siege_config["magicWand"].get("properties", {}).get("tags", []))
 
+        # siegePritzMage is a MAP-LOCAL definition, not a globally-registered type: it only
+        # becomes instantiable after the siege map is loaded and registers its config types.
+        # (Same ordering the sibling siege tests rely on when calling g.createObject("siegePritz").)
         game = load_game_module()
-        g = game.CGameLoader.loadGame()
+        g, _game_map, _player = load_game_map_with_player("siege")
 
         mage = g.createObject("siegePritzMage")
         self.assertIsNotNone(mage)

--- a/test.py
+++ b/test.py
@@ -14330,6 +14330,52 @@ class GameTest(unittest.TestCase):
         return True, json.dumps(spawn_states, sort_keys=True)
 
     @game_test
+    def test_siege_pritz_mage_keeps_single_wand_and_player_controller(self):
+        # Regression guard for the upcoming creature-archetype migration: the siege
+        # mage must keep referencing PritzMage, carry exactly one quest magicWand in
+        # its own inventory (not promoted into a class/race definition), and target
+        # the player. See res/maps/siege/config.json (siegePritzMage / magicWand).
+        siege_config = json.loads((MAPS_DIR / "siege" / "config.json").read_text())
+
+        mage_config = siege_config["siegePritzMage"]
+        self.assertEqual("PritzMage", mage_config.get("ref"))
+        config_items = mage_config.get("properties", {}).get("items") or []
+        self.assertEqual(["magicWand"], [item.get("ref") for item in config_items])
+        config_controller = mage_config.get("properties", {}).get("controller", {})
+        self.assertEqual("CTargetController", config_controller.get("class"))
+        self.assertEqual("player", config_controller.get("properties", {}).get("target"))
+        self.assertIn("quest", siege_config["magicWand"].get("properties", {}).get("tags", []))
+
+        game = load_game_module()
+        g = game.CGameLoader.loadGame()
+
+        mage = g.createObject("siegePritzMage")
+        self.assertIsNotNone(mage)
+
+        items = list(mage.getItems())
+        self.assertNotIn(None, items)
+        self.assertEqual(["magicWand"], sorted(item.getTypeId() for item in items))
+
+        mage_json = json.loads(game.jsonify(mage))
+        mage_properties = mage_json.get("properties", {})
+        spawned_items = mage_properties.get("items") or []
+        self.assertEqual(["magicWand"], sorted(item["properties"]["typeId"] for item in spawned_items))
+        spawned_controller = mage_properties.get("controller", {})
+        self.assertEqual("CTargetController", spawned_controller.get("class"))
+        self.assertEqual("player", spawned_controller.get("properties", {}).get("target"))
+
+        return True, json.dumps(
+            {
+                "ref": mage_config.get("ref"),
+                "config_wand_refs": [item.get("ref") for item in config_items],
+                "spawned_wand_type_ids": sorted(item.getTypeId() for item in items),
+                "controller_class": spawned_controller.get("class"),
+                "controller_target": spawned_controller.get("properties", {}).get("target"),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_siege_spawn_point_defers_blocking_sealed_occupied_gate(self):
         class FakeEvent:
             def __init__(self, cause):


### PR DESCRIPTION
## Issue
`[EPIC_05][STORY_01][SUBSTORY_03]Preserve siege mage wand flow` — claim `d1ef4cfd…`, owner `controller/ctrl-vm-4039-a70f65a5/subagent-24`.

## What changed (test-only, +46 in `test.py`)
`GameTest.test_siege_pritz_mage_keeps_single_wand_and_player_controller` — a regression guard that pins the siege mage's current, correct shape so a later archetype migration can't break it. Verified against `res/maps/siege/config.json`: `siegePritzMage` → `"ref":"PritzMage"`, its `properties.items` is exactly one `{"ref":"magicWand"}` (wand stays in the creature's own inventory, not promoted into class/race), and its controller is `CTargetController` targeting `"player"`; `magicWand` is `quest`-tagged.

The test asserts both source-level (config shape) and runtime (`createObject("siegePritzMage")` → `getItems()` yields exactly one `magicWand`; jsonified controller is `CTargetController`/`player`), reusing the established `@game_test` siege-harness helpers (`load_game_module`, `CGameLoader.loadGame`, `getItems`/`getTypeId`, `jsonify`). No production change — content is already correct.

## Validation
`python3 test.py GameTest.test_siege_pritz_mage_keeps_single_wand_and_player_controller` (runtime portion runs on CI via `--suite gameplay`). `python3 scripts/validate_content.py` → passed. `python3 -m py_compile test.py` OK; `git diff --check` clean. No `black` on `test.py`.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_