### PR TITLE
Record workflow observation: P1 race-authoring rows dep0 but gated on in-flight loader

### DIFF
--- a/planning/workflow_observations/records/20260630T235534Z-ctrl-vm-31216-edb5360c-7d2e4262.json
+++ b/planning/workflow_observations/records/20260630T235534Z-ctrl-vm-31216-edb5360c-7d2e4262.json
@@ -1,0 +1,90 @@
+{
+  "affectedPaths": [
+    "planning/fall_of_nouraajd_creature_archetype_jira_plan.xlsx",
+    "src/core/CLoader.cpp"
+  ],
+  "category": "other",
+  "controllerId": "ctrl-vm-31216-edb5360c",
+  "createdAtUtc": "2026-06-30T23:55:34Z",
+  "details": "P1-tier shortlist marks the creature race/class authoring rows as immediately eligible (Dependencies Parsed: []),\nbut those rows are functionally gated on upstream work that has not merged:\n\n- Rows authoring res/config/creature_races.json and res/config/creature_classes.json\n  (e.g. EPIC_04 r49/r56/r62, EPIC_05 r65/r67/r69/r72) are NOT_STARTED with dep0, yet neither\n  creature_races.json nor creature_classes.json exists on main, and the race-aware loader that\n  consumes them ([EPIC_04][STORY_04][SUBSTORY_01] \"Add race-aware loader overload\", src/core/CLoader.cpp,\n  row 58) is IN_PROGRESS under another controller.\n- Dispatching a worker on a race-authoring row before the loader merges would change a concrete monster\n  (e.g. Gooby) to reference a race the current loader cannot compose, breaking the row's own baseline\n  acceptance tests. With no native build available to a controller (engine GameTests run only in CI and\n  the CI log API returns only a cleanup tail; see prior observation about undiagnosable engine failures),\n  such a premature claim turns into an undiagnosable BLOCK rather than a clean failure.\n\nSeparately, the P1 \"workflow/controller\" tooling rows (e.g. #620 r8, #621 r9, #624 r12) all edit the live\ncontrol-plane files (AGENTS.md, scripts/issue_queue.py, prompts/codex-queue-controller.md and sibling\nprompts/docs), and the queue reports AGENTS.md as an Active File Overlap (concurrent edits in flight). Running\na worker that refactors the live control plane while multiple controllers are actively reading it is unsafe\nand conflict-prone.\n\nNet effect: at this snapshot a single controller can only safely fill ~2 of its 4 target implementation\nslots from the highest eligible (P1) tier without either dispatching functionally-blocked race-authoring\nwork or churning the live control plane. The remaining eligible P1 rows are queue-data drift (already\nimplemented) or hot CLoader/CMap core files already contended by other controllers.\n\nSuggested optimizer follow-up: model the implicit dependency of the race/class *authoring* rows on the\nrace-aware loader row (and on a schema-establishing first-author row) in the queue's Dependencies column so\nthe shortlist does not present loader-gated rows as immediately eligible; and consider a serialization/\ncoordination marker for live control-plane (AGENTS.md / issue_queue.py / controller-prompt) rows so only one\nis claimable at a time.\n",
+  "evidence": [
+    {
+      "controllerSafeFillableThisSnapshot": 2,
+      "controllerTargetSlots": 4,
+      "highestEligibleTier": "P1",
+      "highestPriorityEligibleCount": 36,
+      "missingSchemaFilesOnMain": [
+        "res/config/creature_races.json",
+        "res/config/creature_classes.json"
+      ],
+      "raceAuthoringRowsDep0ButGated": [
+        {
+          "dep": [],
+          "issue": "[EPIC_04][STORY_01][SUBSTORY_01]Add approved player-selectable races",
+          "row": 49,
+          "status": "NOT_STARTED"
+        },
+        {
+          "dep": [],
+          "issue": "[EPIC_05][STORY_01][SUBSTORY_01]Create approved PritzRace",
+          "row": 62,
+          "status": "NOT_STARTED"
+        },
+        {
+          "dep": [],
+          "issue": "[EPIC_05][STORY_02][SUBSTORY_01]Create GoblinRace and thief class",
+          "row": 65,
+          "status": "NOT_STARTED"
+        },
+        {
+          "dep": [],
+          "issue": "[EPIC_05][STORY_03][SUBSTORY_01]Create GoobyRace and class assignment",
+          "row": 67,
+          "status": "NOT_STARTED"
+        }
+      ],
+      "snapshotMainCommit": "42d6ca247e01f9eb596767a4cea55fe02d6afc09",
+      "toolingRowsLiveControlPlaneActiveOverlap": [
+        {
+          "activeFileOverlaps": [
+            "AGENTS.md"
+          ],
+          "issue": "#620 Consolidate mechanical controller policy",
+          "row": 8
+        },
+        {
+          "activeFileOverlaps": [
+            "AGENTS.md"
+          ],
+          "issue": "#621 Standardize structured worker reports",
+          "row": 9
+        },
+        {
+          "activeFileOverlaps": [
+            "AGENTS.md",
+            "scripts/poll_pr_checks.py"
+          ],
+          "issue": "#624 Deduplicate stale status-check attempts",
+          "row": 12
+        }
+      ],
+      "upstreamLoaderRowInProgress": {
+        "file": "src/core/CLoader.cpp",
+        "issue": "[EPIC_04][STORY_04][SUBSTORY_01]Add race-aware loader overload",
+        "owner": "controller/ctrl-vm-4039-a70f65a5/subagent-22",
+        "row": 58,
+        "status": "IN_PROGRESS"
+      }
+    }
+  ],
+  "fingerprint": "p<n> race authoring rows dep<n> but gated on race-aware loader and missing config schema",
+  "id": "20260630T235534Z-ctrl-vm-31216-edb5360c-7d2e4262",
+  "impact": "Controllers may dispatch workers on loader-gated race rows that cannot pass their own baseline tests, producing undiagnosable BLOCKs; a single controller can safely fill only ~2 of 4 P1 slots this snapshot",
+  "phase": "claim",
+  "role": "controller",
+  "schemaVersion": 1,
+  "severity": "medium",
+  "sourceCommit": "42d6ca247e01f9eb596767a4cea55fe02d6afc09",
+  "suggestedImprovement": "Model the race/class authoring rows' dependency on the race-aware loader row (and a schema-establishing first-author row) in the Dependencies column; add a serialization marker for live control-plane rows (AGENTS.md/issue_queue.py/controller prompts) so only one is claimable at a time",
+  "summary": "P1 race/class authoring rows are dep0 but functionally gated on the in-flight race-aware loader and an unestablished config schema"
+}


### PR DESCRIPTION
Record-only workflow observation (append-only; adds exactly one file under `planning/workflow_observations/records/`).

**Observation id:** `20260630T235534Z-ctrl-vm-31216-edb5360c-7d2e4262`

**Summary:** The P1 race/class authoring rows (e.g. r49/r62/r65/r67) are marked `dep0` and surfaced as immediately eligible, but `res/config/creature_races.json` and `creature_classes.json` do not yet exist on main and the race-aware loader that consumes them (`[EPIC_04][STORY_04][SUBSTORY_01]`, `src/core/CLoader.cpp`, row 58) is IN_PROGRESS under another controller. Dispatching a worker on a race-authoring row before the loader merges would break that row's own baseline tests — and with no native build available to a controller, the failure is undiagnosable.

Separately, the P1 tooling rows (#620/#621/#624) all edit the live control plane (`AGENTS.md`, `scripts/issue_queue.py`, controller prompts) with `AGENTS.md` reported as an active overlap.

**Impact:** A single controller can safely fill only ~2 of 4 P1 slots this snapshot without dispatching functionally-blocked work or churning the live control plane.

**Suggested follow-up (for optimizer):** model the authoring rows' dependency on the loader row (and a schema-establishing first-author row) in the Dependencies column; add a serialization marker for live control-plane rows.

`workflow_observations.py validate` and `validate --base origin/main` both pass. No XLSX, source, or workflow-code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_