### PR TITLE
Compose race/class archetype actions in getEffectiveInteractions

### DIFF
--- a/docs/design/creature_archetypes.md
+++ b/docs/design/creature_archetypes.md
@@ -338,6 +338,19 @@ specific) action. This contract is pinned by the native regression test
 `test_creature_action_merge_dedupes_by_type_id` in
 `tests/unit/test_object.cpp`.
 
+The four-source composition itself is implemented by
+`CCreature::getEffectiveInteractions` (`src/object/CCreature.cpp`), which folds
+the sources in precedence order — `race.actions`, then `creatureClass.actions`,
+then `creatureClass.levelling` (level-gated), then the concrete template's own
+`levelling` (level-gated) and `actions` — and deduplicates by the key above with
+last/most-specific winning. Each archetype reference is independently
+null-guarded, so a legacy creature with neither a race nor a `creatureClass`
+composes only its own concrete sources. This composition is pinned by
+`test_creature_effective_interactions_compose_archetype_sources` (race/class
+sources fold in at the documented positions, including the legacy no-archetype
+path) alongside `test_creature_effective_interactions_compose_and_dedupe_sources`
+in `tests/unit/test_object.cpp`.
+
 ---
 
 # Creature stat precedence contract

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -159,23 +159,24 @@ std::set<std::shared_ptr<CInteraction>> CCreature::getInteractions() { return ge
 
 std::set<std::shared_ptr<CInteraction>> CCreature::getEffectiveInteractions() {
     // Composes the creature's effective interaction set from every source that
-    // backs it today, de-duplicated so identical actions are never exposed
-    // twice. Dedupe key is the action typeId, falling back to its name when the
-    // typeId is empty (matching the identity rules CGameObject uses elsewhere).
+    // backs it, de-duplicated so identical actions are never exposed twice.
+    // Dedupe key is the action typeId, falling back to its name when the typeId
+    // is empty (matching the identity rules CGameObject uses elsewhere).
     //
-    // Precedence (lowest first, so later sources override earlier duplicates):
-    //   1. race actions          -- extension point (no backing object yet)
-    //   2. creature-class actions -- extension point (no backing object yet)
-    //   3. class level unlocks    -- levelling entries unlocked up to the
-    //                                current level (the model expresses class
-    //                                level unlocks through `levelling` today)
-    //   4. concrete own actions   -- the creature's own configured actions win
+    // Precedence (docs/design/creature_archetypes.md, "Creature action merge
+    // contract"), lowest first so later sources override earlier duplicates:
+    //   1. race innate actions      -- race.actions (null on legacy creatures)
+    //   2. class starting actions   -- creatureClass.actions (null on legacy)
+    //   3. class level unlocks       -- creatureClass.levelling entries unlocked
+    //                                   up to the current level
+    //   4. concrete template         -- the creature's own levelling unlocks then
+    //                                   its own configured actions (most specific)
     //
-    // Race / creature-class archetype objects (CCreatureClass) do not exist in
-    // the codebase yet, so there is nothing to pull their actions from. The
-    // ordered composition below is structured so those sources slot in ahead of
-    // the level unlocks once the archetype foundation lands, without changing
-    // the concrete-actions-win precedence.
+    // The race / creatureClass archetype references are independently null: a
+    // legacy creature (neither set) contributes nothing from positions 1-3 and
+    // composes exactly the concrete-template sources, matching the legacy
+    // behavior. When present, archetype sources slot in ahead of the concrete
+    // template without changing the concrete-actions-win precedence.
 
     std::vector<std::shared_ptr<CInteraction>> ordered;
 
@@ -187,30 +188,51 @@ std::set<std::shared_ptr<CInteraction>> CCreature::getEffectiveInteractions() {
         return "N:" + action->getName();
     };
 
-    // 1-2. race / creature-class actions: extension point. Nothing to add until
-    //      the archetype foundation provides those objects.
+    // Appends every levelling entry whose unlock level is at or below the current
+    // level. Keys are the level at which the entry unlocks (see getLevelAction /
+    // levelUp); a non-numeric key is treated as ungated so no configured action
+    // is silently dropped.
+    auto appendUnlockedLevelling = [&](const CInteractionMap &source) {
+        for (const auto &[levelKey, action] : source) {
+            if (!action) {
+                continue;
+            }
+            int unlockLevel = 0;
+            try {
+                unlockLevel = std::stoi(levelKey);
+            } catch (...) {
+                unlockLevel = 0;
+            }
+            if (unlockLevel <= level) {
+                ordered.push_back(action);
+            }
+        }
+    };
 
-    // 3. class level unlocks: levelling entries unlocked up to the current
-    //    level. Keys are the level at which the entry unlocks (see
-    //    getLevelAction / levelUp).
-    for (const auto &[levelKey, action] : levelling) {
-        if (!action) {
-            continue;
-        }
-        int unlockLevel = 0;
-        try {
-            unlockLevel = std::stoi(levelKey);
-        } catch (...) {
-            // Non-numeric levelling keys are not level-gated unlocks; include
-            // them so no configured action is silently dropped.
-            unlockLevel = 0;
-        }
-        if (unlockLevel <= level) {
-            ordered.push_back(action);
+    // 1. race innate actions.
+    if (race) {
+        for (const auto &action : race->getActions()) {
+            if (action) {
+                ordered.push_back(action);
+            }
         }
     }
 
-    // 4. concrete own actions: added last so they win duplicate-key conflicts.
+    // 2. class starting actions.
+    if (creatureClass) {
+        for (const auto &action : creatureClass->getActions()) {
+            if (action) {
+                ordered.push_back(action);
+            }
+        }
+        // 3. class level unlocks: the class's own levelling map, level-gated.
+        appendUnlockedLevelling(creatureClass->getLevelling());
+    }
+
+    // 4a. concrete template level unlocks: the creature's own levelling map.
+    appendUnlockedLevelling(levelling);
+
+    // 4b. concrete own actions: added last so they win duplicate-key conflicts.
     for (const auto &action : actions) {
         if (action) {
             ordered.push_back(action);

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "handler/CTooltipHandler.h"
 #include "object/CCreature.h"
 #include "object/CCreatureClass.h"
+#include "object/CCreatureRace.h"
 #include "object/CDialog.h"
 #include "object/CEffect.h"
 #include "object/CGameObject.h"
@@ -932,6 +933,80 @@ void test_creature_effective_interactions_compose_and_dedupe_sources() {
     expect_true(creature->getInteractions() == effective,
                 "getInteractions should delegate to the effective, de-duplicated interaction set");
 }
+void test_creature_effective_interactions_compose_archetype_sources() {
+    // Pins that getEffectiveInteractions folds the race/class archetype sources
+    // into the composed set at the documented precedence positions
+    // (docs/design/creature_archetypes.md, "Creature action merge contract"):
+    //   1. race innate -> 2. class starting -> 3. class level unlocks ->
+    //   4. concrete template (own levelling then own actions), most-specific wins.
+    auto interaction = [](const std::string &typeId, const std::string &name) {
+        auto action = std::make_shared<CInteraction>();
+        action->setType("CInteraction");
+        action->setTypeId(typeId);
+        action->setName(name);
+        return action;
+    };
+
+    auto creature = std::make_shared<CCreature>();
+    creature->setLevel(2);
+
+    // (1) race innate: a generic Attack and a race-only ability.
+    auto raceAttack = interaction("Attack", "raceAttack");
+    auto raceClaw = interaction("Claw", "raceClaw");
+    auto race = std::make_shared<CCreatureRace>();
+    race->setActions({raceAttack, raceClaw});
+    creature->setRace(race);
+
+    // (2) class starting: a duplicate Attack overriding the race's Attack.
+    auto classAttack = interaction("Attack", "classAttack");
+    // (3) class level unlocks: one unlocked at the current level, one gated above it.
+    auto classStrike = interaction("Strike", "classStrike");
+    auto classUltimate = interaction("Ultimate", "classUltimate");
+    auto klass = std::make_shared<CCreatureClass>();
+    klass->setActions({classAttack});
+    CInteractionMap classLevelling;
+    classLevelling["1"] = classStrike;
+    classLevelling["5"] = classUltimate;
+    klass->setLevelling(classLevelling);
+    creature->setCreatureClass(klass);
+
+    // (4) concrete template: the most specific Attack override plus a unique action.
+    auto concreteAttack = interaction("Attack", "concreteAttack");
+    auto concreteFinisher = interaction("Finisher", "concreteFinisher");
+    creature->addAction(concreteAttack);
+    creature->addAction(concreteFinisher);
+
+    auto effective = creature->getEffectiveInteractions();
+    auto contains = [&effective](const std::shared_ptr<CInteraction> &action) {
+        return effective.find(action) != effective.end();
+    };
+    auto count_with_type = [&effective](const std::string &typeId) {
+        return std::count_if(effective.begin(), effective.end(),
+                             [&typeId](const auto &action) { return action && action->getTypeId() == typeId; });
+    };
+
+    // Attack is defined by race, class and concrete sources; only the concrete
+    // (most-specific) definition survives, exactly once.
+    expect_true(count_with_type("Attack") == 1,
+                "Attack duplicated across race/class/concrete should collapse to one entry");
+    expect_true(contains(concreteAttack) && !contains(raceAttack) && !contains(classAttack),
+                "the concrete Attack should win over the race and class definitions");
+    // Unique actions from every source are preserved.
+    expect_true(contains(raceClaw), "race innate actions should be exposed in the composed set");
+    expect_true(contains(classStrike), "class level unlocks at/below current level should be exposed");
+    expect_true(contains(concreteFinisher), "unique concrete actions should be exposed");
+    // The class level unlock gated above the current level is withheld.
+    expect_true(!contains(classUltimate), "class level unlocks above the current level should not be exposed");
+    expect_true(effective.size() == 4,
+                "composed set should be Attack (concrete) + Claw + Strike + Finisher");
+
+    // Legacy creature (no race, no class) still composes only its own sources.
+    auto legacy = std::make_shared<CCreature>();
+    legacy->addAction(interaction("Attack", "legacyAttack"));
+    auto legacyEffective = legacy->getEffectiveInteractions();
+    expect_true(legacyEffective.size() == 1,
+                "a creature with no race/class should compose only its own actions");
+}
 void test_creature_action_merge_dedupes_by_type_id() {
     // Pins the approved creature action merge contract
     // (docs/design/creature_archetypes.md, "Creature action merge contract"):
@@ -1565,6 +1640,7 @@ int main() {
     test_creature_class_main_stat_is_authoritative_over_race();
     test_creature_archetype_identity_accessors_use_fallbacks();
     test_creature_effective_interactions_compose_and_dedupe_sources();
+    test_creature_effective_interactions_compose_archetype_sources();
     test_creature_action_merge_dedupes_by_type_id();
     test_creature_duplicate_attack_from_race_and_class_collapses_to_single_identity();
     test_no_archetype_creature_level_up_mutates_actions_via_levelling();


### PR DESCRIPTION
## Summary

Implements the four-source action merge that was previously stubbed out in `CCreature::getEffectiveInteractions`. The race/class archetype objects (`CCreatureRace`, `CCreatureClass`) already existed and were wired into `CCreature`, and the stat-composition side was implemented — but the action-composition path still treated race/class actions as an "extension point (no backing object yet)".

## Changes

- **`src/object/CCreature.cpp`** — `getEffectiveInteractions()` now folds all four sources in the precedence order from the "Creature action merge contract" (`docs/design/creature_archetypes.md`), lowest → highest:
  1. `race->getActions()` — race innate actions
  2. `creatureClass->getActions()` — class starting actions
  3. `creatureClass->getLevelling()` — class level unlocks, gated to the current level
  4. concrete template: the creature's own `levelling` (level-gated) then its own `actions` (most-specific, wins dedupe)

  Each archetype reference is independently null-guarded, so a legacy creature with neither a race nor a `creatureClass` composes only its own concrete sources — identical to prior behavior. The `std::stoi` level-gating is factored into a shared `appendUnlockedLevelling` helper reused for both the class and concrete levelling maps.

- **`tests/unit/test_object.cpp`** — adds `test_creature_effective_interactions_compose_archetype_sources`, pinning: concrete `Attack` overriding both the race and class `Attack`, unique race/class/concrete actions preserved, an above-level class unlock withheld, and the legacy no-archetype path composing only its own actions.

- **`docs/design/creature_archetypes.md`** — refreshes the now-stale note that claimed the composition was unimplemented.

## Validation

- `scripts/validate_content.py` → passed
- `tests.test_content_validator` → 127 tests OK

The `_game` native build and `for_unit_tests` could not be run in the authoring environment (the `vstd` / `random-dungeon-generator` submodules are outside its egress scope), so the new native regression test is validated by CI on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRsp3dwLXZSefBtSzz3Pjz)_