### PR TITLE
Add Highlander and Wanderer player races with distinct stat identities

### DIFF
--- a/res/config/creature_races.json
+++ b/res/config/creature_races.json
@@ -57,5 +57,41 @@
         }
       }
     }
+  },
+  "highlanderRace": {
+    "class": "CCreatureRace",
+    "properties": {
+      "label": "Highlander",
+      "creatureType": "human",
+      "subtypes": ["highlander"],
+      "playerSelectable": true,
+      "baseStats": {
+        "class": "CStats",
+        "properties": {
+          "strength": 2,
+          "stamina": 1,
+          "agility": -1,
+          "intelligence": -2
+        }
+      }
+    }
+  },
+  "wandererRace": {
+    "class": "CCreatureRace",
+    "properties": {
+      "label": "Wanderer",
+      "creatureType": "human",
+      "subtypes": ["wanderer"],
+      "playerSelectable": true,
+      "baseStats": {
+        "class": "CStats",
+        "properties": {
+          "agility": 2,
+          "intelligence": 1,
+          "strength": -1,
+          "stamina": -2
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Broadens the character-creation race menu now that the race-stat mechanism and validator are in place (Phase 2). Adds two more human lineages, each a **net-zero** trade-off in the nested CStats `baseStats` form the engine loads under strict mode (proven by `outlanderRace` in the prior change):

- **Highlander** (mountain clans): `strength +2, stamina +1, agility −1, intelligence −2` — a brawny front-liner.
- **Wanderer** (rootless nomads): `agility +2, intelligence +1, strength −1, stamina −2` — quick and worldly-wise but frail.

The selectable set now spans four distinct identities:

| Race | Identity | baseStats delta |
|---|---|---|
| Human | Balanced (default) | — |
| Outlander | Hardy survivor | str +1, stam +2, agi −1, int −2 |
| Highlander | Brawny front-liner | str +2, stam +1, agi −1, int −2 |
| Wanderer | Nimble & clever | agi +2, int +1, str −1, stam −2 |

Distinct labels (no duplicate-label validation issue); numbers are easily tunable.

## Changes

- `res/config/creature_races.json` — add `highlanderRace`, `wandererRace` (player-selectable, nested `baseStats`).

## Validation

- `scripts/validate_content.py` → passed
- `tests.test_content_validator` → 128 OK

Structurally identical to the already-CI-verified Phase 2 race `baseStats`, so strict-load safety is established; the native CI reconfirms load + composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRsp3dwLXZSefBtSzz3Pjz)_