### PR TITLE
[resolution] Resolve classifier over-classification observation via #1170

### DIFF
--- a/planning/workflow_observations/resolutions/20260630T115959Z-ctrl-vm-17796-c8464bae-2a044064.json
+++ b/planning/workflow_observations/resolutions/20260630T115959Z-ctrl-vm-17796-c8464bae-2a044064.json
@@ -1,0 +1,18 @@
+{
+  "evidence": [
+    {
+      "command": "python3 -m unittest tests.test_ci_change_classifier",
+      "mergedPr": 1170,
+      "result": "17 OK including the merge-base regression"
+    }
+  ],
+  "mergeCommit": "33df1c46dc2779baef8a300ef63d37795b85e335",
+  "mergedPr": 1170,
+  "observationId": "20260630T115959Z-ctrl-vm-17796-c8464bae-2a044064",
+  "resolutionSummary": "Fixed by PR #1170: ci_change_classifier.changedPaths now resolves the diff base to git merge-base(base, head) via resolveDiffBase, so changed-path detection is restricted to the PR's own changes and no longer sweeps in files merged into the base branch after the branch point. Lightweight PRs are no longer misclassified native/coverage-needed when main advances. Regression test_changed_paths_ignores_files_merged_into_base_after_branch_point fails without the fix and passes with it.",
+  "resolvedAtUtc": "2026-07-01T05:50:51Z",
+  "resolver": "optimizer-ctrl-vm-17796-c8464bae",
+  "schemaVersion": 1,
+  "sourceCommit": "949e916928c348e669416e6c7c9cec4213b00a34",
+  "status": "resolved"
+}


### PR DESCRIPTION
## Workflow observation resolution (resolution-only)

Adds one append-only receipt under `planning/workflow_observations/resolutions/`. No source, workbook, or workflow-code change.

- **Resolves:** `20260630T115959Z-ctrl-vm-17796-c8464bae-2a044064` ("ci_change_classifier over-classifies PRs as native when the base branch advances")
- **Status:** resolved · **Merged PR:** #1170 · **Merge commit:** `33df1c4`

### Why this is resolved

The observation's fix — diff changed paths against the merge-base — landed in PR #1170: `changedPaths` now resolves the diff base to `git merge-base(base, head)` via `resolveDiffBase`, so a lightweight PR is no longer misclassified `native`/`coverage`-needed when `main` advances with C++ changes after the branch point.

### Verification

- `resolveDiffBase` present on `main` (`scripts/ci_change_classifier.py`).
- Regression `test_changed_paths_ignores_files_merged_into_base_after_branch_point` fails without the fix, passes with it; `tests.test_ci_change_classifier` → 17 OK.
- #1170 merged with the full native + Windows CI green and independent review.

Append-only; unique receipt path; no existing record or receipt modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016D8Ra7XE7j7cBsVqzKfbou)_