### PR TITLE
Record observation: gameplay-walkthrough CI gate red swarm-wide (huge-map timeouts)

### DIFF
--- a/planning/workflow_observations/records/20260701T114356Z-ctrl-vm-2979-76c8b262-1680614e.json
+++ b/planning/workflow_observations/records/20260701T114356Z-ctrl-vm-2979-76c8b262-1680614e.json
@@ -1,0 +1,47 @@
+{
+  "affectedPaths": [
+    ".github/workflows/build.yml"
+  ],
+  "category": "ci",
+  "controllerId": "ctrl-vm-2979-76c8b262",
+  "createdAtUtc": "2026-07-01T11:43:56Z",
+  "details": "The build workflow 'test (python gameplay)' step fails on every PR because recently-added large maps time out a test shard (exit 124): ninemarches (1000x1000, #1198), sunderedmarch and kadath (200x200, #1189/#1183); test_stdio_map_walkthrough_ninemarches also fails an object lookup. Pre-existing and change-independent (revert #1197 failed identically; workbook/doc PRs fail too). The gameplay walkthrough is the only gate exercising real end-to-end gameplay and is exactly what caught the WarriorClass config-staging regression (#1192/#1197) that unit tests + validate_content.py passed. With it red for unrelated reasons, controllers merge source PRs (incl. active archetype content migrations) on build + campaign-smoke + C++ unit tests alone, so a future content migration can ship a runtime-broken creature undetected.",
+  "evidence": [
+    {
+      "changeIndependenceProof": [
+        "revert #1197 (removed all WarriorClass changes) failed the same gameplay step identically",
+        "pure workbook/doc PRs (#1199,#1201) also show build-workflow failure"
+      ],
+      "failingStep": "test (python gameplay)",
+      "failingTests": [
+        "test_stdio_map_walkthrough_ninemarches",
+        "test_stdio_map_walkthrough_sunderedmarch"
+      ],
+      "gateValueEvidence": "the gameplay walkthrough caught the WarriorClass config-staging regression #1192 (No config found for: WarriorClass -> empty class -> Warrior had no actions) that unit tests + validate_content.py both passed; that PR was reverted in #1197",
+      "hugeMaps": {
+        "kadath": "200x200 (#1183)",
+        "ninemarches": "1000x1000 (#1198)",
+        "sunderedmarch": "200x200 (#1189)"
+      },
+      "objectLookupError": "None is not an instance of dict : Expected object handle for ninemarchesStart",
+      "observedGreenSignalsUsedInstead": [
+        "build test targets",
+        "campaign gate (nouraajd smoke)",
+        "campaign gate (quest state and rewards)",
+        "test (c++)",
+        "performance guard (native)"
+      ],
+      "shardOutcome": "exit 124 (timeout) after 1236s; other shards exit -6"
+    }
+  ],
+  "fingerprint": "gameplay-walkthrough-gate-red-huge-map-timeouts",
+  "id": "20260701T114356Z-ctrl-vm-2979-76c8b262-1680614e",
+  "impact": "Every native/source PR shows a red required gate that must be manually reasoned past, and genuine gameplay regressions in ongoing archetype content migrations can merge undetected because the catching gate is masked by unrelated huge-map timeouts.",
+  "phase": "validation",
+  "role": "controller",
+  "schemaVersion": 1,
+  "severity": "high",
+  "sourceCommit": "a0e8c660",
+  "suggestedImprovement": "Time-box or shard the huge-map walkthroughs (raise shard budget for 200x200/1000x1000 maps, shard them individually, or gate them behind an opt-in label like the full-route scenarios) so the core gameplay walkthrough gate goes green and again blocks real regressions; fix or skip the ninemarchesStart object-handle lookup.",
+  "summary": "Gameplay-walkthrough CI gate red swarm-wide: new huge-map walkthroughs time out, masking the check that catches content-migration regressions"
+}


### PR DESCRIPTION
Immutable workflow-observation record only (no source).

The build workflow's `test (python gameplay)` step fails on every PR because recently-added large maps time out a test shard (exit 124): `ninemarches` (1000×1000, #1198), `sunderedmarch`/`kadath` (200×200, #1189/#1183); `test_stdio_map_walkthrough_ninemarches` also fails an object-handle lookup. This is **pre-existing and change-independent** — the revert #1197 (which removed all WarriorClass changes) failed the same step identically, and workbook/doc PRs fail it too.

Why it matters: the gameplay walkthrough is the only gate exercising real end-to-end gameplay, and it's exactly what caught the WarriorClass config-staging regression (#1192, reverted #1197) that unit tests + `validate_content.py` both passed. With it masked red for unrelated reasons, controllers are merging source PRs (including the active archetype content migrations) on build + campaign-smoke + C++ unit tests alone — so a future content migration can ship a runtime-broken creature undetected.

Suggested fix: time-box/shard the huge-map walkthroughs (or gate them behind an opt-in label like the full-route scenarios) so the core gameplay gate goes green and again blocks real regressions.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVs74ScY29D4F63H4rT1t2)_