### PR TITLE
Route interaction effects through selfTarget (E06/S01/SS02)

### DIFF
--- a/src/object/CInteraction.cpp
+++ b/src/object/CInteraction.cpp
@@ -46,14 +46,14 @@ void CInteraction::onAction(std::shared_ptr<CCreature> first, std::shared_ptr<CC
             if (effect->getLabel().empty()) {
                 effect->setLabel(getLabel());
             }
-            if (effect->hasTag(CTag::Buff)) {
+            if (effectRoutesToCaster(effect)) {
                 effect->setVictim(first);
                 first->addEffect(effect);
             } else if (second) {
                 effect->setVictim(second);
                 second->addEffect(effect);
             } else {
-                vstd::logger::warning("Skipping non-buff effect without target:", this->to_string());
+                vstd::logger::warning("Skipping opponent-target effect without target:", this->to_string());
             }
         }
     }
@@ -66,6 +66,17 @@ void CInteraction::setManaCost(int value) { manaCost = value; }
 bool CInteraction::getSelfTarget() const { return selfTarget; }
 
 void CInteraction::setSelfTarget(bool value) { selfTarget = value; }
+
+bool CInteraction::effectRoutesToCaster(const std::shared_ptr<CEffect> &effect) const {
+    // An explicit selfTarget always routes the effect to the caster, regardless of
+    // tags. Otherwise, preserve the legacy behavior where a Buff-tagged effect is a
+    // self-buff (compatibility fallback for configs authored before selfTarget); every
+    // other effect routes to the opponent.
+    if (selfTarget) {
+        return true;
+    }
+    return effect && effect->hasTag(CTag::Buff);
+}
 
 std::shared_ptr<CEffect> CInteraction::getEffect() const { return effect; }
 

--- a/src/object/CInteraction.h
+++ b/src/object/CInteraction.h
@@ -55,6 +55,14 @@ class CInteraction : public CGameObject {
 
     void setSelfTarget(bool value);
 
+    // Effect target routing (EPIC_06/STORY_01/SUBSTORY_02): true when this
+    // interaction's effect applies to the caster rather than the opponent. An
+    // explicit selfTarget routes to the caster; otherwise a legacy Buff-tagged effect
+    // keeps its historical caster-target behavior (compatibility fallback), and every
+    // other effect routes to the opponent. Routing therefore no longer depends solely
+    // on effect tags, while old buff configs keep working.
+    bool effectRoutesToCaster(const std::shared_ptr<CEffect> &effect) const;
+
   private:
     int manaCost = 0;
     bool selfTarget = false;

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -804,8 +804,7 @@ void test_creature_class_main_stat_is_authoritative_over_race() {
     // No class: composed main stat falls back to the legacy base main stat.
     expect_true(creature->getStats()->getMainStat() == "strength",
                 "with no creatureClass the composed main stat falls back to the legacy base main stat");
-    expect_true(creature->getStats()->getMainValue() == 3,
-                "the legacy fallback main value reads strength (3)");
+    expect_true(creature->getStats()->getMainValue() == 3, "the legacy fallback main value reads strength (3)");
 
     // Attach a creatureClass declaring intelligence as its main stat: class wins.
     auto klass = std::make_shared<CCreatureClass>();
@@ -997,15 +996,13 @@ void test_creature_effective_interactions_compose_archetype_sources() {
     expect_true(contains(concreteFinisher), "unique concrete actions should be exposed");
     // The class level unlock gated above the current level is withheld.
     expect_true(!contains(classUltimate), "class level unlocks above the current level should not be exposed");
-    expect_true(effective.size() == 4,
-                "composed set should be Attack (concrete) + Claw + Strike + Finisher");
+    expect_true(effective.size() == 4, "composed set should be Attack (concrete) + Claw + Strike + Finisher");
 
     // Legacy creature (no race, no class) still composes only its own sources.
     auto legacy = std::make_shared<CCreature>();
     legacy->addAction(interaction("Attack", "legacyAttack"));
     auto legacyEffective = legacy->getEffectiveInteractions();
-    expect_true(legacyEffective.size() == 1,
-                "a creature with no race/class should compose only its own actions");
+    expect_true(legacyEffective.size() == 1, "a creature with no race/class should compose only its own actions");
 }
 void test_creature_action_merge_dedupes_by_type_id() {
     // Pins the approved creature action merge contract
@@ -1137,8 +1134,7 @@ void test_creature_duplicate_attack_from_race_and_class_collapses_to_single_iden
                 "the effective interaction set must expose the deduplicated Attack exactly once");
     expect_true(effective.find(classAttack) != effective.end() && effective.find(raceAttack) == effective.end(),
                 "getEffectiveInteractions should keep the most-specific Attack identity");
-    expect_true(effective.size() == 2,
-                "the effective interaction set should contain no duplicate action identity");
+    expect_true(effective.size() == 2, "the effective interaction set should contain no duplicate action identity");
 }
 
 void test_no_archetype_creature_level_up_mutates_actions_via_levelling() {
@@ -1614,6 +1610,33 @@ void test_creature_get_dmg_hit_chance_is_not_inverted() {
     expect_true(highConnects == iterations, "attack=100 fully offsets a 0-99 dice roll, so every swing connects");
 }
 
+// CInteraction routes its effect to the caster or the opponent via effectRoutesToCaster
+// (EPIC_06/STORY_01/SUBSTORY_02): an explicit selfTarget always routes to the caster, a
+// legacy Buff-tagged effect without selfTarget stays a self-buff, and every other effect
+// routes to the opponent -- so routing no longer depends solely on effect tags while old
+// buff configs still work.
+void test_interaction_effect_routes_to_caster_via_self_target() {
+    auto interaction = std::make_shared<CInteraction>();
+
+    auto buff = std::make_shared<CEffect>();
+    buff->addTag(CTag::Buff);
+    auto debuff = std::make_shared<CEffect>(); // untagged -> opponent
+
+    // No selfTarget: legacy tag-based routing is preserved exactly.
+    expect_true(interaction->effectRoutesToCaster(buff),
+                "a Buff effect without selfTarget keeps its legacy self-buff routing");
+    expect_true(!interaction->effectRoutesToCaster(debuff),
+                "a non-buff effect without selfTarget routes to the opponent");
+    expect_true(!interaction->effectRoutesToCaster(nullptr),
+                "a null effect without selfTarget does not route to the caster");
+
+    // selfTarget overrides tags: the effect always routes to the caster.
+    interaction->setSelfTarget(true);
+    expect_true(interaction->effectRoutesToCaster(debuff),
+                "selfTarget routes an otherwise-opponent effect to the caster");
+    expect_true(interaction->effectRoutesToCaster(buff), "selfTarget keeps a buff on the caster");
+}
+
 } // namespace
 
 int main() {
@@ -1623,6 +1646,7 @@ int main() {
     test_typed_engine_signal_still_fires_directly();
     test_effect_applies_for_exactly_its_duration_without_underflow();
     test_creature_get_dmg_hit_chance_is_not_inverted();
+    test_interaction_effect_routes_to_caster_via_self_target();
     test_tooltip_handler_builds_labels_descriptions_and_item_bonuses();
     test_market_guard_paths_and_item_transfers();
     test_market_prices_are_bounded_and_non_exploitable();


### PR DESCRIPTION
## Issue
`[EPIC_06][STORY_01][SUBSTORY_02]Route effects through selfTarget` (P2). Builds on the `selfTarget` property (E06/S01/SS01, already on main).

## What changed
`CInteraction::onAction` now decides the effect target via a new `effectRoutesToCaster(effect)` helper instead of the effect's `Buff` tag alone:
- explicit **selfTarget** → always applies to the **caster**, regardless of tags;
- otherwise a legacy **Buff**-tagged effect (no selfTarget) keeps its historical **self-buff** behavior (compatibility fallback);
- every other effect routes to the **opponent**.

So target routing no longer depends solely on effect tags, while old buff configs still work (matches the acceptance criteria). **The flag defaults false and no content sets it yet, so existing effect application is byte-for-byte unchanged** — for `selfTarget=false` the new routing reduces exactly to the previous `Buff ? caster : opponent` logic.

## Validation
`tests/unit/test_object.cpp::test_interaction_effect_routes_to_caster_via_self_target` covers the legacy self-buff route, the opponent-debuff route, a null effect, and the selfTarget override. Native `object_unit_tests` validates it on CI. (The opponent-target "no-op missing opponent" branch in `onAction` is unchanged existing behavior.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_