### PR TITLE
Add Curse canonical gameplay tag

### DIFF
--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -389,6 +389,7 @@ void init_game_module(py::module_ &m) {
 
     py::enum_<CTag>(m, "CTag", "Canonical gameplay tag identifier.")
         .value("BUFF", CTag::Buff)
+        .value("CURSE", CTag::Curse)
         .value("HEAL", CTag::Heal)
         .value("MANA", CTag::Mana)
         .value("QUEST", CTag::Quest)

--- a/src/core/CTags.cpp
+++ b/src/core/CTags.cpp
@@ -26,8 +26,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 namespace {
 using TagDefinition = std::pair<CTag, std::string_view>;
 
-const std::array<TagDefinition, 6> TAG_DEFINITIONS = {{
+const std::array<TagDefinition, 7> TAG_DEFINITIONS = {{
     {CTag::Buff, "buff"},
+    {CTag::Curse, "curse"},
     {CTag::Heal, "heal"},
     {CTag::Mana, "mana"},
     {CTag::Quest, "quest"},

--- a/src/core/CTags.h
+++ b/src/core/CTags.h
@@ -28,6 +28,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 enum class CTag {
     Buff,
+    Curse,
     Heal,
     Mana,
     Quest,

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -593,6 +593,19 @@ void test_tag_round_trip_and_ordering() {
         expect_true(CTags::fromString(text) == tag, "Tag conversion should round-trip between enum and string");
     }
 
+    // Curse is a canonical tag (the negative counterpart to Buff): it maps to "curse", round-trips,
+    // and is distinct from the other tags.
+    expect_true(CTags::toString(CTag::Curse) == "curse", "Curse should serialize to the canonical string \"curse\"");
+    expect_true(CTags::fromString("curse") == CTag::Curse, "\"curse\" should parse back to CTag::Curse");
+    expect_true(CTag::Curse != CTag::Buff, "Curse must be a distinct tag from Buff");
+    expect_true(std::find(CTags::all().begin(), CTags::all().end(), CTag::Curse) != CTags::all().end(),
+                "Curse should be enumerated among the canonical tags");
+
+    CTags curseTags;
+    curseTags.insert(CTag::Curse);
+    expect_true(curseTags.contains(CTag::Curse) && !curseTags.contains(CTag::Buff),
+                "A CTags set should track Curse independently of Buff");
+
     CTags tags;
     tags.insert(CTag::Quest);
     tags.insert(CTag::Buff);


### PR DESCRIPTION
## Summary

Adds a **`Curse`** tag to the canonical `CTag` enum — the negative counterpart to `Buff`.

`Buff` marks a beneficial, self-targeted effect (in `CInteraction::onAction`, `Buff`-tagged effects apply to the caster); `Curse` marks a harmful one. Non-buff effects already target the victim by default, so a `Curse`-tagged effect lands on the enemy with **no behavioral wiring change** — `Curse` is a canonical marker that content and future mechanics (curse cleansing/resistance, AI targeting) can key off, exactly like the other tags.

## Changes
- **`CTags.h` / `CTags.cpp`** — add `CTag::Curse` and its `"curse"` string definition (keeping the tag list alphabetical), and grow `TAG_DEFINITIONS` to 7 entries.
- **`CModule.cpp`** — expose `CTag.CURSE` through the pybind `CTag` enum, so scripts/configs can tag effects as curses (and the `"curse"` authored-tag string becomes canonical).
- **`test_core.cpp`** — assert `Curse` maps to `"curse"`, round-trips, is distinct from `Buff`, is enumerated by `CTags::all()`, and is tracked independently in a `CTags` set.

## Safety
Purely additive: no `switch` over `CTag` exists to break exhaustiveness, the build uses `-Wall` without `-Werror`, and existing content still validates (`scripts/validate_content.py` passes — nothing uses `"curse"` yet, and it's now an accepted canonical tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgwwEuSehxkjEsvFNu9fS)_