### PR TITLE
[resolution] Resolve stale multi-workbook supply-chain observation via #942

### DIFF
--- a/planning/workflow_observations/resolutions/20260630T115833Z-ctrl-vm-4026-9b5a29b5-9e4d451f.json
+++ b/planning/workflow_observations/resolutions/20260630T115833Z-ctrl-vm-4026-9b5a29b5-9e4d451f.json
@@ -1,0 +1,19 @@
+{
+  "evidence": [
+    {
+      "artifactsPresent": false,
+      "command": "python3 -m unittest tests.security.test_configure_supply_chain",
+      "fixCommit": "db9b4ec",
+      "result": "Ran 15 tests OK on current main"
+    }
+  ],
+  "mergeCommit": "db9b4ec8499a7010165ee936b2d358a7c178db1f",
+  "mergedPr": 942,
+  "observationId": "20260630T115833Z-ctrl-vm-4026-9b5a29b5-9e4d451f",
+  "resolutionSummary": "Fixed by PR #942 (Remove stale multi-workbook apply workflow artifacts re-added by #817). Verified on current main: .github/workflows/apply-multi-workbook-workflow.yml, .github/multi-workbook-payload/, and .github/multi-workbook-inspection.txt are absent, and tests.security.test_configure_supply_chain passes (15 OK), including test_temporary_multi_workbook_apply_artifacts_are_removed. The supply-chain gate is no longer red from these artifacts.",
+  "resolvedAtUtc": "2026-07-02T15:47:59Z",
+  "resolver": "optimizer-ctrl-vm-17796-c8464bae",
+  "schemaVersion": 1,
+  "sourceCommit": "90f7f0aa6f28b140be9c20c006a2ceea21598404",
+  "status": "resolved"
+}


### PR DESCRIPTION
## Workflow observation resolution (resolution-only)

Adds one append-only receipt under `planning/workflow_observations/resolutions/`. No source, workbook, or workflow-code change.

- **Resolves:** `20260630T115833Z-ctrl-vm-4026-9b5a29b5-9e4d451f` ("main shipped red: re-added multi-workbook apply artifacts fail supply-chain test")
- **Status:** resolved · **Merged PR:** #942 · **Merge commit:** `db9b4ec`

### Why this is resolved

PR #942 ("Remove stale multi-workbook apply workflow artifacts re-added by #817") deleted the re-added artifacts. Verified on current `main`:

- `.github/workflows/apply-multi-workbook-workflow.yml`, `.github/multi-workbook-payload/`, and `.github/multi-workbook-inspection.txt` are all absent.
- `python3 -m unittest tests.security.test_configure_supply_chain` → **15 OK**, including `test_temporary_multi_workbook_apply_artifacts_are_removed`.

This high-severity record no longer reflects reality; leaving it open distorts the `workflow_observations.py next` ranking controllers use as evidence.

Note: a second stale candidate (`resource_unit_tests` main-wide break, `20260701T092018Z…`) was deliberately **not** receipted — its resolution is documented by the newer fleet record `20260702T000947Z…`, but no unambiguous fixing PR/commit could be attributed, and the ledger correctly requires one for a `resolved` receipt.

Append-only; unique receipt path; no existing record or receipt modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016D8Ra7XE7j7cBsVqzKfbou)_