### PR TITLE
Extract WarriorClass into creature_classes.json (E04/S02/SS01, re-land)

### DIFF
--- a/res/config/creature_classes.json
+++ b/res/config/creature_classes.json
@@ -10,5 +10,49 @@
     "properties": {
       "mainStat": "intelligence"
     }
+  },
+  "WarriorClass": {
+    "class": "CCreatureClass",
+    "properties": {
+      "mainStat": "strength",
+      "levelStats": {
+        "class": "CStats",
+        "properties": {
+          "strength": 3,
+          "stamina": 2,
+          "agility": 2,
+          "intelligence": 1,
+          "hit": 3,
+          "crit": 1,
+          "dmgMin": 2,
+          "dmgMax": 3
+        }
+      },
+      "actions": [
+        {
+          "ref": "Attack"
+        }
+      ],
+      "levelling": {
+        "1": {
+          "ref": "Strike"
+        },
+        "2": {
+          "ref": "Barrier"
+        },
+        "3": {
+          "ref": "BloodThirst"
+        },
+        "4": {
+          "ref": "Bloodlash"
+        },
+        "5": {
+          "ref": "DeathStrike"
+        },
+        "6": {
+          "ref": "DoubleAttack"
+        }
+      }
+    }
   }
 }

--- a/res/config/monsters.json
+++ b/res/config/monsters.json
@@ -374,11 +374,9 @@
   "Warrior": {
     "class": "CPlayer",
     "properties": {
-      "actions": [
-        {
-          "ref": "Attack"
-        }
-      ],
+      "creatureClass": {
+        "ref": "WarriorClass"
+      },
       "animation": "images/players/warrior",
       "equipped": {
         "0": {
@@ -393,39 +391,6 @@
       },
       "items": [],
       "label": "Warrior",
-      "levelStats": {
-        "class": "CStats",
-        "properties": {
-          "agility": 2,
-          "crit": 1,
-          "dmgMax": 3,
-          "dmgMin": 2,
-          "hit": 3,
-          "intelligence": 1,
-          "stamina": 2,
-          "strength": 3
-        }
-      },
-      "levelling": {
-        "1": {
-          "ref": "Strike"
-        },
-        "2": {
-          "ref": "Barrier"
-        },
-        "3": {
-          "ref": "BloodThirst"
-        },
-        "4": {
-          "ref": "Bloodlash"
-        },
-        "5": {
-          "ref": "DeathStrike"
-        },
-        "6": {
-          "ref": "DoubleAttack"
-        }
-      },
       "baseStats": {
         "class": "CStats",
         "properties": {

--- a/tests/fixtures/creature_stat_scale_baseline.json
+++ b/tests/fixtures/creature_stat_scale_baseline.json
@@ -311,24 +311,8 @@
         "strength": 5
       },
       "class": "CPlayer",
-      "levelStats": {
-        "agility": 2,
-        "crit": 1,
-        "dmgMax": 3,
-        "dmgMin": 2,
-        "hit": 3,
-        "intelligence": 1,
-        "stamina": 2,
-        "strength": 3
-      },
-      "levelling": {
-        "1": "Strike",
-        "2": "Barrier",
-        "3": "BloodThirst",
-        "4": "Bloodlash",
-        "5": "DeathStrike",
-        "6": "DoubleAttack"
-      }
+      "levelStats": {},
+      "levelling": {}
     },
     "Wayfarer": {
       "baseStats": {

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -3294,13 +3294,18 @@ class UnmigratedCreatureReportTest(unittest.TestCase):
         self.assertEqual([], [str(issue) for issue in validate_repo(REPO_ROOT)])
 
         report = report_unmigrated_creatures(REPO_ROOT)
-        # The report is non-empty on current content (nothing is migrated yet) and the
-        # production player templates surface as still needing migration.
+        # The report is non-empty on current content (migration is still in progress)
+        # and the not-yet-migrated production player templates surface as still needing
+        # migration.
         self.assertTrue(report)
         report_ids = {creature.config_id for creature in report}
-        for player in ("Assasin", "Inquisitor", "Sorcerer", "Warrior", "Wayfarer"):
+        for player in ("Assasin", "Inquisitor", "Sorcerer", "Wayfarer"):
             self.assertIn(player, report_ids)
             self.assertEqual(("creatureClass", "race"), next(c.missing for c in report if c.config_id == player))
+        # Warrior has been migrated to a creatureClass (WarriorClass, EPIC_04/STORY_02/
+        # SUBSTORY_01); it still surfaces in the report but now only lacks a race.
+        self.assertIn("Warrior", report_ids)
+        self.assertEqual(("race",), next(c.missing for c in report if c.config_id == "Warrior"))
 
 
 class RequiredProductionArchetypeTest(unittest.TestCase):

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -1638,9 +1638,25 @@ void test_creature_effective_stats_baseline_capture() {
         if (!creature) {
             continue;
         }
+        auto race = creature->getRace();
+        auto creatureClass = creature->getCreatureClass();
         for (int level : kBaselineLevels) {
             auto expectedStats = std::make_shared<CStats>();
+            // race.baseStats then creatureClass.baseStats (null on legacy creatures,
+            // so the extra terms drop out and this reduces to the legacy layering).
+            if (race && race->getBaseStats()) {
+                expectedStats->addBonus(race->getBaseStats());
+            }
+            if (creatureClass && creatureClass->getBaseStats()) {
+                expectedStats->addBonus(creatureClass->getBaseStats());
+            }
             expectedStats->addBonus(creature->getBaseStats());
+            // creatureClass.levelStats per level, then creature.levelStats per level.
+            if (creatureClass && creatureClass->getLevelStats()) {
+                for (int i = 0; i < level; i++) {
+                    expectedStats->addBonus(creatureClass->getLevelStats());
+                }
+            }
             for (int i = 0; i < level; i++) {
                 expectedStats->addBonus(creature->getLevelStats());
             }


### PR DESCRIPTION
Re-lands the WarriorClass extraction reverted in #1197.

## Why #1192 failed (and why this won't)
The original #1192 failed the windows **gameplay walkthrough**: the engine logged `No config found for: WarriorClass falling back to class-name construction` and the Warrior got an **empty** class (no abilities). Root cause: config files are staged into the build's `config/` dir via explicit `configure_file()` calls in `CMakeLists.txt` — there is no glob — and #1192 added `creature_classes.json` **without** its staging line, so the engine never loaded it. (`validate_content.py` passed because the validator reads `res/` directly.)

That staging line **now exists on main** (added alongside the peer `bruteClass` work), so the engine loads `creature_classes.json` at runtime. This PR adds `WarriorClass` next to the existing `bruteClass`.

## Changes
- **`res/config/creature_classes.json`**: add `WarriorClass` (mainStat `strength`, `Attack`, per-level `levelStats`, 1–6 `levelling`) next to `bruteClass`.
- **`res/config/monsters.json`**: Warrior `CPlayer` references `creatureClass: WarriorClass`; moved `actions`/`levelStats`/`levelling` removed; `baseStats`/animation/label/equipment kept.
- **`tests/fixtures/creature_stat_scale_baseline.json`**: regenerated for the Warrior's new config shape.
- **`tests/unit/test_core.cpp`**: effective-stats layering law folds race/class `baseStats` + class per-level growth (null-guarded → legacy creatures unchanged).
- **`tests/test_content_validator.py`**: Warrior now reports only a missing race.

## Validation
Local: `validate_content.py` ✓, `test_creature_stat_scale_baseline` ✓, unmigrated-report ✓. Full native `linux`+`windows` including the C++ unit tests and the **gameplay walkthrough** run on CI — will not merge until the walkthrough is green this time.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_