### PR TITLE
Add CInteraction selfTarget bool property (EPIC_06/STORY_01/SUBSTORY_01)

### DIFF
--- a/src/object/CInteraction.cpp
+++ b/src/object/CInteraction.cpp
@@ -63,6 +63,10 @@ int CInteraction::getManaCost() const { return manaCost; }
 
 void CInteraction::setManaCost(int value) { manaCost = value; }
 
+bool CInteraction::getSelfTarget() const { return selfTarget; }
+
+void CInteraction::setSelfTarget(bool value) { selfTarget = value; }
+
 std::shared_ptr<CEffect> CInteraction::getEffect() const { return effect; }
 
 void CInteraction::setEffect(const std::shared_ptr<CEffect> value) { effect = value; }

--- a/src/object/CInteraction.h
+++ b/src/object/CInteraction.h
@@ -29,7 +29,8 @@ class CEffect;
 class CInteraction : public CGameObject {
 
     V_META(CInteraction, CGameObject, V_PROPERTY(CInteraction, std::shared_ptr<CEffect>, effect, getEffect, setEffect),
-           V_PROPERTY(CInteraction, int, manaCost, getManaCost, setManaCost))
+           V_PROPERTY(CInteraction, int, manaCost, getManaCost, setManaCost),
+           V_PROPERTY(CInteraction, bool, selfTarget, getSelfTarget, setSelfTarget))
 
   public:
     CInteraction();
@@ -50,7 +51,12 @@ class CInteraction : public CGameObject {
 
     void setManaCost(int value);
 
+    bool getSelfTarget() const;
+
+    void setSelfTarget(bool value);
+
   private:
     int manaCost = 0;
+    bool selfTarget = false;
     std::shared_ptr<CEffect> effect;
 };

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -1883,9 +1883,10 @@ void test_interaction_self_target_property_round_trip() {
     expect_true(round_trip->getSelfTarget(), "selfTarget should survive a serialize/deserialize round-trip");
 
     // JSON that omits selfTarget (e.g. existing content) must remain valid and keep the false default.
-    auto legacy = std::make_shared<json>();
-    add_member(legacy, "class", CInteraction::static_meta()->name());
-    add_member(legacy, "properties", std::make_shared<json>());
+    auto legacy = std::make_shared<json>(*serialized);
+    (*legacy)["properties"].erase("selfTarget");
+    expect_true(!(*legacy)["properties"].contains("selfTarget"),
+                "legacy fixture should omit the selfTarget property");
     auto legacy_loaded = std::dynamic_pointer_cast<CInteraction>(
         CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game, legacy));
     expect_true(legacy_loaded && !legacy_loaded->getSelfTarget(),

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -1853,6 +1853,45 @@ void test_creature_effective_actions_baseline_capture() {
     std::cout << "creature-actions-baseline-levelling-unlocks-observed\t" << templatesWithLevellingUnlock << '\n';
 }
 
+// CInteraction.selfTarget is a bool metadata property (default false). This pins
+// its default, that a configured value serializes through CSerialization and
+// survives a serialize/deserialize round-trip, and that JSON which omits the
+// property stays valid (deserializing to the false default).
+void test_interaction_self_target_property_round_trip() {
+    CTypes::register_type_metadata<CInteraction, CGameObject>();
+
+    auto game = std::make_shared<CGame>();
+    game->getObjectHandler()->registerType(CInteraction::static_meta()->name(),
+                                           []() { return std::make_shared<CInteraction>(); });
+
+    auto fresh = std::make_shared<CInteraction>();
+    expect_true(!fresh->getSelfTarget(), "selfTarget should default to false");
+
+    auto action = std::make_shared<CInteraction>();
+    action->setGame(game);
+    action->setSelfTarget(true);
+    expect_true(action->getSelfTarget(), "setSelfTarget(true) should be reflected by getSelfTarget()");
+
+    auto serialized = CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::serialize(action);
+    expect_true((*serialized)["properties"].contains("selfTarget") &&
+                    (*serialized)["properties"]["selfTarget"].get<bool>(),
+                "a configured selfTarget should serialize as a true JSON property");
+
+    auto round_trip = std::dynamic_pointer_cast<CInteraction>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game, serialized));
+    expect_true(round_trip != nullptr, "a CInteraction should deserialize back into a CInteraction");
+    expect_true(round_trip->getSelfTarget(), "selfTarget should survive a serialize/deserialize round-trip");
+
+    // JSON that omits selfTarget (e.g. existing content) must remain valid and keep the false default.
+    auto legacy = std::make_shared<json>();
+    add_member(legacy, "class", CInteraction::static_meta()->name());
+    add_member(legacy, "properties", std::make_shared<json>());
+    auto legacy_loaded = std::dynamic_pointer_cast<CInteraction>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game, legacy));
+    expect_true(legacy_loaded && !legacy_loaded->getSelfTarget(),
+                "interaction JSON without selfTarget should deserialize to the false default");
+}
+
 // CCreatureRace is a CGameObject-derived metadata definition. This pins that it
 // round-trips through CSerialization with all of its metadata (base stats, innate
 // actions, creatureType, subtypes, playerSelectable, plus inherited label/
@@ -2388,6 +2427,7 @@ int main() {
     test_serialization_collection_and_error_helpers();
     test_creature_effective_stats_baseline_capture();
     test_creature_effective_actions_baseline_capture();
+    test_interaction_self_target_property_round_trip();
     test_creature_race_metadata_round_trip();
     test_creature_class_metadata_round_trip();
     test_creature_archetype_property_wiring();


### PR DESCRIPTION
## Summary

Implements **[EPIC_06][STORY_01][SUBSTORY_01] Add CInteraction selfTarget property**.

Adds a `bool selfTarget` property to `CInteraction` (default `false`) so an interaction can explicitly declare that its effect/action targets the caster.

### Changes
- **`CInteraction.h` / `.cpp`** — new `selfTarget` member (default `false`) with `getSelfTarget`/`setSelfTarget`, registered in the existing `V_META` reflection block.
- **`tests/unit/test_core.cpp`** — `test_interaction_self_target_property_round_trip` covering the default, a configured value, the serialize/deserialize round-trip, and that interaction JSON which omits `selfTarget` still loads (as `false`).

### Why no `CModule.cpp` / `validate_content.py` edits
Both targets listed in the issue turned out not to need changes:
- **Serialization + pybind**: `V_META`/`register_type_metadata<CInteraction>` already drives serialization and generic property access (the sibling `manaCost` property has no explicit pybind binding either), so the new property is exposed automatically.
- **Content validator**: `scripts/validate_content.py` parses `V_META` property declarations directly from the header. Verified that it now recognizes `selfTarget` (`bool`), and `python3 scripts/validate_content.py --repo-root .` still passes.

The property is purely additive — existing interaction JSON without `selfTarget` deserializes to the `false` default. Behavioral consumption of the flag is intentionally left to a follow-up substory; this change establishes the declaration, serialization, and validation surface.

### Local validation
- `python3 scripts/validate_content.py --repo-root .` → passes; validator recognizes `selfTarget`.
- New unit test built as `core_unit_tests` (runs under the native CI jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgwwEuSehxkjEsvFNu9fS)_