### PR TITLE
Disable drag-and-drop for interaction/command lists (EPIC_03/STORY_01/SUBSTORY_01 #625)

### DIFF
--- a/res/config/panels.json
+++ b/res/config/panels.json
@@ -7,6 +7,7 @@
           "class": "CListView",
           "properties": {
             "collection": "interactionsCollection",
+            "dragEnabled": false,
             "layout": {
               "class": "CLayout",
               "properties": {
@@ -279,6 +280,7 @@
           "properties": {
             "callback": "interactionsCallback",
             "collection": "interactionsCollection",
+            "dragEnabled": false,
             "layout": {
               "class": "CLayout",
               "properties": {

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -93,6 +93,13 @@ bool CListView::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int bu
     if (button == SDL_BUTTON_RIGHT) {
         return invokeRightClickCallback(gui, index, object);
     }
+    // Command/interaction lists are non-draggable: a left mouse-down must never start a
+    // drag session or capture the pointer; it only runs the normal click callback so
+    // pointer motion never suppresses the click and first/second click semantics hold.
+    if (!dragEnabled) {
+        invokeCallback(gui, index, object);
+        return true;
+    }
     if (gui && !dragStart.empty()) {
         if (invokeDragStart(gui, index, object)) {
             auto rect = getLayout() ? getLayout()->getRect(this->ptr<CGameGraphicsObject>()) : CUtil::rect(0, 0, 0, 0);
@@ -481,6 +488,13 @@ void CListView::addItem(const std::shared_ptr<CGui> &gui, std::list<std::shared_
             }
             if (button == SDL_BUTTON_LEFT) {
                 const bool deferSourceCallback = self->invokeSelect(gui, itemIndex, object);
+                // Command/interaction lists are non-draggable: never start a drag session,
+                // capture the pointer, or defer the source callback. The normal click
+                // callback always fires so first-click-select / second-click-confirm works.
+                if (!self->dragEnabled) {
+                    self->invokeCallback(gui, itemIndex, object);
+                    return true;
+                }
                 bool dragStarted = false;
                 if (auto source = sourceGraphic.lock()) {
                     auto rect = source->getLayout() ? source->getLayout()->getRect(source) : CUtil::rect(0, 0, 0, 0);
@@ -766,6 +780,10 @@ void CListView::setTileSize(int _tileSize) { tileSize = std::clamp(_tileSize, 1,
 bool CListView::getAllowOversize() { return allowOversize; }
 
 void CListView::setAllowOversize(bool _allowOversize) { allowOversize = _allowOversize; }
+
+bool CListView::getDragEnabled() { return dragEnabled; }
+
+void CListView::setDragEnabled(bool _dragEnabled) { dragEnabled = _dragEnabled; }
 
 bool CListView::getShowEmpty() { return showEmpty; }
 

--- a/src/gui/panel/CListView.h
+++ b/src/gui/panel/CListView.h
@@ -42,6 +42,7 @@ class CListView : public CProxyTargetGraphicsObject {
            V_PROPERTY(CListView, int, yPrefferedSize, getYPrefferedSize, setYPrefferedSize),
            V_PROPERTY(CListView, int, tileSize, getTileSize, setTileSize),
            V_PROPERTY(CListView, bool, allowOversize, getAllowOversize, setAllowOversize),
+           V_PROPERTY(CListView, bool, dragEnabled, getDragEnabled, setDragEnabled),
            V_PROPERTY(CListView, bool, showEmpty, getShowEmpty, setShowEmpty),
            V_PROPERTY(CListView, bool, grouping, getGrouping, setGrouping), V_METHOD(CListView, initialize),
            V_METHOD(CListView, refreshFromRefreshEvent),
@@ -121,6 +122,12 @@ class CListView : public CProxyTargetGraphicsObject {
 
     bool allowOversize = true;
 
+    // When false, this list is a pure command/interaction list: a populated item's
+    // mouse-down must never start a GUI drag session, capture the pointer for drag,
+    // defer the source click callback, or create a drag proxy. Defaults true so every
+    // existing list (inventory/equipment/etc.) keeps its current draggable behavior.
+    bool dragEnabled = true;
+
     bool showEmpty = true;
 
     bool grouping = false;
@@ -141,6 +148,10 @@ class CListView : public CProxyTargetGraphicsObject {
     bool getAllowOversize();
 
     void setAllowOversize(bool _allowOversize);
+
+    bool getDragEnabled();
+
+    void setDragEnabled(bool _dragEnabled);
 
     bool getGrouping();
 

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -39,6 +39,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/panel/CListView.h"
 #include "handler/CObjectHandler.h"
 #include "object/CCreature.h"
+#include "object/CInteraction.h"
 #include "object/CItem.h"
 #include "object/CPlayer.h"
 #include "object/CTile.h"
@@ -1103,6 +1104,105 @@ void test_list_view_legacy_click_callback_still_fires_without_drag_callbacks() {
                 "legacy click should keep the clicked item object");
 }
 
+void test_list_view_non_draggable_does_click_only_press_motion_release() {
+    auto harness = create_drag_list_harness();
+    harness.source->setDragEnabled(false);
+
+    // Mouse-down on a non-draggable command list must run the click callback and never
+    // start a drag session or capture the pointer.
+    expect_true(harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 25, 25),
+                "non-draggable list should consume the left click");
+    expect_true(harness.panel->source_clicks == 1, "non-draggable list should fire the click callback once on press");
+    expect_true(harness.panel->drag_starts == 0, "non-draggable list should never call drag-start");
+    expect_true(!harness.gui->hasDragSession(), "non-draggable list must not create a drag session");
+    expect_true(!harness.gui->hasPointerCapture(), "non-draggable list must not capture the pointer");
+
+    // Pointer motion and release must not suppress or duplicate the click callback, and must
+    // not retroactively spawn a session/proxy.
+    harness.gui->updateDragSession(180, 25);
+    expect_true(!harness.gui->hasDragSession(), "motion without a session must not create one");
+    expect_true(harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONUP, SDL_BUTTON_LEFT, 180, 25),
+                "non-draggable list should consume the release");
+    expect_true(harness.panel->source_clicks == 1, "motion/release must not suppress or duplicate the click callback");
+    expect_true(harness.panel->drag_cancels == 0, "non-draggable list release must not report a drag cancel");
+    expect_true(!harness.gui->hasDragSession(), "non-draggable list must leave no drag session after release");
+    expect_true(!harness.gui->hasPointerCapture(), "non-draggable list must leave no pointer capture after release");
+}
+
+void test_list_view_non_draggable_repeated_click_preserves_first_select_second_confirm() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto game = std::make_shared<CGame>();
+    auto map = std::make_shared<CMap>();
+    auto gui = std::make_shared<CGui>();
+    auto player = std::make_shared<CPlayer>();
+    auto interaction = std::make_shared<CInteraction>();
+    auto panel = std::make_shared<CGameFightPanel>();
+
+    game->setMap(map);
+    game->setGui(gui);
+    map->setGame(game);
+    gui->setGame(game);
+
+    player->setGame(game);
+    player->setBaseStats(player_stats());
+    player->setMana(player->getManaMax());
+    map->setPlayer(player);
+
+    interaction->setGame(game);
+    interaction->setName("nonDraggableInteraction");
+    interaction->setTypeId("nonDraggableInteractionType");
+    interaction->setManaCost(0);
+    player->addAction(interaction);
+
+    // First combat click selects (highlights) the affordable interaction.
+    panel->interactionsCallback(gui, 0, interaction);
+    expect_true(panel->interactionsSelect(gui, 0, interaction),
+                "first combat interaction click should select the interaction");
+
+    // Second click on the same interaction confirms it; selection is preserved until the
+    // blocking select loop consumes finalSelected, so the highlight remains.
+    panel->interactionsCallback(gui, 0, interaction);
+    expect_true(panel->interactionsSelect(gui, 0, interaction),
+                "second combat interaction click should confirm without losing the selection");
+}
+
+void test_list_view_draggable_default_still_drags_after_non_draggable_change() {
+    auto harness = create_drag_list_harness();
+    // Default (unset dragEnabled) preserves legacy draggable behavior: a populated item
+    // still starts the generic drag session on press (inventory/equipment regression).
+    expect_true(harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 25, 25),
+                "default draggable list should consume the click");
+    expect_true(harness.gui->hasDragSession(), "default draggable list should still create the existing drag session");
+    expect_true(harness.panel->source_clicks == 1, "default draggable list should still fire the click callback");
+    harness.gui->clearDragSession();
+    harness.gui->releasePointerCapture();
+
+    // Explicitly enabling drag keeps the same behavior.
+    harness.source->setDragEnabled(true);
+    expect_true(harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 25, 25),
+                "explicitly draggable list should consume the click");
+    expect_true(harness.gui->hasDragSession(), "explicitly draggable list should still create a drag session");
+    harness.gui->clearDragSession();
+    harness.gui->releasePointerCapture();
+}
+
+void test_list_view_non_draggable_panel_removal_during_input_leaves_no_session_or_capture() {
+    auto harness = create_drag_list_harness();
+    harness.source->setDragEnabled(false);
+
+    // Press on the non-draggable list (no session/capture is created), then remove the
+    // owning panel mid-interaction. Nothing dangling should remain.
+    harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 25, 25);
+    expect_true(!harness.gui->hasDragSession(), "non-draggable press should not create a session before removal");
+    expect_true(!harness.gui->hasPointerCapture(), "non-draggable press should not capture the pointer before removal");
+
+    harness.gui->removeChild(harness.panel);
+    expect_true(!harness.gui->hasDragSession(), "panel removal during input must leave no dangling drag session");
+    expect_true(!harness.gui->hasPointerCapture(), "panel removal during input must leave no dangling pointer capture");
+}
+
 void test_panel_event_callbacks_stop_after_close() {
     SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
@@ -1534,6 +1634,10 @@ int main() {
     test_list_view_drag_callbacks_validate_and_drop_without_click_fallback();
     test_list_view_drag_callbacks_cancel_and_preserve_unmoved_clicks();
     test_list_view_legacy_click_callback_still_fires_without_drag_callbacks();
+    test_list_view_non_draggable_does_click_only_press_motion_release();
+    test_list_view_non_draggable_repeated_click_preserves_first_select_second_confirm();
+    test_list_view_draggable_default_still_drags_after_non_draggable_change();
+    test_list_view_non_draggable_panel_removal_during_input_leaves_no_session_or_capture();
     test_panel_event_callbacks_stop_after_close();
     test_gui_routes_mouse_motion_to_target_child();
     test_loader_gui_sessions_shutdown_stale_callbacks();


### PR DESCRIPTION
## Issue
`[EPIC_03][STORY_01][SUBSTORY_01] #625 Disable drag-and-drop for interaction lists` — claim `c0935304…`, owner `controller/ctrl-vm-4039-a70f65a5/subagent-26`.

## Root cause
`CListView` started a generic drag session + proxy for every populated item on mouse-down (the generic `else` branch in `addItem`'s callback at `CListView.cpp:494`, and `CListView::mouseEvent` at `:108`), so combat/character **interaction (command)** lists wrongly inherited inventory-style drag.

## Change (+135, backward-compatible)
- `src/gui/panel/CListView.{h,cpp}`: new `dragEnabled` bool property (getter/setter), **default `true`**. Both drag-initiation paths short-circuit *before* any `startDragSession`/`capturePointer`/proxy when `dragEnabled == false`, calling the click callback directly instead — left/right click still fire, pointer motion can't suppress the click, and no session/capture/proxy is ever created (so cancellation/panel-removal cleanup has nothing to do).
- `res/config/panels.json`: `"dragEnabled": false` on the two interaction/command lists only (CGameCharacterPanel + CGameFightPanel interaction collections). Default `true` preserves every other list — verified by auditing all 10 `CListView` usages, including the inventory/equipment lists that genuinely drag.

## Tests (`tests/unit/test_gui.cpp`, +104; registered in `main()`)
Non-draggable click-only press/motion/release (click once, no session/capture); repeated combat click preserves first-select/second-confirm via `CGameFightPanel::interactionsCallback`; draggable default STILL drags (regression); panel removal during input leaves no session/capture.

## Validation
`ctest -R '^for_unit_tests\.(gui_unit_tests|gui_drag_proxy_unit_tests)$'` (run on CI). `python3 scripts/validate_content.py` → passed. `panels.json` valid JSON; clang-format applied; `git diff --check` clean. `CGui.cpp` untouched.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_