### PR TITLE
Add a combined class+race character-creation panel

### DIFF
--- a/res/game.py
+++ b/res/game.py
@@ -181,6 +181,29 @@ def choose_player_race(g):
     return display.get(selection, "")
 
 
+def choose_character(g):
+    # Combined class + race character-creation screen: one panel with two columns
+    # of buttons (classes on the left, stat-previewed races on the right), closing
+    # once both are picked. Returns (class_type, race_id); an empty class_type means
+    # the choice was cancelled. Falls back to the sequential menus when either side
+    # has no options (e.g. no player-selectable races), preserving old behaviour.
+    class_options = player_class_options(g)  # {label: player_type}
+    race_options = player_race_options(g)  # {label: race_type}
+    race_display = {}
+    for label, race_type in race_options.items():
+        preview = race_stat_preview(g.createObject(race_type))
+        race_display[f"{label} - {preview}"] = race_type
+    if not class_options or not race_display:
+        return choose_player_class(g), choose_player_race(g)
+    class_label, race_label = g.getGuiHandler().showCharacterCreation(
+        list_string(g, list(class_options.keys())),
+        list_string(g, list(race_display.keys())),
+    )
+    if not class_label:
+        return "", ""
+    return class_options.get(class_label, class_label), race_display.get(race_label, "")
+
+
 def new():
     g = CGameLoader.loadGame()
     CGameLoader.loadGui(g)
@@ -193,8 +216,9 @@ def new():
         map = g.getGuiHandler().showSelection(list_string(g, maps))
         if not map:
             return
-        player = choose_player_class(g)
-        race = choose_player_race(g)
+        player, race = choose_character(g)
+        if not player:
+            return
         CGameLoader.startGameWithPlayer(g, map, player, race)
     elif selection == "LOAD":
         saves = CResourcesProvider.getInstance().getFiles("SAVE")
@@ -206,8 +230,9 @@ def new():
             return
         CGameLoader.loadSavedGame(g, save)
     elif selection == "RANDOM":
-        player = choose_player_class(g)
-        race = choose_player_race(g)
+        player, race = choose_character(g)
+        if not player:
+            return
         CGameLoader.startRandomGameWithPlayer(g, player, race)
     while event_loop.instance().run():
         pass

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -683,6 +683,8 @@ void init_game_module(py::module_ &m) {
         .def("showDialog", &CGuiHandler::showDialog, "Open a dialog panel.")
         .def("showQuestion", &CGuiHandler::showQuestion, "Open a question/choice panel.")
         .def("showSelection", &CGuiHandler::showSelection, "Open a selection panel.")
+        .def("showCharacterCreation", &CGuiHandler::showCharacterCreation, py::arg("classes"), py::arg("races"),
+             "Open the class+race character-creation panel; returns a (classLabel, raceLabel) tuple.")
         .def("showInfo", &CGuiHandler::showInfo, py::arg("message"), py::arg("centered") = false, "Open an info panel.")
         .def("openPanel", &CGuiHandler::openPanel, "Open a configured panel without blocking for user input.")
         .def("showLoot", &CGuiHandler::showLoot, "Show loot acquisition UI.")

--- a/src/handler/CGuiHandler.cpp
+++ b/src/handler/CGuiHandler.cpp
@@ -235,6 +235,90 @@ std::string CGuiHandler::showSelection(std::shared_ptr<CListString> list) {
     return selected ? *selected : "";
 }
 
+std::pair<std::string, std::string> CGuiHandler::showCharacterCreation(std::shared_ptr<CListString> classes,
+                                                                       std::shared_ptr<CListString> races) {
+    auto game = _game.lock();
+    if (!game || !game->getGui()) {
+        return {"", ""};
+    }
+
+    auto classValues = classes ? classes->getValues() : std::set<std::string>();
+    auto raceValues = races ? races->getValues() : std::set<std::string>();
+    if (classValues.empty() || raceValues.empty()) {
+        // Nothing to compose a two-column chooser from; let the caller fall back.
+        return {"", ""};
+    }
+    if (CPlaytestTrace::enabled()) {
+        json fields = {{"blocking", true},
+                       {"classCount", static_cast<unsigned long long>(classValues.size())},
+                       {"raceCount", static_cast<unsigned long long>(raceValues.size())},
+                       {"panel", "selectionPanel"},
+                       {"panelKind", "characterCreation"}};
+        CPlaytestTrace::addMapContext(fields, game->getMap());
+        CPlaytestTrace::record("gui_panel_opened", fields);
+    }
+
+    std::shared_ptr<CGamePanel> panel = game->createObject<CGamePanel>("selectionPanel");
+    const std::size_t rows = classValues.size() > raceValues.size() ? classValues.size() : raceValues.size();
+    if (auto centered = vstd::cast<CCenteredLayout>(panel->getLayout())) {
+        centered->setW("600");
+        centered->setH(vstd::str(75 * rows));
+    }
+
+    std::shared_ptr<std::string> selectedClass;
+    std::shared_ptr<std::string> selectedRace;
+    std::set<std::shared_ptr<CGameGraphicsObject>> widgets;
+
+    // Builds one vertical column of option buttons occupying the [x, x+w] band.
+    // `selected` is a pointer to a caller-owned local (valid for the whole call,
+    // including the wait_until below); each button captures that pointer by value
+    // and writes the picked label into it on click. TODO: unify with showSelection.
+    auto buildColumn = [&](const std::set<std::string> &values, std::shared_ptr<std::string> *selected,
+                           const std::string &prefix, const std::string &x, const std::string &w) {
+        int i = 0;
+        for (auto item : values) {
+            std::string clickName = prefix + vstd::str(i);
+
+            panel->meta()->set_method<CGameGraphicsObject, void, std::shared_ptr<CGui>>(
+                clickName, panel, [item, selected](CGameGraphicsObject *self, std::shared_ptr<CGui> gui) {
+                    *selected = std::make_shared<std::string>(item);
+                });
+
+            std::shared_ptr<CButton> widget = game->createObject<CButton>("CButton");
+            widget->setClick(clickName);
+            widget->setText(item);
+
+            std::shared_ptr<CLayout> layout = game->createObject<CLayout>("CLayout");
+            const int y0 = 100 * i / values.size();
+            const int y1 = 100 * (i + 1) / values.size();
+            layout->setX(x);
+            layout->setY(vstd::str(y0) + "%");
+            layout->setW(w);
+            layout->setH(vstd::str(y1 - y0) + "%");
+            widget->setLayout(layout);
+            widgets.insert(widget);
+            i++;
+        }
+    };
+
+    buildColumn(classValues, &selectedClass, "clickClass", "0%", "50%");
+    buildColumn(raceValues, &selectedRace, "clickRace", "50%", "50%");
+
+    panel->setChildren(widgets);
+
+    game->getGui()->pushChild(panel);
+
+    // Close once both a class and a race are chosen (or the panel is torn down).
+    vstd::wait_until([&]() { return (selectedClass && selectedRace) || !panel->getGui(); });
+
+    panel->close();
+
+    if (!selectedClass || !selectedRace) {
+        return {"", ""};
+    }
+    return {*selectedClass, *selectedRace};
+}
+
 void CGuiHandler::showTooltip(std::string text, int x, int y) {
     if (text.length() > 0) {
         auto game = _game.lock();

--- a/src/handler/CGuiHandler.h
+++ b/src/handler/CGuiHandler.h
@@ -19,6 +19,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "object/CGameObject.h"
 
+#include <utility>
+
 class CListString;
 
 class CGamePanel;
@@ -52,6 +54,14 @@ class CGuiHandler : public CGameObject {
     void showLoot(std::shared_ptr<CCreature>, std::set<std::shared_ptr<CItem>> items);
 
     std::string showSelection(std::shared_ptr<CListString> list);
+
+    // Blocking character-creation chooser: two columns of buttons (class options
+    // and race options, each an already-formatted label string), returning the
+    // picked {classLabel, raceLabel}. Returns {"",""} if either column is empty
+    // or the panel is closed without a full pick. The caller (res/game.py) owns
+    // building the labels and mapping them back to ids.
+    std::pair<std::string, std::string> showCharacterCreation(std::shared_ptr<CListString> classes,
+                                                              std::shared_ptr<CListString> races);
 
     void showTooltip(std::string text, int x, int y);
 

--- a/test.py
+++ b/test.py
@@ -11504,6 +11504,24 @@ class GameTest(unittest.TestCase):
         self.assertLess(time.monotonic() - started_at, 1.0)
         return True, json.dumps({"selected": selected})
 
+    @game_test
+    def test_character_creation_empty_columns_return_without_waiting(self):
+        game = load_game_module()
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.loadGui(g)
+
+        empty = g.createObject("CListString")
+        non_empty = g.createObject("CListString")
+        non_empty.addValue("Warrior")
+
+        started_at = time.monotonic()
+        # Either column empty -> no panel, returns a ("", "") tuple immediately.
+        self.assertEqual(("", ""), tuple(g.getGuiHandler().showCharacterCreation(empty, empty)))
+        self.assertEqual(("", ""), tuple(g.getGuiHandler().showCharacterCreation(non_empty, empty)))
+        self.assertEqual(("", ""), tuple(g.getGuiHandler().showCharacterCreation(empty, non_empty)))
+        self.assertLess(time.monotonic() - started_at, 1.0)
+        return True, json.dumps({"ok": True})
+
     def test_new_game_load_with_no_saves_reports_message(self):
         game = load_game_module()
 


### PR DESCRIPTION
## Summary

Implements the graphical character-creation screen from `docs/design/character_creation_panel.md` (Approach A): **one panel, two columns of text buttons** — classes on the left, stat-previewed races on the right — that closes once **both** are picked, replacing the two sequential `showSelection` menus.

## Design (mirrors the proven `showSelection`)

- **`CGuiHandler::showCharacterCreation(classes, races)`** is a near-clone of `showSelection`: it reuses the `selectionPanel`, builds `CButton`+`CLayout` children dynamically, registers per-button `clickN` callbacks via `panel->meta()->set_method`, `vstd::wait_until`s, and `close()`s — extended to two columns and blocking until a class **and** a race are chosen. Returns the picked `{classLabel, raceLabel}`; `{"",""}` when a column is empty or the panel is torn down.
  - Click lambdas capture a **pointer to the caller's selection locals** (valid across the wait), avoiding the dangling-reference trap of capturing a helper's reference parameter.
- Bound on the `CGuiHandler` pybind class; `std::pair` → Python tuple via the already-included `pybind11/stl.h`.
- **`res/game.py`**: `choose_character(g)` builds the class labels + preview-tagged race labels (reusing `player_class_options` / `player_race_options` / `race_stat_preview`), calls `showCharacterCreation`, and maps the picks back to ids. NEW and RANDOM use it; **falls back** to the sequential menus when there are no selectable races (preserves prior behaviour).
- **`test.py`**: `test_character_creation_empty_columns_return_without_waiting` (empty column → immediate `("","")`, no panel).

## Why buttons (not `CListView`)

Per the design doc: `CListView` renders each item as its **animation/icon** (`CListView.cpp:39`) and races have no art, so a list would render blank tiles. `CButton`/`CTextWidget` renders **text** — so the chooser is button-based, exactly like `showSelection`.

## Validation

- Local: `game.py`/`test.py` compile; `scripts/validate_content.py` and `tests.test_content_validator` (134) pass; `choose_character` control flow (pick / cancel / fallback) verified standalone.
- The C++ build, the pybind binding, and the interactive click-through are validated by the **native gameplay CI** (I can't build `_game` locally). This is a close clone of the proven `showSelection`, but flagging that the interactive two-click path is CI/manual-verified, not unit-tested (coordinate-based SDL simulation would be brittle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRsp3dwLXZSefBtSzz3Pjz)_