### PR TITLE
Assign octoBogzRace + bruteClass to OctoBogz (archetype identity, baseline-preserving)

### DIFF
--- a/res/config/creature_races.json
+++ b/res/config/creature_races.json
@@ -6,5 +6,13 @@
       "subtypes": [],
       "playerSelectable": false
     }
+  },
+  "octoBogzRace": {
+    "class": "CCreatureRace",
+    "properties": {
+      "creatureType": "octoBogz",
+      "subtypes": [],
+      "playerSelectable": false
+    }
   }
 }

--- a/res/config/monsters.json
+++ b/res/config/monsters.json
@@ -171,6 +171,12 @@
           "strength": 10
         }
       },
+      "race": {
+        "ref": "octoBogzRace"
+      },
+      "creatureClass": {
+        "ref": "bruteClass"
+      },
       "sw": 2
     }
   },


### PR DESCRIPTION
## Summary

Continues the creature class/race separation by giving OctoBogz its archetype identity, following the approved taxonomy in `docs/design/creature_archetypes.md` and mirroring the Gooby assignment (#1191).

OctoBogz is a `strength`-main melee aberration, so it maps to:
- **`octoBogzRace`** — new race family (distinct octopus/hare shadowcraft lineage), added to `res/config/creature_races.json`.
- **`bruteClass`** — the existing strength-melee combat role, reused.

## Baseline-preserving

The assignment is identity-only. `octoBogzRace` carries no `baseStats`/`actions`, and `bruteClass` only declares `mainStat: strength` — which already matches OctoBogz's own `baseStats.mainStat`. With no archetype-contributed stats, actions, or level growth, `CCreature::buildComposedStats` and `getEffectiveInteractions` compose exactly the legacy stat block and action set, so OctoBogz's gameplay (including the OctoBogz reward/cave-state regression covered by #1154) is unchanged.

## Changes

- `res/config/creature_races.json` — add `octoBogzRace` (`CCreatureRace`, `creatureType: octoBogz`).
- `res/config/monsters.json` — add `race: {ref: octoBogzRace}` and `creatureClass: {ref: bruteClass}` to the OctoBogz template.

## Validation

- `scripts/validate_content.py` → passed
- `tests.test_content_validator` → 127 tests OK

Native build/gameplay suites are validated by CI (the `vstd` / `random-dungeon-generator` submodules are outside this environment's network scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRsp3dwLXZSefBtSzz3Pjz)_