### PR TITLE
Add player class and race profile configs with validation (EPIC_06/STORY_02/SUBSTORY_02)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,8 @@ add_native_plugin(native_gameplay native_plugins/native_gameplay.cpp)
 add_dependencies(_game ${NATIVE_PLUGIN_TARGETS})
 
 configure_file(res/config/armors.json config/armors.json)
+configure_file(res/config/classes.json config/classes.json)
+configure_file(res/config/races.json config/races.json)
 configure_file(res/config/panels.json config/panels.json)
 configure_file(res/config/buildings.json config/buildings.json)
 configure_file(res/config/crafting.json config/crafting.json)

--- a/docs/content.md
+++ b/docs/content.md
@@ -100,7 +100,7 @@ it may carry a `slots` object mapping slot ids to item ids.
 | `profileKind`          | yes      | string `"playerRace"` | Marks the entry as a race profile. |
 | `label`                | yes      | non-empty string | Display name. |
 | `baseStatContribution` | yes      | object (stat name → integer) | Base stat contribution of the race. |
-| `tags`                 | no       | array of non-empty strings | Race tags. |
+| `traits`               | no       | array of non-empty strings | Race traits (distinct from canonical gameplay tags). |
 | `resistances`          | no       | object (name → integer) | Damage/effect resistances. |
 | `visual`               | no       | object | Optional visual variation (e.g. an `animation` root). |
 

--- a/docs/content.md
+++ b/docs/content.md
@@ -67,3 +67,41 @@ within it. The validator rejects a declaration when its `path`:
 
 A `path` may not be declared more than once within a single map's `assets`
 array.
+
+## Player class and race profiles (`res/config/classes.json`, `res/config/races.json`)
+
+Player **class** and **race** profiles are data-only config entries that describe
+the composable pieces of a player build. They are intentionally *not* engine
+object configs: each profile omits `class`/`ref`, so the engine's config loader
+skips them (they are read by higher-level class/race code, introduced
+separately). This keeps existing player templates in `res/config/monsters.json`
+working unchanged while the profiles are staged and validated.
+
+Both files are top-level JSON objects keyed by a profile id.
+
+### Class profile (`classes.json`)
+
+| Field              | Required | Type | Description |
+| ------------------ | -------- | ---- | ----------- |
+| `profileKind`      | yes      | string `"playerClass"` | Marks the entry as a class profile. |
+| `label`            | yes      | non-empty string | Display name. |
+| `actions`          | yes      | array of non-empty strings | Base action ids granted by the class. |
+| `levelling`        | yes      | object (level string → action id string) | Actions unlocked per level. |
+| `statContribution` | yes      | object (stat name → integer) | Per-level stat contribution of the class. |
+| `startingEquipment`| yes      | object | Starting equipment policy — see below. |
+
+`startingEquipment` requires a `policy` of `"fixed"` or `"none"`; when `"fixed"`
+it may carry a `slots` object mapping slot ids to item ids.
+
+### Race profile (`races.json`)
+
+| Field                  | Required | Type | Description |
+| ---------------------- | -------- | ---- | ----------- |
+| `profileKind`          | yes      | string `"playerRace"` | Marks the entry as a race profile. |
+| `label`                | yes      | non-empty string | Display name. |
+| `baseStatContribution` | yes      | object (stat name → integer) | Base stat contribution of the race. |
+| `tags`                 | no       | array of non-empty strings | Race tags. |
+| `resistances`          | no       | object (name → integer) | Damage/effect resistances. |
+| `visual`               | no       | object | Optional visual variation (e.g. an `animation` root). |
+
+Unknown top-level keys in a profile are reported so typos are caught.

--- a/res/config/classes.json
+++ b/res/config/classes.json
@@ -1,0 +1,32 @@
+{
+  "warrior": {
+    "profileKind": "playerClass",
+    "label": "Warrior",
+    "actions": ["Attack"],
+    "levelling": {
+      "1": "Strike",
+      "2": "Barrier",
+      "3": "BloodThirst",
+      "4": "Bloodlash",
+      "5": "DeathStrike",
+      "6": "DoubleAttack"
+    },
+    "statContribution": {
+      "strength": 3,
+      "stamina": 2,
+      "agility": 2,
+      "intelligence": 1,
+      "hit": 3,
+      "crit": 1,
+      "dmgMin": 2,
+      "dmgMax": 3
+    },
+    "startingEquipment": {
+      "policy": "fixed",
+      "slots": {
+        "0": "Sword",
+        "3": "PlateArmor"
+      }
+    }
+  }
+}

--- a/res/config/races.json
+++ b/res/config/races.json
@@ -1,0 +1,21 @@
+{
+  "human": {
+    "profileKind": "playerRace",
+    "label": "Human",
+    "baseStatContribution": {
+      "strength": 5,
+      "agility": 5,
+      "stamina": 5,
+      "intelligence": 5,
+      "hit": 75,
+      "crit": 10,
+      "dmgMin": 10,
+      "dmgMax": 12
+    },
+    "tags": ["humanoid"],
+    "resistances": {},
+    "visual": {
+      "animation": "images/players/warrior"
+    }
+  }
+}

--- a/res/config/races.json
+++ b/res/config/races.json
@@ -12,7 +12,7 @@
       "dmgMin": 10,
       "dmgMax": 12
     },
-    "tags": ["humanoid"],
+    "traits": ["humanoid"],
     "resistances": {},
     "visual": {
       "animation": "images/players/warrior"

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -22,6 +22,21 @@ OBJECT_SCHEMA_KEYS = {"class", "ref", "properties"}
 # Recognised kinds for an optional map.json top-level "assets" declaration. Each declared asset
 # is a safe relative path under its own map directory; the kind documents how the entry resolves.
 MAP_ASSET_KINDS = {"file", "directory", "animationRoot", "logicalId"}
+# Player class/race profile config files and their allowed top-level profile keys. Profiles are
+# data-only config entries (no "class"/"ref"), so the engine's config loader skips them; this
+# validator gives them an explicit schema so malformed profiles are still caught.
+PLAYER_CLASS_PROFILE_FILE = "classes.json"
+PLAYER_RACE_PROFILE_FILE = "races.json"
+PLAYER_CLASS_PROFILE_KEYS = {
+    "profileKind",
+    "label",
+    "actions",
+    "levelling",
+    "statContribution",
+    "startingEquipment",
+}
+PLAYER_RACE_PROFILE_KEYS = {"profileKind", "label", "baseStatContribution", "tags", "resistances", "visual"}
+STARTING_EQUIPMENT_POLICIES = {"fixed", "none"}
 SCRIPT_REF_CALLS = {"createObject", "addObjectByName"}
 SCRIPT_ITEM_CALLS = {"addItem"}
 SCRIPT_QUEST_CALLS = {"addQuest", "ensure_quest", "_grant_quest", "grant_quest"}
@@ -1590,6 +1605,7 @@ class ContentValidator:
         self._validate_creature_archetype_naming()
         self._validate_duplicate_player_selectable_race_labels(visible)
         self._validate_required_production_archetypes(visible)
+        self._validate_profile_configs()
 
     def _validate_map_context(self, context: MapContext) -> None:
         visible = self._visible_entries(context)
@@ -2160,6 +2176,97 @@ class ContentValidator:
                 )
                 continue
             self._validate_map_asset_target(context, location, path_value, kind)
+
+    def _validate_profile_configs(self) -> None:
+        for path, data in self.global_files.items():
+            if path.name == PLAYER_CLASS_PROFILE_FILE:
+                self._validate_profile_file(path, data, "playerClass", PLAYER_CLASS_PROFILE_KEYS)
+            elif path.name == PLAYER_RACE_PROFILE_FILE:
+                self._validate_profile_file(path, data, "playerRace", PLAYER_RACE_PROFILE_KEYS)
+
+    def _validate_profile_file(self, path: Path, data: Any, kind: str, allowed_keys: set[str]) -> None:
+        if not isinstance(data, dict):
+            self._issue(path, "$", "expected top-level JSON object")
+            return
+        for profile_id, profile in data.items():
+            self._validate_profile_entry(path, profile_id, profile, kind, allowed_keys)
+
+    def _validate_profile_entry(self, path: Path, profile_id: str, profile: Any, kind: str, allowed: set[str]) -> None:
+        if not isinstance(profile, dict):
+            self._issue(path, profile_id, "expected object")
+            return
+        if profile.get("profileKind") != kind:
+            self._issue(path, f"{profile_id}.profileKind", f'expected "{kind}"')
+        unexpected = sorted(set(profile) - allowed)
+        if unexpected:
+            self._issue(path, profile_id, f"unsupported profile keys: {', '.join(unexpected)}")
+        label = profile.get("label")
+        if not isinstance(label, str) or not label:
+            self._issue(path, f"{profile_id}.label", "expected non-empty string")
+        if kind == "playerClass":
+            self._validate_string_list(path, f"{profile_id}.actions", profile.get("actions"), required=True)
+            self._validate_string_valued_map(path, f"{profile_id}.levelling", profile.get("levelling"), required=True)
+            self._validate_int_valued_map(
+                path, f"{profile_id}.statContribution", profile.get("statContribution"), required=True
+            )
+            self._validate_starting_equipment(path, f"{profile_id}.startingEquipment", profile.get("startingEquipment"))
+        else:
+            self._validate_int_valued_map(
+                path, f"{profile_id}.baseStatContribution", profile.get("baseStatContribution"), required=True
+            )
+            self._validate_string_list(path, f"{profile_id}.tags", profile.get("tags"), required=False)
+            self._validate_int_valued_map(
+                path, f"{profile_id}.resistances", profile.get("resistances"), required=False
+            )
+
+    def _validate_string_list(self, path: Path, location: str, value: Any, *, required: bool) -> None:
+        if value is None:
+            if required:
+                self._issue(path, location, "expected array of non-empty strings")
+            return
+        if not isinstance(value, list):
+            self._issue(path, location, "expected array")
+            return
+        for index, item in enumerate(value):
+            if not isinstance(item, str) or not item:
+                self._issue(path, f"{location}[{index}]", "expected non-empty string")
+
+    def _validate_string_valued_map(self, path: Path, location: str, value: Any, *, required: bool) -> None:
+        if value is None:
+            if required:
+                self._issue(path, location, "expected object of non-empty string values")
+            return
+        if not isinstance(value, dict):
+            self._issue(path, location, "expected object")
+            return
+        for key, item in value.items():
+            if not isinstance(item, str) or not item:
+                self._issue(path, f"{location}.{key}", "expected non-empty string")
+
+    def _validate_int_valued_map(self, path: Path, location: str, value: Any, *, required: bool) -> None:
+        if value is None:
+            if required:
+                self._issue(path, location, "expected object of integer values")
+            return
+        if not isinstance(value, dict):
+            self._issue(path, location, "expected object")
+            return
+        for key, item in value.items():
+            if isinstance(item, bool) or not isinstance(item, int):
+                self._issue(path, f"{location}.{key}", "expected integer")
+
+    def _validate_starting_equipment(self, path: Path, location: str, value: Any) -> None:
+        if value is None:
+            self._issue(path, location, "expected object with a 'policy'")
+            return
+        if not isinstance(value, dict):
+            self._issue(path, location, "expected object")
+            return
+        policy = value.get("policy")
+        if policy not in STARTING_EQUIPMENT_POLICIES:
+            self._issue(path, f"{location}.policy", f"expected one of {sorted(STARTING_EQUIPMENT_POLICIES)}")
+        if "slots" in value:
+            self._validate_string_valued_map(path, f"{location}.slots", value.get("slots"), required=False)
 
     def _validate_map_asset_target(self, context: MapContext, location: str, path_value: str, kind: str) -> None:
         if kind == "logicalId":

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -35,7 +35,7 @@ PLAYER_CLASS_PROFILE_KEYS = {
     "statContribution",
     "startingEquipment",
 }
-PLAYER_RACE_PROFILE_KEYS = {"profileKind", "label", "baseStatContribution", "tags", "resistances", "visual"}
+PLAYER_RACE_PROFILE_KEYS = {"profileKind", "label", "baseStatContribution", "traits", "resistances", "visual"}
 STARTING_EQUIPMENT_POLICIES = {"fixed", "none"}
 SCRIPT_REF_CALLS = {"createObject", "addObjectByName"}
 SCRIPT_ITEM_CALLS = {"addItem"}
@@ -2214,7 +2214,7 @@ class ContentValidator:
             self._validate_int_valued_map(
                 path, f"{profile_id}.baseStatContribution", profile.get("baseStatContribution"), required=True
             )
-            self._validate_string_list(path, f"{profile_id}.tags", profile.get("tags"), required=False)
+            self._validate_string_list(path, f"{profile_id}.traits", profile.get("traits"), required=False)
             self._validate_int_valued_map(
                 path, f"{profile_id}.resistances", profile.get("resistances"), required=False
             )

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -194,7 +194,7 @@ class ContentValidatorTest(unittest.TestCase):
                 "profileKind": "playerRace",
                 "label": "Human",
                 "baseStatContribution": {"strength": 5, "agility": 5},
-                "tags": ["humanoid"],
+                "traits": ["humanoid"],
                 "resistances": {},
                 "visual": {"animation": "images/players/warrior"},
             }
@@ -244,7 +244,7 @@ class ContentValidatorTest(unittest.TestCase):
                     "profileKind": "playerRace",
                     "label": "Human",
                     "baseStatContribution": {"strength": 1.5},
-                    "tags": ["ok", 2],
+                    "traits": ["ok", 2],
                     "resistances": {"fire": True},
                 }
             },
@@ -253,7 +253,7 @@ class ContentValidatorTest(unittest.TestCase):
         issues = validate_repo(root)
 
         self.assertIssueContains(issues, "res/config/races.json", "human.baseStatContribution.strength", "expected integer")
-        self.assertIssueContains(issues, "human.tags[1]", "expected non-empty string")
+        self.assertIssueContains(issues, "human.traits[1]", "expected non-empty string")
         self.assertIssueContains(issues, "human.resistances.fire", "expected integer")
 
     def test_unreachable_dialog_state_reports_dialog_and_state(self):

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -176,6 +176,86 @@ class ContentValidatorTest(unittest.TestCase):
 
         self.assertIssueContains(issues, "assets[1].path", "duplicate asset declaration: shared.id")
 
+    def _valid_class_profile(self):
+        return {
+            "warrior": {
+                "profileKind": "playerClass",
+                "label": "Warrior",
+                "actions": ["Attack"],
+                "levelling": {"1": "Strike", "2": "Barrier"},
+                "statContribution": {"strength": 3, "stamina": 2},
+                "startingEquipment": {"policy": "fixed", "slots": {"0": "Sword"}},
+            }
+        }
+
+    def _valid_race_profile(self):
+        return {
+            "human": {
+                "profileKind": "playerRace",
+                "label": "Human",
+                "baseStatContribution": {"strength": 5, "agility": 5},
+                "tags": ["humanoid"],
+                "resistances": {},
+                "visual": {"animation": "images/players/warrior"},
+            }
+        }
+
+    def test_class_and_race_profiles_valid_pass_validation(self):
+        root = self.make_fixture()
+        write_json(root / "res/config/classes.json", self._valid_class_profile())
+        write_json(root / "res/config/races.json", self._valid_race_profile())
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
+    def test_class_profile_missing_and_mistyped_fields_are_flagged(self):
+        root = self.make_fixture()
+        write_json(
+            root / "res/config/classes.json",
+            {
+                "warrior": {
+                    "profileKind": "playerRace",
+                    "label": "",
+                    "actions": ["Attack", ""],
+                    "statContribution": {"strength": "high"},
+                    "startingEquipment": {"policy": "bogus"},
+                    "extra": 1,
+                }
+            },
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(issues, "res/config/classes.json", "warrior.profileKind", 'expected "playerClass"')
+        self.assertIssueContains(issues, "warrior.label", "expected non-empty string")
+        self.assertIssueContains(issues, "warrior.actions[1]", "expected non-empty string")
+        self.assertIssueContains(issues, "warrior.levelling", "expected object")
+        self.assertIssueContains(issues, "warrior.statContribution.strength", "expected integer")
+        self.assertIssueContains(issues, "warrior.startingEquipment.policy", "expected one of")
+        self.assertIssueContains(issues, "warrior", "unsupported profile keys: extra")
+
+    def test_race_profile_invalid_types_are_flagged(self):
+        root = self.make_fixture()
+        write_json(
+            root / "res/config/races.json",
+            {
+                "human": {
+                    "profileKind": "playerRace",
+                    "label": "Human",
+                    "baseStatContribution": {"strength": 1.5},
+                    "tags": ["ok", 2],
+                    "resistances": {"fire": True},
+                }
+            },
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(issues, "res/config/races.json", "human.baseStatContribution.strength", "expected integer")
+        self.assertIssueContains(issues, "human.tags[1]", "expected non-empty string")
+        self.assertIssueContains(issues, "human.resistances.fire", "expected integer")
+
     def test_unreachable_dialog_state_reports_dialog_and_state(self):
         root = self.make_fixture()
         dialog_path = root / "res/maps/broken/dialog.json"


### PR DESCRIPTION
## Summary

Implements **[EPIC_06][STORY_02][SUBSTORY_02] Add class and race profile configs**. Introduces `res/config/classes.json` and `res/config/races.json` holding data-driven player class/race profiles, plus a validation schema, CMake staging, docs, and fixtures.

This is a **schema proposal** implementing the fields enumerated in the issue — happy to adjust field names/shape in review.

### Why it's safe / additive
Profiles are **data-only** config entries (no `class`/`ref`). The engine's config loader already skips such entries (`CObjectHandler::registerConfig` ignores class-less/ref-less objects), so the game loads them as inert data and existing player templates in `monsters.json` keep working unchanged. Consumption of the profiles by the class/race system is left to later substories per the story ("only after schema review").

### Schema
- **`classes.json`** — a class profile owns its `label`, base `actions`, per-level `levelling` table, per-level `statContribution`, and `startingEquipment` policy (`fixed`/`none`). The seed `warrior` profile mirrors the existing `Warrior` template.
- **`races.json`** — a race profile owns its `label`, `baseStatContribution`, `tags`, `resistances`, and optional `visual` variation. The seed `human` profile matches the default player race id (`DEFAULT_PLAYER_RACE_ID = "human"`).

### Validation
`scripts/validate_content.py` validates each profile file's schema — required fields, value types, allowed starting-equipment policies — and reports unsupported top-level keys so typos are caught.

### Other changes
- `CMakeLists.txt` — stage both files into `config/`.
- `docs/content.md` — document both profile schemas.
- `tests/test_content_validator.py` — fixtures for valid profiles and for missing/mistyped/unknown-key fields.

### Local validation
- `python3 scripts/validate_content.py --repo-root .` → passes (existing content unaffected).
- `python3 -m unittest tests.test_content_validator.ContentValidatorTest` → 107 tests pass, incl. the new profile cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgwwEuSehxkjEsvFNu9fS)_