### PR TITLE
Record observation: shortlist not claim/merge-aware, completed rows stay eligible

### DIFF
--- a/planning/workflow_observations/records/20260701T164846Z-ctrl-nouraajd-queue-erl33f-95dd2d9d.json
+++ b/planning/workflow_observations/records/20260701T164846Z-ctrl-nouraajd-queue-erl33f-95dd2d9d.json
@@ -1,0 +1,52 @@
+{
+  "affectedPaths": [
+    "planning/fall_of_nouraajd_issue_proposals.xlsx",
+    "scripts/issue_queue.py"
+  ],
+  "category": "queue_lease",
+  "controllerId": "ctrl-nouraajd-queue-erl33f",
+  "createdAtUtc": "2026-07-01T16:48:46Z",
+  "details": "The issue_queue.py shortlist is not claim/merge-aware: an issue stays eligible until a\nhuman marks its workbook row DONE, so issues whose code has already landed on main keep\nbeing surfaced as the next work. A controller that trusts the shortlist re-investigates\n(and can re-implement) completed work.\n\nVerified already-implemented-in-main on 5ecdac1 while working the EPIC_06/EPIC_07 cluster:\n\n- [EPIC_07][STORY_02][SUBSTORY_03] Add runtime actor cleanup helpers (P1, still eligible)\n  remove_runtime_actors already lives in res/game.py:47 and is used at all four call sites\n  the ticket names (script.py:24 _clear_victor_encounter, :1006 OldWomanTrigger, :1051\n  complete_amulet_quest, plus CultLeaderQuestTrigger via _clear_victor_encounter), with\n  dedicated + regression + static-usage tests in test.py. Nothing left to implement.\n\n- [EPIC_06][STORY_02][SUBSTORY_05] Update class checks and character panel (P2, eligible)\n  Nouraajd checks already read getPlayerClassId; panels.json charSheet already shows Class\n  and Race separately. Landed via #1177/#1211/#1219.\n\n- [EPIC_06][STORY_03][SUBSTORY_02] Audit class-specific dialogs and actions (P2, eligible)\n  Dialog conditions already gate on getPlayerClassId, and the four named interaction plugins\n  scale purely on progression counters (inquisitor_clues/wayfarer_routes) with no class-id\n  gating, so there is no getTypeId() usage to migrate.\n\n- [EPIC_04][STORY_03][SUBSTORY_01] Define map assets schema (P2, eligible)\n  MAP_ASSET_KINDS + _validate_map_assets + docs/content.md map-assets section already exist\n  (#1121).\n\nAdditionally, the two rows completed THIS controller run remain eligible immediately after\nmerge:\n  [EPIC_06][STORY_03][SUBSTORY_05] Validate class-id references (#1229, main ed705b1)\n  [EPIC_06][STORY_01][SUBSTORY_03] Migrate interaction JSON to selfTarget (#1230, main d243c7f)\n\nNet effect for this environment: after those merges, every eligible row that is pure\nPython/JSON/validator (locally verifiable without the C++ engine build, which is unavailable\nhere) is already satisfied; the only genuinely-open eligible rows are C++-heavy\n(EPIC_02 provider migration, EPIC_02 transition API, EPIC_03 serialization, EPIC_05 GUI),\nwhich cannot be compile-verified in an environment without the vstd/SDL2 toolchain.\n",
+  "evidence": [
+    {
+      "alreadyImplementedEligibleIssues": [
+        {
+          "evidence": "remove_runtime_actors defined res/game.py:47; used res/maps/nouraajd/script.py:24 (_clear_victor_encounter), :1006 (OldWomanTrigger), :1051 (complete_amulet_quest); tests test_nouraajd_remove_runtime_actors_helper (test.py:12891) plus victor good/bad-end + amulet cleanup and static helper-usage assertions (test.py:12756-12771)",
+          "issue": "[EPIC_07][STORY_02][SUBSTORY_03]Add runtime actor cleanup helpers",
+          "priority": "P1"
+        },
+        {
+          "evidence": "script.py class checks use getPlayerClassId (res/maps/nouraajd/script.py:648,691,753,846,863); character panel shows separate Class/Race (res/config/panels.json:34-35 Class->getPlayerClassId, Race->getRaceId; CGameCharacterPanel.cpp nested int/string callback try-catch). Landed via #1177/#1211/#1219",
+          "issue": "[EPIC_06][STORY_02][SUBSTORY_05]Update class checks and character panel",
+          "priority": "P2"
+        },
+        {
+          "evidence": "can_chart_wayfarer_route/can_inspect_stained_glass gate on getPlayerClassId (script.py:748-863); interaction.py ExposeCorruption/SanctifiedWard/WayfarersStride/SmugglersMark scale on progression properties inquisitor_clues/wayfarer_routes with no class-identity gating (res/plugins/interaction.py:186-260); coverage at test.py:14101/14196/14248",
+          "issue": "[EPIC_06][STORY_03][SUBSTORY_02]Audit class-specific dialogs and actions",
+          "priority": "P2"
+        },
+        {
+          "evidence": "MAP_ASSET_KINDS + _validate_map_assets in scripts/validate_content.py:24,2298; schema documented docs/content.md:10-48. Landed via #1121",
+          "issue": "[EPIC_04][STORY_03][SUBSTORY_01]Define map assets schema",
+          "priority": "P2"
+        }
+      ],
+      "mergedThisSessionStillEligible": [
+        "[EPIC_06][STORY_03][SUBSTORY_05]Validate class-id references (PR #1229, main ed705b1)",
+        "[EPIC_06][STORY_01][SUBSTORY_03]Migrate interaction JSON to selfTarget (PR #1230, main d243c7f)"
+      ],
+      "shortlistImpact": "issue_queue.py shortlist reports eligibleCount 14 with highestPriority P1; of the 4 P1 eligible, 1 is already implemented and 3 are pure C++; the pure-Python/validator eligible rows are all already satisfied or merged this session",
+      "snapshotMainCommit": "5ecdac141645cfe8fe21cfa6ca4a4a848701e05c"
+    }
+  ],
+  "fingerprint": "shortlist not claim aware already implemented rows stay eligible epic<n> epic<n> queue hygiene",
+  "id": "20260701T164846Z-ctrl-nouraajd-queue-erl33f-95dd2d9d",
+  "impact": "Controllers trusting the shortlist repeatedly claim/investigate (and risk re-implementing) work already on main; in an environment without the C++ engine build, every locally-verifiable eligible row is already satisfied, leaving only unbuildable C++ rows as genuinely open",
+  "phase": "claim",
+  "role": "controller",
+  "schemaVersion": 1,
+  "severity": "medium",
+  "sourceCommit": "5ecdac141645cfe8fe21cfa6ca4a4a848701e05c",
+  "suggestedImprovement": "Mark the already-landed rows DONE (EPIC_07/S02/SS03, EPIC_06/S02/SS05, EPIC_06/S03/SS02, EPIC_04/S03/SS01) and the two merged this run (EPIC_06/S03/SS05 #1229, EPIC_06/S01/SS03 #1230); optionally teach issue_queue.py shortlist to cross-check a row's acceptance against main (or a merged-PR ledger) so completed-but-unmarked rows are filtered from eligibility",
+  "summary": "issue_queue shortlist not claim/merge-aware: multiple already-implemented rows (incl. a P1) stay eligible, so controllers re-investigate completed work"
+}


### PR DESCRIPTION
## Summary

Adds one immutable workflow-observation record (no code/content change).

While driving the EPIC_06/EPIC_07 cluster, I found that `issue_queue.py shortlist`
is **not claim/merge-aware**: a row stays eligible until a human marks its
workbook row DONE, so rows whose code has already landed on `main` keep being
surfaced as the next work. A controller that trusts the shortlist re-investigates
(and could re-implement) completed work.

## Already-implemented eligible rows (verified on `main` 5ecdac1)

- **[EPIC_07][STORY_02][SUBSTORY_03] Add runtime actor cleanup helpers** (P1) —
  `remove_runtime_actors` at `res/game.py:47`, used at all four call sites the
  ticket names (`script.py:24/1006/1051` + `CultLeaderQuestTrigger`), with
  dedicated/regression/static-usage tests in `test.py`.
- **[EPIC_06][STORY_02][SUBSTORY_05] Update class checks and character panel** (P2)
  — checks read `getPlayerClassId`; `panels.json` charSheet shows Class/Race
  separately (#1177/#1211/#1219).
- **[EPIC_06][STORY_03][SUBSTORY_02] Audit class-specific dialogs and actions** (P2)
  — dialog conditions gate on `getPlayerClassId`; the four named interaction
  plugins scale on progression counters with no class-id gating to migrate.
- **[EPIC_04][STORY_03][SUBSTORY_01] Define map assets schema** (P2) —
  `MAP_ASSET_KINDS` + `_validate_map_assets` + `docs/content.md` section (#1121).

The two rows completed earlier this run (#1229, #1230) also remain eligible
immediately after merge.

## Suggested follow-up

Mark the landed rows DONE, and optionally teach `issue_queue.py shortlist` to
cross-check a row's acceptance against `main` (or a merged-PR ledger) so
completed-but-unmarked rows drop out of eligibility.

## Validation

- `python3 scripts/workflow_observations.py validate` → ledger OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERgwwEuSehxkjEsvFNu9fS)_