### PR TITLE
Show class and race on the character panel (EPIC_06/STORY_02/SUBSTORY_05)

### DIFF
--- a/res/config/panels.json
+++ b/res/config/panels.json
@@ -31,6 +31,8 @@
         "class": "CMapStringString",
         "properties": {
           "values": {
+            "Class": "getPlayerClassId",
+            "Race": "getRaceId",
             "Level": "getLevel",
             "Experience": "getExp",
             "Gold": "getGold",

--- a/src/gui/panel/CGameCharacterPanel.cpp
+++ b/src/gui/panel/CGameCharacterPanel.cpp
@@ -30,11 +30,17 @@ void CGameCharacterPanel::renderObject(std::shared_ptr<CGui> gui, std::shared_pt
             continue;
         }
         // Config-driven reflective accessor: fail closed so a missing / mistyped
-        // char-sheet method name can never crash the render loop.
+        // char-sheet method name can never crash the render loop. Numeric accessors are
+        // shown directly; string accessors (e.g. class / race identity) fall back to a
+        // string invocation so they render as their text value rather than being skipped.
         try {
             text += key + ": " + vstd::str(player->meta()->invoke_method<int>(value, player)) + "\n";
-        } catch (const std::exception &exception) {
-            vstd::logger::warning("Ignoring character sheet value callback failure:", value, exception.what());
+        } catch (const std::exception &) {
+            try {
+                text += key + ": " + player->meta()->invoke_method<std::string>(value, player) + "\n";
+            } catch (const std::exception &exception) {
+                vstd::logger::warning("Ignoring character sheet value callback failure:", value, exception.what());
+            }
         }
     }
     gui->getTextManager()->drawText(text, rect->x, rect->y, rect->w);


### PR DESCRIPTION
## Summary

Completes the character-panel half of **[EPIC_06][STORY_02][SUBSTORY_05] Update class checks and character panel** (the script-side class-check migration landed in #1211). The character sheet now displays the player's **class and race as separate rows**.

### Changes
- **`CGameCharacterPanel::renderObject`** — the render loop drove every char-sheet accessor through `invoke_method<int>`, so string-valued accessors were skipped (logged and dropped). Added a string fallback: numeric accessors render as before; if the int invocation throws, the loop retries the accessor as a string so identity accessors render as text. The existing fail-closed `try/catch` is preserved (a missing/mistyped accessor still cannot crash the render loop).
- **`res/config/panels.json`** — added `"Class" → getPlayerClassId` and `"Race" → getRaceId` to the `characterPanel` charSheet.

### Why this resolves correctly
`getPlayerClassId` / `getRaceId` are `CPlayer` `V_PROPERTY` getters, exactly like the `int` getters already on the sheet (`getExp`, `getGold`, `getLevel`, `getHp`), so they resolve through the same reflective `invoke_method` path — just with a `std::string` return. `getPlayerClassId` falls back to the type id for players saved before the identity model, so old saves still show a class.

### Validation
- `python3 scripts/validate_content.py --repo-root .` → passes; `panels.json` is valid JSON.
- Native CI compiles the change (windows / linux-coverage) and runs the panel layout test.

> Note: `main`'s `linux` job currently has a pre-existing, unrelated failure in `test_stdio_map_walkthrough_ninemarches`/`sunderedmarch` (newer maps added by other work); that is orthogonal to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgwwEuSehxkjEsvFNu9fS)_