### PR TITLE
Validate race before replacing active map (EPIC_04/STORY_04/SUBSTORY_02)

### DIFF
--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -1033,8 +1033,16 @@ std::shared_ptr<CMap> CMapLoader::loadNewMapWithPlayer(const std::shared_ptr<CGa
 
 std::shared_ptr<CMap> CMapLoader::loadNewMapWithPlayer(const std::shared_ptr<CGame> &game, const std::string &name,
                                                        std::string player, const std::string &raceId) {
-    std::shared_ptr<CMap> map = loadNewMap(game, name);
+    // Validate the player template and (for a non-empty raceId) the race BEFORE loadNewMap replaces
+    // the active map. If the race id cannot be resolved, keep the current map untouched and return it
+    // so the caller's setMap re-set is a no-op instead of attaching a partial player onto a new map.
     std::shared_ptr<CPlayer> ptr = createPlayer(game, player, raceId);
+    if (!ptr) {
+        vstd::logger::warning("Keeping the active map unchanged; player could not be created for:", name);
+        return game->getMap();
+    }
+
+    std::shared_ptr<CMap> map = loadNewMap(game, name);
     map->setPlayer(ptr);
 
     return map;
@@ -1043,17 +1051,24 @@ std::shared_ptr<CMap> CMapLoader::loadNewMapWithPlayer(const std::shared_ptr<CGa
 // TODO: move to map, set player as well as triggers
 std::shared_ptr<CPlayer> CMapLoader::createPlayer(const std::shared_ptr<CGame> &game, std::string &player,
                                                   const std::string &raceId) {
-    auto ptr = game->createObject<CPlayer>(std::move(player));
-
-    // An empty raceId means "no override": preserve the template's default race so the existing
-    // three-argument loaders behave exactly as before. A non-empty raceId is resolved against the
-    // object handler; because no race content ships in the repo yet, an unknown id resolves to a
-    // null CCreatureRace, which we deliberately ignore rather than attach (and never crash on).
-    if (ptr && !raceId.empty()) {
-        ptr->setRaceId(raceId);
-        if (auto race = game->createObject<CCreatureRace>(raceId)) {
-            ptr->setRace(std::move(race));
+    // Resolve and type-check the requested race BEFORE the caller replaces the active map. An empty
+    // raceId means "no override": preserve the template's default race so the existing three-argument
+    // loaders behave exactly as before. A non-empty raceId must resolve to a CCreatureRace; if it
+    // does not (unknown id or an id that maps to a non-race object), we log the exact id and return
+    // null so the caller can abort without switching maps or attaching a partial player.
+    std::shared_ptr<CCreatureRace> race;
+    if (!raceId.empty()) {
+        race = game->createObject<CCreatureRace>(raceId);
+        if (!race) {
+            vstd::logger::warning("Rejected player creation for unresolved race id:", raceId);
+            return nullptr;
         }
+    }
+
+    auto ptr = game->createObject<CPlayer>(std::move(player));
+    if (ptr && race) {
+        ptr->setRaceId(raceId);
+        ptr->setRace(std::move(race));
     }
 
     return ptr;
@@ -1065,8 +1080,15 @@ std::shared_ptr<CMap> CMapLoader::loadRandomMapWithPlayer(const std::shared_ptr<
 
 std::shared_ptr<CMap> CMapLoader::loadRandomMapWithPlayer(const std::shared_ptr<CGame> &game, std::string player,
                                                           const std::string &raceId) {
-    std::shared_ptr<CMap> map = CRandomMapGenerator::loadRandomMap(game);
+    // Validate the player template and (for a non-empty raceId) the race before generating and
+    // installing the random map. On an unresolved race id, keep the current map untouched.
     std::shared_ptr<CPlayer> ptr = createPlayer(game, player, raceId);
+    if (!ptr) {
+        vstd::logger::warning("Keeping the active map unchanged; player could not be created for random map");
+        return game->getMap();
+    }
+
+    std::shared_ptr<CMap> map = CRandomMapGenerator::loadRandomMap(game);
     map->setPlayer(ptr);
     return map;
 }

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -2145,17 +2145,14 @@ void test_loader_race_overloads_preserve_default_and_attach_race() {
                 "empty raceId override must preserve the template's default race id");
     expect_true(empty_player->getRace() == nullptr, "empty raceId override must not attach a CCreatureRace");
 
-    // New four-argument path with an unknown raceId: the id is recorded on the player, but because
-    // no such race content exists the resolved CCreatureRace is null and is deliberately not
-    // attached. The key acceptance is that this does not crash.
+    // New four-argument path with an unknown raceId: the race is resolved and type-checked BEFORE
+    // the active map is replaced. Because no such race content exists, the resolved CCreatureRace is
+    // null, so the loader aborts without switching maps or attaching a partial player
+    // ([EPIC_04][STORY_04][SUBSTORY_02]). Starting from a fresh game leaves no active map.
     auto race_game = CGameLoader::loadGame();
     CGameLoader::startGameWithPlayer(race_game, "test", "Warrior", "nonexistent-race");
-    auto race_player = race_game->getMap()->getPlayer();
-    expect_true(race_player != nullptr, "four-argument loader with a raceId should still attach a player");
-    expect_true(race_player->getRaceId() == "nonexistent-race",
-                "a non-empty raceId override should be recorded on the player");
-    expect_true(race_player->getRace() == nullptr,
-                "an unknown raceId should resolve to a null race and not be attached (no crash)");
+    expect_true(race_game->getMap() == nullptr,
+                "an unknown raceId must abort before replacing the active map (no partial player)");
 
     // The random-map four-argument overload with an empty raceId must also load without crashing.
     auto random_game = CGameLoader::loadGame();
@@ -2167,10 +2164,46 @@ void test_loader_race_overloads_preserve_default_and_attach_race() {
                 "random-map empty raceId override must preserve the template's default race id");
 }
 
+// Validate race before replacing the active map ([EPIC_04][STORY_04][SUBSTORY_02]). A game is
+// already running on a map; attempting to (re)start with an invalid non-empty raceId must leave the
+// active map and its player completely unchanged -- no map switch, no partial player -- while a
+// subsequent start with an empty raceId still succeeds.
+void test_loader_invalid_race_leaves_active_map_unchanged() {
+    auto game = CGameLoader::loadGame();
+    CGameLoader::startGameWithPlayer(game, "test", "Warrior");
+
+    auto original_map = game->getMap();
+    expect_true(original_map != nullptr, "the initial start should install an active map");
+    auto original_player = original_map->getPlayer();
+    expect_true(original_player != nullptr, "the initial start should attach a player");
+    original_map->setTurn(41);
+
+    // Attempt a start with an invalid (unknown, non-empty) raceId. The race cannot resolve to a
+    // CCreatureRace, so creation must abort before the active map is replaced.
+    CGameLoader::startGameWithPlayer(game, "ritual", "Warrior", "nonexistent-race");
+
+    expect_true(game->getMap() == original_map, "an invalid raceId must not replace the active map");
+    expect_true(game->getMap()->getMapName() == original_map->getMapName(),
+                "the active map name must be unchanged after a rejected invalid-race start");
+    expect_true(game->getMap()->getTurn() == 41,
+                "the active map state (turn) must be preserved after a rejected invalid-race start");
+    expect_true(original_map->getPlayer() == original_player,
+                "the original player must remain attached after a rejected invalid-race start");
+    expect_true(count_players_on_map(original_map) == 1,
+                "no partial player may be attached after a rejected invalid-race start");
+
+    // An empty raceId (no override) on the same running game still succeeds and switches maps.
+    CGameLoader::startGameWithPlayer(game, "ritual", "Warrior", std::string());
+    expect_true(game->getMap() != nullptr, "an empty raceId start should install a map");
+    expect_true(game->getMap()->getMapName() == "ritual", "an empty raceId start should switch to the requested map");
+    expect_true(game->getMap()->getPlayer() != nullptr, "an empty raceId start should attach a player");
+}
+
 int main() {
     pybind11::scoped_interpreter guard{};
 
     test_loader_race_overloads_preserve_default_and_attach_race();
+    test_loader_invalid_race_leaves_active_map_unchanged();
     test_scene_manager_state_duplicate_and_player_transfer();
     test_game_change_map_duplicate_requests_commit_once();
     test_scene_manager_transition_generation_start_and_commit();


### PR DESCRIPTION
## Issue
`[EPIC_04][STORY_04][SUBSTORY_02]Validate race before replacing active map` — claim `ff9dc803…`, owner `controller/ctrl-vm-4039-a70f65a5/subagent-29`. Builds on the race-aware loader (#1113).

## Root cause / change (`src/core/CLoader.cpp`, +44/-…)
The active map was replaced (`setMap`, `CLoader.cpp:1013`) **before** the race was validated — an invalid non-empty `raceId` silently left the game on a freshly-swapped map with a partial player. Reordered so validation precedes map replacement:
- `createPlayer` resolves + type-checks the race **first**. Empty `raceId` → no override (unchanged 3-arg behavior). Non-empty `raceId` that doesn't resolve to a `CCreatureRace` → logs the exact id (`vstd::logger::warning`) and returns `nullptr`.
- `loadNewMapWithPlayer` / `loadRandomMapWithPlayer` now call `createPlayer` **before** `loadNewMap`/`loadRandomMap`; on null they log and return the current active map (`getMap()`) — a genuine no-op, so no map switch and no partial player.

## Test (`tests/unit/test_map.cpp`)
`test_loader_invalid_race_leaves_active_map_unchanged`: start on map `test` (turn 41), attempt `startGameWithPlayer(game,"ritual","Warrior","nonexistent-race")` → same map/name/turn, same single player (no partial). Empty-raceId start still switches to `ritual`. Updated the existing `test_loader_race_overloads_preserve_default_and_attach_race` invalid-race expectation to the new abort semantics.

## Validation
`ctest -R '^for_unit_tests\.map_unit_tests$'` (run on CI). clang-format applied; `git diff --check` clean.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_