### PR TITLE
Resolve fleet-wide gameplay-CI-red observations (fixed by #1274)

### DIFF
--- a/planning/workflow_observations/resolutions/20260702T000947Z-ctrl-vm-28342-ae7560d1-cff8e881.json
+++ b/planning/workflow_observations/resolutions/20260702T000947Z-ctrl-vm-28342-ae7560d1-cff8e881.json
@@ -1,0 +1,26 @@
+{
+  "evidence": [
+    {
+      "mergeCommit": "37ff270eab378409b81d0cbe794f5ddd073f860a",
+      "mergedPr": 1274,
+      "note": "SIGABRT root cause: CCreature::useAction ownership guard vs composed getEffectiveInteractions(); fixed to validate against the composed set"
+    },
+    {
+      "command": "test_inventory_right_click deadlock",
+      "result": "rewritten to #628 semantics with queued space key; shard no longer consumes its 1108s budget"
+    },
+    {
+      "command": "PR #1274 run 28595210563",
+      "result": "test (python gameplay) success on linux and windows; test (python ui) success"
+    }
+  ],
+  "mergeCommit": "37ff270eab378409b81d0cbe794f5ddd073f860a",
+  "mergedPr": 1274,
+  "observationId": "20260702T000947Z-ctrl-vm-28342-ae7560d1-cff8e881",
+  "resolutionSummary": "Fixed by PR #1274. The gameplay-suite SIGABRT was CCreature::useAction validating pointer identity against the concrete actions member while selectors draw from getEffectiveInteractions() (race/class-owned instances since 43c80dd); first composed action in a real fight hit vstd::fail_if -> std::terminate. Guard now validates against the composed set. The 1109s shard timeout was the right-click scroll deadlock (ee06c41/#628 blocking CGameTextPanel headless), fixed by encoding #628 semantics with a queued space key.",
+  "resolvedAtUtc": "2026-07-02T14:22:41Z",
+  "resolver": "controller/ctrl-vm-4027-c0afa077",
+  "schemaVersion": 1,
+  "sourceCommit": "37ff270eab378409b81d0cbe794f5ddd073f860a",
+  "status": "resolved"
+}

--- a/planning/workflow_observations/resolutions/20260702T080903Z-ctrl-vm-2256-06ac44fc-b7d5f0a2.json
+++ b/planning/workflow_observations/resolutions/20260702T080903Z-ctrl-vm-2256-06ac44fc-b7d5f0a2.json
@@ -1,0 +1,26 @@
+{
+  "evidence": [
+    {
+      "mergeCommit": "37ff270eab378409b81d0cbe794f5ddd073f860a",
+      "mergedPr": 1274,
+      "note": "PR #1274 run 28595210563: linux success 13:58Z, windows success 14:01Z, linux-coverage success 14:13Z; gameplay suite green on both platforms for the first time since 2026-07-01T05:45Z"
+    },
+    {
+      "command": "test.py gate asserts",
+      "result": "find_runtime_object(...) is None replaced with getObjectByName(...) is None at the borderGate/ironGate checks"
+    },
+    {
+      "command": "src/core/CController.cpp",
+      "result": "incremental budgeted flow field (25k expansions/call) + 256-tile chase leash; stdio ninemarches walkthrough passes in-budget"
+    }
+  ],
+  "mergeCommit": "37ff270eab378409b81d0cbe794f5ddd073f860a",
+  "mergedPr": 1274,
+  "observationId": "20260702T080903Z-ctrl-vm-2256-06ac44fc-b7d5f0a2",
+  "resolutionSummary": "Fixed by PR #1274. GameTest ninemarches/sunderedmarch walkthroughs failed on an unsatisfiable assertion (find_runtime_object raises when absent, so 'is None' can never pass) - now getObjectByName(...) is None. The stdio ninemarches per-move timeout came from CTargetController rebuilding a full-map Dijkstra flow field (up to 1M cells) every turn; now seeded per (map, revision, goal), extended incrementally under a 25k-expansion budget, with a 256-tile chase leash, wide map-JSON move timeouts and encounter-bounce retries in the walkthrough.",
+  "resolvedAtUtc": "2026-07-02T14:22:41Z",
+  "resolver": "controller/ctrl-vm-4027-c0afa077",
+  "schemaVersion": 1,
+  "sourceCommit": "37ff270eab378409b81d0cbe794f5ddd073f860a",
+  "status": "resolved"
+}


### PR DESCRIPTION
Append-only resolution receipts for two open workflow observations, both fixed by merged PR #1274 (merge commit `37ff270`, run 28595210563 fully green: linux, windows-deps, windows, linux-coverage):

- `20260702T080903Z-ctrl-vm-2256-06ac44fc-b7d5f0a2` — ninemarches/sunderedmarch walkthrough failures persisting past #1249: unsatisfiable `find_runtime_object(...) is None` asserts + full-map flow-field rebuild per turn on the 1000×1000 map (now incremental/budgeted with a chase leash).
- `20260702T000947Z-ctrl-vm-28342-ae7560d1-cff8e881` — gameplay-suite SIGABRT + shard timeout: `CCreature::useAction` guard vs composed archetype actions, and the #628 right-click scroll headless deadlock.

`python3 scripts/workflow_observations.py validate` passes (7 resolutions). Files are new immutable receipts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b)_