### PR TITLE
Differentiated racial stats: Outlander trade-off + race baseStats validator fix (Phase 2)

### DIFF
--- a/res/config/creature_races.json
+++ b/res/config/creature_races.json
@@ -46,7 +46,16 @@
       "label": "Outlander",
       "creatureType": "human",
       "subtypes": ["outlander"],
-      "playerSelectable": true
+      "playerSelectable": true,
+      "baseStats": {
+        "class": "CStats",
+        "properties": {
+          "strength": 1,
+          "stamina": 2,
+          "agility": -1,
+          "intelligence": -2
+        }
+      }
     }
   }
 }

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -3365,6 +3365,9 @@ class ContentValidator:
             )
 
     def _validate_creature_race_base_stats(self, path: Path, location: str, base_stats: Any) -> None:
+        allowed_keys = self._creature_race_stats_property_names()
+        if allowed_keys is None:
+            return
         if not isinstance(base_stats, dict):
             self._issue(
                 path,
@@ -3372,14 +3375,35 @@ class ContentValidator:
                 f"expected {CREATURE_RACE_STATS_SCHEMA_CLASS}-compatible object; got {json_value_kind(base_stats)}",
             )
             return
-        allowed_keys = self._creature_race_stats_property_names()
-        if allowed_keys is None:
+        # baseStats is deserialized through the standard object envelope
+        # ({"class": "CStats", "properties": {<stat>: <int>}}) -- the same nested form every
+        # other CStats payload in content uses -- and content loads under a strict deserialize
+        # scope, so a bare/flat stat map (stat keys at the top level, no "class") fails to
+        # construct at load time. Require the envelope and validate the inner stat keys.
+        if "class" not in base_stats and "ref" not in base_stats:
+            self._issue(
+                path,
+                location,
+                f'expected a {CREATURE_RACE_STATS_SCHEMA_CLASS} object node '
+                f'(e.g. {{"class": "{CREATURE_RACE_STATS_SCHEMA_CLASS}", "properties": {{...}}}})',
+            )
             return
-        for stat_key in base_stats:
+        stat_properties = base_stats.get("properties")
+        if stat_properties is None:
+            return
+        if not isinstance(stat_properties, dict):
+            self._issue(
+                path,
+                append_field(location, "properties"),
+                f"expected object; got {json_value_kind(stat_properties)}",
+            )
+            return
+        properties_location = append_field(location, "properties")
+        for stat_key in stat_properties:
             if stat_key not in allowed_keys:
                 self._issue(
                     path,
-                    append_field(location, stat_key),
+                    append_field(properties_location, stat_key),
                     f'"{stat_key}" is not a {CREATURE_RACE_STATS_SCHEMA_CLASS} property; '
                     f"expected one of {', '.join(sorted(allowed_keys))}",
                 )

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -2574,7 +2574,10 @@ class ContentValidatorTest(unittest.TestCase):
         self._write_creature_race(
             root,
             {
-                "baseStats": {"strength": 5, "agility": 3, "mainStat": "strength"},
+                "baseStats": {
+                    "class": "CStats",
+                    "properties": {"strength": 5, "agility": 3, "mainStat": "strength"},
+                },
                 "actions": [
                     {"ref": "Attack"},
                     {"class": "CInteraction", "properties": {"effect": {"ref": "HitEffect"}}},
@@ -2589,15 +2592,34 @@ class ContentValidatorTest(unittest.TestCase):
     def test_creature_race_unknown_base_stats_key_is_reported(self):
         root = self.make_fixture()
         self.write_creature_race_stats_fixture(root)
-        self._write_creature_race(root, {"baseStats": {"strenght": 5}})
+        self._write_creature_race(
+            root, {"baseStats": {"class": "CStats", "properties": {"strenght": 5}}}
+        )
 
         issues = validate_repo(root)
 
         self.assertIssueContains(
             issues,
             "res/config/creature_races.json",
-            "humanRace.properties.baseStats.strenght",
+            "humanRace.properties.baseStats.properties.strenght",
             '"strenght" is not a CStats property; expected one of agility, intelligence, mainStat, name, strength',
+        )
+
+    def test_creature_race_flat_base_stats_without_envelope_is_reported(self):
+        # A bare/flat stat map fails to deserialize under the engine's strict object envelope
+        # ({"class": "CStats", "properties": {...}}), so the validator must reject it up front
+        # rather than green-light content that crashes at load time.
+        root = self.make_fixture()
+        self.write_creature_race_stats_fixture(root)
+        self._write_creature_race(root, {"baseStats": {"strength": 5}})
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/creature_races.json",
+            "humanRace.properties.baseStats",
+            "expected a CStats object node",
         )
 
     def test_creature_race_action_not_resolving_to_interaction_is_reported(self):


### PR DESCRIPTION
## Summary

Phase 2 of player race selection: make the selectable races **mechanically distinct**. `CCreature::buildComposedStats` layers `race.baseStats` onto the player, so race stats act as **modifiers**.

- **`outlanderRace`** gains a net-zero trade-off: `strength +1, stamina +2, agility −1, intelligence −2` — a hardy frontier survivor (physically tough, less nimble/learned).
- **`humanRace` stays neutral** (no `baseStats`), so it remains the backward-compatible default — every existing player and test that defaults to human is unchanged, and only players who *choose* Outlander get modifiers. Numbers are easily tunable.

## Validator fix (the interesting part)

Authoring race `baseStats` surfaced a **latent validator bug**. `_validate_creature_race_base_stats` expected a **flat** stat map, but the engine deserializes a `CStats` property through the standard object envelope — `{"class": "CStats", "properties": {…}}` — under a **strict** deserialize scope (`CSerialization::StrictScope`). Evidence:
- `object_deserialize` (CSerialization.cpp) requires `"class"`/`"ref"`; there's no flat path and `CStats` isn't a primitive wrapper.
- **Every** CStats block in content (10 files) uses the nested form; there is **zero** flat usage.

So a flat map would **throw at load time** — the validator was green-lighting content that crashes the game. Per CLAUDE.md ("trust the code, update the checker"), the validator now requires the nested envelope, validates the inner stat keys, and rejects the flat form up front. Updated the two race-baseStats tests to nested and added a test asserting flat is rejected.

## Changes

- `res/config/creature_races.json` — `outlanderRace.baseStats` (nested).
- `scripts/validate_content.py` — `_validate_creature_race_base_stats` requires the nested CStats envelope.
- `tests/test_content_validator.py` — 2 tests updated to nested; 1 test added for flat rejection.

## Validation

- `scripts/validate_content.py` → passed
- `tests.test_content_validator` → 128 OK

The stat application to a chosen-Outlander player is composition logic (unit-tested in `test_object.cpp`) exercised by the native gameplay CI (which builds `_game` and loads the nested race baseStats under strict mode — the smoke/campaign gates would catch a load failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRsp3dwLXZSefBtSzz3Pjz)_