### PR TITLE
Fix inverted turncoat companion leave check in Nine Marches

### DIFF
--- a/res/maps/ninemarches/script.py
+++ b/res/maps/ninemarches/script.py
@@ -345,6 +345,13 @@ def load(self, context):
         ITEM = None
         BOON = None
         LEAVE_AT = -5
+        # Direction of the reputation break: most companions leave when your standing
+        # sinks to/below LEAVE_AT; a turncoat leaves when it rises to/above it instead.
+        LEAVE_WHEN_ABOVE = False
+        LEAVE_MESSAGE = (
+            "Your reputation in the marches has sunk past what your companion can stomach. They take their "
+            "leave - the war-gift stays, but their sword does not."
+        )
 
         def not_met(self):
             game_map = self.getGame().getMap()
@@ -380,15 +387,16 @@ def load(self, context):
             game_map.getPlayer().checkQuests()
 
         def banter(self):
-            # Baldur's-Gate-style reputation reactivity: a companion may leave if you sink too low.
+            # Baldur's-Gate-style reputation reactivity: a companion may leave if your
+            # standing drifts past what they can stomach. Most break when it sinks too low
+            # (LEAVE_WHEN_ABOVE is False); a turncoat breaks when you grow too righteous.
             game_map = self.getGame().getMap()
             if game_map.getBoolProperty(self.JOINED_FLAG) and not game_map.getBoolProperty(self.LEFT_FLAG):
-                if reputation(game_map) <= self.LEAVE_AT:
+                rep = reputation(game_map)
+                left = rep >= self.LEAVE_AT if self.LEAVE_WHEN_ABOVE else rep <= self.LEAVE_AT
+                if left:
                     game_map.setBoolProperty(self.LEFT_FLAG, True)
-                    self.getGame().getGuiHandler().showMessage(
-                        "Your reputation in the marches has sunk past what your companion can stomach. They take their "
-                        "leave - the war-gift stays, but their sword does not."
-                    )
+                    self.getGame().getGuiHandler().showMessage(self.LEAVE_MESSAGE)
 
     # Dialog action/condition callbacks are resolved on the exact registered class, so each
     # companion dialog re-declares the shared callbacks as thin delegates to the base logic.
@@ -460,7 +468,13 @@ def load(self, context):
         QUEST = "corvynQuest"
         ITEM = "ashRelic"
         BOON = "corvynsBlade"
-        LEAVE_AT = 5  # the turncoat leaves if you get too righteous for his taste
+        # The turncoat leaves if you get too righteous for his taste: break upward, not downward.
+        LEAVE_AT = 5
+        LEAVE_WHEN_ABOVE = True
+        LEAVE_MESSAGE = (
+            "You have grown too clean and beloved for the turncoat's taste. Corvyn remembers he works for "
+            "coin, not causes, and takes his leave - the war-gift stays, but his sword does not."
+        )
 
         def not_met(self):
             return CompanionDialog.not_met(self)

--- a/test.py
+++ b/test.py
@@ -4818,6 +4818,22 @@ def walkthrough_ninemarches_map():
     assert player.getNumericProperty("reputation") == rep_before + 2, "Recruiting a companion should raise reputation."
     assert player.countItems("aegisOfHalda") >= 1, "Recruiting Ser Halda should grant her war-gift boon."
 
+    # Turncoat companion: Corvyn breaks the other way -- he leaves if you grow *too
+    # righteous*, not when your standing sinks. Regression guard for the inverted leave
+    # check that made him desert the moment he was recruited.
+    sellsword = g.createObject("sellswordDialog")
+    sellsword.start()
+    assert "corvynQuest" in quest_names(player), "Talking to Corvyn should start his quest."
+    player.addItem("ashRelic")
+    sellsword.recruit()
+    assert game_map.getBoolProperty("corvyn_joined"), "Returning the ash relic should recruit Corvyn."
+    player.setNumericProperty("reputation", 0)
+    sellsword.banter()
+    assert not game_map.getBoolProperty("corvyn_left"), "The turncoat must not desert at low reputation."
+    player.setNumericProperty("reputation", 5)
+    sellsword.banter()
+    assert game_map.getBoolProperty("corvyn_left"), "The turncoat should leave once you grow too righteous."
+
     # Heroes-3 obelisk -> Grail hunt: read all six march-obelisks.
     for obelisk in obelisks:
         move_to_object(obelisk)


### PR DESCRIPTION
## Summary

The Corvyn companion (`SellswordDialog`) in the Nine Marches map is designed to desert the player if their reputation grows **too high** — his `LEAVE_AT` is `+5` with a comment stating he "leaves if you get too righteous for his taste". But the shared `CompanionDialog.banter()` only compared `reputation <= LEAVE_AT`, which is the *low*-reputation direction used by the honourable companions (Halda/Morrigane, `LEAVE_AT = -5`).

Because reputation starts at `0` and recruiting a companion grants `+2`, the check `reputation (2) <= 5` was immediately true, so **Corvyn deserted on the very next banter right after being recruited** — the opposite of the documented intent, making him effectively unusable as an ally.

## Fix

- Generalise the leave direction with a `LEAVE_WHEN_ABOVE` flag and a per-companion `LEAVE_MESSAGE`:
  - Honourable companions keep breaking when reputation **sinks to/below** their threshold (unchanged behaviour).
  - The turncoat (Corvyn) now breaks when reputation **rises to/above** his threshold, matching the design comment, with a message that fits the "too righteous" case.

## Test

- Extends the `ninemarches` walkthrough to recruit Corvyn, assert he **stays** at low reputation, and assert he **leaves** once the player grows too righteous (`reputation = 5`).

## Validation

- `python3 scripts/validate_content.py --repo-root .` → passes
- `python3 -m py_compile res/maps/ninemarches/script.py test.py` → passes

Note: the local `_game` extension could not be built in this environment (the `vstd` / `random-dungeon-generator` submodules are outside the egress policy allow-list), so the gameplay walkthrough itself is validated by CI. The change is pure map-script content plus a regression assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WUArzYDXEz48Z5iSuQ5WD

---
_Generated by [Claude Code](https://claude.ai/code/session_018WUArzYDXEz48Z5iSuQ5WD)_