### PR TITLE
[EPIC_02][STORY_01][SUBSTORY_03] Migrate engine loading call sites to instance-based providers

### DIFF
--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -49,11 +49,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <dlfcn.h>
 #endif
 
-std::set<std::string> getConfigPaths(const std::string &mapName);
+std::set<std::string> getConfigPaths(const std::shared_ptr<CResourcesProvider> &resourcesProvider,
+                                     const std::string &mapName);
 
 std::string getMapPath(std::string mapName);
 
-std::set<std::string> get_saved_map_dependencies(const json &save, const std::string &mapName);
+std::set<std::string> get_saved_map_dependencies(const std::shared_ptr<CGame> &game, const json &save,
+                                                 const std::string &mapName);
 
 void load_map_resources(const std::shared_ptr<CGame> &game, const std::string &mapName);
 
@@ -301,18 +303,18 @@ bool is_allowed_dynamic_library_path(const std::string &library) {
     return normalized && normalized->rfind("plugins/native/", 0) == 0;
 }
 
-std::string resolve_dynamic_library_path(const std::string &library) {
+std::string resolve_dynamic_library_path(const std::shared_ptr<CResourcesProvider> &resourcesProvider,
+                                         const std::string &library) {
     if (!is_allowed_dynamic_library_path(library)) {
         vstd::logger::warning("Rejected dynamic C++ plugin outside packaged native plugin paths:", library);
         return {};
     }
 
-    auto provider = CResourcesProvider::getInstance();
     for (const auto &candidate : dynamic_library_candidates(library)) {
         if (!is_allowed_dynamic_library_path(candidate)) {
             continue;
         }
-        auto resolved = provider->getPath(candidate);
+        auto resolved = resourcesProvider->getPath(candidate);
         if (!resolved.empty()) {
             return std::filesystem::absolute(resolved).lexically_normal().string();
         }
@@ -515,11 +517,12 @@ std::expected<std::shared_ptr<json>, std::string> build_save_envelope(const std:
     return CSaveFormat::buildEnvelope(snapshot, map->getMapName());
 }
 
-void apply_authored_map_metadata(const std::shared_ptr<CMap> &map, const std::string &mapName) {
-    if (!map) {
+void apply_authored_map_metadata(const std::shared_ptr<CGame> &game, const std::shared_ptr<CMap> &map,
+                                 const std::string &mapName) {
+    if (!game || !map) {
         return;
     }
-    if (std::shared_ptr<json> mapc = CConfigurationProvider::getConfig(getMapPath(mapName))) {
+    if (std::shared_ptr<json> mapc = game->getConfigurationProvider()->getConfiguration(getMapPath(mapName))) {
         map->setDefaultTiles({});
         map->setOutOfBoundsTiles({});
         map->setXBounds({});
@@ -607,7 +610,7 @@ bool rehydrate_loaded_map(const std::shared_ptr<CGame> &game, const std::shared_
         return false;
     }
 
-    apply_authored_map_metadata(map, mapName);
+    apply_authored_map_metadata(game, map, mapName);
 
     return map->restorePlayerAfterLoad(error);
 }
@@ -622,7 +625,7 @@ restore_save_document(const std::shared_ptr<CGame> &game, const CSaveFormat::Dec
     {
         CScopedGameMap scopedMap(game);
         load_map_resources(game, saveDocument.mapName);
-        for (const auto &requiredMap : get_saved_map_dependencies(*saveDocument.snapshot, saveDocument.mapName)) {
+        for (const auto &requiredMap : get_saved_map_dependencies(game, *saveDocument.snapshot, saveDocument.mapName)) {
             if (requiredMap != saveDocument.mapName) {
                 load_map_resources(game, requiredMap);
             }
@@ -689,18 +692,20 @@ std::optional<SaveLoadResult> try_load_saved_map(const std::shared_ptr<CGame> &g
     return std::nullopt;
 }
 
-void repair_recovered_backup(const SaveLoadResult &loaded, const std::string &slotName) {
+void repair_recovered_backup(const std::shared_ptr<CGame> &game, const SaveLoadResult &loaded,
+                             const std::string &slotName) {
     if (!loaded.recoveredFromBackup) {
         return;
     }
-    const auto backupBytes = CResourcesProvider::getInstance()->load(loaded.sourcePath);
+    auto resourcesProvider = game->getResourcesProvider();
+    const auto backupBytes = resourcesProvider->load(loaded.sourcePath);
     if (backupBytes.empty()) {
         vstd::logger::warning("Recovered backup could not be read for primary repair:", slotName, loaded.sourcePath);
         return;
     }
     const auto primaryPath = CSaveFormat::primaryPath(slotName);
     std::error_code errorCode;
-    const auto resolvedPrimaryPath = CResourcesProvider::getInstance()->getPath(primaryPath);
+    const auto resolvedPrimaryPath = resourcesProvider->getPath(primaryPath);
     if (!resolvedPrimaryPath.empty()) {
         std::filesystem::remove(resolvedPrimaryPath, errorCode);
     }
@@ -709,19 +714,18 @@ void repair_recovered_backup(const SaveLoadResult &loaded, const std::string &sl
                               primaryPath, "resolved:", resolvedPrimaryPath, "reason:", errorCode.message());
         return;
     }
-    if (CResourcesProvider::getInstance()->save(primaryPath, backupBytes)) {
+    if (resourcesProvider->save(primaryPath, backupBytes)) {
         vstd::logger::warning("Repaired save primary from recovered backup:", slotName, primaryPath);
     } else {
         vstd::logger::warning("Failed to repair save primary from recovered backup:", slotName, primaryPath);
     }
 }
 
-std::shared_ptr<json> load_plugin_manifest() {
-    auto provider = CResourcesProvider::getInstance();
-    if (provider->getPath(PLUGIN_MANIFEST_PATH).empty()) {
+std::shared_ptr<json> load_plugin_manifest(const std::shared_ptr<CResourcesProvider> &resourcesProvider) {
+    if (resourcesProvider->getPath(PLUGIN_MANIFEST_PATH).empty()) {
         return nullptr;
     }
-    return provider->loadJson(PLUGIN_MANIFEST_PATH);
+    return resourcesProvider->loadJson(PLUGIN_MANIFEST_PATH);
 }
 
 bool load_plugin_entry(const std::shared_ptr<CGame> &game, const json &entry,
@@ -830,14 +834,15 @@ void CMapLoader::loadFromTmx(const std::shared_ptr<CMap> &map, const std::shared
     }
 }
 
-std::set<std::string> getConfigPaths(const std::string &mapName) {
+std::set<std::string> getConfigPaths(const std::shared_ptr<CResourcesProvider> &resourcesProvider,
+                                     const std::string &mapName) {
     if (!CSaveFormat::isValidMapName(mapName)) {
         vstd::logger::warning("Rejected invalid map name while loading config:", mapName);
         return {};
     }
 
     const auto logicalMapPath = "maps/" + mapName;
-    const auto resolvedMapPath = CResourcesProvider::getInstance()->getPath(logicalMapPath);
+    const auto resolvedMapPath = resourcesProvider->getPath(logicalMapPath);
     std::error_code errorCode;
     if (resolvedMapPath.empty() || !std::filesystem::is_directory(resolvedMapPath, errorCode)) {
         vstd::logger::warning("Map config directory is missing:", logicalMapPath, "resolved:", resolvedMapPath);
@@ -967,9 +972,10 @@ bool config_matches_saved_quest_refs(const json &entry, const CSavedQuestRefs &r
     return false;
 }
 
-bool map_defines_saved_quest_refs(const std::string &mapName, const CSavedQuestRefs &refs) {
-    for (const auto &configPath : getConfigPaths(mapName)) {
-        auto config = CConfigurationProvider::getConfig(configPath);
+bool map_defines_saved_quest_refs(const std::shared_ptr<CGame> &game, const std::string &mapName,
+                                  const CSavedQuestRefs &refs) {
+    for (const auto &configPath : getConfigPaths(game->getResourcesProvider(), mapName)) {
+        auto config = game->getConfigurationProvider()->getConfiguration(configPath);
         if (!config || !config->is_object()) {
             continue;
         }
@@ -982,7 +988,8 @@ bool map_defines_saved_quest_refs(const std::string &mapName, const CSavedQuestR
     return false;
 }
 
-std::set<std::string> get_saved_map_dependencies(const json &save, const std::string &mapName) {
+std::set<std::string> get_saved_map_dependencies(const std::shared_ptr<CGame> &game, const json &save,
+                                                 const std::string &mapName) {
     std::set<std::string> maps = {mapName};
     CSavedQuestRefs questRefs;
     collect_saved_quest_refs(save, questRefs);
@@ -990,11 +997,11 @@ std::set<std::string> get_saved_map_dependencies(const json &save, const std::st
         return maps;
     }
 
-    for (const auto &candidate : CResourcesProvider::getInstance()->getFiles(CResType::MAP)) {
+    for (const auto &candidate : game->getResourcesProvider()->getFiles(CResType::MAP)) {
         if (!CSaveFormat::isValidMapName(candidate)) {
             continue;
         }
-        if (map_defines_saved_quest_refs(candidate, questRefs)) {
+        if (map_defines_saved_quest_refs(game, candidate, questRefs)) {
             maps.insert(candidate);
         }
     }
@@ -1002,13 +1009,13 @@ std::set<std::string> get_saved_map_dependencies(const json &save, const std::st
 }
 
 void load_map_resources(const std::shared_ptr<CGame> &game, const std::string &mapName) {
-    game->getObjectHandler()->registerConfig(getConfigPaths(mapName));
+    game->getObjectHandler()->registerConfig(getConfigPaths(game->getResourcesProvider(), mapName));
     CPluginLoader::loadMapPlugins(game, mapName);
-    game->getObjectHandler()->registerConfig(getConfigPaths(mapName));
+    game->getObjectHandler()->registerConfig(getConfigPaths(game->getResourcesProvider(), mapName));
 }
 
 std::shared_ptr<CMap> CMapLoader::loadNewMap(const std::shared_ptr<CGame> &game, const std::string &mapName) {
-    if (std::shared_ptr<json> mapc = CConfigurationProvider::getConfig(getMapPath(mapName))) {
+    if (std::shared_ptr<json> mapc = game->getConfigurationProvider()->getConfiguration(getMapPath(mapName))) {
         std::shared_ptr<CMap> map = game->getObjectHandler()->createObject<CMap>(game);
         game->setMap(map);
         load_map_resources(game, mapName);
@@ -1261,7 +1268,7 @@ std::shared_ptr<CGame> CGameLoader::loadGame() {
     game->getResourcesProvider();
     game->getConfigurationProvider();
     initObjectHandler(game->getObjectHandler());
-    initConfigurations(game->getObjectHandler());
+    initConfigurations(game);
     initScriptHandler(game->getScriptHandler(), game);
     return game;
 }
@@ -1287,7 +1294,7 @@ void CGameLoader::startRandomGameWithPlayer(const std::shared_ptr<CGame> &game, 
 void CGameLoader::loadSavedGame(const std::shared_ptr<CGame> &game, const std::string &save) {
     if (auto loaded = try_load_saved_map(game, save)) {
         game->setMap(loaded->map);
-        repair_recovered_backup(*loaded, save);
+        repair_recovered_backup(game, *loaded, save);
         return;
     }
     vstd::logger::warning("Saved game was not loaded; keeping the active map unchanged:", save);
@@ -1305,9 +1312,9 @@ void CGameLoader::changeMap(const std::shared_ptr<CGame> &game, const std::strin
     game->getSceneManager()->requestMapChange(game, name);
 }
 
-void CGameLoader::initConfigurations(const std::shared_ptr<CObjectHandler> &handler) {
-    for (const std::string &path : CResourcesProvider::getInstance()->getFiles(CResType::CONFIG)) {
-        handler->registerConfig(path);
+void CGameLoader::initConfigurations(const std::shared_ptr<CGame> &game) {
+    for (const std::string &path : game->getResourcesProvider()->getFiles(CResType::CONFIG)) {
+        game->getObjectHandler()->registerConfig(path);
     }
 }
 
@@ -1417,7 +1424,7 @@ bool CPluginLoader::loadDynamicPlugin(const std::shared_ptr<CGame> &game, const 
     }
 
     const auto symbolName = entry.empty() ? std::string(DYNAMIC_PLUGIN_DEFAULT_ENTRY) : entry;
-    const auto resolvedPath = resolve_dynamic_library_path(library);
+    const auto resolvedPath = resolve_dynamic_library_path(game->getResourcesProvider(), library);
     if (resolvedPath.empty()) {
         vstd::logger::warning("Failed to resolve dynamic C++ plugin library:", library);
         return false;
@@ -1453,7 +1460,7 @@ bool CPluginLoader::loadGlobalPlugins(const std::shared_ptr<CGame> &game) {
     std::set<std::string> loadedPythonPlugins;
     std::set<std::string> loadedDynamicPlugins;
 
-    if (auto manifest = load_plugin_manifest()) {
+    if (auto manifest = load_plugin_manifest(game->getResourcesProvider())) {
         if (manifest->contains("global")) {
             loadedAll = load_plugin_entries(game, (*manifest)["global"], loadedPythonPlugins, loadedDynamicPlugins) &&
                         loadedAll;
@@ -1479,7 +1486,7 @@ bool CPluginLoader::loadMapPlugins(const std::shared_ptr<CGame> &game, const std
     std::set<std::string> loadedPythonPlugins;
     std::set<std::string> loadedDynamicPlugins;
 
-    if (auto manifest = load_plugin_manifest()) {
+    if (auto manifest = load_plugin_manifest(game->getResourcesProvider())) {
         if (manifest->contains("maps")) {
             const auto &mapEntries = (*manifest)["maps"];
             if (mapEntries.is_object() && mapEntries.contains(mapName)) {

--- a/src/core/CLoader.h
+++ b/src/core/CLoader.h
@@ -80,7 +80,7 @@ class CGameLoader {
   private:
     static void initObjectHandler(const std::shared_ptr<CObjectHandler> &handler);
 
-    static void initConfigurations(const std::shared_ptr<CObjectHandler> &handler);
+    static void initConfigurations(const std::shared_ptr<CGame> &game);
 
     static void initScriptHandler(const std::shared_ptr<CScriptHandler> &handler, const std::shared_ptr<CGame> &game);
 };

--- a/src/core/CProvider.cpp
+++ b/src/core/CProvider.cpp
@@ -579,7 +579,11 @@ std::string CResource::getFilePath() const {
 
 std::string CTextResource::getText() {
     const auto filePath = getFilePath();
-    auto resolvedPath = CResourcesProvider::getInstance()->getPath(filePath);
+    // Resolve through the owning game's per-session resources provider; fall back to the process
+    // singleton only for resources that were never attached to a game (compatibility path).
+    auto game = getGame();
+    auto resourcesProvider = game ? game->getResourcesProvider() : CResourcesProvider::getInstance();
+    auto resolvedPath = resourcesProvider->getPath(filePath);
     if (resolvedPath.empty()) {
         return {};
     }

--- a/src/gui/CAnimation.cpp
+++ b/src/gui/CAnimation.cpp
@@ -136,7 +136,13 @@ void CDynamicAnimation::initialize() {
                             return;
                         }
                         std::string path = currentObject->getAnimation();
-                        auto time = CConfigurationProvider::getConfig(path + "/" + "time.json");
+                        const auto timingPath = path + "/" + "time.json";
+                        // Load timing tables through the owning game's per-session configuration
+                        // provider; fall back to the legacy process-wide accessor only when the
+                        // animation is detached from a game (compatibility path).
+                        auto game = self->getGame();
+                        auto time = game ? game->getConfigurationProvider()->getConfiguration(timingPath)
+                                         : CConfigurationProvider::getConfig(timingPath);
                         if (!time || !time->is_object() || time->empty()) {
                             vstd::logger::warning("CDynamicAnimation: missing or malformed timing table", path);
                             return;

--- a/src/gui/CTextManager.cpp
+++ b/src/gui/CTextManager.cpp
@@ -68,7 +68,11 @@ fn::sdl::TexturePtr CTextManager::loadTexture(std::string text, int width) {
 CTextManager::CTextManager(const std::shared_ptr<CGui> &_gui) {
     SDL_SAFE(TTF_Init());
     constexpr const char *fontResource = "fonts/ampersand.ttf";
-    const auto resolvedFont = CResourcesProvider::getInstance()->getPath(fontResource);
+    // Resolve through the owning game's per-session resources provider; fall back to the process
+    // singleton only when the manager is created without a live GUI/game (compatibility path).
+    auto game = _gui ? _gui->getGame() : nullptr;
+    auto resourcesProvider = game ? game->getResourcesProvider() : CResourcesProvider::getInstance();
+    const auto resolvedFont = resourcesProvider->getPath(fontResource);
     if (resolvedFont.empty()) {
         vstd::logger::error("CTextManager: cannot resolve font", fontResource, "resolved:", resolvedFont);
     } else {

--- a/src/gui/CTextureCache.cpp
+++ b/src/gui/CTextureCache.cpp
@@ -100,7 +100,12 @@ SDL_Texture *CTextureCache::getTexture(std::string path) {
 }
 
 fn::sdl::TexturePtr CTextureCache::loadTexture(std::string path) {
-    const auto resolvedPath = CResourcesProvider::getInstance()->getPath(path);
+    auto gui = _gui.lock();
+    // Resolve through the owning game's per-session resources provider; fall back to the process
+    // singleton only when the cache is detached from a live GUI/game (compatibility path).
+    auto game = gui ? gui->getGame() : nullptr;
+    auto resourcesProvider = game ? game->getResourcesProvider() : CResourcesProvider::getInstance();
+    const auto resolvedPath = resourcesProvider->getPath(path);
     if (resolvedPath.empty()) {
         vstd::logger::error("CTextureCache::loadTexture: cannot resolve", path, "resolved:", resolvedPath);
         return nullptr;
@@ -110,7 +115,6 @@ fn::sdl::TexturePtr CTextureCache::loadTexture(std::string path) {
         vstd::logger::error("CTextureCache::loadTexture: cannot load", path, "resolved:", resolvedPath);
         return nullptr;
     }
-    auto gui = _gui.lock();
     return gui ? CTextureUtil::calculateAlpha(gui->getRenderer(), std::move(surface)) : nullptr;
 }
 

--- a/tests/unit/test_resource.cpp
+++ b/tests/unit/test_resource.cpp
@@ -216,6 +216,58 @@ void test_load_game_creates_context_owned_providers() {
     expect_true(first_items != second_items, "separate game contexts should not share configuration provider caches");
 }
 
+void test_map_load_resolves_through_context_owned_providers() {
+    auto singletonResources = CResourcesProvider::getInstance();
+    const auto itemsPath = std::filesystem::path(singletonResources->getPath("config/items.json"));
+    expect_true(!itemsPath.empty(), "items config should resolve before context-owned map load test");
+    if (itemsPath.empty()) {
+        return;
+    }
+    const auto resourceRoot = itemsPath.parent_path().parent_path();
+
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const std::string mapName = "unit_ctx_map_" + std::to_string(nonce);
+    const auto mapDir = resourceRoot / "maps" / mapName;
+    std::filesystem::create_directories(mapDir);
+    const auto mapConfigPath = mapDir / "map.json";
+    const std::string logicalMapConfig = "maps/" + mapName + "/map.json";
+
+    expect_true(write_text_file(mapConfigPath, R"({"marker":"first","properties":{"x":0,"y":0,"z":0},"layers":[]})"),
+                "temporary map fixture should be written");
+    if (!std::filesystem::exists(mapConfigPath)) {
+        std::filesystem::remove_all(mapDir);
+        return;
+    }
+
+    auto game = CGameLoader::loadGame();
+    expect_true(game->getResourcesProvider() != singletonResources,
+                "map load test should run against a context-owned resource provider");
+
+    auto map = CMapLoader::loadNewMap(game, mapName);
+    expect_true(map && map->getMapName() == mapName,
+                "loadNewMap should load the authored map through the game's provider instances");
+
+    // Rewrite the fixture: only a cache primed while loadNewMap ran keeps the original content, so
+    // the assertions below can tell exactly which provider instance the load path went through.
+    expect_true(write_text_file(mapConfigPath, R"({"marker":"second","properties":{"x":0,"y":0,"z":0},"layers":[]})"),
+                "temporary map fixture should be rewritable");
+
+    auto cachedConfig = game->getConfigurationProvider()->getConfiguration(logicalMapConfig);
+    expect_true(json_string_value(cachedConfig, "marker") == "first",
+                "loadNewMap should prime the game's own configuration provider cache");
+
+    CConfigurationProvider explicitProvider(game->getResourcesProvider());
+    auto freshConfig = explicitProvider.getConfiguration(logicalMapConfig);
+    expect_true(json_string_value(freshConfig, "marker") == "second",
+                "an explicitly-passed provider instance should load the map config independently");
+
+    auto legacyConfig = CConfigurationProvider::getConfig(logicalMapConfig);
+    expect_true(json_string_value(legacyConfig, "marker") == "second",
+                "map load must not populate the process-wide configuration provider cache");
+
+    std::filesystem::remove_all(mapDir);
+}
+
 void test_resource_plugin_trust_boundary_rejects_escapes() {
     auto provider = CResourcesProvider::getInstance();
     const auto itemsPath = std::filesystem::path(provider->getPath("config/items.json"));
@@ -258,9 +310,8 @@ void test_resource_plugin_trust_boundary_rejects_escapes() {
     // the _game pybind bindings, which this game_core unit-test binary does not link, so its return
     // value cannot distinguish a boundary rejection from a runtime failure here.
     auto game = CGameLoader::loadGame();
-    for (const std::string &untrusted :
-         {std::string("../evil.py"), std::string("/tmp/evil.py"), std::string("config/items.json"),
-          std::string("plugins/../../escape.py")}) {
+    for (const std::string &untrusted : {std::string("../evil.py"), std::string("/tmp/evil.py"),
+                                         std::string("config/items.json"), std::string("plugins/../../escape.py")}) {
         expect_true(!CPluginLoader::isTrustedPluginPath(untrusted),
                     "paths outside the trusted plugin roots must not be trusted");
         expect_true(!CPluginLoader::loadPlugin(game, untrusted),
@@ -283,6 +334,7 @@ int main() {
     test_resource_provider_save_uses_provider_root_when_cwd_changes();
     test_configuration_provider_instances_do_not_share_config_cache();
     test_load_game_creates_context_owned_providers();
+    test_map_load_resolves_through_context_owned_providers();
     test_resource_plugin_trust_boundary_rejects_escapes();
 
     return finish_tests();


### PR DESCRIPTION
## Summary

Migrates the engine loading call sites off the process-singleton resource/configuration provider onto the instance-based providers introduced by SUBSTORY_01/02 (per-`CGameContext` `CResourcesProvider` / `CConfigurationProvider`, reached via `CGame::getResourcesProvider()` / `CGame::getConfigurationProvider()`). Pure dependency-injection refactor: resources resolve exactly as before.

### Migrated call sites

**src/core/CLoader.cpp**
- Map load: `CMapLoader::loadNewMap` and `apply_authored_map_metadata` now read `map.json` through the game's configuration provider; `getConfigPaths` / `load_map_resources` resolve map config directories through the game's resources provider.
- Plugin load: `load_plugin_manifest` and `resolve_dynamic_library_path` take the game's resources provider (threaded from `CPluginLoader::loadGlobalPlugins` / `loadMapPlugins` / `loadDynamicPlugin`).
- Save/load: `repair_recovered_backup`, `get_saved_map_dependencies`, and `map_defines_saved_quest_refs` use the loading game's providers.
- Normal game load: `CGameLoader::initConfigurations` now registers configs through the game's resources provider (signature updated in `src/core/CLoader.h`).

**src/core/CProvider.cpp**
- `CTextResource::getText` resolves through the owning game's resources provider; singleton fallback kept only for resources never attached to a game (e.g. bare `CConfigResourceLoader` output).

**src/gui/CTextureCache.cpp / src/gui/CTextManager.cpp**
- Texture and font path resolution go through the owning GUI's game provider, with a compatibility fallback when constructed without a live GUI/game.

**src/gui/CAnimation.cpp**
- `CDynamicAnimation` timing tables (`time.json`) load through the owning game's configuration provider (animation-load acceptance criterion), with a legacy fallback for detached animations.

The only remaining intentional singleton uses in these paths are the documented compatibility fallbacks (e.g. `CMapLoader::save` for maps detached from their game).

### Testing
- New unit test `test_map_load_resolves_through_context_owned_providers` in `tests/unit/test_resource.cpp`: loads an authored map via `CMapLoader::loadNewMap`, then proves the load primed the game's own configuration provider cache (stale-after-rewrite check), that an explicitly-constructed provider instance reads independently, and that the process-wide provider cache was never populated by the load.
- `clang-format` clean; CI validates the build and test suites.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_