### PR TITLE
Add player race selection to the new-game flow (character creation)

### DIFF
--- a/res/config/creature_races.json
+++ b/res/config/creature_races.json
@@ -34,9 +34,19 @@
   "humanRace": {
     "class": "CCreatureRace",
     "properties": {
+      "label": "Human",
       "creatureType": "human",
       "subtypes": [],
-      "playerSelectable": false
+      "playerSelectable": true
+    }
+  },
+  "outlanderRace": {
+    "class": "CCreatureRace",
+    "properties": {
+      "label": "Outlander",
+      "creatureType": "human",
+      "subtypes": ["outlander"],
+      "playerSelectable": true
     }
   }
 }

--- a/res/game.py
+++ b/res/game.py
@@ -144,6 +144,19 @@ def choose_player_class(g):
     return options.get(selection, selection)
 
 
+def choose_player_race(g):
+    # Offer the player-selectable races (CCreatureRace entries flagged
+    # playerSelectable). Returns the chosen race id, or "" when no race is
+    # selectable or the choice is cancelled -- an empty race id means "no
+    # override", so the player keeps its template's default race and the flow
+    # behaves exactly as before races were selectable.
+    options = player_race_options(g)
+    if not options:
+        return ""
+    selection = g.getGuiHandler().showSelection(list_string(g, sorted(options.keys())))
+    return options.get(selection, "")
+
+
 def new():
     g = CGameLoader.loadGame()
     CGameLoader.loadGui(g)
@@ -157,7 +170,8 @@ def new():
         if not map:
             return
         player = choose_player_class(g)
-        CGameLoader.startGameWithPlayer(g, map, player)
+        race = choose_player_race(g)
+        CGameLoader.startGameWithPlayer(g, map, player, race)
     elif selection == "LOAD":
         saves = CResourcesProvider.getInstance().getFiles("SAVE")
         if not saves:
@@ -169,7 +183,8 @@ def new():
         CGameLoader.loadSavedGame(g, save)
     elif selection == "RANDOM":
         player = choose_player_class(g)
-        CGameLoader.startRandomGameWithPlayer(g, player)
+        race = choose_player_race(g)
+        CGameLoader.startRandomGameWithPlayer(g, player, race)
     while event_loop.instance().run():
         pass
 


### PR DESCRIPTION
## Summary

Makes **race** a player choice at character creation, alongside the existing class choice, reusing the current `showSelection()` menu UI. This is the first end-to-end slice of the class/race **selection GUI** (Phase 0 + Phase 1 of the plan).

Context: the runtime already had the plumbing — `player_race_options()`, the 4-arg `startGameWithPlayer`/`startRandomGameWithPlayer` overrides, and `CMapLoader::createPlayer(raceId)` — but **no race was player-selectable** and `new()` never offered one (it passed an empty `raceId`, defaulting to the template's race).

## Phase 0 — data (`res/config/creature_races.json`)

- Mark `humanRace` `playerSelectable: true` + `label: "Human"`.
- Add `outlanderRace` (`label: "Outlander"`) as a second selectable race.

Both are **identity-only** (no `baseStats`), so choosing one changes nothing mechanically yet — meaningful racial stat differentiation is a follow-up (Phase 2) that needs gameplay validation. Making `humanRace` selectable/labelled is **baseline-preserving for its existing monster use** (Cultist/CultLeader): `playerSelectable` is read only by the race-options helper and `label` is display-only, so composition is unchanged.

## Phase 1 — wiring (`res/game.py`)

- Add `choose_player_race(g)` mirroring `choose_player_class`.
- Call it in the **NEW** and **RANDOM** paths, passing the chosen race id to the 4-arg overloads.
- Empty race id = "no override" → when no race is selectable or the choice is cancelled, the flow behaves exactly as before. Class identity keeps flowing through `CPlayer.getPlayerClassId()`'s existing `typeId` fallback, so no extra plumbing there.

## Validation

- `scripts/validate_content.py` → passed
- `tests.test_content_validator` → 127 OK
- `res/game.py` compiles; the single `new()`-flow test (LOAD path) is unaffected, and the `player_race_options` tests either compute from the live registry or use their own fakes.

The **race application and the race menu are runtime behavior verified by the native/gameplay CI** (which builds `_game`) — I can't run that in the authoring environment (submodules egress-blocked), so those jobs are the real check here.

## Not in this PR (follow-ups)

- Phase 2: give races differentiated stats (wire `races.json`'s `baseStatContribution` / race `baseStats`) — needs gameplay validation.
- Phase 3: a richer character-creation panel (class + race with a stat preview) instead of two sequential lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRsp3dwLXZSefBtSzz3Pjz)_