### PR TITLE
Fix resource_unit_tests: register _game bindings so plugin execution works

### DIFF
--- a/tests/unit/test_resource.cpp
+++ b/tests/unit/test_resource.cpp
@@ -27,6 +27,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <algorithm>
 #include <chrono>
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -280,8 +281,30 @@ void test_resource_plugin_trust_boundary_rejects_escapes() {
 
 } // namespace
 
+// Registers the engine's pybind bindings (CGame and friends) in the embedded
+// interpreter. The plugin-execution path exercised by the trust-boundary test
+// casts the live CGame into Python (CPluginLoader::loadPlugin ->
+// pybind11::cast(game)), which only works once init_game_module has run. That
+// initializer lives solely in the _game module, so we import it here. On Linux
+// this test binary and _game link the same shared game_core, so the imported
+// bindings register against the identical CGame type this binary uses. Also
+// preloads the json module so the sandbox import proxy can expose it. Best
+// effort: failure is logged but does not abort the suite (other tests do not
+// need the bindings).
+void register_engine_bindings() {
+    try {
+        pybind11::module_::import("sys").attr("path").attr("insert")(0, pybind11::str("."));
+        pybind11::module_::import("json");
+        pybind11::module_::import("_game");
+    } catch (const pybind11::error_already_set &exception) {
+        PyErr_Clear();
+        std::fprintf(stderr, "WARNING: could not import _game bindings for resource tests: %s\n", exception.what());
+    }
+}
+
 int main() {
     pybind11::scoped_interpreter guard{};
+    register_engine_bindings();
 
     test_resource_provider_paths_and_config_loader();
     test_resource_provider_save_uses_provider_root_when_cwd_changes();


### PR DESCRIPTION
## Summary

Fixes the pre-existing `for_unit_tests.resource_unit_tests` failure that has been red on `main`'s native `linux` / `linux-coverage` jobs.

## Root cause

`test_resource_plugin_trust_boundary_rejects_escapes` writes a trusted plugin and asserts it loads and executes via `CPluginLoader::loadPlugin`. That path casts the live `CGame` into Python (`pybind11::cast(game)` in `src/core/CLoader.cpp`). The cast only succeeds once `init_game_module` has registered the `CGame` pybind class — but on Linux that initializer is compiled **only into the `_game` module**, never into the `game_core_objects` the unit-test binaries use. The standalone `resource_unit_tests` interpreter therefore had no `CGame` binding, so every Python plugin load failed with:

```
Unable to convert call argument '1' to Python object
FAIL: trusted in-root plugin path must still load and execute
```

(`crafting.py` separately failed on `Allowed Python resource plugin module is not initialized: json` because `json` was never imported into the sandbox interpreter.)

## Fix

Import `_game` (and `json`) at test startup in `tests/unit/test_resource.cpp`. On Linux this test binary and `_game` link the **same shared `game_core`**, so the imported bindings register against the identical `CGame` type the test uses, and `pybind11::cast(game)` resolves. The import is best-effort (logged, non-fatal) — the other resource tests don't need the bindings. Preloading `json` also lets the sandbox import proxy expose it to plugins.

Test-only change; no production or CMake changes.

## Validation

Content validation and `tests.test_content_validator` pass locally. The native `_game` build and `for_unit_tests` can't be run in the authoring environment (the `vstd` / `random-dungeon-generator` submodules are outside its egress scope), so this fix is validated by CI on this branch — specifically the `linux` / `linux-coverage` jobs that were previously failing on `resource_unit_tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRsp3dwLXZSefBtSzz3Pjz)_