### PR TITLE
Remove stale configure_file for deleted res/images/paper.png

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,7 +354,6 @@ configure_file(res/images/interactions/stun.png images/interactions/stun.png COP
 configure_file(res/images/interactions/abyssalshadows.png images/interactions/abyssalshadows.png COPYONLY)
 
 configure_file(res/images/panel.png images/panel.png COPYONLY)
-configure_file(res/images/paper.png images/paper.png COPYONLY)
 configure_file(res/images/arrows/left.png images/arrows/left.png COPYONLY)
 configure_file(res/images/arrows/right.png images/arrows/right.png COPYONLY)
 configure_file(res/images/item.png images/item.png COPYONLY)


### PR DESCRIPTION
## Summary

Cleanup #1297 (`526aef0`) deleted the unused `res/images/paper.png` asset (cleanup plan item 0.4) but left its `configure_file` line in `CMakeLists.txt` (line 357). Since it landed at 15:27Z, **every CMake configure on main fails** with:

```
CMake Error: File .../res/images/paper.png does not exist.
CMake Error at CMakeLists.txt:357 (configure_file)
```

This broke the `linux`, `linux-coverage`, and `windows` jobs of all PR runs triggered after that point (e.g. #1269's run 28603061351, failing in under a minute at the configure step).

## Change

- Remove the single stale `configure_file(res/images/paper.png images/paper.png COPYONLY)` line.

## Validation

- Audited every remaining `configure_file(res/...)` source in `CMakeLists.txt` against the tree: `paper.png` was the only missing one.
- Full configure/build could not be run in this environment (no SDL2/native deps); CI on this PR supplies the configure+build evidence per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQ2ByiJr6AtPdrTtpBqoft

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQ2ByiJr6AtPdrTtpBqoft)_