### PR TITLE
Fix linux test shard imbalance and premature shard timeouts

### DIFF
--- a/test.py
+++ b/test.py
@@ -20395,9 +20395,18 @@ def test_duration_weight(test_name, timings):
         return 10.0
     if "walkthrough" in test_name:
         return 8.0
+    # Scenario/simulation harnesses and full serialize/save-load round-trips drive
+    # many engine steps and are among the slowest gameplay tests. Without a recorded
+    # timing sample they would otherwise fall through to the generic default below
+    # and be packed onto a single shard, which both unbalances the shards and
+    # under-sizes that shard's timeout (derived from the summed weights).
+    if "scenario_harness" in test_name or "simulation_run" in test_name:
+        return 8.0
+    if "save_load" in test_name or "serialize_clone" in test_name:
+        return 4.0
     if test_name.startswith("McpServerTest."):
         return 6.0
-    return 1.0
+    return 2.5
 
 
 def is_serial_test_name(test_name):
@@ -20467,7 +20476,16 @@ def test_group_timeout_seconds(test_names, timings=None):
     timings = timings or {}
     duration_hint = sum(test_duration_weight(test_name, timings) for test_name in test_names)
     multiplier = 8 if os.environ.get("GAME_COVERAGE_RUN") == "1" else 4
-    return max(30, int(duration_hint * multiplier))
+    # Add fixed headroom and a higher floor so a shard whose tests lack recorded
+    # timing samples (cold cache or newly added tests, weighted by the conservative
+    # defaults in test_duration_weight) is not killed before it can finish and write
+    # real timings. Timings are only persisted on a successful run, so a shard that
+    # is killed early perpetuates its own under-estimate on every retry; allowing it
+    # to complete self-heals the cached timings, after which both shard balancing and
+    # this timeout become accurate. Genuine hangs remain bounded by the job-level
+    # timeout configured in the workflow.
+    headroom = 240 if os.environ.get("GAME_COVERAGE_RUN") == "1" else 120
+    return max(180, int(duration_hint * multiplier) + headroom)
 
 
 def run_test_subprocess(test_names, shard_name, extra_env=None):


### PR DESCRIPTION
## Problem

The Python gameplay/ui test runner (`test.py`) shards tests by summed per-test duration weight and derives **each shard's timeout from that same sum** (`weight * 4`, floor 30s). Tests without a recorded timing sample fall through to a flat **1.0s** default. Several of the slowest gameplay tests — scenario/simulation harnesses (`test_mcp_scenario_harness_drives_*`, `McpServerTest.test_simulation_run_tool_*`), and full serialize/save-load round-trips (`*_save_load_*`, `*serialize_clone*`) — are **not** in `DEFAULT_TEST_DURATIONS` and match no heavy prefix, so they were weighted at 1.0s despite taking several seconds each.

Under-weighting compounds two ways:
1. The greedy balancer **packs** these heavy tests onto a single shard.
2. That shard's **timeout is under-sized**, so it is killed (`exit 124`) before finishing.

Because timings are only persisted on a **successful** run (`write_test_timings` runs only on `return 0`), a shard killed early never records real durations — so every retry reproduced the same under-estimate and the same timeout. This surfaced as repeated `[test shard 3] timed out after ~200s` failures on the `linux` lane for PRs whose branches pulled in recently-added tests, while sibling shards finished 60+ tests in ~54s.

## Change (`test.py`, runner only — no test behavior change)

- **`test_duration_weight`**: weight scenario/simulation harnesses (8s) and serialize/save-load round-trips (4s), and raise the generic fallback from **1.0s → 2.5s** so unknown tests are estimated more conservatively. This both balances the shards and sizes their timeouts realistically.
- **`test_group_timeout_seconds`**: add fixed headroom (120s; 240s under coverage) and raise the floor (30s → 180s) so a shard with cold or partial timing data can finish and **self-heal** the cached timings. Genuine hangs remain bounded by the job-level `timeout-minutes` in the workflow.

## Verification

Replayed the exact 60-test group from a failing shard-3 run through the old vs new logic:

| | balanced shards (est → timeout) |
|---|---|
| **old** | packed: ~39s est → **156s** timeout (real work > 211s → killed) |
| **new** | spread evenly ~62s est → **~370s** timeout per shard |

`python3 -m py_compile test.py` OK; `git diff --check` clean; only `test.py` changed (+20/-2); not run through `black` (file is not black-clean upstream).

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_