### PR TITLE
Assign goblinRace (race-only) to GoblinThief (archetype identity, baseline-preserving)

### DIFF
--- a/res/config/creature_races.json
+++ b/res/config/creature_races.json
@@ -22,5 +22,13 @@
       "subtypes": [],
       "playerSelectable": false
     }
+  },
+  "goblinRace": {
+    "class": "CCreatureRace",
+    "properties": {
+      "creatureType": "goblin",
+      "subtypes": [],
+      "playerSelectable": false
+    }
   }
 }

--- a/res/config/monsters.json
+++ b/res/config/monsters.json
@@ -574,6 +574,9 @@
           "strength": 5
         }
       },
+      "race": {
+        "ref": "goblinRace"
+      },
       "sw": 1
     }
   },


### PR DESCRIPTION
## Summary

Gives GoblinThief its race identity per the approved taxonomy in `docs/design/creature_archetypes.md`, which reserves `goblinRace` as the goblin race family for GoblinThief and future goblin templates. Continues the baseline-preserving assignment series (Gooby #1191, OctoBogz #1204, Pritz #1205, PritzMage #1206).

## Why race-only (class deferred)

The taxonomy also proposes `thiefClass` (an agility rogue role) for GoblinThief. But GoblinThief's own `baseStats.mainStat` is **`strength`**, so attaching a `mainStat: agility` `thiefClass` would flip its composed main stat — a real behavior change, **not** a baseline-preserving identity assignment. The class assignment is therefore deferred to a deliberate design/rebalance decision; only the race identity is assigned here.

## Baseline-preserving

`goblinRace` carries no `baseStats`/`actions`, and with no `creatureClass` the composed main stat falls back to GoblinThief's own `strength`. `CCreature::buildComposedStats` and `getEffectiveInteractions` compose exactly the legacy stat block and action set, so GoblinThief's gameplay (the `preciousAmulet` carrier in the amulet quest) is unchanged.

## Changes

- `res/config/creature_races.json` — add `goblinRace` (`CCreatureRace`, `creatureType: goblin`).
- `res/config/monsters.json` — add `race: {ref: goblinRace}` to the GoblinThief template (no `creatureClass`).

## Validation

- `scripts/validate_content.py` → passed
- `tests.test_content_validator` → 127 tests OK

Native build/gameplay suites are validated by CI (the `vstd` / `random-dungeon-generator` submodules are outside this environment's network scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRsp3dwLXZSefBtSzz3Pjz)_