### PR TITLE
Assign pritzRace + bruteClass to Pritz (archetype identity, baseline-preserving)

### DIFF
--- a/res/config/creature_races.json
+++ b/res/config/creature_races.json
@@ -14,5 +14,13 @@
       "subtypes": [],
       "playerSelectable": false
     }
+  },
+  "pritzRace": {
+    "class": "CCreatureRace",
+    "properties": {
+      "creatureType": "pritz",
+      "subtypes": [],
+      "playerSelectable": false
+    }
   }
 }

--- a/res/config/monsters.json
+++ b/res/config/monsters.json
@@ -226,6 +226,12 @@
           "strength": 5
         }
       },
+      "race": {
+        "ref": "pritzRace"
+      },
+      "creatureClass": {
+        "ref": "bruteClass"
+      },
       "sw": 1
     }
   },


### PR DESCRIPTION
## Summary

Continues the creature class/race separation, following the approved taxonomy in `docs/design/creature_archetypes.md` and mirroring Gooby (#1191) and OctoBogz (#1204).

Pritz is the `strength`-main Pritscher siege/ritual footsoldier, so it maps to:
- **`pritzRace`** — new race family (the shared Pritz lineage; the `PritzMage` caster variant will reference the same `pritzRace` with `mageClass` in a follow-up), added to `res/config/creature_races.json`.
- **`bruteClass`** — the existing strength-melee combat role, reused.

## Baseline-preserving

Identity-only: `pritzRace` carries no `baseStats`/`actions`, and `bruteClass` only declares `mainStat: strength` — which already matches Pritz's own `baseStats.mainStat`. With no archetype-contributed stats, actions, or level growth, `CCreature::buildComposedStats` and `getEffectiveInteractions` compose exactly the legacy stat block and action set, so Pritz's gameplay (siege/ritual waves) is unchanged.

## Changes

- `res/config/creature_races.json` — add `pritzRace` (`CCreatureRace`, `creatureType: pritz`).
- `res/config/monsters.json` — add `race: {ref: pritzRace}` and `creatureClass: {ref: bruteClass}` to the Pritz template.

## Validation

- `scripts/validate_content.py` → passed
- `tests.test_content_validator` → 127 tests OK

Native build/gameplay suites are validated by CI (the `vstd` / `random-dungeon-generator` submodules are outside this environment's network scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRsp3dwLXZSefBtSzz3Pjz)_