### PR TITLE
Assign thiefClass to GoblinThief (numerically baseline-preserving)

### DIFF
--- a/docs/design/creature_archetypes.md
+++ b/docs/design/creature_archetypes.md
@@ -24,17 +24,18 @@ so composed stats and actions equal the pre-archetype legacy result.
 | `OctoBogz` | `octoBogzRace` | `bruteClass` | Assigned |
 | `Pritz` | `pritzRace` | `bruteClass` | Assigned |
 | `PritzMage` | `pritzRace` | `mageClass` | Assigned |
-| `GoblinThief` | `goblinRace` | (deferred) | Race only |
+| `GoblinThief` | `goblinRace` | `thiefClass` | Assigned |
 | `Cultist` | `humanRace` | (deferred) | Race only (CRA-1 resolved) |
 | `CultLeader` | `humanRace` | (deferred) | Race only (CRA-1 resolved) |
 
 Notes:
 
-- **`GoblinThief` class deferred**: the taxonomy proposes `thiefClass` (agility),
-  but `GoblinThief`'s own `baseStats.mainStat` is `strength`, so a
-  `mainStat: agility` class would change its composed main stat. That is a
-  deliberate rebalance decision, not a baseline-preserving identity change, so
-  only the race is assigned for now.
+- **`GoblinThief` → `thiefClass`**: the taxonomy's rogue role. Although the
+  class selects `mainStat: agility` over `GoblinThief`'s own `strength`, this is
+  numerically baseline-preserving *for this creature*: its `agility` and
+  `strength` are equal at base (5 = 5) and in `levelStats` (2 = 2), and it wears
+  no equipment, so `getMainValue()` returns the identical value under either main
+  stat. Composed stats/actions therefore equal the legacy result.
 - **`Cultist`/`CultLeader` race resolved as `humanRace`**: CRA-1 is resolved in
   favor of the human-faction interpretation — "cult" is an affiliation, not a
   biological race, and every use of the `Cultist` template (hostile cultists and

--- a/res/config/creature_classes.json
+++ b/res/config/creature_classes.json
@@ -104,5 +104,11 @@
         }
       }
     }
+  },
+  "thiefClass": {
+    "class": "CCreatureClass",
+    "properties": {
+      "mainStat": "agility"
+    }
   }
 }

--- a/res/config/monsters.json
+++ b/res/config/monsters.json
@@ -507,6 +507,9 @@
       "race": {
         "ref": "goblinRace"
       },
+      "creatureClass": {
+        "ref": "thiefClass"
+      },
       "sw": 1
     }
   },


### PR DESCRIPTION
## Summary

Completes GoblinThief's archetype with the taxonomy's rogue role, `thiefClass`, and introduces the `thiefClass` class definition.

## Why this is baseline-preserving despite the main-stat change

`thiefClass` selects `mainStat: agility`, whereas GoblinThief's own `baseStats.mainStat` is `strength` — but this is **numerically neutral for this creature**:
- `agility == strength` at base (`5 == 5`),
- `agility == strength` in `levelStats` (`2 == 2`),
- GoblinThief wears no equipment.

So `getMainValue()` returns the identical value under either main stat at every level, and `CCreature::buildComposedStats`/`getEffectiveInteractions` compose exactly the legacy stat block and action set. (This is why the earlier GoblinThief PR #1207 deferred the class — on re-examination the equal-stat invariant makes it safe.)

## Changes

- `res/config/creature_classes.json` — add `thiefClass` (`CCreatureClass`, `mainStat: agility`).
- `res/config/monsters.json` — add `creatureClass: {ref: thiefClass}` to GoblinThief (already `goblinRace`).
- `docs/design/creature_archetypes.md` — GoblinThief now fully assigned; status table + note updated with the equal-stat rationale.

## Validation

- `scripts/validate_content.py` → passed
- `tests.test_content_validator` → 127 tests OK

Native/gameplay suites are validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRsp3dwLXZSefBtSzz3Pjz)_