### PR TITLE
[EPIC_07][STORY_03][SUBSTORY_01] Extend objectRef for creatures

### DIFF
--- a/src/core/CPlaytestTrace.cpp
+++ b/src/core/CPlaytestTrace.cpp
@@ -19,6 +19,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "core/CMap.h"
 #include "object/CCreature.h"
+#include "object/CCreatureClass.h"
+#include "object/CCreatureRace.h"
 #include "object/CGameObject.h"
 #include "object/CItem.h"
 
@@ -245,6 +247,20 @@ json CPlaytestTrace::objectRef(const std::shared_ptr<CGameObject> &object) {
     };
     if (auto creature = std::dynamic_pointer_cast<CCreature>(object)) {
         ref["isPlayer"] = creature->isPlayer();
+        // The "id"/"typeId" above already capture the concrete spawn/template id.
+        // Record the archetype race/class definition ids separately so traces can
+        // distinguish the spawned creature from its race/class archetypes. These
+        // stay empty on legacy (non-archetype) creatures that carry no definition.
+        if (auto race = creature->getRace()) {
+            ref["raceId"] = truncateValue(race->getTypeId());
+        } else {
+            ref["raceId"] = "";
+        }
+        if (auto creatureClass = creature->getCreatureClass()) {
+            ref["classId"] = truncateValue(creatureClass->getTypeId());
+        } else {
+            ref["classId"] = "";
+        }
     }
     return ref;
 }

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -2199,6 +2199,47 @@ void test_loader_invalid_race_leaves_active_map_unchanged() {
     expect_true(game->getMap()->getPlayer() != nullptr, "an empty raceId start should attach a player");
 }
 
+void test_playtest_trace_objectref_distinguishes_creature_spawn_from_archetype_ids() {
+    // An archetype creature: the concrete spawn/template id lives on the creature
+    // itself, while the race/class ids come from the referenced archetype
+    // definitions. objectRef must record all three distinctly.
+    auto archetype_creature = std::make_shared<CCreature>();
+    archetype_creature->setTypeId("goblinRaider");
+    auto race = std::make_shared<CCreatureRace>();
+    race->setTypeId("goblin");
+    auto klass = std::make_shared<CCreatureClass>();
+    klass->setTypeId("raider");
+    archetype_creature->setRace(race);
+    archetype_creature->setCreatureClass(klass);
+
+    json archetype_ref = CPlaytestTrace::objectRef(archetype_creature);
+    expect_true(archetype_ref.contains("typeId") && archetype_ref["typeId"].get<std::string>() == "goblinRaider",
+                "archetype creature trace should keep the concrete spawn/template id in typeId");
+    expect_true(archetype_ref.contains("id") && archetype_ref["id"].get<std::string>() == "goblinRaider",
+                "archetype creature trace should keep the concrete spawn id in id");
+    expect_true(archetype_ref.contains("raceId") && archetype_ref["raceId"].get<std::string>() == "goblin",
+                "archetype creature trace should record the race archetype id separately");
+    expect_true(archetype_ref.contains("classId") && archetype_ref["classId"].get<std::string>() == "raider",
+                "archetype creature trace should record the class archetype id separately");
+    expect_true(archetype_ref["raceId"].get<std::string>() != archetype_ref["typeId"].get<std::string>(),
+                "archetype race id must be distinct from the concrete spawn id");
+    expect_true(archetype_ref["classId"].get<std::string>() != archetype_ref["typeId"].get<std::string>(),
+                "archetype class id must be distinct from the concrete spawn id");
+
+    // A legacy (non-archetype) creature carries no race/class definition, so the
+    // additive fields must stay present but empty for backward compatibility.
+    auto legacy_creature = std::make_shared<CCreature>();
+    legacy_creature->setTypeId("wildBoar");
+
+    json legacy_ref = CPlaytestTrace::objectRef(legacy_creature);
+    expect_true(legacy_ref.contains("typeId") && legacy_ref["typeId"].get<std::string>() == "wildBoar",
+                "legacy creature trace should keep the concrete spawn/template id in typeId");
+    expect_true(legacy_ref.contains("raceId") && legacy_ref["raceId"].get<std::string>().empty(),
+                "legacy creature trace should leave the race id empty when no archetype is present");
+    expect_true(legacy_ref.contains("classId") && legacy_ref["classId"].get<std::string>().empty(),
+                "legacy creature trace should leave the class id empty when no archetype is present");
+}
+
 int main() {
     pybind11::scoped_interpreter guard{};
 
@@ -2245,5 +2286,6 @@ int main() {
 
     test_post_combat_player_path_stops_after_encounter();
     test_post_combat_player_suppresses_destination_visit_events();
+    test_playtest_trace_objectref_distinguishes_creature_spawn_from_archetype_ids();
     return finish_tests();
 }


### PR DESCRIPTION
## Summary

Extends `CPlaytestTrace::objectRef` so creature trace records distinguish the concrete spawn/template id from the race and class archetype ids.

- The existing `id` / `typeId` fields still capture the concrete spawn/template id, unchanged.
- Two additive fields are recorded for creatures: `raceId` (from the referenced `CCreatureRace` definition's typeId) and `classId` (from the referenced `CCreatureClass` definition's typeId).
- The new fields are populated only when the archetype definition is present; they stay empty for legacy (non-archetype) creatures, preserving backward compatibility.

## Acceptance criteria

Playtest trace records distinguish the concrete spawn id from the race/class ids.

## Tests

Adds `test_playtest_trace_objectref_distinguishes_creature_spawn_from_archetype_ids` in `tests/unit/test_map.cpp` (registered in `main()`):
- An archetype creature records the concrete spawn id in `id`/`typeId` and its race/class ids separately in `raceId`/`classId`, each distinct from the spawn id.
- A non-archetype creature leaves `raceId`/`classId` empty.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_