### PR TITLE
Shell-quote untrusted fields in subagent_registry sweep recommendedCommand

### DIFF
--- a/scripts/subagent_registry.py
+++ b/scripts/subagent_registry.py
@@ -39,6 +39,7 @@ import argparse
 import dataclasses
 import json
 import os
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -676,10 +677,25 @@ def sweepRegistry(
             "reasons": reasons,
         }
         if recommended != "NONE":
-            finding["recommendedCommand"] = (
-                f"python3 scripts/subagent_registry.py mark --registry {registryPath} "
-                f"--registration-id {record.registrationId} --to {recommended} "
-                f"--reason {json.dumps('; '.join(reasons))}"
+            # Shell-quote every interpolated field. registrationId/branch/worktree
+            # are attacker-influenced (a subagent registers them), and reasons embed
+            # branch/worktree text; json.dumps only double-quotes, which still lets
+            # bash run $(...)/`...` command substitution when an operator pastes the
+            # command. shlex.join produces a safe, copy-pasteable argv.
+            finding["recommendedCommand"] = shlex.join(
+                [
+                    "python3",
+                    "scripts/subagent_registry.py",
+                    "mark",
+                    "--registry",
+                    str(registryPath),
+                    "--registration-id",
+                    record.registrationId,
+                    "--to",
+                    recommended,
+                    "--reason",
+                    "; ".join(reasons),
+                ]
             )
         findings.append(finding)
     return {

--- a/tests/test_subagent_registry.py
+++ b/tests/test_subagent_registry.py
@@ -4,6 +4,7 @@ import contextlib
 import io
 import json
 import os
+import shlex
 import subprocess
 import tempfile
 import unittest
@@ -272,6 +273,29 @@ class SubagentRegistryTest(unittest.TestCase):
         self.assertIn(missing["registrationId"], findings[missing_owner]["recommendedCommand"])
         self.assertEqual(len(result["recommendations"]), 1)
         del healthy
+
+    def test_sweep_recommended_command_shell_quotes_untrusted_fields(self) -> None:
+        # A subagent registers its own branch/worktree, so those strings are
+        # untrusted. They flow into the operator-facing recommendedCommand; if it
+        # is not shell-quoted, pasting it runs $(...)/`...`/; embedded by an
+        # attacker. The command must be a single safely-quoted argv instead.
+        repo = self.init_git_repo([])
+        malicious_branch = "codex/x$(touch pwned)`id`; rm -rf ."
+        record = self.register_default(branch=malicious_branch)
+
+        finding = subagent_registry.sweepRegistry(self.registry_path, repoRoot=repo)["findings"][0]
+        command = finding["recommendedCommand"]
+
+        # shlex.split tokenizes exactly as a POSIX shell would: the untrusted
+        # branch survives only as one inert --reason argument and never splits
+        # into active words like "rm"/"-rf" or a substitution token.
+        argv = shlex.split(command)
+        self.assertEqual(argv[:3], ["python3", "scripts/subagent_registry.py", "mark"])
+        self.assertEqual(argv[argv.index("--registration-id") + 1], record["registrationId"])
+        self.assertIn(malicious_branch, argv[argv.index("--reason") + 1])
+        self.assertNotIn("rm", argv)
+        self.assertNotIn("-rf", argv)
+        self.assertNotIn("$(touch", "".join(token for token in argv if token != argv[argv.index("--reason") + 1]))
 
     def test_sweep_recommends_unreachable_for_missing_branch_or_stale_last_seen(self) -> None:
         repo = self.init_git_repo([])


### PR DESCRIPTION
## Summary

`subagent_registry.py`'s read-only `sweep` emits a `recommendedCommand` string for an operator to copy‑paste and run. It was built with an f-string plus `json.dumps('; '.join(reasons))`. `json.dumps` only **double-quotes** the value, but a POSIX shell still performs `$(...)` / `` `...` `` command substitution **inside double quotes** — so the emitted command executes arbitrary code when pasted.

The interpolated fields are attacker-influenceable through the **normal `register` API**: a subagent supplies its own `branch` and `worktree`, and those strings flow into the sweep `reasons` (and thus `--reason`); `--registration-id` was interpolated unquoted entirely.

**Failure scenario (no file tampering):** a worker registers with `branch="$(touch pwned)"` and a live worktree. Its branch later fails `git rev-parse --verify`, so the `UNREACHABLE` finding's reason embeds the branch, and the emitted command is:

```
... mark ... --reason "branch $(touch pwned) is not resolvable ..."
```

Running that string in bash executes `touch pwned`.

## Fix

Build the command with `shlex.join([...])`, which safely quotes every interpolated token (`--registry`, `--registration-id`, `--to`, `--reason`). The result remains a correct, copy-pasteable argv, but untrusted text can only ever be an inert single argument.

## Tests

- New `test_sweep_recommended_command_shell_quotes_untrusted_fields`: registers a branch `codex/x$(touch pwned)`id`; rm -rf .` and asserts the emitted command tokenizes (via `shlex.split`) into the intended argv with the malicious branch confined to one `--reason` argument — no active `rm`/`-rf`/substitution tokens leak.
- `python3 -m unittest tests.test_subagent_registry` → **17 tests, OK**.

## Discovery

Found during a proactive correctness/security review of recently-merged control-plane Python. A parallel review of `pr_review_audit.py` surfaced no confirmed defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_