### PR TITLE
Flag control-plane rows in the shortlist as advisory metadata

### DIFF
--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -103,8 +103,15 @@ keeps only the highest currently eligible priority tier for `storyGroups`, and e
 `selected.issue.issueName`. It also reports `activeClaims.total`, `activeClaims.unexpired`, `activeClaims.healthy`,
 `activeClaims.stale`, `activeClaims.leaseExpired`, `activeClaims.suspect`, `activeClaims.reclaimable`,
 `activeClaims.inactive`, `staleClaimCount`, `staleClaims`, `advisoryTargetFileOverlapCount`,
-`advisoryTargetFileOverlaps`, and per-issue `activeFileOverlaps` so heartbeat-overdue claims, expired leases, recovery
+`advisoryTargetFileOverlaps`, `advisoryControlPlaneRowCount`, `advisoryControlPlaneRows`, and per-issue
+`activeFileOverlaps` so heartbeat-overdue claims, expired leases, recovery
 rows, and exact target-file overlaps can inform dispatch decisions without becoming automatic blockers.
+`advisoryControlPlaneRows` maps each eligible row whose `Target Files / Modules` rewrite the shared CI merge-gate or
+controller governance (`.github/workflows/build.yml`, `AGENTS.md`, `scripts/ci_change_classifier.py`,
+`scripts/poll_pr_checks.py`) to the matched files. Such a row can be status-and-dependency `CLEAN` yet unsafe for an
+autonomous controller to auto-claim, since rewriting the validation authority mid-run risks the CI gate for every
+concurrent PR; treat the flag as advisory evidence to route the row to a supervised lane, not as an automatic claim
+blocker.
 `activeClaims.unexpired` is retained as the healthy live-claim count: heartbeat not overdue and lease not expired. When
 `--controller-id` is provided, it also reports `controllerCapacity`: the current controller's healthy owned issues,
 suspect owned issues, reclaimable owned issues, recovery-required state, deficit to the four-issue controller target,

--- a/scripts/issue_queue.py
+++ b/scripts/issue_queue.py
@@ -101,6 +101,18 @@ ISSUE_NAME_PATTERN = re.compile(r"^\[EPIC_\d{2}\]\[STORY_\d{2}\]\[SUBSTORY_\d{2}
 ISSUE_NAME_TOKENS = re.compile(r"^\[(EPIC_\d{2})\]\[(STORY_\d{2})\]\[(SUBSTORY_\d{2})\](.+)$")
 PRIORITY_ORDER = {"P0": 0, "P1": 1, "P2": 2}
 VALID_PRIORITIES = ("P0", "P1", "P2")
+# Shared CI merge-gate and controller-governance files. A row whose declared
+# target files modify these rewrites the validation authority that gates every
+# concurrent PR, so no single autonomous controller can safely validate the
+# fleet-wide blast radius mid-run. Surfaced as advisory shortlist metadata (not
+# an automatic eligibility filter) so a controller/PM can route such rows to a
+# supervised lane instead of auto-claiming them.
+CONTROL_PLANE_PATHS = (
+    ".github/workflows/build.yml",
+    "AGENTS.md",
+    "scripts/ci_change_classifier.py",
+    "scripts/poll_pr_checks.py",
+)
 DEFAULT_RECLAIM_AGE_MINUTES = 240
 DEFAULT_HEARTBEAT_INTERVAL_MINUTES = DEFAULT_RECLAIM_AGE_MINUTES // 2
 DEFAULT_CONTROLLER_ACTIVE_ISSUE_FLOOR = 4
@@ -856,6 +868,26 @@ def targetFileOverlapAdvisories(
     return advisories
 
 
+def controlPlaneAdvisories(tasks: Iterable[TaskRecord]) -> dict[str, list[str]]:
+    """Map issue name -> matched control-plane target files for the given tasks.
+
+    A row is flagged when its declared ``Target Files / Modules`` include the
+    shared CI merge-gate or controller-governance files (``CONTROL_PLANE_PATHS``).
+    This is advisory metadata only: eligibility and claim semantics are
+    unchanged. It lets the controller/PM see that an otherwise-``CLEAN`` eligible
+    row rewrites the validation authority gating all concurrent PRs and route it
+    to a supervised lane rather than auto-claiming it.
+    """
+
+    controlPlane = set(CONTROL_PLANE_PATHS)
+    advisories: dict[str, list[str]] = {}
+    for task in tasks:
+        matched = sorted(task.targetFiles & controlPlane)
+        if matched:
+            advisories[task.issueName] = matched
+    return advisories
+
+
 def rejectionReasonKey(reason: str) -> str:
     return reason.split(":", 1)[0].split("=", 1)[0]
 
@@ -1056,6 +1088,7 @@ def shortlistTasks(
     activeClaims = activeClaimSummary(state, stale, now=now)
     activeFiles = activeTargetFiles(state, stale=stale, now=now)
     advisoryOverlaps = targetFileOverlapAdvisories(state, stale=stale, now=now)
+    controlPlaneRows = controlPlaneAdvisories(eligible)
     selectionSeed = seed or uuid.uuid4().hex
     payload: dict[str, Any] = {
         "eligible": bool(eligible),
@@ -1076,10 +1109,12 @@ def shortlistTasks(
         "rejectedCount": len(rejected),
         "rejectionSummary": rejectionSummary(rejected),
         "advisoryTargetFileOverlapCount": len(advisoryOverlaps),
+        "advisoryControlPlaneRowCount": len(controlPlaneRows),
         "mechanicalFilters": [
             "status=NOT_STARTED",
             "dependencies=DONE",
             "direct target-file overlaps reported as advisory metadata",
+            "control-plane (CI gate/governance) target files reported as advisory metadata",
         ],
     }
     if controllerId:
@@ -1094,6 +1129,7 @@ def shortlistTasks(
     if includeRejected:
         payload["rejected"] = rejected
         payload["advisoryTargetFileOverlaps"] = advisoryOverlaps
+        payload["advisoryControlPlaneRows"] = controlPlaneRows
     if not eligible:
         payload["reason"] = "No eligible task"
         return payload

--- a/tests/test_issue_queue.py
+++ b/tests/test_issue_queue.py
@@ -360,6 +360,35 @@ class IssueQueueTest(unittest.TestCase):
         self.assertNotIn(self.issue_d, payload["rejected"])
         self.assertNotIn("active-file-overlap", payload["rejectionSummary"])
 
+    def test_shortlist_flags_control_plane_rows_as_advisory_without_rejecting(self) -> None:
+        control_plane = "[EPIC_02][STORY_01][SUBSTORY_02]Harden CI validation authority"
+        normal = "[EPIC_09][STORY_01][SUBSTORY_01]Normal engine work"
+        self.create_workbook(
+            [
+                self.task_row(
+                    control_plane,
+                    "P0",
+                    None,
+                    ".github/workflows/build.yml\nscripts/poll_pr_checks.py",
+                ),
+                self.task_row(normal, "P0", None, "src/core/CGame.cpp"),
+            ]
+        )
+        state = issue_queue.loadQueue(self.workbook_path)
+
+        payload = issue_queue.shortlistTasks(state, seed="control-plane", includeRejected=True)
+
+        # Advisory only: the control-plane row stays eligible and is not rejected.
+        self.assertTrue(payload["eligible"])
+        self.assertEqual(2, payload["eligibleCount"])
+        self.assertEqual(1, payload["advisoryControlPlaneRowCount"])
+        self.assertEqual(
+            {control_plane: [".github/workflows/build.yml", "scripts/poll_pr_checks.py"]},
+            payload["advisoryControlPlaneRows"],
+        )
+        self.assertNotIn(control_plane, payload.get("rejected", {}))
+        self.assertNotIn(normal, payload["advisoryControlPlaneRows"])
+
     def test_shortlist_cli_reports_without_mutating_workbook(self) -> None:
         before = self.workbook_path.read_bytes()
         stdout = io.StringIO()


### PR DESCRIPTION
## Motivation

Recorded observation `20260701T202326Z` ("Top P0 tier is queue-CLEAN but unclaimable"): the shortlist surfaces status-and-dependency CLEAN rows whose `Target Files / Modules` rewrite the shared CI merge-gate or controller governance (`.github/workflows/build.yml`, `AGENTS.md`, `scripts/ci_change_classifier.py`, `scripts/poll_pr_checks.py`) as top eligible work. Rewriting those mid-run risks the CI gate for every concurrent PR, so no single autonomous controller can validate the blast radius — but the mechanical "CLEAN" shortlist flag did not capture this, so auto-selection pointed controllers at structurally unclaimable work.

## Changes

- **`scripts/issue_queue.py`**: new `CONTROL_PLANE_PATHS` constant and `controlPlaneAdvisories()` helper (mirrors the existing `targetFileOverlapAdvisories` pattern). `shortlistTasks` now reports `advisoryControlPlaneRowCount` (always) and `advisoryControlPlaneRows` (with `--include-rejected`), mapping each **eligible** row that declares a control-plane target file to the matched files, plus a `mechanicalFilters` note. **Advisory only** — eligibility, rejection, selection, and claim semantics are unchanged; the signal lets a controller/PM route such rows to a supervised lane instead of auto-claiming them.
- **`docs/codex-agent-queue.md`**: documents the two new fields and their advisory (non-blocking) semantics.
- **`tests/test_issue_queue.py`**: `test_shortlist_flags_control_plane_rows_as_advisory_without_rejecting` — a P0 control-plane row and a P0 normal row; asserts the flagged row keeps its eligibility (not rejected), the count/map are exact, and the normal row is not flagged.

## Evidence

- `python3 -m unittest tests.test_issue_queue` → 46 OK (+1)
- Focused baseline (issue_queue + workflow_observations + ci_change_classifier + poll_pr_checks + pr_review_audit + controller_resource_audit + coverage_report + prompt_inventory) → 213 OK
- `python3 scripts/issue_queue.py validate` → OK

## Risks

Very low. Purely additive payload fields computed from the already-finalized eligible list; independently verified that the result feeds only the two new keys and never `eligible`/`rejected`/`selected`, and that no claim path is touched. `CONTROL_PLANE_PATHS` is a local literal (no import of authority files), keeping `issue_queue.py` non-authority/lightweight.

## Manual review items

None outstanding. Independently reviewed: advisory-only semantics, exact-match profile (no false positives), eligible-scope correctness, structural mirror of the existing advisory, and test quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016D8Ra7XE7j7cBsVqzKfbou)_