### PR TITLE
[EPIC_07][STORY_02][SUBSTORY_01] Add race/class tooltip lines

### DIFF
--- a/src/handler/CTooltipHandler.cpp
+++ b/src/handler/CTooltipHandler.cpp
@@ -16,11 +16,42 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "CTooltipHandler.h"
+#include "object/CCreature.h"
+#include "object/CCreatureClass.h"
+#include "object/CCreatureRace.h"
 #include "object/CItem.h"
+
+#include <set>
+#include <string>
+
+namespace {
+// Appends a single archetype line, skipping empty text and any description that
+// was already emitted (guards against duplicating the creature's own or the
+// other archetype's description).
+void add_archetype_line(std::string &tooltip, std::set<std::string> &seen, const std::string &line) {
+    if (line.empty() || !seen.insert(line).second) {
+        return;
+    }
+    vstd::add_line(tooltip, line);
+}
+} // namespace
 
 std::string CTooltipHandler::buildTooltip(std::shared_ptr<CGameObject> object) {
     std::string tooltip = object->getLabel();
     vstd::add_line(tooltip, object->getDescription());
+    if (object->meta()->inherits("CCreature")) {
+        auto creature = vstd::cast<CCreature>(object);
+        std::set<std::string> seen;
+        seen.insert(object->getDescription());
+        if (auto race = creature->getRace()) {
+            add_archetype_line(tooltip, seen, race->getLabel());
+            add_archetype_line(tooltip, seen, race->getDescription());
+        }
+        if (auto creatureClass = creature->getCreatureClass()) {
+            add_archetype_line(tooltip, seen, creatureClass->getLabel());
+            add_archetype_line(tooltip, seen, creatureClass->getDescription());
+        }
+    }
     if (object->meta()->inherits("CItem")) {
         auto bonus = vstd::cast<CItem>(object)->getBonus();
         bonus->meta()->for_all_properties(bonus, [&](auto prop) {

--- a/tests/unit/test_handler.cpp
+++ b/tests/unit/test_handler.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "handler/CQuestHandler.h"
 #include "handler/CRngHandler.h"
 #include "handler/CScriptHandler.h"
+#include "handler/CTooltipHandler.h"
 #include "core/CController.h"
 #include "core/CGame.h"
 #include "core/CJsonUtil.h"
@@ -31,6 +32,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CGui.h"
 #include "gui/panel/CGameFightPanel.h"
 #include "object/CCreature.h"
+#include "object/CCreatureClass.h"
+#include "object/CCreatureRace.h"
 #include "object/CInteraction.h"
 #include "object/CEffect.h"
 #include "object/CItem.h"
@@ -1692,6 +1695,79 @@ void test_creature_subtype_inventory_is_enumerable_on_loaded_game() {
                 "inventory should record exactly one row per enumerated CCreature subtype id");
 }
 
+void test_tooltip_handler_exposes_present_archetypes_without_duplicate_descriptions() {
+    // EPIC_07/STORY_02/SUBSTORY_01: creature tooltips should surface the race and
+    // class archetypes only when they are present, and never repeat a description
+    // that is already shown.
+    auto legacy = std::make_shared<CCreature>();
+    legacy->setLabel("Wandering Rat");
+    legacy->setDescription("A small, mangy rat.");
+
+    const auto legacyTooltip = CTooltipHandler::buildTooltip(legacy);
+    expect_true(legacyTooltip.find("Wandering Rat") != std::string::npos,
+                "legacy creature tooltips should still show the creature label");
+    expect_true(legacyTooltip.find("A small, mangy rat.") != std::string::npos,
+                "legacy creature tooltips should still show the creature description");
+
+    auto race = std::make_shared<CCreatureRace>();
+    race->setLabel("Orc");
+    race->setDescription("Brutish and strong.");
+    auto creatureClass = std::make_shared<CCreatureClass>();
+    creatureClass->setLabel("Warrior");
+    creatureClass->setDescription("Master of arms.");
+
+    auto archetyped = std::make_shared<CCreature>();
+    archetyped->setLabel("Grommash");
+    archetyped->setDescription("A scarred veteran.");
+    archetyped->setRace(race);
+    archetyped->setCreatureClass(creatureClass);
+
+    const auto archetypeTooltip = CTooltipHandler::buildTooltip(archetyped);
+    const auto count_occurrences = [](const std::string &haystack, const std::string &needle) {
+        int count = 0;
+        for (std::size_t pos = haystack.find(needle); pos != std::string::npos;
+             pos = haystack.find(needle, pos + needle.size())) {
+            count++;
+        }
+        return count;
+    };
+
+    expect_true(count_occurrences(archetypeTooltip, "Orc") == 1,
+                "present race archetypes should appear exactly once in the tooltip");
+    expect_true(count_occurrences(archetypeTooltip, "Brutish and strong.") == 1,
+                "present race descriptions should appear exactly once in the tooltip");
+    expect_true(count_occurrences(archetypeTooltip, "Warrior") == 1,
+                "present class archetypes should appear exactly once in the tooltip");
+    expect_true(count_occurrences(archetypeTooltip, "Master of arms.") == 1,
+                "present class descriptions should appear exactly once in the tooltip");
+    expect_true(count_occurrences(archetypeTooltip, "A scarred veteran.") == 1,
+                "the creature description should never be duplicated by archetype lines");
+
+    // A shared description across the creature and its archetypes must not be echoed
+    // multiple times.
+    auto sharedDescRace = std::make_shared<CCreatureRace>();
+    sharedDescRace->setLabel("Human");
+    sharedDescRace->setDescription("A scarred veteran.");
+    auto shared = std::make_shared<CCreature>();
+    shared->setLabel("Reginald");
+    shared->setDescription("A scarred veteran.");
+    shared->setRace(sharedDescRace);
+
+    const auto sharedTooltip = CTooltipHandler::buildTooltip(shared);
+    expect_true(count_occurrences(sharedTooltip, "A scarred veteran.") == 1,
+                "an archetype sharing the creature description must not duplicate that line");
+    expect_true(count_occurrences(sharedTooltip, "Human") == 1,
+                "the race label should still appear when only its description is a duplicate");
+
+    // Creatures without archetypes must not emit any archetype lines.
+    auto noArchetype = std::make_shared<CCreature>();
+    noArchetype->setLabel("Plain Creature");
+    noArchetype->setDescription("Nothing special.");
+    const auto plainTooltip = CTooltipHandler::buildTooltip(noArchetype);
+    expect_true(plainTooltip == "Plain Creature\nNothing special.",
+                "creatures without archetypes should not gain any archetype lines");
+}
+
 } // namespace
 
 int main() {
@@ -1700,6 +1776,7 @@ int main() {
     test_script_handler_executes_commands_and_wraps_functions();
     test_handler_constructors_are_covered_by_native_tests();
     test_creature_scale_preserves_level_plus_sw_invariant();
+    test_tooltip_handler_exposes_present_archetypes_without_duplicate_descriptions();
     test_rng_handler_builds_encounters_from_concrete_creature_sw();
     test_rng_handler_excludes_archetype_definitions_from_encounters();
     test_rng_handler_excludes_player_templates_from_encounters();


### PR DESCRIPTION
## Summary

Creature tooltips now expose the creature's race and class archetypes, but only when those archetype definitions are actually present, and without duplicating a description that is already shown.

## Change

- `src/handler/CTooltipHandler.cpp`: after emitting the creature's own label and description, `buildTooltip` now branches on `object->meta()->inherits("CCreature")`. When the creature carries a race (`getRace()`) and/or a class (`getCreatureClass()`) definition (both `CGameObject`-derived metadata, null on legacy creatures), it appends that archetype's label and description lines using the existing `vstd::add_line` idiom.
- A small `add_archetype_line` helper seeds a `seen` set with the creature's own description and skips any empty text or any line already emitted. This guards against duplicating the creature's description or repeating a description shared between the creature and an archetype (or between the two archetypes).

## Root cause

Archetype metadata (`CCreatureRace` / `CCreatureClass`) was introduced as referenced definitions on `CCreature`, but the tooltip builder only rendered the creature's own label/description and the `CItem` bonus lines. It never surfaced the race/class archetypes. Because the same human-authored description text can legitimately appear on the creature and its archetype definitions, naively appending each description would echo the same line multiple times; the dedup guard prevents that.

## Tests

Added `test_tooltip_handler_exposes_present_archetypes_without_duplicate_descriptions` (registered in `main()`), verifying:
- a creature with a race and class shows each archetype label and description exactly once,
- a description shared between the creature and its race is not duplicated (while the race label still appears),
- a creature without archetypes gains no archetype lines and no duplicated descriptions.

Only the two target files were touched; formatting applied via clang-format and `git diff --check` is clean.

Worker implementation branch did not modify any queue workbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_