### PR TITLE
Extract WarriorClass into creature_classes.json (E04/S02/SS01)

### DIFF
--- a/res/config/creature_classes.json
+++ b/res/config/creature_classes.json
@@ -1,0 +1,46 @@
+{
+  "WarriorClass": {
+    "class": "CCreatureClass",
+    "properties": {
+      "mainStat": "strength",
+      "levelStats": {
+        "class": "CStats",
+        "properties": {
+          "strength": 3,
+          "stamina": 2,
+          "agility": 2,
+          "intelligence": 1,
+          "hit": 3,
+          "crit": 1,
+          "dmgMin": 2,
+          "dmgMax": 3
+        }
+      },
+      "actions": [
+        {
+          "ref": "Attack"
+        }
+      ],
+      "levelling": {
+        "1": {
+          "ref": "Strike"
+        },
+        "2": {
+          "ref": "Barrier"
+        },
+        "3": {
+          "ref": "BloodThirst"
+        },
+        "4": {
+          "ref": "Bloodlash"
+        },
+        "5": {
+          "ref": "DeathStrike"
+        },
+        "6": {
+          "ref": "DoubleAttack"
+        }
+      }
+    }
+  }
+}

--- a/res/config/monsters.json
+++ b/res/config/monsters.json
@@ -350,11 +350,9 @@
   "Warrior": {
     "class": "CPlayer",
     "properties": {
-      "actions": [
-        {
-          "ref": "Attack"
-        }
-      ],
+      "creatureClass": {
+        "ref": "WarriorClass"
+      },
       "animation": "images/players/warrior",
       "equipped": {
         "0": {
@@ -369,39 +367,6 @@
       },
       "items": [],
       "label": "Warrior",
-      "levelStats": {
-        "class": "CStats",
-        "properties": {
-          "agility": 2,
-          "crit": 1,
-          "dmgMax": 3,
-          "dmgMin": 2,
-          "hit": 3,
-          "intelligence": 1,
-          "stamina": 2,
-          "strength": 3
-        }
-      },
-      "levelling": {
-        "1": {
-          "ref": "Strike"
-        },
-        "2": {
-          "ref": "Barrier"
-        },
-        "3": {
-          "ref": "BloodThirst"
-        },
-        "4": {
-          "ref": "Bloodlash"
-        },
-        "5": {
-          "ref": "DeathStrike"
-        },
-        "6": {
-          "ref": "DoubleAttack"
-        }
-      },
       "baseStats": {
         "class": "CStats",
         "properties": {

--- a/tests/fixtures/creature_stat_scale_baseline.json
+++ b/tests/fixtures/creature_stat_scale_baseline.json
@@ -311,24 +311,8 @@
         "strength": 5
       },
       "class": "CPlayer",
-      "levelStats": {
-        "agility": 2,
-        "crit": 1,
-        "dmgMax": 3,
-        "dmgMin": 2,
-        "hit": 3,
-        "intelligence": 1,
-        "stamina": 2,
-        "strength": 3
-      },
-      "levelling": {
-        "1": "Strike",
-        "2": "Barrier",
-        "3": "BloodThirst",
-        "4": "Bloodlash",
-        "5": "DeathStrike",
-        "6": "DoubleAttack"
-      }
+      "levelStats": {},
+      "levelling": {}
     },
     "Wayfarer": {
       "baseStats": {

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -3294,13 +3294,18 @@ class UnmigratedCreatureReportTest(unittest.TestCase):
         self.assertEqual([], [str(issue) for issue in validate_repo(REPO_ROOT)])
 
         report = report_unmigrated_creatures(REPO_ROOT)
-        # The report is non-empty on current content (nothing is migrated yet) and the
-        # production player templates surface as still needing migration.
+        # The report is non-empty on current content (migration is still in progress)
+        # and the not-yet-migrated production player templates surface as still needing
+        # migration.
         self.assertTrue(report)
         report_ids = {creature.config_id for creature in report}
-        for player in ("Assasin", "Inquisitor", "Sorcerer", "Warrior", "Wayfarer"):
+        for player in ("Assasin", "Inquisitor", "Sorcerer", "Wayfarer"):
             self.assertIn(player, report_ids)
             self.assertEqual(("creatureClass", "race"), next(c.missing for c in report if c.config_id == player))
+        # Warrior has been migrated to a creatureClass (WarriorClass, EPIC_04/STORY_02/
+        # SUBSTORY_01); it still surfaces in the report but now only lacks a race.
+        self.assertIn("Warrior", report_ids)
+        self.assertEqual(("race",), next(c.missing for c in report if c.config_id == "Warrior"))
 
 
 class RequiredProductionArchetypeTest(unittest.TestCase):

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -1626,21 +1626,40 @@ void test_creature_effective_stats_baseline_capture() {
                 "capturing effective creature stats twice in-process should be byte-for-byte reproducible");
 
     // Layering law: getStats() composes the effective stats least- to
-    // most-specific as baseStats + (level copies of) levelStats + equipment
-    // bonuses + effect bonuses (src/object/CCreature.cpp:834-874). Recompute that
-    // exact layering independently here so the captured numbers are proven to be
-    // the deterministic linear composition of the configured stat sources rather
-    // than any other path. Monotonicity is intentionally NOT asserted because
-    // levelStats deltas may be negative in config, so the engine does not promise
-    // non-decreasing stats across levels.
+    // most-specific. For a legacy creature (no race/creatureClass) that is
+    // baseStats + (level copies of) levelStats + equipment + effects; for an
+    // archetype creature it additionally folds the race/class baseStats and the
+    // class per-level growth ahead of the concrete template, matching
+    // buildComposedStats (src/object/CCreature.cpp). Recompute that exact layering
+    // independently here so the captured numbers are proven to be the deterministic
+    // linear composition of the configured stat sources rather than any other path.
+    // Each archetype reference is null on legacy creatures, so the extra terms drop
+    // out and this reduces to the legacy layering. Monotonicity is intentionally NOT
+    // asserted because levelStats deltas may be negative in config, so the engine
+    // does not promise non-decreasing stats across levels.
     for (const auto &type : subtypes) {
         auto creature = game->createObject<CCreature>(type);
         if (!creature) {
             continue;
         }
+        auto race = creature->getRace();
+        auto creatureClass = creature->getCreatureClass();
         for (int level : kBaselineLevels) {
             auto expectedStats = std::make_shared<CStats>();
+            // race.baseStats then creatureClass.baseStats (null on legacy creatures).
+            if (race && race->getBaseStats()) {
+                expectedStats->addBonus(race->getBaseStats());
+            }
+            if (creatureClass && creatureClass->getBaseStats()) {
+                expectedStats->addBonus(creatureClass->getBaseStats());
+            }
             expectedStats->addBonus(creature->getBaseStats());
+            // creatureClass.levelStats per level, then creature.levelStats per level.
+            if (creatureClass && creatureClass->getLevelStats()) {
+                for (int i = 0; i < level; i++) {
+                    expectedStats->addBonus(creatureClass->getLevelStats());
+                }
+            }
             for (int i = 0; i < level; i++) {
                 expectedStats->addBonus(creature->getLevelStats());
             }


### PR DESCRIPTION
## Issue
`[EPIC_04][STORY_02][SUBSTORY_01]Extract WarriorClass` (P1, claim `1b75a6fa…`). First class extraction onto the now-complete archetype runtime (composed stats #1072 + composed actions #1185).

## What changed
- **`res/config/creature_classes.json`** (new): native `CCreatureClass` **WarriorClass** — `mainStat: strength`, the starting `Attack` action, per-level `levelStats` (the Warrior's old growth), and the level 1–6 `levelling` unlock map (Strike…DoubleAttack).
- **`res/config/monsters.json`**: the Warrior `CPlayer` template now references `"creatureClass": {"ref": "WarriorClass"}` and no longer declares `actions`/`levelStats`/`levelling` (moved to the class). It keeps `baseStats`, `animation`, `label`, `Sword`/`PlateArmor` equipment, `items`, and `fightController` unchanged — exactly per the substory spec (the class owns mainStat/actions/levelStats/levelling; the template keeps its concrete base).

## Why behavior is preserved (matches pre-migration baseline)
`usesArchetypeComposition()` now routes the Warrior through the composed paths:
- **Stats** — `buildComposedStats`: `class.levelStats` == the Warrior's old `levelStats`, `baseStats` unchanged on the template, `mainStat` class-authoritative `strength` == old. Composed total is identical at every level.
- **Actions** — `getEffectiveInteractions` folds `class.actions` (Attack) + `class.levelling` unlocks. Every gameplay consumer already reads the composed set (`CGameFightPanel`, `CGameCharacterPanel`, `CController` → `getInteractions`); raw `getActions()` is used only inside `CCreature` itself. So abilities surface unchanged in-game.

## Validation
- Local (pure-Python): `validate_content.py` passes (the `creatureClass` ref resolves, `WarriorClass` validates, `mainStat` names a numeric `CStats` property); `tests/test_creature_stat_scale_baseline` passes after regenerating the fixture for the Warrior's new config shape.
- Regenerated `tests/fixtures/creature_stat_scale_baseline.json` (Warrior's `levelStats`/`levelling` now empty on the template — deliberate migration regen).
- Updated `test_creature_effective_stats_baseline_capture`'s independent layering law to fold race/class `baseStats` + class per-level growth (null-guarded → legacy creatures reduce to the existing layering). Native `core_unit_tests`, the effective-stats/actions captures, save-compat, and the gameplay walkthrough run on CI.

Race extraction (moving `baseStats` into a `CCreatureRace`) is intentionally out of scope — the substory assigns only mainStat/actions/levelStats/levelling to the class; the template keeps `baseStats`, so the class extraction is baseline-preserving standalone.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_