### PR TITLE
[EPIC_04][STORY_05][SUBSTORY_01] Test every class/race combination

### DIFF
--- a/test.py
+++ b/test.py
@@ -16752,6 +16752,55 @@ class GameTest(unittest.TestCase):
 
         return True, json.dumps(summary, sort_keys=True)
 
+    @game_test
+    def test_every_class_race_combination_starts_and_retains_identity(self):
+        # Acceptance: every approved class x race combination must start successfully and
+        # retain its expected identities. The approved lists are the runtime-selectable ones
+        # exposed by the merged menu helpers (player_class_options -> {label: playerType},
+        # player_race_options -> {label: raceId}), so this stays in sync with the config and
+        # never hard-codes an ad-hoc list. For each combination we start a fresh game with the
+        # chosen class + race (the four-argument startGameWithPlayer override applies the race),
+        # then assert the constructed player is a live, valid CPlayer whose class identity
+        # (getPlayerClassId) and race identity (getRaceId) match what was selected.
+        game = load_game_module()
+
+        options_game = game.CGameLoader.loadGame()
+        class_options = game.player_class_options(options_game)
+        race_options = game.player_race_options(options_game)
+        class_types = sorted(class_options.values())
+        race_ids = sorted(race_options.values())
+        self.assertGreater(len(class_types), 0, "no player-selectable classes")
+        self.assertGreater(len(race_ids), 0, "no player-selectable races")
+
+        results = {}
+        for player_type in class_types:
+            for race_id in race_ids:
+                combination = f"{player_type}+{race_id}"
+                g = game.CGameLoader.loadGame()
+                game.CGameLoader.startGameWithPlayer(g, "test", player_type, race_id)
+                game_map = g.getMap()
+                self.assertIsNotNone(game_map, combination)
+                player = game_map.getPlayer()
+
+                # Started successfully: the player exists, is a real controllable CPlayer, and is alive.
+                self.assertIsNotNone(player, combination)
+                self.assertIsNotNone(get_player_controller(player), combination)
+                self.assertTrue(player.isAlive(), combination)
+
+                # Retains its expected identities: the selected class id and race id round-trip.
+                self.assertEqual(player_type, player.getPlayerClassId(), combination)
+                self.assertEqual(race_id, player.getRaceId(), combination)
+
+                results[combination] = {
+                    "playerClassId": player.getPlayerClassId(),
+                    "raceId": player.getRaceId(),
+                    "alive": player.isAlive(),
+                }
+
+        # Full coverage of the approved matrix, with a distinct entry per combination.
+        self.assertEqual(len(class_types) * len(race_ids), len(results))
+        return True, json.dumps(results, sort_keys=True)
+
 
 class ConsoleEventIsolationTest(unittest.TestCase):
     def test_console_key_history_in_fresh_process(self):


### PR DESCRIPTION
## Summary

Adds a single new `GameTest` (`test_every_class_race_combination_starts_and_retains_identity`) that iterates over every approved player class x race combination and asserts each starts successfully and retains its expected identities.

## Details

- The approved class and race lists are derived at runtime from the merged menu helpers `player_class_options(g)` (`{label: playerType}`) and `player_race_options(g)` (`{label: raceId}`), so the matrix stays in sync with `res/config/creature_classes.json` / `res/config/creature_races.json` and never hard-codes an ad-hoc list.
- For each combination, a fresh game is started via the four-argument `CGameLoader.startGameWithPlayer(g, "test", playerType, raceId)` override (the fourth argument applies the selected race).
- Each combination asserts: the constructed player exists and is a controllable `CPlayer` (`get_player_controller`), is alive (`isAlive()`), and retains its identities via `getPlayerClassId()` == selected class and `getRaceId()` == selected race.
- Full-coverage guard asserts `len(class_types) * len(race_ids)` distinct result entries.

test.py is additions-only; `python3 -m py_compile test.py` passes and `git diff --stat` shows only test.py changed.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_