### PR TITLE
Extract SorcererClass into creature_classes.json (E04/S02/SS02)

### DIFF
--- a/res/config/creature_classes.json
+++ b/res/config/creature_classes.json
@@ -54,5 +54,55 @@
         }
       }
     }
+  },
+  "SorcererClass": {
+    "class": "CCreatureClass",
+    "properties": {
+      "mainStat": "intelligence",
+      "levelStats": {
+        "class": "CStats",
+        "properties": {
+          "strength": 1,
+          "stamina": 1,
+          "agility": 2,
+          "intelligence": 3,
+          "hit": 1,
+          "crit": 1,
+          "dmgMin": 1,
+          "dmgMax": 1
+        }
+      },
+      "actions": [
+        {
+          "ref": "Attack"
+        }
+      ],
+      "levelling": {
+        "1": {
+          "ref": "MagicMissile"
+        },
+        "2": {
+          "ref": "AbyssalShadows"
+        },
+        "3": {
+          "ref": "FrostBolt"
+        },
+        "4": {
+          "ref": "EndlessPain"
+        },
+        "5": {
+          "ref": "ArmorOfEndlessWinter"
+        },
+        "7": {
+          "ref": "ShadowBolt"
+        },
+        "8": {
+          "ref": "Devour"
+        },
+        "10": {
+          "ref": "ChaosBlast"
+        }
+      }
+    }
   }
 }

--- a/res/config/monsters.json
+++ b/res/config/monsters.json
@@ -297,11 +297,9 @@
   "Sorcerer": {
     "class": "CPlayer",
     "properties": {
-      "actions": [
-        {
-          "ref": "Attack"
-        }
-      ],
+      "creatureClass": {
+        "ref": "SorcererClass"
+      },
       "animation": "images/players/sorcerer",
       "equipped": {
         "0": {
@@ -316,45 +314,6 @@
       },
       "items": [],
       "label": "Sorcerer",
-      "levelStats": {
-        "class": "CStats",
-        "properties": {
-          "agility": 2,
-          "crit": 1,
-          "dmgMax": 1,
-          "dmgMin": 1,
-          "hit": 1,
-          "intelligence": 3,
-          "stamina": 1,
-          "strength": 1
-        }
-      },
-      "levelling": {
-        "1": {
-          "ref": "MagicMissile"
-        },
-        "10": {
-          "ref": "ChaosBlast"
-        },
-        "2": {
-          "ref": "AbyssalShadows"
-        },
-        "3": {
-          "ref": "FrostBolt"
-        },
-        "4": {
-          "ref": "EndlessPain"
-        },
-        "5": {
-          "ref": "ArmorOfEndlessWinter"
-        },
-        "7": {
-          "ref": "ShadowBolt"
-        },
-        "8": {
-          "ref": "Devour"
-        }
-      },
       "baseStats": {
         "class": "CStats",
         "properties": {

--- a/tests/fixtures/creature_stat_scale_baseline.json
+++ b/tests/fixtures/creature_stat_scale_baseline.json
@@ -277,26 +277,8 @@
         "strength": 5
       },
       "class": "CPlayer",
-      "levelStats": {
-        "agility": 2,
-        "crit": 1,
-        "dmgMax": 1,
-        "dmgMin": 1,
-        "hit": 1,
-        "intelligence": 3,
-        "stamina": 1,
-        "strength": 1
-      },
-      "levelling": {
-        "1": "MagicMissile",
-        "10": "ChaosBlast",
-        "2": "AbyssalShadows",
-        "3": "FrostBolt",
-        "4": "EndlessPain",
-        "5": "ArmorOfEndlessWinter",
-        "7": "ShadowBolt",
-        "8": "Devour"
-      }
+      "levelStats": {},
+      "levelling": {}
     },
     "Warrior": {
       "baseStats": {

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -3299,13 +3299,15 @@ class UnmigratedCreatureReportTest(unittest.TestCase):
         # migration.
         self.assertTrue(report)
         report_ids = {creature.config_id for creature in report}
-        for player in ("Assasin", "Inquisitor", "Sorcerer", "Wayfarer"):
+        for player in ("Assasin", "Inquisitor", "Wayfarer"):
             self.assertIn(player, report_ids)
             self.assertEqual(("creatureClass", "race"), next(c.missing for c in report if c.config_id == player))
-        # Warrior has been migrated to a creatureClass (WarriorClass, EPIC_04/STORY_02/
-        # SUBSTORY_01); it still surfaces in the report but now only lacks a race.
-        self.assertIn("Warrior", report_ids)
-        self.assertEqual(("race",), next(c.missing for c in report if c.config_id == "Warrior"))
+        # Warrior and Sorcerer have been migrated to a creatureClass (WarriorClass /
+        # SorcererClass, EPIC_04/STORY_02/SUBSTORY_01–02); each still surfaces in the
+        # report but now only lacks a race.
+        for migrated in ("Warrior", "Sorcerer"):
+            self.assertIn(migrated, report_ids)
+            self.assertEqual(("race",), next(c.missing for c in report if c.config_id == migrated))
 
 
 class RequiredProductionArchetypeTest(unittest.TestCase):


### PR DESCRIPTION
## Issue
`[EPIC_04][STORY_02][SUBSTORY_02]Extract SorcererClass` (P1). Second player-class extraction, same proven pattern as WarriorClass (#1203).

## Changes
- **`res/config/creature_classes.json`**: add `SorcererClass` (mainStat `intelligence`, the starting `Attack` action, per-level `levelStats`, level 1–10 `levelling`) next to `warrior`/`brute`/`mage`.
- **`res/config/monsters.json`**: Sorcerer `CPlayer` references `creatureClass: SorcererClass`; moved `actions`/`levelStats`/`levelling` removed; `baseStats`, animation, label, `Staff`/`Robe` equipment, items, fightController kept.
- **`tests/fixtures/creature_stat_scale_baseline.json`**: regenerated for the Sorcerer's new config shape.
- **`tests/test_content_validator.py`**: Sorcerer now reports only a missing race.

No CMake or `test_core.cpp` change needed — `creature_classes.json` staging and the composed-stats layering law both landed with WarriorClass (#1203).

## Validation
Local: `validate_content.py` ✓, `test_creature_stat_scale_baseline` ✓, unmigrated-report ✓. The extraction mechanism (config staging + ref resolution + composed stats/actions) is already proven end-to-end by WarriorClass. Native C++ unit tests validate the composed Sorcerer.

Note: main's gameplay-walkthrough gate is currently red for the whole swarm due to unrelated new huge maps (`ninemarches` 1000×1000 #1198, `sunderedmarch`/`kadath` 200×200 #1189/#1183) whose walkthroughs time out — independent of this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_