### PR TITLE
Self-heal linux test-shard timings and raise cold-cache timeout

### DIFF
--- a/test.py
+++ b/test.py
@@ -20560,8 +20560,14 @@ def test_group_timeout_seconds(test_names, timings=None):
     # to complete self-heals the cached timings, after which both shard balancing and
     # this timeout become accurate. Genuine hangs remain bounded by the job-level
     # timeout configured in the workflow.
-    headroom = 240 if os.environ.get("GAME_COVERAGE_RUN") == "1" else 120
-    return max(180, int(duration_hint * multiplier) + headroom)
+    # The floor and headroom are deliberately generous: on a cold cache the balancer
+    # can still concentrate the genuinely-slow tests onto one shard (their default
+    # weights understate reality), so that shard must be allowed to run to completion
+    # at least once to record real timings that fix the balance on the next run. A
+    # single observed cold-cache shard needed >320s, so the floor is set well above
+    # that. Genuine hangs remain bounded by the job-level timeout in the workflow.
+    headroom = 420 if os.environ.get("GAME_COVERAGE_RUN") == "1" else 300
+    return max(600, int(duration_hint * multiplier) + headroom)
 
 
 def run_test_subprocess(test_names, shard_name, extra_env=None):
@@ -20672,15 +20678,26 @@ def run_sharded_tests(test_names, jobs, *, allow_xvfb_sidecar=False):
         if return_code != 0:
             failures.append(("xvfb-long", return_code))
 
+    # Persist whatever timings the workers recorded, even when a shard failed or
+    # timed out. Each worker writes its own timings only after it finishes, so a
+    # shard killed on timeout contributes nothing -- but the shards that DID finish
+    # recorded real per-test durations. Writing them unconditionally lets the cached
+    # timings self-heal after a single run: the next run weights those tests
+    # accurately, so the balancer stops concentrating the genuinely-slow tests onto
+    # one shard and stops under-sizing that shard's timeout. Writing only on overall
+    # success meant one slow shard discarded every other shard's real timings and the
+    # cold-cache under-estimate was reproduced on every retry.
+    combined_timings = {}
+    for timings_path in (TEST_OUTPUT_DIR / "workers").glob("*/test-timings.json"):
+        combined_timings.update(load_test_timings(timings_path))
+    if combined_timings:
+        write_test_timings(TEST_TIMINGS_FILE, combined_timings)
+
     if failures:
         for shard_name, return_code in failures:
             print(f"[test shard {shard_name}] failed with exit code {return_code}", file=sys.stderr, flush=True)
         return 1
 
-    combined_timings = {}
-    for timings_path in (TEST_OUTPUT_DIR / "workers").glob("*/test-timings.json"):
-        combined_timings.update(load_test_timings(timings_path))
-    write_test_timings(TEST_TIMINGS_FILE, combined_timings)
     return 0
 
 


### PR DESCRIPTION
## Follow-up to #1164

#1164 improved shard weighting and raised the per-shard timeout, but the `linux` lane can still fail on a **cold timings cache**: with no recorded durations, the balancer concentrates the genuinely-slow gameplay tests (walkthroughs, scenario harnesses, save/load round-trips) onto one shard whose default weights understate reality. That shard then exceeds even the raised timeout and is killed (`exit 124`) while sibling shards finish 60 tests in ~50s. Observed on a rebased PR: `[test shard 2] timed out after 322s` (the timeout did rise from ~211s, but not enough), the three other shards `OK`.

The deadlock is structural: **timings are written only on overall success**, so one slow shard discards every other shard's real timings, and the cold-cache under-estimate recurs on every retry — the cache never populates to fix the balance.

## Changes (`test.py`, runner only — no test behavior change)

- **`run_sharded_tests`** now persists the combined worker timings **even when a shard fails or times out**. Workers that finished recorded real per-test durations; writing them unconditionally lets the cached timings self-heal after a single run, so the next run weights those tests accurately and the balancer stops piling the slow tests onto one shard. (`actions/cache`'s post-step caches the file regardless of job status, so this carries across runs via the existing `restore-keys`.)
- **`test_group_timeout_seconds`** raises the floor to **600s** (300s headroom; 420s under coverage) so a cold-cache shard that still draws a heavy concentration can run to completion at least once and record the timings that fix the balance. The observed failing shard needed >320s. Genuine hangs remain bounded by the job-level `timeout-minutes`.

## Verification

`python3 -m py_compile test.py` OK; `git diff --check` clean; only `test.py` changed (+23/-6); not run through `black` (file is not black-clean upstream). New timeout for the failing ~50s-estimate shard: **600s** (was 322s).

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_