### PR TITLE
Add legacy layer properties to the Warden's Road map layers

### DIFF
--- a/res/maps/gravemoor/map.json
+++ b/res/maps/gravemoor/map.json
@@ -29,6 +29,20 @@
    "visible": true,
    "x": 0,
    "y": 0,
+   "properties": {
+    "default": "SwampTile",
+    "outOfBounds": "MountainTile",
+    "level": "0",
+    "xBound": "23",
+    "yBound": "23"
+   },
+   "propertytypes": {
+    "default": "string",
+    "outOfBounds": "string",
+    "level": "string",
+    "xBound": "string",
+    "yBound": "string"
+   },
    "data": [
     12,
     12,
@@ -616,6 +630,12 @@
    "x": 0,
    "y": 0,
    "draworder": "topdown",
+   "properties": {
+    "level": "0"
+   },
+   "propertytypes": {
+    "level": "string"
+   },
    "objects": [
     {
      "height": 32,

--- a/res/maps/hearthfall/map.json
+++ b/res/maps/hearthfall/map.json
@@ -29,6 +29,20 @@
    "visible": true,
    "x": 0,
    "y": 0,
+   "properties": {
+    "default": "GrassTile",
+    "outOfBounds": "MountainTile",
+    "level": "0",
+    "xBound": "23",
+    "yBound": "23"
+   },
+   "propertytypes": {
+    "default": "string",
+    "outOfBounds": "string",
+    "level": "string",
+    "xBound": "string",
+    "yBound": "string"
+   },
    "data": [
     12,
     12,
@@ -616,6 +630,12 @@
    "x": 0,
    "y": 0,
    "draworder": "topdown",
+   "properties": {
+    "level": "0"
+   },
+   "propertytypes": {
+    "level": "string"
+   },
    "objects": [
     {
      "height": 32,

--- a/res/maps/usurpergate/map.json
+++ b/res/maps/usurpergate/map.json
@@ -29,6 +29,20 @@
    "visible": true,
    "x": 0,
    "y": 0,
+   "properties": {
+    "default": "WastelandTile",
+    "outOfBounds": "MountainTile",
+    "level": "0",
+    "xBound": "23",
+    "yBound": "23"
+   },
+   "propertytypes": {
+    "default": "string",
+    "outOfBounds": "string",
+    "level": "string",
+    "xBound": "string",
+    "yBound": "string"
+   },
    "data": [
     12,
     12,
@@ -616,6 +630,12 @@
    "x": 0,
    "y": 0,
    "draworder": "topdown",
+   "properties": {
+    "level": "0"
+   },
+   "propertytypes": {
+    "level": "string"
+   },
    "objects": [
     {
      "height": 32,


### PR DESCRIPTION
Follow-up fix for #1314. `CMapLoader` indexes each Tiled layer's object-style `properties` map directly, so every layer needs `level` (plus `default`/`outOfBounds`/`xBound`/`yBound` on tile layers). The generated hearthfall/gravemoor/usurpergate maps omitted them, which made the loader reject the maps at runtime on `main`: object layers never populated (no StartEvent, no quest grants, MCP object lookups returning nothing) and all map-context config entries failed to create — failing every new-map walkthrough, both wardensRoad campaign route tests, `test_config_entries_create_in_global_and_map_contexts`, and `test_map_json_tiled_compatibility` in [run 2899](https://github.com/lisu188/fall-of-nouraajd/actions/runs/28609565157).

The three map layers now carry the same property shape as vhulmarn's (per-map fallback tiles included), and `validate_map_json_tiled_compatibility` reports zero issues for all twelve maps locally. Content validation and the full `tests/` discovery (568 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxyPhWoHXUxZ6YSXx4a2Vp

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxyPhWoHXUxZ6YSXx4a2Vp)_