### PR TITLE
Add 25 Baldur's Gate inspired interactions with supporting effects

### DIFF
--- a/res/config/effects.json
+++ b/res/config/effects.json
@@ -94,5 +94,104 @@
     "properties": {
       "duration": 3
     }
+  },
+  "ArmorOfFaithEffect": {
+    "class": "ArmorOfFaithEffect",
+    "properties": {
+      "duration": 4,
+      "tags": [
+        "buff"
+      ]
+    }
+  },
+  "BlessEffect": {
+    "class": "BlessEffect",
+    "properties": {
+      "duration": 4,
+      "tags": [
+        "buff"
+      ]
+    }
+  },
+  "ChillTouchEffect": {
+    "class": "ChillTouchEffect",
+    "properties": {
+      "duration": 3
+    }
+  },
+  "CloudkillEffect": {
+    "class": "CloudkillEffect",
+    "properties": {
+      "duration": 4
+    }
+  },
+  "DoomEffect": {
+    "class": "DoomEffect",
+    "properties": {
+      "duration": 4
+    }
+  },
+  "DrawUponHolyMightEffect": {
+    "class": "DrawUponHolyMightEffect",
+    "properties": {
+      "duration": 3,
+      "tags": [
+        "buff"
+      ]
+    }
+  },
+  "HasteEffect": {
+    "class": "HasteEffect",
+    "properties": {
+      "duration": 3,
+      "tags": [
+        "buff"
+      ]
+    }
+  },
+  "HoldPersonEffect": {
+    "class": "HoldPersonEffect",
+    "properties": {
+      "duration": 2,
+      "tags": [
+        "stun"
+      ]
+    }
+  },
+  "MelfsAcidArrowEffect": {
+    "class": "MelfsAcidArrowEffect",
+    "properties": {
+      "duration": 3
+    }
+  },
+  "MirrorImageEffect": {
+    "class": "MirrorImageEffect",
+    "properties": {
+      "duration": 3,
+      "tags": [
+        "buff"
+      ]
+    }
+  },
+  "SlowEffect": {
+    "class": "SlowEffect",
+    "properties": {
+      "duration": 3
+    }
+  },
+  "StoneskinEffect": {
+    "class": "StoneskinEffect",
+    "properties": {
+      "duration": 4,
+      "tags": [
+        "buff"
+      ]
+    }
+  },
+  "WebEffect": {
+    "class": "WebEffect",
+    "properties": {
+      "duration": 3
+    }
   }
 }

--- a/res/config/interactions.json
+++ b/res/config/interactions.json
@@ -253,5 +253,256 @@
       "label": "Smuggler's Mark",
       "manaCost": 20
     }
+  },
+  "AgannazarsScorcher": {
+    "class": "AgannazarsScorcher",
+    "properties": {
+      "animation": "images/interactions/chaosblast",
+      "label": "Agannazar's Scorcher",
+      "manaCost": 14
+    }
+  },
+  "ArmorOfFaith": {
+    "class": "ArmorOfFaith",
+    "properties": {
+      "animation": "images/interactions/armorofendlesswinter",
+      "effect": {
+        "ref": "ArmorOfFaithEffect"
+      },
+      "label": "Armor of Faith",
+      "manaCost": 12,
+      "selfTarget": true
+    }
+  },
+  "Bless": {
+    "class": "Bless",
+    "properties": {
+      "animation": "images/interactions/barrier",
+      "effect": {
+        "ref": "BlessEffect"
+      },
+      "label": "Bless",
+      "manaCost": 10,
+      "selfTarget": true
+    }
+  },
+  "BurningHands": {
+    "class": "BurningHands",
+    "properties": {
+      "animation": "images/interactions/chaosblast",
+      "label": "Burning Hands",
+      "manaCost": 8
+    }
+  },
+  "ChillTouch": {
+    "class": "ChillTouch",
+    "properties": {
+      "animation": "images/interactions/frostbolt",
+      "effect": {
+        "ref": "ChillTouchEffect"
+      },
+      "label": "Chill Touch",
+      "manaCost": 10
+    }
+  },
+  "ChromaticOrb": {
+    "class": "ChromaticOrb",
+    "properties": {
+      "animation": "images/interactions/magicmissile",
+      "label": "Chromatic Orb",
+      "manaCost": 15
+    }
+  },
+  "Cloudkill": {
+    "class": "Cloudkill",
+    "properties": {
+      "animation": "images/interactions/lethalpoison",
+      "effect": {
+        "ref": "CloudkillEffect"
+      },
+      "label": "Cloudkill",
+      "manaCost": 40
+    }
+  },
+  "ConeOfCold": {
+    "class": "ConeOfCold",
+    "properties": {
+      "animation": "images/interactions/frostbolt",
+      "label": "Cone of Cold",
+      "manaCost": 35
+    }
+  },
+  "Doom": {
+    "class": "Doom",
+    "properties": {
+      "animation": "images/interactions/endlesspain",
+      "effect": {
+        "ref": "DoomEffect"
+      },
+      "label": "Doom",
+      "manaCost": 12
+    }
+  },
+  "DrawUponHolyMight": {
+    "class": "DrawUponHolyMight",
+    "properties": {
+      "animation": "images/interactions/bloodthirst",
+      "effect": {
+        "ref": "DrawUponHolyMightEffect"
+      },
+      "label": "Draw Upon Holy Might",
+      "manaCost": 25,
+      "selfTarget": true
+    }
+  },
+  "FingerOfDeath": {
+    "class": "FingerOfDeath",
+    "properties": {
+      "animation": "images/interactions/shadowbolt",
+      "label": "Finger of Death",
+      "manaCost": 50
+    }
+  },
+  "Fireball": {
+    "class": "Fireball",
+    "properties": {
+      "animation": "images/interactions/chaosblast",
+      "label": "Fireball",
+      "manaCost": 30
+    }
+  },
+  "FlameStrike": {
+    "class": "FlameStrike",
+    "properties": {
+      "animation": "images/interactions/chaosblast",
+      "label": "Flame Strike",
+      "manaCost": 30
+    }
+  },
+  "Haste": {
+    "class": "Haste",
+    "properties": {
+      "animation": "images/interactions/doubleattack",
+      "effect": {
+        "ref": "HasteEffect"
+      },
+      "label": "Haste",
+      "manaCost": 30,
+      "selfTarget": true
+    }
+  },
+  "HoldPerson": {
+    "class": "HoldPerson",
+    "properties": {
+      "animation": "images/interactions/stun",
+      "effect": {
+        "ref": "HoldPersonEffect"
+      },
+      "label": "Hold Person",
+      "manaCost": 35
+    }
+  },
+  "LarlochsMinorDrain": {
+    "class": "LarlochsMinorDrain",
+    "properties": {
+      "animation": "images/interactions/bloodthirst",
+      "label": "Larloch's Minor Drain",
+      "manaCost": 4,
+      "tags": [
+        "heal"
+      ]
+    }
+  },
+  "LightningBolt": {
+    "class": "LightningBolt",
+    "properties": {
+      "animation": "images/interactions/magicmissile",
+      "label": "Lightning Bolt",
+      "manaCost": 25
+    }
+  },
+  "MelfsAcidArrow": {
+    "class": "MelfsAcidArrow",
+    "properties": {
+      "animation": "images/interactions/lethalpoison",
+      "effect": {
+        "ref": "MelfsAcidArrowEffect"
+      },
+      "label": "Melf's Acid Arrow",
+      "manaCost": 12
+    }
+  },
+  "MirrorImage": {
+    "class": "MirrorImage",
+    "properties": {
+      "animation": "images/interactions/barrier",
+      "effect": {
+        "ref": "MirrorImageEffect"
+      },
+      "label": "Mirror Image",
+      "manaCost": 20,
+      "selfTarget": true
+    }
+  },
+  "SkullTrap": {
+    "class": "SkullTrap",
+    "properties": {
+      "animation": "images/interactions/shadowbolt",
+      "label": "Skull Trap",
+      "manaCost": 20
+    }
+  },
+  "Slow": {
+    "class": "Slow",
+    "properties": {
+      "animation": "images/interactions/chloroform",
+      "effect": {
+        "ref": "SlowEffect"
+      },
+      "label": "Slow",
+      "manaCost": 25
+    }
+  },
+  "SpiritualHammer": {
+    "class": "SpiritualHammer",
+    "properties": {
+      "animation": "images/interactions/strike",
+      "label": "Spiritual Hammer",
+      "manaCost": 12
+    }
+  },
+  "Stoneskin": {
+    "class": "Stoneskin",
+    "properties": {
+      "animation": "images/interactions/armorofendlesswinter",
+      "effect": {
+        "ref": "StoneskinEffect"
+      },
+      "label": "Stoneskin",
+      "manaCost": 45,
+      "selfTarget": true
+    }
+  },
+  "VampiricTouch": {
+    "class": "VampiricTouch",
+    "properties": {
+      "animation": "images/interactions/bloodthirst",
+      "label": "Vampiric Touch",
+      "manaCost": 18,
+      "tags": [
+        "heal"
+      ]
+    }
+  },
+  "Web": {
+    "class": "Web",
+    "properties": {
+      "animation": "images/interactions/chloroform",
+      "effect": {
+        "ref": "WebEffect"
+      },
+      "label": "Web",
+      "manaCost": 15
+    }
   }
 }

--- a/res/plugins/effect.py
+++ b/res/plugins/effect.py
@@ -17,6 +17,7 @@ def load(self, context):
     from game import CTag
     from game import CEffect
     from game import CDamage
+    from game import randint
     from game import register
 
     def is_cultist(creature):
@@ -114,3 +115,76 @@ def load(self, context):
                 max(1, caster.getStats().getNumericProperty("agility") // 3 + caster.getLevel() // 2 + routes),
             )
             self.getVictim().hurt(damage)
+
+    # Baldur's Gate inspired repertoire.
+
+    @register(context)
+    class MelfsAcidArrowEffect(CEffect):
+        def onEffect(self):
+            self.getVictim().hurt(2 + self.getCaster().getLevel() // 2)
+
+    @register(context)
+    class CloudkillEffect(CEffect):
+        def onEffect(self):
+            damage = CDamage()
+            damage.setNumericProperty("shadow", 3 + self.getCaster().getLevel())
+            self.getVictim().hurt(damage)
+
+    @register(context)
+    class HoldPersonEffect(CEffect):
+        def onEffect(self):
+            pass
+
+    @register(context)
+    class WebEffect(CEffect):
+        def onEffect(self):
+            agility = self.getVictim().getStats().getNumericProperty("agility")
+            if randint(1, 100) <= 35 + agility * 2:
+                self.removeTag(CTag.STUN)
+            else:
+                self.addTag(CTag.STUN)
+
+    @register(context)
+    class SlowEffect(CEffect):
+        def onEffect(self):
+            pass
+
+    @register(context)
+    class ChillTouchEffect(CEffect):
+        def onEffect(self):
+            pass
+
+    @register(context)
+    class DoomEffect(CEffect):
+        def onEffect(self):
+            pass
+
+    @register(context)
+    class HasteEffect(CEffect):
+        def onEffect(self):
+            pass
+
+    @register(context)
+    class MirrorImageEffect(CEffect):
+        def onEffect(self):
+            pass
+
+    @register(context)
+    class StoneskinEffect(CEffect):
+        def onEffect(self):
+            pass
+
+    @register(context)
+    class BlessEffect(CEffect):
+        def onEffect(self):
+            pass
+
+    @register(context)
+    class ArmorOfFaithEffect(CEffect):
+        def onEffect(self):
+            pass
+
+    @register(context)
+    class DrawUponHolyMightEffect(CEffect):
+        def onEffect(self):
+            pass

--- a/res/plugins/interaction.py
+++ b/res/plugins/interaction.py
@@ -261,3 +261,245 @@ def load(self, context):
             effect.setBonus(stats)
             effect.setNumericProperty("wayfarer_routes", routes)
             return True
+
+    # Baldur's Gate inspired repertoire.
+
+    @register(context)
+    class BurningHands(CInteraction):
+        def performAction(self, first, second):
+            damage = CDamage()
+            damage.setNumericProperty("fire", 3 + first.getLevel() * 2)
+            second.hurt(damage)
+
+    @register(context)
+    class AgannazarsScorcher(CInteraction):
+        def performAction(self, first, second):
+            damage = CDamage()
+            damage.setNumericProperty("fire", 6 + first.getStats().getNumericProperty("intelligence") // 2)
+            second.hurt(damage)
+
+    @register(context)
+    class Fireball(CInteraction):
+        def performAction(self, first, second):
+            rolled = 0
+            for _ in range(max(1, first.getLevel())):
+                rolled += randint(1, 6)
+            damage = CDamage()
+            damage.setNumericProperty("fire", rolled)
+            second.hurt(damage)
+
+    @register(context)
+    class FlameStrike(CInteraction):
+        def performAction(self, first, second):
+            damage = CDamage()
+            damage.setNumericProperty("fire", 10 + first.getLevel() * 2)
+            second.hurt(damage)
+
+    @register(context)
+    class LightningBolt(CInteraction):
+        def performAction(self, first, second):
+            rolled = 0
+            for _ in range(max(1, first.getLevel())):
+                rolled += randint(1, 6)
+            damage = CDamage()
+            damage.setNumericProperty("thunder", rolled)
+            second.hurt(damage)
+
+    @register(context)
+    class ChromaticOrb(CInteraction):
+        def performAction(self, first, second):
+            kinds = ["fire", "frost", "thunder", "shadow", "normal"]
+            damage = CDamage()
+            base = 4 + first.getLevel() + first.getStats().getNumericProperty("intelligence") // 3
+            damage.setNumericProperty(kinds[randint(0, len(kinds) - 1)], base)
+            second.hurt(damage)
+
+    @register(context)
+    class ConeOfCold(CInteraction):
+        def performAction(self, first, second):
+            intelligence = first.getStats().getNumericProperty("intelligence")
+            damage = CDamage()
+            damage.setNumericProperty("frost", 8 + first.getLevel() + intelligence // 2)
+            second.hurt(damage)
+
+    @register(context)
+    class SkullTrap(CInteraction):
+        def performAction(self, first, second):
+            rolled = 0
+            for _ in range(max(1, first.getLevel())):
+                rolled += randint(1, 6)
+            damage = CDamage()
+            damage.setNumericProperty("shadow", rolled)
+            second.hurt(damage)
+
+    @register(context)
+    class LarlochsMinorDrain(CInteraction):
+        def performAction(self, first, second):
+            drained = 4 + first.getLevel()
+            damage = CDamage()
+            damage.setNumericProperty("shadow", drained)
+            second.hurt(damage)
+            first.heal(drained)
+
+    @register(context)
+    class VampiricTouch(CInteraction):
+        def performAction(self, first, second):
+            drained = 6 + first.getLevel() * 2
+            damage = CDamage()
+            damage.setNumericProperty("shadow", drained)
+            second.hurt(damage)
+            first.heal(drained // 2)
+
+    @register(context)
+    class FingerOfDeath(CInteraction):
+        def performAction(self, first, second):
+            damage = CDamage()
+            damage.setNumericProperty("shadow", first.getDmg() * 2)
+            second.hurt(damage)
+            if second.getHpRatio() < 20 and second.isAlive():
+                second.hurt(int(first.getDmg() * 1.5))
+
+    @register(context)
+    class SpiritualHammer(CInteraction):
+        def performAction(self, first, second):
+            damage = CDamage()
+            strength = first.getStats().getNumericProperty("strength")
+            damage.setNumericProperty("normal", 3 + first.getLevel() + strength // 3)
+            second.hurt(damage)
+
+    @register(context)
+    class MelfsAcidArrow(CInteraction):
+        def performAction(self, first, second):
+            damage = CDamage()
+            damage.setNumericProperty("normal", 2 + randint(1, 4) + first.getLevel() // 2)
+            second.hurt(damage)
+
+    @register(context)
+    class Cloudkill(CInteraction):
+        pass
+
+    @register(context)
+    class HoldPerson(CInteraction):
+        def configureEffect(self, effect):
+            return randint(1, 3) != 1
+
+    @register(context)
+    class Web(CInteraction):
+        pass
+
+    @register(context)
+    class Slow(CInteraction):
+        def configureEffect(self, effect):
+            caster = effect.getCaster()
+            if not caster:
+                return False
+            stats = CStats()
+            stats.setNumericProperty("agility", -(2 + caster.getLevel() // 2))
+            stats.setNumericProperty("hit", -(3 + caster.getLevel() // 3))
+            stats.setNumericProperty("block", -4)
+            effect.setBonus(stats)
+            return True
+
+    @register(context)
+    class ChillTouch(CInteraction):
+        def performAction(self, first, second):
+            damage = CDamage()
+            damage.setNumericProperty("frost", 2 + randint(1, 8))
+            second.hurt(damage)
+
+        def configureEffect(self, effect):
+            caster = effect.getCaster()
+            if not caster:
+                return False
+            stats = CStats()
+            stats.setNumericProperty("hit", -(2 + caster.getLevel() // 3))
+            effect.setBonus(stats)
+            return True
+
+    @register(context)
+    class Doom(CInteraction):
+        def configureEffect(self, effect):
+            caster = effect.getCaster()
+            if not caster:
+                return False
+            stats = CStats()
+            stats.setNumericProperty("armor", -(2 + caster.getLevel() // 2))
+            stats.setNumericProperty("block", -2)
+            stats.setNumericProperty("hit", -2)
+            effect.setBonus(stats)
+            return True
+
+    @register(context)
+    class Haste(CInteraction):
+        def configureEffect(self, effect):
+            caster = effect.getCaster()
+            if not caster:
+                return False
+            stats = CStats()
+            stats.setNumericProperty("agility", 3 + caster.getLevel() // 2)
+            stats.setNumericProperty("hit", 3)
+            stats.setNumericProperty("crit", 2)
+            effect.setBonus(stats)
+            return True
+
+    @register(context)
+    class MirrorImage(CInteraction):
+        def configureEffect(self, effect):
+            caster = effect.getCaster()
+            if not caster:
+                return False
+            stats = CStats()
+            stats.setNumericProperty("block", 15 + caster.getLevel() * 2)
+            effect.setBonus(stats)
+            return True
+
+    @register(context)
+    class Stoneskin(CInteraction):
+        def configureEffect(self, effect):
+            caster = effect.getCaster()
+            if not caster:
+                return False
+            stats = CStats()
+            stats.setNumericProperty("armor", 6 + caster.getStats().getNumericProperty("armor") // 2)
+            stats.setNumericProperty("normalResist", 5)
+            effect.setBonus(stats)
+            return True
+
+    @register(context)
+    class Bless(CInteraction):
+        def configureEffect(self, effect):
+            caster = effect.getCaster()
+            if not caster:
+                return False
+            stats = CStats()
+            stats.setNumericProperty("hit", 2 + caster.getLevel() // 4)
+            stats.setNumericProperty("attack", 1)
+            effect.setBonus(stats)
+            return True
+
+    @register(context)
+    class ArmorOfFaith(CInteraction):
+        def configureEffect(self, effect):
+            caster = effect.getCaster()
+            if not caster:
+                return False
+            stats = CStats()
+            stats.setNumericProperty("armor", 3 + caster.getLevel() // 2)
+            stats.setNumericProperty("normalResist", 3)
+            stats.setNumericProperty("shadowResist", 3)
+            effect.setBonus(stats)
+            return True
+
+    @register(context)
+    class DrawUponHolyMight(CInteraction):
+        def configureEffect(self, effect):
+            caster = effect.getCaster()
+            if not caster:
+                return False
+            boost = 2 + caster.getLevel() // 3
+            stats = CStats()
+            stats.setNumericProperty("strength", boost)
+            stats.setNumericProperty("agility", boost)
+            stats.setNumericProperty("stamina", boost)
+            effect.setBonus(stats)
+            return True


### PR DESCRIPTION
## Summary

Adds 25 new Baldur's Gate–inspired interactions and 13 supporting effects as pure content (Python plugins + config JSON) — no engine changes.

**Instant spells (12):** Burning Hands, Agannazar's Scorcher, Fireball, Flame Strike, Lightning Bolt, Chromatic Orb, Cone of Cold, Skull Trap, Larloch's Minor Drain, Vampiric Touch, Finger of Death, Spiritual Hammer

**With hostile effects (7):** Melf's Acid Arrow (acid DoT), Cloudkill (shadow DoT), Hold Person (save-or-stun), Web (agility-checked entangle), Slow (agility/hit/block debuff), Chill Touch (frost + hit debuff), Doom (armor/block/hit debuff)

**Self buffs (6):** Haste, Mirror Image, Stoneskin, Bless, Armor of Faith, Draw Upon Holy Might

## Implementation notes

- Interactions follow the existing plugin patterns (`performAction` for damage, `configureEffect` for stat bonuses/save gates); scaling uses caster level/intelligence/strength like the existing repertoire.
- Buff-tagged effects declare `selfTarget: true` on their interaction per the validator's explicit effect-routing rule.
- Drain spells (Vampiric Touch, Larloch's Minor Drain) carry the `heal` tag mirroring BloodThirst.
- Animations reuse existing interaction sprites; no new assets.

## Validation

- `python3 scripts/validate_content.py --repo-root .` — passed
- `python3 -m unittest tests.test_content_validator` — 160 tests OK
- `black -l 120 --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FVGwTN4J3WiURLg7c3HJQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014FVGwTN4J3WiURLg7c3HJQ)_