### PR TITLE
Gate Wayfarer/Inquisitor dialog routes on playerClassId (EPIC_06/STORY_03/SUBSTORY_02)

### DIFF
--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -747,7 +747,10 @@ def load(self, context):
 
         def can_chart_wayfarer_route(self):
             player = self.getGame().getMap().getPlayer()
-            return player.getTypeId() == "Wayfarer" and not player.getBoolProperty("charted_smuggler_route")
+            # Gate on the class identity (playerClassId) rather than the raw type id; getPlayerClassId
+            # falls back to the type id for players saved before the identity model, so existing
+            # Wayfarer saves keep working while explicit class identities are honored.
+            return player.getPlayerClassId() == "Wayfarer" and not player.getBoolProperty("charted_smuggler_route")
 
         def chart_wayfarer_route(self):
             player = self.getGame().getMap().getPlayer()
@@ -839,7 +842,10 @@ def load(self, context):
 
         def can_inspect_stained_glass(self):
             player = self.getGame().getMap().getPlayer()
-            return player.getTypeId() == "Inquisitor" and not player.getBoolProperty("inspected_stained_glass")
+            # Gate on the class identity (playerClassId) with type-id fallback for pre-identity saves.
+            return player.getPlayerClassId() == "Inquisitor" and not player.getBoolProperty(
+                "inspected_stained_glass"
+            )
 
         def inspect_stained_glass(self):
             player = self.getGame().getMap().getPlayer()

--- a/test.py
+++ b/test.py
@@ -13772,6 +13772,7 @@ class GameTest(unittest.TestCase):
             "wayfarer_condition_method": "def can_chart_wayfarer_route(self):" in script,
             "wayfarer_action_method": "def chart_wayfarer_route(self):" in script,
             "wayfarer_player_property": "wayfarer_routes" in script,
+            "wayfarer_condition_uses_class_id": 'player.getPlayerClassId() == "Wayfarer"' in script,
             "wayfarer_dialog_option": any(
                 option.get("properties", {}).get("condition") == "can_chart_wayfarer_route"
                 and option.get("properties", {}).get("action") == "chart_wayfarer_route"
@@ -13780,6 +13781,7 @@ class GameTest(unittest.TestCase):
             "inquisitor_condition_method": "def can_inspect_stained_glass(self):" in script,
             "inquisitor_action_method": "def inspect_stained_glass(self):" in script,
             "inquisitor_player_property": "inquisitor_clues" in script,
+            "inquisitor_condition_uses_class_id": 'player.getPlayerClassId() == "Inquisitor"' in script,
             "inquisitor_dialog_option": any(
                 option.get("properties", {}).get("condition") == "can_inspect_stained_glass"
                 and option.get("properties", {}).get("action") == "inspect_stained_glass"
@@ -13892,6 +13894,58 @@ class GameTest(unittest.TestCase):
                 "asked_about_girl": game_map.getBoolProperty("ASKED_ABOUT_GIRL"),
             }
 
+        return True, json.dumps(results, sort_keys=True)
+
+    @game_test
+    def test_nouraajd_class_dialogs_honor_player_class_id_over_type(self):
+        # After the identity migration, class-specific dialog routes gate on the player's class
+        # identity (playerClassId) rather than the raw type id. A player whose type id is not the
+        # class type but whose playerClassId names the class should unlock the route and accumulate
+        # its progression counter/flag; the raw type id alone must not unlock it beforehand.
+        cases = [
+            {
+                "class_id": "Wayfarer",
+                "dialog_type": "townHallDialog",
+                "condition": "can_chart_wayfarer_route",
+                "action": "chart_wayfarer_route",
+                "counter": "wayfarer_routes",
+                "flag": "charted_smuggler_route",
+            },
+            {
+                "class_id": "Inquisitor",
+                "dialog_type": "berenDialog",
+                "condition": "can_inspect_stained_glass",
+                "action": "inspect_stained_glass",
+                "counter": "inquisitor_clues",
+                "flag": "inspected_stained_glass",
+            },
+        ]
+        results = {}
+        for case in cases:
+            g, game_map, player = load_game_map_with_player("nouraajd", "Warrior")
+            dialog = g.createObject(case["dialog_type"])
+
+            # A plain Warrior type id must not unlock the class-specific route.
+            self.assertFalse(getattr(dialog, case["condition"])())
+
+            # Assigning the class identity unlocks it via getPlayerClassId().
+            player.setPlayerClassId(case["class_id"])
+            self.assertEqual(case["class_id"], player.getPlayerClassId())
+            self.assertTrue(getattr(dialog, case["condition"])())
+
+            getattr(dialog, case["action"])()
+            self.assertFalse(getattr(dialog, case["condition"])())
+            self.assertEqual(1, player.getNumericProperty(case["counter"]))
+            self.assertTrue(player.getBoolProperty(case["flag"]))
+
+            # Re-running the action after the flag is set is idempotent.
+            getattr(dialog, case["action"])()
+            self.assertEqual(1, player.getNumericProperty(case["counter"]))
+
+            results[case["class_id"]] = {
+                "counter": player.getNumericProperty(case["counter"]),
+                "flag": player.getBoolProperty(case["flag"]),
+            }
         return True, json.dumps(results, sort_keys=True)
 
     @game_test


### PR DESCRIPTION
## Summary

Implements **[EPIC_06][STORY_03][SUBSTORY_02] Audit class-specific dialogs and actions**. (Re-opened as a fresh PR after #1177's CI failed to trigger the native build workflow.)

Audits the class-specific dialog routes so they resolve the player's class through the identity model instead of the raw type id:
- `TownHallDialog.can_chart_wayfarer_route` and `BerenDialog.can_inspect_stained_glass` now compare `player.getPlayerClassId()` rather than `player.getTypeId()`.

`getPlayerClassId()` falls back to the type id for players saved before the identity model, so **existing Wayfarer/Inquisitor saves keep unlocking their routes** while explicit class identities are honored (old-save fallback preserved). The `chart_wayfarer_route` / `inspect_stained_glass` actions gate on the `can_` methods and are covered transitively; the progression properties (`wayfarer_routes` / `inquisitor_clues` and their flags) are unchanged.

The named class-scaling interactions (`ExposeCorruption`, `SanctifiedWard`, `WayfarersStride`, `SmugglersMark`) already scale off those **progression counters** rather than class identity, so they preserve progression properties and need no change — the audit confirmed this.

## Tests
- `test_nouraajd_class_dialogs_honor_player_class_id_over_type` — a plain `Warrior` does not unlock the routes until its `playerClassId` is set to `Wayfarer`/`Inquisitor`, after which the route unlocks and its counter/flag accumulate (and re-running stays idempotent).
- Static-source checks pinning the `getPlayerClassId` gating.
- The existing `test_nouraajd_class_specific_dialog_routes_unlock_for_type_ids` continues to cover the type-id path via the fallback.

## Validation
- `python3 scripts/validate_content.py --repo-root .` → passes.
- Migration is behavior-preserving for existing type-based players.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgwwEuSehxkjEsvFNu9fS)_