### PR TITLE
Fix platform-dependent GUI z-order and resource plugin trust-boundary unit tests

### DIFF
--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -1359,8 +1359,10 @@ void CGameLoader::loadGui(const std::shared_ptr<CGame> &game) {
     });
 }
 
+bool CPluginLoader::isTrustedPluginPath(const std::string &path) { return is_allowed_python_plugin_path(path); }
+
 bool CPluginLoader::loadPlugin(const std::shared_ptr<CGame> &game, const std::string &path) {
-    if (!is_allowed_python_plugin_path(path)) {
+    if (!isTrustedPluginPath(path)) {
         vstd::logger::warning("Rejected Python plugin outside trusted resource plugin paths:", path);
         return false;
     }

--- a/src/core/CLoader.h
+++ b/src/core/CLoader.h
@@ -87,6 +87,12 @@ class CGameLoader {
 
 class CPluginLoader {
   public:
+    // Returns whether a Python plugin path is inside the trusted resource plugin roots (under
+    // plugins/ or a map's script.py). This is the trust-boundary decision loadPlugin makes before
+    // executing any plugin code; it is exposed so the boundary can be tested without a full pybind
+    // runtime (the game_core unit-test binary has no _game bindings to execute plugins with).
+    static bool isTrustedPluginPath(const std::string &path);
+
     static bool loadPlugin(const std::shared_ptr<CGame> &game, const std::string &path);
 
     static bool loadCppPlugin(const std::shared_ptr<CGame> &game, const std::string &type);

--- a/src/gui/object/CGameGraphicsObject.cpp
+++ b/src/gui/object/CGameGraphicsObject.cpp
@@ -212,11 +212,15 @@ int CGameGraphicsObject::getPriority() { return priority; }
 void CGameGraphicsObject::setPriority(int _priority) { this->priority = _priority; }
 
 int CGameGraphicsObject::getTopPriority() {
-    auto iterator = std::max_element(children.begin(), children.end());
-    if (iterator != children.end()) {
-        return (*iterator)->getPriority();
+    // children is ordered by priority_comparator (priority ascending, pointer tie-break), so the
+    // last element carries the highest priority. std::max_element without a comparator would instead
+    // compare the shared_ptrs by address and return an arbitrary child's priority, which made
+    // pushChild assign non-strictly-increasing priorities and produced platform-dependent z-order
+    // (equal-priority ties resolved by heap address).
+    if (children.empty()) {
+        return -1;
     }
-    return -1;
+    return (*children.rbegin())->getPriority();
 }
 
 void CGameGraphicsObject::pushChild(const std::shared_ptr<CGameGraphicsObject> &child) {

--- a/tests/unit/test_resource.cpp
+++ b/tests/unit/test_resource.cpp
@@ -253,29 +253,25 @@ void test_resource_plugin_trust_boundary_rejects_escapes() {
     std::filesystem::remove_all(outsideDir, errorCode);
 
     // Untrusted: Python plugin/script loads outside the trusted plugin/map roots must be refused
-    // before any code is executed.
+    // before any code is executed. The trust-boundary decision (isTrustedPluginPath) is the
+    // security-relevant behavior, so assert it directly -- loadPlugin executing plugin code needs
+    // the _game pybind bindings, which this game_core unit-test binary does not link, so its return
+    // value cannot distinguish a boundary rejection from a runtime failure here.
     auto game = CGameLoader::loadGame();
-    expect_true(!CPluginLoader::loadPlugin(game, "../evil.py"),
-                "parent-traversal plugin paths must be rejected before execution");
-    expect_true(!CPluginLoader::loadPlugin(game, "/tmp/evil.py"),
-                "absolute plugin paths must be rejected before execution");
-    expect_true(!CPluginLoader::loadPlugin(game, "config/items.json"),
-                "non-plugin resource paths must not be executed as plugins");
-    expect_true(!CPluginLoader::loadPlugin(game, "plugins/../../escape.py"),
-                "traversal that escapes the plugins root must be rejected");
-
-    // Trusted: an in-root plugin path under plugins/ is accepted and executed.
-    const std::string trustedPluginLogical = "plugins/trust_boundary_ok_" + std::to_string(nonce) + ".py";
-    const auto trustedPluginPath = resourceRoot / trustedPluginLogical;
-    const std::string trustedPluginBody = "_trust_boundary_loaded = []\n"
-                                          "def load(self, context):\n"
-                                          "    _trust_boundary_loaded.append(True)\n";
-    expect_true(write_text_file(trustedPluginPath, trustedPluginBody), "trusted plugin fixture should be written");
-    if (std::filesystem::exists(trustedPluginPath)) {
-        expect_true(CPluginLoader::loadPlugin(game, trustedPluginLogical),
-                    "trusted in-root plugin path must still load and execute");
+    for (const std::string &untrusted :
+         {std::string("../evil.py"), std::string("/tmp/evil.py"), std::string("config/items.json"),
+          std::string("plugins/../../escape.py")}) {
+        expect_true(!CPluginLoader::isTrustedPluginPath(untrusted),
+                    "paths outside the trusted plugin roots must not be trusted");
+        expect_true(!CPluginLoader::loadPlugin(game, untrusted),
+                    "untrusted plugin paths must be rejected before execution");
     }
-    std::filesystem::remove(trustedPluginPath, errorCode);
+
+    // Trusted: an in-root plugin path under plugins/ is accepted by the boundary. Its actual
+    // execution is exercised by the gameplay suites that run with the real _game module.
+    const std::string trustedPluginLogical = "plugins/trust_boundary_ok_" + std::to_string(nonce) + ".py";
+    expect_true(CPluginLoader::isTrustedPluginPath(trustedPluginLogical),
+                "an in-root plugin path under plugins/ must be trusted by the boundary");
 }
 
 } // namespace


### PR DESCRIPTION
## Background

After the `build.yml` startup-failure fix (#1181) let the native jobs run on `main` again, two native unit tests surfaced as failing. Both are **pre-existing** issues that had been masked: push-to-`main` hadn't executed the native jobs in a long time, and on PRs these jobs are skipped when the change classifier reports `native-needed=false`.

## 1. `gui_unit_tests` (Windows) — *"a modal panel should take precedence over the minimap overlay"*

`CGameGraphicsObject::getTopPriority()` called `std::max_element` over the `children` set **with no comparator**, so it compared the `shared_ptr` elements by address and returned an arbitrary child's priority instead of the maximum. `pushChild` then assigned non-strictly-increasing priorities, so a newly pushed modal panel could **tie** an existing overlay. `priority_comparator` breaks ties by pointer address, so the resulting z-order depended on heap layout — it happened to pass on Linux and fail on Windows.

**Fix:** `children` is already ordered by priority ascending, so return the last element's priority (`*children.rbegin()`). Priorities are now strictly increasing and z-order is deterministic across platforms. This is a genuine engine bug, not just a test issue.

## 2. `resource_unit_tests` (Linux) — *"trusted in-root plugin path must still load and execute"*

The assertion required `CPluginLoader::loadPlugin` to **fully execute** a Python plugin, which needs the `_game` pybind bindings (`py::class_<CGame>` et al.) and a pre-imported `json` module. On Linux those live only in the `_game` module; the `game_core` unit-test binary links neither, so casting `game` into Python failed (`Unable to convert call argument '1'`) and the restricted import proxy couldn't find `json`. `loadPlugin` therefore returned `false` for **every** path — which also made the untrusted-path rejection assertions pass for the wrong reason.

**Fix:** expose the trust-boundary decision as `CPluginLoader::isTrustedPluginPath` and assert it directly for trusted and untrusted paths. This tests the actual security-relevant behavior without a full pybind runtime; end-to-end plugin execution stays covered by the gameplay suites that run with the real `_game` module.

## Verification

- Can't build locally in this environment (the `vstd` / `random-dungeon-generator` submodules are out of scope), so correctness of the C++ changes is verified by this PR's `linux` + `windows` native CI jobs.
- Python-side checks pass locally: `tests.security.test_configure_supply_chain` (15/15) and `scripts/validate_content.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgfqcdgwR74njdPgTzHmkL)_