### PR TITLE
Fix build.yml startup failure from runner.temp in job-level env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,7 +355,6 @@ jobs:
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}\vcpkg_installed\fast
       VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}\cmake\triplets
       VCPKG_TARGET_TRIPLET: x64-windows-release
-      WINDOWS_FAST_TOOLS_DIR: ${{ runner.temp }}\windows-fast-tools\bin
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Set up Python
@@ -418,9 +417,10 @@ jobs:
           $ErrorActionPreference = "Stop"
 
           # Trusted tools must live OUTSIDE the (possibly attacker-controlled) PR
-          # workspace so a committed tool shim can never be picked up. Refuse to
-          # proceed if the configured tools directory is inside the workspace.
-          $toolsDir = $env:WINDOWS_FAST_TOOLS_DIR
+          # workspace so a committed tool shim can never be picked up. The runner
+          # temp dir is outside the workspace; refuse to proceed if the resolved
+          # tools directory is ever inside the workspace anyway.
+          $toolsDir = Join-Path $env:RUNNER_TEMP "windows-fast-tools\bin"
           $workspaceFull = [System.IO.Path]::GetFullPath($env:GITHUB_WORKSPACE)
           $toolsDirFull = [System.IO.Path]::GetFullPath($toolsDir)
           if ($toolsDirFull.StartsWith($workspaceFull, [System.StringComparison]::OrdinalIgnoreCase)) {

--- a/tests/security/test_configure_supply_chain.py
+++ b/tests/security/test_configure_supply_chain.py
@@ -134,20 +134,28 @@ class ConfigureSupplyChainTest(unittest.TestCase):
 
     def test_windows_fast_tools_directory_is_outside_workspace(self):
         workflow_text = (REPO_ROOT / ".github" / "workflows" / "build.yml").read_text()
-
-        # Trusted downloaded tools (sccache) must live outside the PR workspace so a
-        # workspace-committed tool shim can never be discovered or executed.
-        match = re.search(r"(?m)^\s*WINDOWS_FAST_TOOLS_DIR:\s*(?P<value>.+?)\s*$", workflow_text)
+        match = re.search(
+            r"(?ms)- &setup-windows-fast-tools\n.*?name: Set up Windows fast tools\n(?P<body>.*?)(?=^      - )",
+            workflow_text,
+        )
         self.assertIsNotNone(match)
-        value = match.group("value")
-        self.assertIn("runner.temp", value)
-        self.assertNotIn("github.workspace", value)
-        self.assertNotIn(".windows-tools", value)
+        body = match.group("body")
+
+        # Trusted downloaded tools (sccache) must live in the runner temp dir, which
+        # is outside the PR workspace, so a workspace-committed tool shim can never be
+        # discovered or executed. The `runner` context is not available in job-level
+        # `env:`, so the directory must be resolved from $env:RUNNER_TEMP in the step.
+        self.assertRegex(
+            body,
+            re.compile(r"""\$toolsDir\s*=\s*Join-Path\s+\$env:RUNNER_TEMP\s+["']windows-fast-tools"""),
+        )
+        self.assertNotIn(".windows-tools", body)
+        self.assertNotIn("Join-Path $env:GITHUB_WORKSPACE", body)
 
         # The setup step must fail closed if the tools dir is ever inside the workspace.
         self.assertIn(
             "Refusing to use a fast-tools directory inside the workspace",
-            workflow_text,
+            body,
         )
 
     def test_windows_sccache_is_hash_verified_unconditionally(self):


### PR DESCRIPTION
## Problem

Every `push`-to-`main` run of `build.yml` was failing **instantly with zero jobs** — a GitHub Actions **startup failure**, not a test failure:

> `Unrecognized named-value: 'runner'. Located at position 1 within expression: runner.temp` (build.yml line 358)

The shared Windows job env anchor (`&windows-env`, used by `windows-deps` and `windows`) set:

```yaml
WINDOWS_FAST_TOOLS_DIR: ${{ runner.temp }}\windows-fast-tools\bin
```

The `runner` context is **not available in job-level `env:`** — only inside steps. GitHub evaluated it eagerly whenever those jobs were scheduled (`native-needed == 'true'`, which happens on main pushes) and rejected the whole workflow. Pull-request runs that skipped the Windows jobs never evaluated the expression, so they passed — which is why `main` stayed red on every push while PRs kept merging. The invalid expression was introduced by the Windows CI hardening change (#1064) and was locked in by a security test that required the value to contain `runner.temp`.

## Fix

- **`.github/workflows/build.yml`**: drop the invalid `WINDOWS_FAST_TOOLS_DIR` job-level env key and resolve the tools directory from `$env:RUNNER_TEMP` inside the shared *"Set up Windows fast tools"* step. The path is byte-identical (`RUNNER_TEMP\windows-fast-tools\bin`), stays outside the workspace, and the fail-closed in-workspace guard is unchanged.
- **`tests/security/test_configure_supply_chain.py`**: update `test_windows_fast_tools_directory_is_outside_workspace` to assert the runner-temp derivation and the guard against the new step construction, instead of pinning the invalid `runner.temp` expression.

## Validation

- `build.yml` parses; no `runner.temp` references remain in job-level env; both Windows jobs still share the full env via the anchor.
- All 15 `tests.security.test_configure_supply_chain` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgfqcdgwR74njdPgTzHmkL)_