### PR TITLE
Add a real click-versus-drag movement threshold (#626)

### DIFF
--- a/src/gui/CGui.cpp
+++ b/src/gui/CGui.cpp
@@ -26,6 +26,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/panel/CGamePanel.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <string>
 
 namespace {
@@ -67,7 +68,10 @@ void removeDragProxyWidget(const std::shared_ptr<CGui> &gui, CGui::DragSession &
 }
 
 void syncDragProxyWidget(const std::shared_ptr<CGui> &gui, CGui::DragSession &session) {
-    if (!gui || !session.payload || session.canceled || session.acceptedTarget.lock()) {
+    // A candidate drag (below-threshold motion) must NOT render a proxy widget: the
+    // interaction is still a click until the movement threshold is crossed.
+    if (!gui || !session.payload || session.canceled || !CGui::isDragActive(session) ||
+        session.acceptedTarget.lock()) {
         removeDragProxyWidget(gui, session);
         return;
     }
@@ -275,9 +279,25 @@ void CGui::startDragSession(std::shared_ptr<CGameGraphicsObject> sourceWidget, s
     syncDragProxyWidget(this->ptr<CGui>(), *dragSession);
 }
 
+bool CGui::dragThresholdCrossed(const DragSession &session) {
+    const int dx = std::abs(session.current.x - session.start.x);
+    const int dy = std::abs(session.current.y - session.start.y);
+    // Chebyshev (max-axis) distance, boundary exclusive: promote to a drag only when
+    // motion strictly exceeds the threshold on either axis.
+    return std::max(dx, dy) > DRAG_MOVEMENT_THRESHOLD;
+}
+
+bool CGui::isDragActive(const DragSession &session) { return session.dragActive; }
+
 void CGui::updateDragSession(int currentX, int currentY) {
     if (dragSession) {
         dragSession->current = {currentX, currentY};
+        // Latch the active-drag state the moment motion first crosses the threshold.
+        // Once active it never demotes back to a candidate/click, matching standard
+        // click-vs-drag UX.
+        if (!dragSession->dragActive && dragThresholdCrossed(*dragSession)) {
+            dragSession->dragActive = true;
+        }
         syncDragProxyWidget(this->ptr<CGui>(), *dragSession);
     }
 }

--- a/src/gui/CGui.h
+++ b/src/gui/CGui.h
@@ -49,7 +49,37 @@ class CGui : public CGameGraphicsObject {
         std::shared_ptr<CGameGraphicsObject> proxyWidget;
         bool canceled = false;
         bool sourceCallbackDeferred = false;
+        // Latched once pointer motion first crosses the click-vs-drag movement
+        // threshold. While false the session is only a *candidate* drag: no proxy
+        // widget is rendered, drops are rejected, and the release is treated as a
+        // plain click. Once true it stays true for the lifetime of the session
+        // (a drag never demotes back to a click), even if the pointer later drifts
+        // back below the threshold. See CGui::dragThresholdCrossed for the rule.
+        bool dragActive = false;
     };
+
+    // Canonical click-versus-drag movement threshold, in pixels. This is the SINGLE
+    // source of truth reused by every click-vs-drag decision (proxy lifecycle,
+    // source-callback deferral, drop acceptance, and the mouse-up branch).
+    //
+    // Distance metric: Chebyshev (max-axis) distance, i.e. max(|dx|, |dy|).
+    // Boundary: EXCLUSIVE. A session is only promoted to an active drag once the
+    // Chebyshev distance is STRICTLY GREATER THAN the threshold. With a threshold of
+    // 4 this means: 0..4 px of motion on both axes stays a click; the first sample
+    // with |dx| >= 5 or |dy| >= 5 becomes a drag. Negative-axis motion is handled by
+    // the absolute values, and diagonal motion is governed by whichever axis is
+    // larger (so exactly-4/4 diagonal is still a click, 5/0 is a drag).
+    static constexpr int DRAG_MOVEMENT_THRESHOLD = 4;
+
+    // Returns true when the displacement between start and current already crosses
+    // the movement threshold (Chebyshev distance > DRAG_MOVEMENT_THRESHOLD).
+    static bool dragThresholdCrossed(const DragSession &session);
+
+    // Returns true when the session has been promoted to an active drag, i.e. its
+    // latched dragActive flag is set. Below-threshold candidate sessions return
+    // false. This is the accessor every non-CGui call site (e.g. CListView) must use
+    // to decide drag-vs-click, so the rule lives in exactly one place.
+    static bool isDragActive(const DragSession &session);
 
     using CGameGraphicsObject::render;
 

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -42,9 +42,11 @@ std::shared_ptr<CAnimation> createListItemAnimation(const std::shared_ptr<CGui> 
     return animation;
 }
 
-bool dragMoved(const CGui::DragSession &session) {
-    return std::abs(session.current.x - session.start.x) > 0 || std::abs(session.current.y - session.start.y) > 0;
-}
+// Single click-vs-drag decision for list drag handling. Delegates to the canonical
+// GUI movement-threshold rule (Chebyshev distance, boundary exclusive) so a drag is
+// only recognized once motion has actually crossed the threshold. Below-threshold
+// jitter therefore stays a click and never triggers a drop or cancel.
+bool dragMoved(const CGui::DragSession &session) { return CGui::isDragActive(session); }
 } // namespace
 
 void CListView::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> loc, int frameTime) {}

--- a/src/gui/panel/CListView.cpp
+++ b/src/gui/panel/CListView.cpp
@@ -82,7 +82,13 @@ bool CListView::mouseEvent(std::shared_ptr<CGui> gui, SDL_EventType type, int bu
         if (sourceList) {
             sourceList->notifySourceDragCancel(gui, session->sourceIndex, session->payload);
         }
-        return false;
+        // This whole branch runs only while a drag session is live (see the guard above), so the
+        // release terminates a gesture the drag machinery owns — consume it, exactly as the
+        // sourceIsSelf branch does. A below-threshold release is a click, not a drop: it performs
+        // no drop/validate (handled above) but must still be consumed rather than leak to other
+        // handlers. Before the click-vs-drag threshold, sub-pixel motion counted as a drag and this
+        // release was already consumed; preserve that.
+        return true;
     }
     if (type != SDL_MOUSEBUTTONDOWN || (button != SDL_BUTTON_LEFT && button != SDL_BUTTON_RIGHT)) {
         return true;

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -1203,6 +1203,163 @@ void test_list_view_non_draggable_panel_removal_during_input_leaves_no_session_o
     expect_true(!harness.gui->hasPointerCapture(), "panel removal during input must leave no dangling pointer capture");
 }
 
+void test_list_view_below_threshold_motion_stays_a_click_no_proxy_no_drop() {
+    // Deferred source callback path (select returns true) so the click is decided at
+    // release: below-threshold motion must fire the click callback exactly once and
+    // never spawn a proxy, drop, or drag-cancel.
+    auto harness = create_drag_list_harness();
+    harness.source->setSelect("");
+    harness.source->setDragStart("sourceDragStart");
+    harness.source->setDragCancel("sourceDragCancel");
+
+    // Press starts a candidate drag session (drag-start deferred the click).
+    expect_true(harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 25, 25),
+                "source press should be consumed");
+    expect_true(harness.gui->hasDragSession(), "press should create a candidate drag session");
+    expect_true(harness.gui->getDragSession() && !harness.gui->getDragSession()->dragActive,
+                "a fresh session must be a candidate, not an active drag");
+    expect_true(harness.panel->source_clicks == 0, "drag-start should defer the click until release");
+
+    // Below-threshold motion (Chebyshev distance 4 <= threshold) keeps it a candidate.
+    harness.gui->updateDragSession(29, 29);
+    expect_true(harness.gui->getDragSession() && !harness.gui->getDragSession()->dragActive,
+                "below-threshold motion must not promote the session to an active drag");
+
+    // Release below threshold: this is a click. The click callback fires exactly once,
+    // and no drag-cancel is reported.
+    expect_true(harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONUP, SDL_BUTTON_LEFT, 29, 29),
+                "below-threshold release should be consumed");
+    expect_true(harness.panel->source_clicks == 1, "below-threshold release must fire the click callback exactly once");
+    expect_true(harness.panel->drag_cancels == 0, "below-threshold click must not report a drag cancel");
+    expect_true(harness.panel->drops == 0, "below-threshold click must not perform a drop");
+}
+
+void test_list_view_exact_boundary_is_a_click_above_boundary_is_a_drag() {
+    // Exact boundary (Chebyshev distance == threshold) is a click (exclusive boundary).
+    {
+        auto harness = create_drag_list_harness();
+        harness.source->setDragStart("sourceDragStart");
+        harness.source->setDragCancel("sourceDragCancel");
+
+        harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 25, 25);
+        harness.gui->updateDragSession(29, 29); // dx = dy = 4 (exact boundary)
+        harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONUP, SDL_BUTTON_LEFT, 29, 29);
+        expect_true(harness.panel->source_clicks == 1, "exact-boundary motion must stay a click and fire once");
+        expect_true(harness.panel->drag_cancels == 0, "exact-boundary click must not report a drag cancel");
+    }
+
+    // One pixel past the boundary is a drag; with no target the source drag is canceled
+    // and the click callback does not fire.
+    {
+        auto harness = create_drag_list_harness();
+        harness.source->setDragStart("sourceDragStart");
+        harness.source->setDragCancel("sourceDragCancel");
+
+        harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 25, 25);
+        harness.gui->updateDragSession(30, 25); // dx = 5 (above boundary)
+        expect_true(harness.gui->getDragSession() && harness.gui->getDragSession()->dragActive,
+                    "above-boundary motion must promote the session to an active drag");
+        harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONUP, SDL_BUTTON_LEFT, 30, 25);
+        expect_true(harness.panel->drag_cancels == 1, "above-boundary release without a target must call drag-cancel");
+        expect_true(harness.panel->source_clicks == 0, "an active drag must not fire the click callback");
+    }
+}
+
+void test_list_view_negative_and_diagonal_motion_follow_the_rule() {
+    // Negative-axis motion above threshold is a drag.
+    {
+        auto harness = create_drag_list_harness();
+        harness.source->setDragStart("sourceDragStart");
+        harness.source->setDragCancel("sourceDragCancel");
+        // Start away from the edge so a negative offset stays inside the widget.
+        harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 40, 40);
+        harness.gui->updateDragSession(35, 40); // dx = -5
+        expect_true(harness.gui->getDragSession() && harness.gui->getDragSession()->dragActive,
+                    "negative-axis motion above threshold must become a drag");
+    }
+
+    // Diagonal 4/4 stays a click; diagonal 5/5 is a drag.
+    {
+        auto harness = create_drag_list_harness();
+        harness.source->setDragStart("sourceDragStart");
+        harness.source->setDragCancel("sourceDragCancel");
+        harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 20, 20);
+        harness.gui->updateDragSession(24, 24); // diagonal 4/4
+        expect_true(harness.gui->getDragSession() && !harness.gui->getDragSession()->dragActive,
+                    "diagonal 4/4 motion must stay a click");
+        harness.gui->updateDragSession(25, 25); // diagonal 5/5
+        expect_true(harness.gui->getDragSession() && harness.gui->getDragSession()->dragActive,
+                    "diagonal 5/5 motion must become a drag");
+    }
+}
+
+void test_list_view_above_threshold_drop_is_accepted_below_threshold_is_not() {
+    // Above-threshold motion onto a valid target performs the drop.
+    {
+        auto harness = create_drag_list_harness();
+        harness.source->setDragStart("sourceDragStart");
+        harness.source->setDragCancel("sourceDragCancel");
+        harness.target->setDragValidate("targetDragValidate");
+        harness.target->setDrop("targetDrop");
+
+        harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 25, 25);
+        harness.gui->updateDragSession(125, 25); // well past the threshold, over the target
+        expect_true(harness.target->mouseEvent(harness.gui, SDL_MOUSEBUTTONUP, SDL_BUTTON_LEFT, 25, 25),
+                    "above-threshold drop should be consumed by the target");
+        expect_true(harness.panel->drops == 1, "above-threshold motion onto a target must drop exactly once");
+        expect_true(harness.panel->drag_cancels == 0, "an accepted drop must not cancel the source drag");
+    }
+
+    // Below-threshold motion must NOT be treated as a drop even if the release lands on
+    // the target rectangle: it is a click on the source.
+    {
+        auto harness = create_drag_list_harness();
+        harness.source->setDragStart("sourceDragStart");
+        harness.source->setDragCancel("sourceDragCancel");
+        harness.target->setDragValidate("targetDragValidate");
+        harness.target->setDrop("targetDrop");
+
+        harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 25, 25);
+        harness.gui->updateDragSession(27, 25); // dx = 2, below threshold
+        expect_true(harness.target->mouseEvent(harness.gui, SDL_MOUSEBUTTONUP, SDL_BUTTON_LEFT, 25, 25),
+                    "below-threshold release should still be consumed");
+        expect_true(harness.panel->drops == 0, "below-threshold motion must not perform a drop");
+        expect_true(harness.panel->drag_validations == 0, "below-threshold motion must not validate a drop target");
+    }
+}
+
+void test_list_view_below_threshold_candidate_panel_removal_leaves_no_session() {
+    // A candidate (below-threshold) session must be cleared correctly when the owning
+    // panel is removed before the threshold is ever crossed.
+    auto harness = create_drag_list_harness();
+    harness.source->setDragStart("sourceDragStart");
+
+    harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 25, 25);
+    harness.gui->updateDragSession(26, 26); // below threshold: still a candidate
+    expect_true(harness.gui->hasDragSession() && !harness.gui->getDragSession()->dragActive,
+                "press + jitter should leave a candidate session before removal");
+
+    harness.gui->removeChild(harness.panel);
+    expect_true(!harness.gui->hasDragSession(),
+                "panel removal must clear a below-threshold candidate drag session");
+    expect_true(!harness.gui->hasPointerCapture(), "panel removal must clear pointer capture for a candidate session");
+}
+
+void test_list_view_active_drag_panel_removal_leaves_no_session() {
+    // An active (above-threshold) drag session must also be cleared on panel removal.
+    auto harness = create_drag_list_harness();
+    harness.source->setDragStart("sourceDragStart");
+
+    harness.source->mouseEvent(harness.gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 25, 25);
+    harness.gui->updateDragSession(120, 25); // above threshold: active drag
+    expect_true(harness.gui->hasDragSession() && harness.gui->getDragSession()->dragActive,
+                "press + threshold-crossing motion should leave an active drag session");
+
+    harness.gui->removeChild(harness.panel);
+    expect_true(!harness.gui->hasDragSession(), "panel removal must clear an active drag session");
+    expect_true(!harness.gui->hasPointerCapture(), "panel removal must clear pointer capture for an active session");
+}
+
 void test_panel_event_callbacks_stop_after_close() {
     SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
@@ -1638,6 +1795,12 @@ int main() {
     test_list_view_non_draggable_repeated_click_preserves_first_select_second_confirm();
     test_list_view_draggable_default_still_drags_after_non_draggable_change();
     test_list_view_non_draggable_panel_removal_during_input_leaves_no_session_or_capture();
+    test_list_view_below_threshold_motion_stays_a_click_no_proxy_no_drop();
+    test_list_view_exact_boundary_is_a_click_above_boundary_is_a_drag();
+    test_list_view_negative_and_diagonal_motion_follow_the_rule();
+    test_list_view_above_threshold_drop_is_accepted_below_threshold_is_not();
+    test_list_view_below_threshold_candidate_panel_removal_leaves_no_session();
+    test_list_view_active_drag_panel_removal_leaves_no_session();
     test_panel_event_callbacks_stop_after_close();
     test_gui_routes_mouse_motion_to_target_child();
     test_loader_gui_sessions_shutdown_stale_callbacks();

--- a/tests/unit/test_gui_drag_proxy.cpp
+++ b/tests/unit/test_gui_drag_proxy.cpp
@@ -138,26 +138,33 @@ void test_gui_drag_session_serializes_proxy_child_and_removes_it_after_drop_or_c
     auto target = attach_drop_target_recorder(gui);
 
     gui->startDragSession(source, drag_payload(game), 4, 40, 50);
-    auto initial_tree = serialize_gui_tree(gui);
-    const json *initial_proxy = find_serialized_drag_proxy(initial_tree, "15", "25");
-    expect_true(initial_proxy != nullptr, "drag start should attach a serialized proxy child");
-    if (initial_proxy) {
-        expect_true(serialized_layout_value(*initial_proxy, "x") == "15" &&
-                        serialized_layout_value(*initial_proxy, "y") == "25",
-                    "drag proxy should be centered on the start pointer coordinates");
-        expect_true(serialized_layout_value(*initial_proxy, "w") == "50" &&
-                        serialized_layout_value(*initial_proxy, "h") == "50",
-                    "drag proxy should use the GUI tile size for its serialized layout");
-    }
+    // A drag start is only a *candidate*: below-threshold motion (here zero motion at
+    // the start point) must NOT attach a proxy widget, because the interaction is still
+    // a potential click.
+    auto candidate_tree = serialize_gui_tree(gui);
+    expect_true(find_serialized_drag_proxy(candidate_tree) == nullptr,
+                "candidate drag (no threshold-crossing motion) should not attach a proxy child");
 
+    // Motion that stays within the Chebyshev threshold (<= 4 px on both axes) keeps the
+    // session a candidate and still shows no proxy.
+    gui->updateDragSession(44, 54);
+    auto below_threshold_tree = serialize_gui_tree(gui);
+    expect_true(find_serialized_drag_proxy(below_threshold_tree) == nullptr,
+                "below-threshold motion should not attach a drag proxy child");
+
+    // Crossing the threshold (Chebyshev distance > 4) promotes the session to an active
+    // drag and attaches the proxy centered on the current pointer coordinates.
     gui->updateDragSession(90, 110);
     auto moved_tree = serialize_gui_tree(gui);
     const json *moved_proxy = find_serialized_drag_proxy(moved_tree, "65", "85");
-    expect_true(moved_proxy != nullptr, "drag update should keep one serialized proxy child");
+    expect_true(moved_proxy != nullptr, "crossing the movement threshold should attach one serialized proxy child");
     if (moved_proxy) {
         expect_true(serialized_layout_value(*moved_proxy, "x") == "65" &&
                         serialized_layout_value(*moved_proxy, "y") == "85",
                     "drag proxy serialized layout should follow pointer coordinates");
+        expect_true(serialized_layout_value(*moved_proxy, "w") == "50" &&
+                        serialized_layout_value(*moved_proxy, "h") == "50",
+                    "drag proxy should use the GUI tile size for its serialized layout");
     }
 
     gui->acceptDragSession(target);
@@ -167,13 +174,98 @@ void test_gui_drag_session_serializes_proxy_child_and_removes_it_after_drop_or_c
     gui->clearDragSession();
 
     gui->startDragSession(source, drag_payload(game), 5, 60, 70);
+    // Fresh candidate session: no proxy until motion crosses the threshold.
     auto restarted_tree = serialize_gui_tree(gui);
-    expect_true(find_serialized_drag_proxy(restarted_tree, "35", "45") != nullptr,
-                "new drag should attach a fresh serialized proxy child");
+    expect_true(find_serialized_drag_proxy(restarted_tree) == nullptr,
+                "a fresh candidate drag should not attach a proxy child before threshold-crossing motion");
+    gui->updateDragSession(120, 130);
+    auto restarted_active_tree = serialize_gui_tree(gui);
+    expect_true(find_serialized_drag_proxy(restarted_active_tree, "95", "105") != nullptr,
+                "crossing the threshold on the new drag should attach a fresh serialized proxy child");
     gui->cancelDragSession();
     auto canceled_tree = serialize_gui_tree(gui);
     expect_true(find_serialized_drag_proxy(canceled_tree) == nullptr,
                 "canceled drag should remove the serialized proxy child");
+    gui->clearDragSession();
+}
+
+// Drives updateDragSession from a fixed start point to (start + dx, start + dy) and
+// reports whether the session became an active drag. A fresh session is started each
+// time so latching from a previous sample does not leak in.
+bool drag_active_after_offset(const std::shared_ptr<CGui> &gui, const std::shared_ptr<CGameGraphicsObject> &source,
+                              const std::shared_ptr<CGameObject> &payload, int start_x, int start_y, int dx, int dy) {
+    gui->startDragSession(source, payload, 0, start_x, start_y);
+    gui->updateDragSession(start_x + dx, start_y + dy);
+    const bool active = gui->getDragSession() && gui->getDragSession()->dragActive;
+    gui->clearDragSession();
+    return active;
+}
+
+void test_gui_drag_movement_threshold_is_deterministic_chebyshev_boundary() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto game = create_gui_game(gui);
+    auto source = attach_mouse_recorder(gui);
+    auto payload = drag_payload(game);
+
+    const int start_x = 100;
+    const int start_y = 100;
+
+    // Zero movement stays a click.
+    expect_true(!drag_active_after_offset(gui, source, payload, start_x, start_y, 0, 0),
+                "zero movement must not promote the session to a drag");
+
+    // Below threshold on each single axis stays a click (positive and negative).
+    expect_true(!drag_active_after_offset(gui, source, payload, start_x, start_y, 1, 0),
+                "1px x motion must stay a click");
+    expect_true(!drag_active_after_offset(gui, source, payload, start_x, start_y, 0, 3),
+                "3px y motion must stay a click");
+    expect_true(!drag_active_after_offset(gui, source, payload, start_x, start_y, -4, 0),
+                "-4px x motion (exact boundary) must stay a click");
+    expect_true(!drag_active_after_offset(gui, source, payload, start_x, start_y, 0, -4),
+                "-4px y motion (exact boundary) must stay a click");
+
+    // Exact boundary (Chebyshev distance == threshold) is EXCLUSIVE -> still a click,
+    // including the diagonal 4/4 case.
+    expect_true(!drag_active_after_offset(gui, source, payload, start_x, start_y, 4, 4),
+                "diagonal 4/4 motion at the exact boundary must stay a click (exclusive boundary)");
+
+    // Above threshold on either axis becomes a drag (positive, negative, diagonal).
+    expect_true(drag_active_after_offset(gui, source, payload, start_x, start_y, 5, 0),
+                "5px x motion must become a drag");
+    expect_true(drag_active_after_offset(gui, source, payload, start_x, start_y, 0, 5),
+                "5px y motion must become a drag");
+    expect_true(drag_active_after_offset(gui, source, payload, start_x, start_y, -5, 0),
+                "-5px x motion must become a drag (negative axis)");
+    expect_true(drag_active_after_offset(gui, source, payload, start_x, start_y, 0, -5),
+                "-5px y motion must become a drag (negative axis)");
+    expect_true(drag_active_after_offset(gui, source, payload, start_x, start_y, 5, 5),
+                "diagonal 5/5 motion must become a drag");
+    expect_true(drag_active_after_offset(gui, source, payload, start_x, start_y, -6, 3),
+                "diagonal motion is governed by the larger axis (|-6| > 4)");
+}
+
+void test_gui_drag_active_latches_and_survives_below_threshold_return() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto game = create_gui_game(gui);
+    auto source = attach_mouse_recorder(gui);
+
+    gui->startDragSession(source, drag_payload(game), 0, 100, 100);
+    expect_true(gui->getDragSession() && !gui->getDragSession()->dragActive,
+                "a fresh session starts as a candidate (not an active drag)");
+
+    gui->updateDragSession(110, 100); // dx = 10 -> crosses threshold
+    expect_true(gui->getDragSession() && gui->getDragSession()->dragActive,
+                "crossing the threshold must latch the session as an active drag");
+
+    gui->updateDragSession(100, 100); // back to start (below threshold again)
+    expect_true(gui->getDragSession() && gui->getDragSession()->dragActive,
+                "an active drag must not demote back to a click when motion returns below the threshold");
     gui->clearDragSession();
 }
 
@@ -183,6 +275,8 @@ int main() {
     pybind11::scoped_interpreter guard{};
 
     test_gui_drag_session_serializes_proxy_child_and_removes_it_after_drop_or_cancel();
+    test_gui_drag_movement_threshold_is_deterministic_chebyshev_boundary();
+    test_gui_drag_active_latches_and_survives_below_threshold_return();
 
     return finish_tests();
 }


### PR DESCRIPTION
Implements queue row 14 — `[EPIC_03][STORY_01][SUBSTORY_02] #626 Add a real click-versus-drag movement threshold`. Depends on #625 (disable drag for interaction lists), already merged.

## Problem
The drag/click decision (`CListView::dragMoved` and `CGui::syncDragProxyWidget`) treated **any** non-zero displacement as a drag, so one-pixel jitter suppressed clicks and could even trigger a drop; the proxy widget rendered on mouse-down before any real movement.

## Change
- **One canonical threshold** in `src/gui/CGui.h`: `DRAG_MOVEMENT_THRESHOLD = 4` px, **Chebyshev (max-axis) distance**, **exclusive** boundary (`max(|dx|,|dy|) > 4` → drag; 0..4 stays a click; negative axes via abs, diagonal governed by the larger axis). Exposed as `dragThresholdCrossed()` / `isDragActive()`.
- `DragSession::dragActive` is **latched** on first crossing in `updateDragSession` and never demotes back to a click.
- Every click-vs-drag decision routes through the single helper: proxy lifecycle (`syncDragProxyWidget`), and `CListView` source-callback deferral, drop acceptance, and mouse-up branch. Below-threshold motion renders no proxy, allows no drop, and lets the click fire exactly once. Cancellation / window-leave / panel-removal clear both candidate and active sessions.

## Validation
- Adds synthetic native mouse-event unit tests in `tests/unit/test_gui.cpp` and `tests/unit/test_gui_drag_proxy.cpp` (no sleeps/hardware): zero / below / exact-boundary / above motion, negative axes, diagonal, accepted drop, cancellation, and panel removal — asserting below-threshold fires the click once with no proxy/drop, and the boundary is deterministic (4 = click, 5 = drag).
- These compile and run under CI via ctest (`gui_unit_tests` / `gui_drag_proxy_unit_tests`); the native `_game` module can't be built locally, so CI gates this merge.

## Acceptance
Below-threshold stays click; exact boundary deterministic; above-threshold drag; negative/diagonal follow the documented rule; below-threshold callback fires once.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_