### PR TITLE
Extract Assasin/Inquisitor/Wayfarer classes (E04/S02/SS03–05)

### DIFF
--- a/res/config/creature_classes.json
+++ b/res/config/creature_classes.json
@@ -116,5 +116,137 @@
     "properties": {
       "mainStat": "strength"
     }
+  },
+  "AssasinClass": {
+    "class": "CCreatureClass",
+    "properties": {
+      "mainStat": "agility",
+      "levelStats": {
+        "class": "CStats",
+        "properties": {
+          "strength": 1,
+          "stamina": 1,
+          "agility": 3,
+          "intelligence": 2,
+          "hit": 3,
+          "crit": 2,
+          "dmgMin": 1,
+          "dmgMax": 2
+        }
+      },
+      "actions": [
+        {
+          "ref": "Attack"
+        }
+      ],
+      "levelling": {
+        "1": {
+          "ref": "SneakAttack"
+        },
+        "2": {
+          "ref": "Mutilation"
+        },
+        "3": {
+          "ref": "LethalPoison"
+        },
+        "4": {
+          "ref": "Chloroform"
+        },
+        "5": {
+          "ref": "Stunner"
+        },
+        "6": {
+          "ref": "Backstab"
+        }
+      }
+    }
+  },
+  "InquisitorClass": {
+    "class": "CCreatureClass",
+    "properties": {
+      "mainStat": "intelligence",
+      "levelStats": {
+        "class": "CStats",
+        "properties": {
+          "strength": 2,
+          "stamina": 2,
+          "agility": 1,
+          "intelligence": 2,
+          "hit": 2,
+          "crit": 1,
+          "dmgMin": 1,
+          "dmgMax": 2
+        }
+      },
+      "actions": [
+        {
+          "ref": "Attack"
+        }
+      ],
+      "levelling": {
+        "1": {
+          "ref": "ExposeCorruption"
+        },
+        "2": {
+          "ref": "Strike"
+        },
+        "3": {
+          "ref": "SanctifiedWard"
+        },
+        "4": {
+          "ref": "FrostBolt"
+        },
+        "5": {
+          "ref": "Barrier"
+        },
+        "6": {
+          "ref": "EndlessPain"
+        }
+      }
+    }
+  },
+  "WayfarerClass": {
+    "class": "CCreatureClass",
+    "properties": {
+      "mainStat": "agility",
+      "levelStats": {
+        "class": "CStats",
+        "properties": {
+          "strength": 2,
+          "stamina": 1,
+          "agility": 3,
+          "intelligence": 1,
+          "hit": 3,
+          "crit": 1,
+          "dmgMin": 1,
+          "dmgMax": 2
+        }
+      },
+      "actions": [
+        {
+          "ref": "Attack"
+        }
+      ],
+      "levelling": {
+        "1": {
+          "ref": "WayfarersStride"
+        },
+        "2": {
+          "ref": "SneakAttack"
+        },
+        "3": {
+          "ref": "SmugglersMark"
+        },
+        "4": {
+          "ref": "DoubleAttack"
+        },
+        "5": {
+          "ref": "Backstab"
+        },
+        "6": {
+          "ref": "BloodThirst"
+        }
+      }
+    }
   }
 }

--- a/res/config/monsters.json
+++ b/res/config/monsters.json
@@ -2,11 +2,9 @@
   "Assasin": {
     "class": "CPlayer",
     "properties": {
-      "actions": [
-        {
-          "ref": "Attack"
-        }
-      ],
+      "creatureClass": {
+        "ref": "AssasinClass"
+      },
       "animation": "images/players/assasin",
       "equipped": {
         "0": {
@@ -21,39 +19,6 @@
       },
       "items": [],
       "label": "Assasin",
-      "levelStats": {
-        "class": "CStats",
-        "properties": {
-          "agility": 3,
-          "crit": 2,
-          "dmgMax": 2,
-          "dmgMin": 1,
-          "hit": 3,
-          "intelligence": 2,
-          "stamina": 1,
-          "strength": 1
-        }
-      },
-      "levelling": {
-        "1": {
-          "ref": "SneakAttack"
-        },
-        "2": {
-          "ref": "Mutilation"
-        },
-        "3": {
-          "ref": "LethalPoison"
-        },
-        "4": {
-          "ref": "Chloroform"
-        },
-        "5": {
-          "ref": "Stunner"
-        },
-        "6": {
-          "ref": "Backstab"
-        }
-      },
       "baseStats": {
         "class": "CStats",
         "properties": {
@@ -522,11 +487,9 @@
   "Inquisitor": {
     "class": "CPlayer",
     "properties": {
-      "actions": [
-        {
-          "ref": "Attack"
-        }
-      ],
+      "creatureClass": {
+        "ref": "InquisitorClass"
+      },
       "animation": "images/players/inquisitor",
       "equipped": {
         "0": {
@@ -541,39 +504,6 @@
       },
       "items": [],
       "label": "Inquisitor",
-      "levelStats": {
-        "class": "CStats",
-        "properties": {
-          "agility": 1,
-          "crit": 1,
-          "dmgMax": 2,
-          "dmgMin": 1,
-          "hit": 2,
-          "intelligence": 2,
-          "stamina": 2,
-          "strength": 2
-        }
-      },
-      "levelling": {
-        "1": {
-          "ref": "ExposeCorruption"
-        },
-        "2": {
-          "ref": "Strike"
-        },
-        "3": {
-          "ref": "SanctifiedWard"
-        },
-        "4": {
-          "ref": "FrostBolt"
-        },
-        "5": {
-          "ref": "Barrier"
-        },
-        "6": {
-          "ref": "EndlessPain"
-        }
-      },
       "baseStats": {
         "class": "CStats",
         "properties": {
@@ -593,11 +523,9 @@
   "Wayfarer": {
     "class": "CPlayer",
     "properties": {
-      "actions": [
-        {
-          "ref": "Attack"
-        }
-      ],
+      "creatureClass": {
+        "ref": "WayfarerClass"
+      },
       "animation": "images/players/wayfarer",
       "equipped": {
         "0": {
@@ -612,39 +540,6 @@
       },
       "items": [],
       "label": "Wayfarer",
-      "levelStats": {
-        "class": "CStats",
-        "properties": {
-          "agility": 3,
-          "crit": 1,
-          "dmgMax": 2,
-          "dmgMin": 1,
-          "hit": 3,
-          "intelligence": 1,
-          "stamina": 1,
-          "strength": 2
-        }
-      },
-      "levelling": {
-        "1": {
-          "ref": "WayfarersStride"
-        },
-        "2": {
-          "ref": "SneakAttack"
-        },
-        "3": {
-          "ref": "SmugglersMark"
-        },
-        "4": {
-          "ref": "DoubleAttack"
-        },
-        "5": {
-          "ref": "Backstab"
-        },
-        "6": {
-          "ref": "BloodThirst"
-        }
-      },
       "baseStats": {
         "class": "CStats",
         "properties": {

--- a/tests/fixtures/creature_stat_scale_baseline.json
+++ b/tests/fixtures/creature_stat_scale_baseline.json
@@ -15,24 +15,8 @@
         "strength": 5
       },
       "class": "CPlayer",
-      "levelStats": {
-        "agility": 3,
-        "crit": 2,
-        "dmgMax": 2,
-        "dmgMin": 1,
-        "hit": 3,
-        "intelligence": 2,
-        "stamina": 1,
-        "strength": 1
-      },
-      "levelling": {
-        "1": "SneakAttack",
-        "2": "Mutilation",
-        "3": "LethalPoison",
-        "4": "Chloroform",
-        "5": "Stunner",
-        "6": "Backstab"
-      }
+      "levelStats": {},
+      "levelling": {}
     },
     "CultLeader": {
       "baseStats": {
@@ -157,24 +141,8 @@
         "strength": 6
       },
       "class": "CPlayer",
-      "levelStats": {
-        "agility": 1,
-        "crit": 1,
-        "dmgMax": 2,
-        "dmgMin": 1,
-        "hit": 2,
-        "intelligence": 2,
-        "stamina": 2,
-        "strength": 2
-      },
-      "levelling": {
-        "1": "ExposeCorruption",
-        "2": "Strike",
-        "3": "SanctifiedWard",
-        "4": "FrostBolt",
-        "5": "Barrier",
-        "6": "EndlessPain"
-      }
+      "levelStats": {},
+      "levelling": {}
     },
     "OctoBogz": {
       "baseStats": {
@@ -309,24 +277,8 @@
         "strength": 6
       },
       "class": "CPlayer",
-      "levelStats": {
-        "agility": 3,
-        "crit": 1,
-        "dmgMax": 2,
-        "dmgMin": 1,
-        "hit": 3,
-        "intelligence": 1,
-        "stamina": 1,
-        "strength": 2
-      },
-      "levelling": {
-        "1": "WayfarersStride",
-        "2": "SneakAttack",
-        "3": "SmugglersMark",
-        "4": "DoubleAttack",
-        "5": "Backstab",
-        "6": "BloodThirst"
-      }
+      "levelStats": {},
+      "levelling": {}
     }
   }
 }

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -3299,13 +3299,11 @@ class UnmigratedCreatureReportTest(unittest.TestCase):
         # migration.
         self.assertTrue(report)
         report_ids = {creature.config_id for creature in report}
-        for player in ("Assasin", "Inquisitor", "Wayfarer"):
-            self.assertIn(player, report_ids)
-            self.assertEqual(("creatureClass", "race"), next(c.missing for c in report if c.config_id == player))
-        # Warrior and Sorcerer have been migrated to a creatureClass (WarriorClass /
-        # SorcererClass, EPIC_04/STORY_02/SUBSTORY_01–02); each still surfaces in the
-        # report but now only lacks a race.
-        for migrated in ("Warrior", "Sorcerer"):
+        # All five production player templates have been migrated to a creatureClass
+        # (Warrior/Sorcerer/Assasin/Inquisitor/Wayfarer, EPIC_04/STORY_02/SUBSTORY_01–05);
+        # each still surfaces in the report but now only lacks a race. Other unmigrated
+        # creatures keep the report non-empty.
+        for migrated in ("Warrior", "Sorcerer", "Assasin", "Inquisitor", "Wayfarer"):
             self.assertIn(migrated, report_ids)
             self.assertEqual(("race",), next(c.missing for c in report if c.config_id == migrated))
 


### PR DESCRIPTION
## Issues
Completes the player-class extraction series (after Warrior #1203, Sorcerer #1209):
- `[EPIC_04][STORY_02][SUBSTORY_03]Extract AssasinClass without renaming public ID` (claim `e8ffc66a…`)
- `[EPIC_04][STORY_02][SUBSTORY_04]Extract InquisitorClass` (claim `fc414441…`)
- `[EPIC_04][STORY_02][SUBSTORY_05]Extract WayfarerClass` (claim `cb7a0ebc…`)

## Changes
- **`res/config/creature_classes.json`**: add `AssasinClass` (mainStat `agility`), `InquisitorClass` (`intelligence`), `WayfarerClass` (`agility`) — each with the class's starting `Attack` action, per-level `levelStats`, and 1–6 `levelling` map.
- **`res/config/monsters.json`**: the three `CPlayer` templates reference their `creatureClass`; moved `actions`/`levelStats`/`levelling` removed; `baseStats`, animation, label, equipment, items, fightController kept. The public template ids (`Assasin`, `Inquisitor`, `Wayfarer`) are unchanged.
- **`tests/fixtures/creature_stat_scale_baseline.json`**: regenerated for the three templates' new shapes.
- **`tests/test_content_validator.py`**: all five production players (Warrior/Sorcerer/Assasin/Inquisitor/Wayfarer) now report only a missing race.

Same proven pattern as Warrior/Sorcerer; `creature_classes.json` staging and the composed-stats layering law are already on main, so no CMake/`test_core.cpp` change is needed. Composed stats/actions preserve each player's pre-migration baseline.

## Validation
Local: `validate_content.py` ✓, `test_creature_stat_scale_baseline` ✓, unmigrated-report ✓. Native build + campaign gates + C++ unit tests validate the composed players (the gameplay-walkthrough gate is separately red main-wide due to unrelated new huge maps).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_