### PR TITLE
Migrate remaining Nouraajd class checks to playerClassId (EPIC_06/STORY_02/SUBSTORY_05)

### DIFF
--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -645,7 +645,7 @@ def load(self, context):
     class DoorDialog(CDialog):
         def can_brace_gate(self):
             player = self.getGame().getMap().getPlayer()
-            return player.getTypeId() == "Warrior" and not player.getBoolProperty("braced_nouraajd_gate")
+            return player.getPlayerClassId() == "Warrior" and not player.getBoolProperty("braced_nouraajd_gate")
 
         def brace_gate(self):
             player = self.getGame().getMap().getPlayer()
@@ -688,7 +688,7 @@ def load(self, context):
 
         def can_shadow_robed_men(self):
             player = self.getGame().getMap().getPlayer()
-            return player.getTypeId() == "Assasin" and not player.getBoolProperty("shadowed_robed_men")
+            return player.getPlayerClassId() == "Assasin" and not player.getBoolProperty("shadowed_robed_men")
 
         def shadow_robed_men(self):
             player = self.getGame().getMap().getPlayer()
@@ -860,7 +860,7 @@ def load(self, context):
 
         def can_decode_stained_glass_ward(self):
             player = self.getGame().getMap().getPlayer()
-            return player.getTypeId() == "Sorcerer" and not player.getBoolProperty("decoded_stained_glass_ward")
+            return player.getPlayerClassId() == "Sorcerer" and not player.getBoolProperty("decoded_stained_glass_ward")
 
         def decode_stained_glass_ward(self):
             player = self.getGame().getMap().getPlayer()

--- a/test.py
+++ b/test.py
@@ -14013,6 +14013,7 @@ class GameTest(unittest.TestCase):
             "warrior_condition_method": "def can_brace_gate(self):" in script,
             "warrior_action_method": "def brace_gate(self):" in script,
             "warrior_player_property": "warrior_barricades" in script and "braced_nouraajd_gate" in script,
+            "warrior_condition_uses_class_id": 'player.getPlayerClassId() == "Warrior"' in script,
             "warrior_dialog_option": any(
                 option.get("properties", {}).get("condition") == "can_brace_gate"
                 and option.get("properties", {}).get("action") == "brace_gate"
@@ -14022,6 +14023,7 @@ class GameTest(unittest.TestCase):
             "assasin_condition_method": "def can_shadow_robed_men(self):" in script,
             "assasin_action_method": "def shadow_robed_men(self):" in script,
             "assasin_player_property": "assasin_trails" in script and "shadowed_robed_men" in script,
+            "assasin_condition_uses_class_id": 'player.getPlayerClassId() == "Assasin"' in script,
             "assasin_dialog_option": tavern_cultist_options is not None
             and any(
                 option.get("properties", {}).get("condition") == "can_shadow_robed_men"
@@ -14050,6 +14052,7 @@ class GameTest(unittest.TestCase):
             "sorcerer_condition_method": "def can_decode_stained_glass_ward(self):" in script,
             "sorcerer_action_method": "def decode_stained_glass_ward(self):" in script,
             "sorcerer_player_property": "sorcerer_sigils" in script and "decoded_stained_glass_ward" in script,
+            "sorcerer_condition_uses_class_id": 'player.getPlayerClassId() == "Sorcerer"' in script,
             "sorcerer_dialog_option": any(
                 option.get("properties", {}).get("condition") == "can_decode_stained_glass_ward"
                 and option.get("properties", {}).get("action") == "decode_stained_glass_ward"


### PR DESCRIPTION
## Summary

Advances **[EPIC_06][STORY_02][SUBSTORY_05] Update class checks and character panel** — the Nouraajd class-check (script) portion.

Extends the class-identity migration to the remaining class-specific dialog gates:
- `DoorDialog.can_brace_gate` (Warrior)
- `TavernDialog.can_shadow_robed_men` (Assasin)
- `BerenDialog.can_decode_stained_glass_ward` (Sorcerer)

These now compare `player.getPlayerClassId()` instead of `player.getTypeId()`, matching the Wayfarer/Inquisitor gates migrated earlier (#1177). `getPlayerClassId()` falls back to the type id for players saved before the identity model, so **existing saves keep working** while explicit class identities are honored. Dialog action/condition method names and resource ids are unchanged; progression properties/flags are untouched.

## Tests
- The existing `test_nouraajd_class_specific_dialog_routes_unlock_for_type_ids` already exercises all five classes by type id and stays valid via the fallback.
- Added static-source checks pinning the `getPlayerClassId` gating for the Warrior, Assasin, and Sorcerer conditions.

## Scope note
This PR covers the **script-side** class-check migration. The character-panel display of separate class/race values requires teaching `CGameCharacterPanel::renderObject` to render string-valued sheet methods (it currently only invokes `int`-returning methods) — a GUI-rendering change I've split into a follow-up.

## Validation
- `python3 scripts/validate_content.py --repo-root .` → passes.
- Behavior-preserving for existing type-based players.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgwwEuSehxkjEsvFNu9fS)_