### PR TITLE
[observation] Engine GameTest failures undiagnosable from controller (build-less + tail-only CI logs)

### DIFF
--- a/planning/workflow_observations/records/20260630T233408Z-ctrl-vm-4078-31cf30b5-1fd687e4.json
+++ b/planning/workflow_observations/records/20260630T233408Z-ctrl-vm-4078-31cf30b5-1fd687e4.json
@@ -1,0 +1,40 @@
+{
+  "affectedPaths": [
+    ".github/workflows/build.yml"
+  ],
+  "category": "observability",
+  "controllerId": "ctrl-vm-4078-31cf30b5",
+  "createdAtUtc": "2026-06-30T23:34:08Z",
+  "details": "Content/gameplay changes that touch behavior exercised by the native engine GameTests are very hard to\nland and reconcile in this build-less controller environment, because of two compounding gaps:\n\n1. Workers cannot run the engine-backed GameTests locally: the native `_game` pybind module is not\n   built (submodules vstd / random-dungeon-generator unfetchable), so test.py GameTest cases only run\n   in GitHub Actions. Workers validate with fake-game/pure-Python harnesses and pass locally, then the\n   real change breaks an engine GameTest only visible in CI.\n2. The CI failure is not diagnosable from the controller side: the GitHub job-log retrieval returns\n   only the post-job cleanup tail (~the last ~60 lines of git-credential teardown), never the failing\n   test name/assertion. The native test runner reports \"[test shard 2] failed with exit code 1\" but the\n   specific failing GameTest and its assertion are mid-log and unreachable, so the controller cannot\n   point a worker at the exact test to fix.\n\nCombined effect: changes iterate \"blind\" through ~10-20 min native-CI cycles. Concrete cases this run:\n- [EPIC_60][STORY_02][SUBSTORY_06] (failed-craft cost): linux failed on an engine GameTest\n  (test_crafting_transactions_are_atomic RNG-failure section); only diagnosed by manually reading every\n  crafting test in test.py and guessing, then reconciling. Landed after 1 extra blind cycle.\n- [EPIC_60][STORY_02][SUBSTORY_07] (crafting resale economy): both economy levers (ManaPotion power\n  nerf; brew_mana_potion gold raise) broke different engine crafting GameTests in shard 2 that could\n  not be identified from the tail-only log after 3 cycles; the row was published BLOCKED.\n\nRecommendation (for an optimizer with native-build access): either (a) make the native test runner emit\nthe failing test id + assertion into the job summary / a junit xml artifact that the controller log\ntooling can read, or (b) provide a controller-runnable native-test path (prebuilt _game module or a\nfetchable submodule mirror) so workers can reproduce engine GameTest failures locally before PR.\n",
+  "evidence": [
+    {
+      "cases": [
+        {
+          "ci": "linux failed on test_crafting_transactions_are_atomic (engine GameTest); diagnosed manually by reading test.py; landed after extra blind cycle",
+          "issue": "[EPIC_60][STORY_02][SUBSTORY_06]Failed crafts consume no ingredients or gold",
+          "pr": 1114
+        },
+        {
+          "ci": "linux failed on an unidentifiable engine crafting GameTest in [test shard 2] across 3 cycles; BLOCKED",
+          "issue": "[EPIC_60][STORY_02][SUBSTORY_07]Crafting cheap potions resale exploit",
+          "outcome": "BLOCKED",
+          "pr": 1119
+        }
+      ],
+      "discoveredBy": "ctrl-vm-4078-31cf30b5",
+      "gaps": [
+        "no native _game module locally (submodules unfetchable)",
+        "job-log API returns only cleanup tail, not the failing test/assertion"
+      ]
+    }
+  ],
+  "fingerprint": "engine gametest failure undiagnosable build-less tail-only ci logs",
+  "id": "20260630T233408Z-ctrl-vm-4078-31cf30b5-1fd687e4",
+  "impact": "Content/gameplay changes iterate blind through long native-CI cycles; row e60-s02-ss07 could not be diagnosed and was BLOCKED",
+  "phase": "validation",
+  "role": "controller",
+  "schemaVersion": 1,
+  "severity": "medium",
+  "sourceCommit": "e8a2c734f0641bf8c6f4789643c26406f539e26c",
+  "summary": "Engine GameTest failures are undiagnosable from the controller (no local _game build + tail-only CI logs), forcing blind iterations and a BLOCKED"
+}


### PR DESCRIPTION
## Observation-only (record-only)
Adds a single append-only record under `planning/workflow_observations/records/`; no queue or source files modified.

## Controller-discovered workflow problem
Content/gameplay changes that touch behavior exercised by the native engine GameTests are hard to land and reconcile in this build-less controller environment, due to two compounding gaps:
1. **No local engine tests** — the native `_game` pybind module isn't built (submodules unfetchable), so `test.py` GameTests run only in CI. Workers validate with fake-game/pure-Python harnesses, pass locally, then the real change breaks an engine GameTest visible only in CI.
2. **Undiagnosable CI failure** — the job-log API returns only the post-job cleanup tail, never the failing test/assertion. The runner reports `[test shard 2] failed with exit code 1`, but the specific GameTest is mid-log and unreachable, so the controller can't point a worker at the exact test.

**Cases this run:** `[EPIC_60][STORY_02][SUBSTORY_06]` (failed-craft cost, #1114) — diagnosed only by manually reading every crafting test and guessing, landed after an extra blind cycle; `[EPIC_60][STORY_02][SUBSTORY_07]` (crafting resale economy, #1119) — both economy levers broke unidentifiable engine GameTests across 3 cycles → **BLOCKED**.

## Recommendation
For an optimizer with native-build access: (a) emit the failing test id + assertion into the job summary / a junit artifact the controller log tooling can read, or (b) provide a controller-runnable native-test path (prebuilt `_game` or fetchable submodule mirror) so workers reproduce engine GameTest failures locally before PR.

`validate` and `validate --base origin/main` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_