### PR TITLE
Record observation: #1249 fix did not resolve ninemarches/sunderedmarch walkthrough failures

### DIFF
--- a/planning/workflow_observations/records/20260702T080903Z-ctrl-vm-2256-06ac44fc-b7d5f0a2.json
+++ b/planning/workflow_observations/records/20260702T080903Z-ctrl-vm-2256-06ac44fc-b7d5f0a2.json
@@ -1,0 +1,39 @@
+{
+  "affectedPaths": [
+    "res/maps/ninemarches/map.json"
+  ],
+  "category": "ci",
+  "controllerId": "ctrl-vm-2256-06ac44fc",
+  "createdAtUtc": "2026-07-02T08:09:03Z",
+  "details": "Follow-up localizing the fleet-wide native gameplay-CI red (see #1227,\n#1260). Investigated the failing gameplay tests seen across recent native\nPR runs (e.g. PR #1252 linux job, base 4451816 which includes #1249):\n\n  [test FAIL 3.492s] test.GameTest.test_map_walkthrough_ninemarches\n  [test FAIL 0.724s] test.GameTest.test_map_walkthrough_sunderedmarch\n  [test FAIL 43.1s ] test.McpServerTest.test_stdio_map_walkthrough_ninemarches\n  [test FAIL 0.022s] test.GameTest.test_player_progression_through_level_six_unlocks_once_per_class\n  + shards abort with SIGABRT (\"terminate called without an active exception\", exit -6)\n  + one shard times out after 1109s (exit 124)\n\nKey finding: commit a4ccfee \"Fix player entry placed on self-removing\nStartEvent (ninemarches, sunderedmarch) (#1249)\" was a TARGETED FIX for the\nninemarches/sunderedmarch walkthrough failures. It moved the player entry\ntwo tiles off the self-removing StartEvent (map.json, 2 lines each) and\nadded a validate_content.py guard. Verified via git:\n  - a4ccfee is on origin/main and is an ancestor of BOTH PR bases 4451816\n    and 0db599f, so those PRs' CI ran WITH the #1249 fix applied.\n  - Yet test_map_walkthrough_ninemarches / _sunderedmarch STILL FAIL in\n    those post-#1249 runs, and fail FAST (3.5s / 0.7s) -- i.e. a real\n    assertion failure, not the huge-map shard timeout that previously\n    masked them (the #1249 message itself notes the failure was masked by\n    the timeout before).\n  => #1249 did NOT close the ninemarches/sunderedmarch walkthrough\n     failures. Either the entry move is insufficient, or (note) #1249\n     changed map.json entry tiles but did NOT update the walkthrough test\n     route, so the scripted GameTest walkthrough may now diverge from the\n     relocated entry. Needs a build-capable follow-up to read the actual\n     current assertion (per-test output was not in the retained CI tail;\n     this environment cannot build the _game extension to reproduce).\n\nImpact: linux/windows native jobs are red on every PR via this shared\ngameplay suite, so per-PR native signal is unusable (e.g. #1261's linux\nand windows failures are this, not the PR's own change). The four adopted\narchetype PRs and the P0 CI-authority work were gated on fast-path +\nown-test evidence for exactly this reason.\n",
+  "evidence": [
+    {
+      "base": "4451816",
+      "note": "base includes a4ccfee (#1249) per git merge-base --is-ancestor",
+      "pr": 1252
+    },
+    {
+      "failFast": [
+        "test_map_walkthrough_ninemarches 3.492s",
+        "test_map_walkthrough_sunderedmarch 0.724s",
+        "test_player_progression_through_level_six_unlocks_once_per_class 0.022s"
+      ]
+    },
+    {
+      "crash": "SIGABRT terminate called without an active exception; shards exit -6; one shard exit 124 after 1109s"
+    },
+    {
+      "priorFix": "a4ccfee #1249 moved entry 2 tiles off StartEvent in ninemarches/sunderedmarch map.json + validate_content.py guard; did NOT touch the walkthrough test route"
+    }
+  ],
+  "fingerprint": "gameplay-walkthrough-ninemarches-sunderedmarch-fail-post-<n>",
+  "id": "20260702T080903Z-ctrl-vm-2256-06ac44fc-b7d5f0a2",
+  "impact": "Native linux/windows red on every PR via the shared gameplay suite; per-PR native signal unusable (e.g. #1261). A prior targeted fix (#1249) is confirmed insufficient, so the gate needs build-capable diagnosis of the current ninemarches/sunderedmarch assertion + the SIGABRT + huge-map shard timeout",
+  "phase": "validation",
+  "role": "controller",
+  "schemaVersion": 1,
+  "severity": "high",
+  "sourceCommit": "9559405",
+  "suggestedImprovement": "Build-capable follow-up: capture the current per-test assertion for the ninemarches/sunderedmarch walkthroughs (no longer masked by timeout post-#1249); check whether #1249's entry relocation left the scripted walkthrough route stale; root-cause the SIGABRT and the huge-map shard 1109s timeout separately",
+  "summary": "#1249's targeted fix did NOT resolve ninemarches/sunderedmarch walkthroughs: they still fail fast (assertion, not timeout) in post-#1249 CI; gameplay suite keeps native CI red fleet-wide"
+}


### PR DESCRIPTION
Append-only workflow observation (single new record file; no source/workbook changes).

Localizes the fleet-wide native gameplay-CI red (follow-up to #1227, #1260). Verified via git + CI logs:

- Commit `a4ccfee` "Fix player entry placed on self-removing StartEvent (ninemarches, sunderedmarch) (#1249)" was a **targeted fix** for those two walkthrough failures — it moved the player entry two tiles off the self-removing StartEvent (2-line `map.json` edits each) + added a `validate_content.py` guard.
- `a4ccfee` is on `main` and is an ancestor of both PR bases `4451816` and `0db599f` (`git merge-base --is-ancestor`), so post-#1249 CI ran **with** the fix.
- Yet `test_map_walkthrough_ninemarches` (3.492s) and `_sunderedmarch` (0.724s) **still FAIL, and fail fast** — a real assertion failure, not the huge-map shard timeout that previously masked them. So **#1249 did not close these failures.** Note #1249 changed the map entry tiles but did *not* update the scripted walkthrough route, which may now be stale relative to the relocated entry.
- The broader gameplay suite also fails: `test_player_progression_through_level_six_unlocks_once_per_class` (0.022s), plus SIGABRT (`terminate called without an active exception`, shards exit `-6`) and a `1109s` shard timeout (exit `124`).

**Impact:** native `linux`/`windows` are red on every PR via this shared suite (e.g. #1261's native failures are this, not the PR's own Python change), so per-PR native signal is unusable. This environment cannot build the `_game` extension to reproduce; a build-capable follow-up should capture the current per-test assertion and root-cause the SIGABRT + timeout separately.

`workflow_observations.py validate` → passes (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_