### PR TITLE
Fix generate_screenshots.py docstring indentation (un-red test_indentation)

### DIFF
--- a/scripts/generate_screenshots.py
+++ b/scripts/generate_screenshots.py
@@ -19,18 +19,18 @@
 regenerated and that it covers, at minimum:
 
 * at least one screenshot showing each type of panel declared in
-  ``res/config/panels.json``; and
+    ``res/config/panels.json``; and
 * at least one screenshot from each map directory under ``res/maps/`` plus one
-  from a randomly generated map.
+    from a randomly generated map.
 
 This script drives a real (GUI) headless game session -- the same
 :class:`game_simulation.GameSimulation` driver and SDL ``read_pixels`` readback
 used by the screenshot tests -- to produce that set:
 
 * ``panel-<resourceId>.png`` for every panel in ``res/config/panels.json``,
-  including the ``creatureView`` and ``statsView`` views (which also appear
-  nested inside ``fightPanel``). Each panel is seeded with representative
-  content so the frame is meaningful rather than empty.
+    including the ``creatureView`` and ``statsView`` views (which also appear
+    nested inside ``fightPanel``). Each panel is seeded with representative
+    content so the frame is meaningful rather than empty.
 * ``map-<name>.png`` for every map directory under ``res/maps/``.
 * ``map-random.png`` for a freshly generated random map.
 


### PR DESCRIPTION
## Summary

`test_indentation` (in `test.py`) flags every tracked `*.py` line whose leading whitespace isn't a multiple of four. Five RST bullet-continuation lines in `scripts/generate_screenshots.py`'s module docstring used a **2-space** indent, so the check has been failing on `main`. This bumps those continuations to 4-space indent.

## Changes

- `scripts/generate_screenshots.py` — docstring-only, whitespace-only: 5 continuation lines 2-space → 4-space.

## Validation

- Replicated `test_indentation`'s exact check across all tracked `*.py`: **0 offenders** after the change (was 5).
- `python3 -m py_compile scripts/generate_screenshots.py` → OK.

No code/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRsp3dwLXZSefBtSzz3Pjz)_