### PR TITLE
Classify changed paths against the merge-base

### DIFF
--- a/scripts/ci_change_classifier.py
+++ b/scripts/ci_change_classifier.py
@@ -152,9 +152,36 @@ def classifyPaths(paths: Sequence[str], *, forceNative: bool = False) -> ChangeC
     )
 
 
-def changedPaths(base: str, head: str) -> tuple[str, ...]:
+def resolveDiffBase(base: str, head: str) -> str:
+    """Resolve the changed-path diff base to the merge-base of ``base`` and ``head``.
+
+    On a pull request the build workflow passes the base *branch tip*
+    (``pull_request.base.sha``), which advances as other PRs merge into the base
+    branch. Diffing ``base..head`` directly then reports every file merged into
+    the base branch after this PR's branch point as changed, so a lightweight PR
+    is misclassified as native/coverage-needed and incurs unnecessary heavy CI.
+    Diffing from the merge-base restricts detection to the PR's own changes.
+    Falls back to ``base`` when no merge-base can be computed (for example an
+    unrelated or shallow history), preserving the previous behavior.
+    """
+
     result = subprocess.run(
-        ["git", "diff", "--name-only", base, head],
+        ["git", "merge-base", base, head],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    mergeBase = result.stdout.strip()
+    if result.returncode == 0 and mergeBase:
+        return mergeBase
+    return base
+
+
+def changedPaths(base: str, head: str) -> tuple[str, ...]:
+    diffBase = resolveDiffBase(base, head)
+    result = subprocess.run(
+        ["git", "diff", "--name-only", diffBase, head],
         check=True,
         text=True,
         stdout=subprocess.PIPE,

--- a/tests/test_ci_change_classifier.py
+++ b/tests/test_ci_change_classifier.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import io
 import json
+import os
+import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -181,6 +183,50 @@ class CiChangeClassifierTest(unittest.TestCase):
             self.assertEqual("true", values["human-review-required"])
             self.assertEqual("true", values["native-needed"])
             self.assertEqual("true", values["coverage-needed"])
+
+    def test_changed_paths_ignores_files_merged_into_base_after_branch_point(self) -> None:
+        def run_git(repo: Path, *args: str) -> str:
+            return subprocess.run(
+                ["git", *args], cwd=repo, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            ).stdout.strip()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            run_git(repo, "init", "-b", "main")
+            run_git(repo, "config", "user.email", "test@example.invalid")
+            run_git(repo, "config", "user.name", "Classifier Test")
+            (repo / "docs").mkdir()
+            (repo / "docs" / "testing.md").write_text("base\n", encoding="utf-8")
+            run_git(repo, "add", "docs/testing.md")
+            run_git(repo, "commit", "-m", "base")
+
+            # Lightweight docs-only PR branch.
+            run_git(repo, "checkout", "-b", "pr")
+            (repo / "docs" / "testing.md").write_text("changed\n", encoding="utf-8")
+            run_git(repo, "add", "docs/testing.md")
+            run_git(repo, "commit", "-m", "lightweight docs change")
+            pr_head = run_git(repo, "rev-parse", "HEAD")
+
+            # The base branch advances with an unrelated native C++ file merged after
+            # the branch point.
+            run_git(repo, "checkout", "main")
+            (repo / "src").mkdir()
+            (repo / "src" / "CGame.cpp").write_text("int x;\n", encoding="utf-8")
+            run_git(repo, "add", "src/CGame.cpp")
+            run_git(repo, "commit", "-m", "concurrent native merge on base")
+            advanced_base = run_git(repo, "rev-parse", "HEAD")
+
+            old_cwd = Path.cwd()
+            try:
+                os.chdir(repo)
+                paths = ci_change_classifier.changedPaths(advanced_base, pr_head)
+            finally:
+                os.chdir(old_cwd)
+
+        # Only the PR's own file is reported; the concurrently merged src/CGame.cpp
+        # must not be swept in and force native/coverage classification.
+        self.assertEqual(("docs/testing.md",), paths)
+        self.assertFalse(ci_change_classifier.classifyPaths(paths).nativeNeeded)
 
     def test_build_workflow_uses_classifier_outputs_for_native_routing(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/build.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## ⚠️ Authority change — awaiting explicit human review (not auto-merged)

This PR edits `scripts/ci_change_classifier.py`, a CI-validation-authority file (per #934's policy), so it forces native + coverage validation and `human-review-required`. It is **not** self-merged; holding for `@lisu188`.

## Root cause

The build workflow's `classify changed paths` step passes `--base "${{ github.event.pull_request.base.sha }}"` — the base **branch tip**, which advances as other PRs merge into the base branch — and `--head <pr head>` to `ci_change_classifier.py`. `changedPaths()` ran a **two-dot** `git diff --name-only base head`, so every file merged into the base branch after this PR's branch point was reported as changed. A lightweight PR was then misclassified as native/coverage-needed and incurred unnecessary heavy native + windows + coverage CI.

This is the same root cause as the ledger two-dot bug fixed in #943, and resolves the recorded observation `ci-change-classifier-two-dot-base-overclassification` (PR #946).

## Fix

`resolveDiffBase(base, head)` computes `git merge-base base head`; `changedPaths` diffs `<merge-base>..head` instead of `base..head`, restricting detection to the PR's own changes regardless of how far the base has advanced. Falls back to `base` when no merge-base can be computed (unrelated or shallow history), preserving prior behavior. `git`-missing / `OSError` still propagate to `main()`'s existing handlers (exit 2).

For push events the workflow already passes a computed `merge_base` as `--base`, so `merge-base(merge_base, head) == merge_base` — a no-op. `--path`/stdin callers don't reach `changedPaths`, so they're unaffected.

## Evidence

- New regression `test_changed_paths_ignores_files_merged_into_base_after_branch_point`: real git repo, lightweight docs-only PR branch, base advanced with `src/CGame.cpp`; asserts `changedPaths(advanced_base, pr_head) == ("docs/testing.md",)` and `classifyPaths(paths).nativeNeeded is False`. **Fails without the fix** (failures=1), **passes with it**.
- `python3 -m unittest tests.test_ci_change_classifier` → 17 OK
- Focused baseline (workflow_observations + issue_queue + poll_pr_checks + pr_review_audit + controller_resource_audit + coverage_report + prompt_inventory) → OK

## Risks

Low. The change only narrows changed-path detection to the PR's own changes (can only *reduce* over-classification), with a safe fallback to today's behavior when merge-base is unavailable. No classification rule, output contract, or authority logic is altered.

## Manual review items

Authority change requires human review per #934. Independently reviewed for merge-base semantics, fallback/shallow-clone safety, push-path no-op, and unaffected authority self-classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016D8Ra7XE7j7cBsVqzKfbou)_