### PR TITLE
Fix silent CDamage/CStats construction failure in spell plugins

### DIFF
--- a/res/plugins/effect.py
+++ b/res/plugins/effect.py
@@ -16,9 +16,13 @@
 def load(self, context):
     from game import CTag
     from game import CEffect
-    from game import CDamage
     from game import randint
     from game import register
+
+    # CDamage has no Python constructor binding, so build damage packets
+    # through the victim's game object factory.
+    def spell_damage(creature):
+        return creature.getGame().createObject("CDamage")
 
     def is_cultist(creature):
         affiliation = creature.getStringProperty("affiliation")
@@ -37,7 +41,7 @@ def load(self, context):
     @register(context)
     class AbyssalShadowsEffect(CEffect):
         def onEffect(self):
-            dmg = CDamage()
+            dmg = spell_damage(self.getVictim())
             if self.getTimeLeft() > 1:
                 dmg.setNumericProperty("shadow", self.getCaster().getDmg() * 45 // 100)
             else:
@@ -86,7 +90,7 @@ def load(self, context):
             base = max(1, caster.getStats().getNumericProperty("intelligence") // 3 + caster.getLevel())
             if is_cultist(victim):
                 base += 2 + clues * 2
-            damage = CDamage()
+            damage = spell_damage(self.getVictim())
             damage.setNumericProperty("fire", base)
             victim.hurt(damage)
 
@@ -109,7 +113,7 @@ def load(self, context):
         def onEffect(self):
             caster = self.getCaster()
             routes = self.getNumericProperty("wayfarer_routes")
-            damage = CDamage()
+            damage = spell_damage(self.getVictim())
             damage.setNumericProperty(
                 "normal",
                 max(1, caster.getStats().getNumericProperty("agility") // 3 + caster.getLevel() // 2 + routes),
@@ -126,10 +130,9 @@ def load(self, context):
     @register(context)
     class CloudkillEffect(CEffect):
         def onEffect(self):
-            victim = self.getVictim()
-            damage = victim.getGame().createObject("CDamage")
+            damage = spell_damage(self.getVictim())
             damage.setNumericProperty("shadow", 3 + self.getCaster().getLevel())
-            victim.hurt(damage)
+            self.getVictim().hurt(damage)
 
     @register(context)
     class HoldPersonEffect(CEffect):

--- a/res/plugins/effect.py
+++ b/res/plugins/effect.py
@@ -126,9 +126,10 @@ def load(self, context):
     @register(context)
     class CloudkillEffect(CEffect):
         def onEffect(self):
-            damage = CDamage()
+            victim = self.getVictim()
+            damage = victim.getGame().createObject("CDamage")
             damage.setNumericProperty("shadow", 3 + self.getCaster().getLevel())
-            self.getVictim().hurt(damage)
+            victim.hurt(damage)
 
     @register(context)
     class HoldPersonEffect(CEffect):

--- a/res/plugins/interaction.py
+++ b/res/plugins/interaction.py
@@ -15,10 +15,17 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 def load(self, context):
     from game import CInteraction
-    from game import CDamage
-    from game import CStats
     from game import randint
     from game import register
+
+    # CDamage/CStats have no Python constructor binding, so build them through
+    # the object factory of the creature's game (the construction path the
+    # engine exposes to content code).
+    def spell_damage(creature):
+        return creature.getGame().createObject("CDamage")
+
+    def bonus_stats(creature):
+        return creature.getGame().createObject("CStats")
 
     def is_cultist(creature):
         affiliation = creature.getStringProperty("affiliation")
@@ -39,7 +46,7 @@ def load(self, context):
     @register(context)
     class ElemStaff(CInteraction):
         def performAction(self, first, second):
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("fire", 1)
             damage.setNumericProperty("frost", 1)
             damage.setNumericProperty("thunder", 1)
@@ -69,7 +76,7 @@ def load(self, context):
     @register(context)
     class ChaosBlast(CInteraction):
         def performAction(self, first, second):
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("fire", first.getMana() // 2)
             damage.setNumericProperty("thunder", first.getMana() // 2)
             second.hurt(damage)
@@ -89,7 +96,7 @@ def load(self, context):
     class FrostBolt(CInteraction):
         def performAction(self, first, second):
             Attack().onAction(first, second)
-            damage = CDamage()
+            damage = spell_damage(first)
             intelligence = first.getStats().getNumericProperty("intelligence")
             damage.setNumericProperty("frost", intelligence * 75 // 100)
             second.hurt(damage)
@@ -105,7 +112,7 @@ def load(self, context):
     @register(context)
     class ShadowBolt(CInteraction):
         def performAction(self, first, second):
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("shadow", int(first.getDmg() * 2.25))
             second.hurt(damage)
 
@@ -177,7 +184,7 @@ def load(self, context):
             caster = effect.getCaster()
             if not caster:
                 return False
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("armor", caster.getStats().getNumericProperty("armor") * 75 // 100)
             effect.setBonus(stats)
             return True
@@ -186,7 +193,7 @@ def load(self, context):
     class ExposeCorruption(CInteraction):
         def performAction(self, first, second):
             Attack().onAction(first, second)
-            damage = CDamage()
+            damage = spell_damage(first)
             clues = first.getNumericProperty("inquisitor_clues")
             base = first.getStats().getNumericProperty("intelligence") // 2 + first.getLevel()
             if is_cultist(second):
@@ -199,7 +206,7 @@ def load(self, context):
             if not caster:
                 return False
             clues = caster.getNumericProperty("inquisitor_clues")
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("armor", -(2 + clues * 2))
             stats.setNumericProperty("block", -(2 + caster.getLevel() // 2))
             effect.setBonus(stats)
@@ -216,7 +223,7 @@ def load(self, context):
             if not caster:
                 return False
             clues = caster.getNumericProperty("inquisitor_clues")
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("armor", 4 + caster.getLevel() + clues)
             stats.setNumericProperty("normalResist", 3 + clues * 2)
             stats.setNumericProperty("hit", 2 + clues)
@@ -234,7 +241,7 @@ def load(self, context):
             if not caster:
                 return False
             routes = caster.getNumericProperty("wayfarer_routes")
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("agility", 2 + routes + caster.getLevel() // 3)
             stats.setNumericProperty("block", 4 + routes * 2)
             stats.setNumericProperty("hit", 3 + routes)
@@ -245,7 +252,7 @@ def load(self, context):
     @register(context)
     class SmugglersMark(CInteraction):
         def performAction(self, first, second):
-            damage = CDamage()
+            damage = spell_damage(first)
             routes = first.getNumericProperty("wayfarer_routes")
             damage.setNumericProperty("normal", max(1, first.getStats().getNumericProperty("agility") // 2 + routes))
             second.hurt(damage)
@@ -255,23 +262,14 @@ def load(self, context):
             if not caster:
                 return False
             routes = caster.getNumericProperty("wayfarer_routes")
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("block", -(3 + routes * 2))
             stats.setNumericProperty("hit", -(2 + caster.getLevel() // 3))
             effect.setBonus(stats)
             effect.setNumericProperty("wayfarer_routes", routes)
             return True
 
-    # Baldur's Gate inspired repertoire.  CDamage/CStats have no Python
-    # constructor binding, so build them through the object factory of the
-    # creature's game (the pattern the engine exposes for content code).
-
-    def spell_damage(creature):
-        return creature.getGame().createObject("CDamage")
-
-    def bonus_stats(creature):
-        return creature.getGame().createObject("CStats")
-
+    # Baldur's Gate inspired repertoire.
     @register(context)
     class BurningHands(CInteraction):
         def performAction(self, first, second):
@@ -411,7 +409,7 @@ def load(self, context):
     @register(context)
     class ChillTouch(CInteraction):
         def performAction(self, first, second):
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("frost", 2 + randint(1, 8))
             second.hurt(damage)
 

--- a/res/plugins/interaction.py
+++ b/res/plugins/interaction.py
@@ -262,19 +262,27 @@ def load(self, context):
             effect.setNumericProperty("wayfarer_routes", routes)
             return True
 
-    # Baldur's Gate inspired repertoire.
+    # Baldur's Gate inspired repertoire.  CDamage/CStats have no Python
+    # constructor binding, so build them through the object factory of the
+    # creature's game (the pattern the engine exposes for content code).
+
+    def spell_damage(creature):
+        return creature.getGame().createObject("CDamage")
+
+    def bonus_stats(creature):
+        return creature.getGame().createObject("CStats")
 
     @register(context)
     class BurningHands(CInteraction):
         def performAction(self, first, second):
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("fire", 3 + first.getLevel() * 2)
             second.hurt(damage)
 
     @register(context)
     class AgannazarsScorcher(CInteraction):
         def performAction(self, first, second):
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("fire", 6 + first.getStats().getNumericProperty("intelligence") // 2)
             second.hurt(damage)
 
@@ -284,14 +292,14 @@ def load(self, context):
             rolled = 0
             for _ in range(max(1, first.getLevel())):
                 rolled += randint(1, 6)
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("fire", rolled)
             second.hurt(damage)
 
     @register(context)
     class FlameStrike(CInteraction):
         def performAction(self, first, second):
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("fire", 10 + first.getLevel() * 2)
             second.hurt(damage)
 
@@ -301,7 +309,7 @@ def load(self, context):
             rolled = 0
             for _ in range(max(1, first.getLevel())):
                 rolled += randint(1, 6)
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("thunder", rolled)
             second.hurt(damage)
 
@@ -309,7 +317,7 @@ def load(self, context):
     class ChromaticOrb(CInteraction):
         def performAction(self, first, second):
             kinds = ["fire", "frost", "thunder", "shadow", "normal"]
-            damage = CDamage()
+            damage = spell_damage(first)
             base = 4 + first.getLevel() + first.getStats().getNumericProperty("intelligence") // 3
             damage.setNumericProperty(kinds[randint(0, len(kinds) - 1)], base)
             second.hurt(damage)
@@ -318,7 +326,7 @@ def load(self, context):
     class ConeOfCold(CInteraction):
         def performAction(self, first, second):
             intelligence = first.getStats().getNumericProperty("intelligence")
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("frost", 8 + first.getLevel() + intelligence // 2)
             second.hurt(damage)
 
@@ -328,7 +336,7 @@ def load(self, context):
             rolled = 0
             for _ in range(max(1, first.getLevel())):
                 rolled += randint(1, 6)
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("shadow", rolled)
             second.hurt(damage)
 
@@ -336,7 +344,7 @@ def load(self, context):
     class LarlochsMinorDrain(CInteraction):
         def performAction(self, first, second):
             drained = 4 + first.getLevel()
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("shadow", drained)
             second.hurt(damage)
             first.heal(drained)
@@ -345,7 +353,7 @@ def load(self, context):
     class VampiricTouch(CInteraction):
         def performAction(self, first, second):
             drained = 6 + first.getLevel() * 2
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("shadow", drained)
             second.hurt(damage)
             first.heal(drained // 2)
@@ -353,7 +361,7 @@ def load(self, context):
     @register(context)
     class FingerOfDeath(CInteraction):
         def performAction(self, first, second):
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("shadow", first.getDmg() * 2)
             second.hurt(damage)
             if second.getHpRatio() < 20 and second.isAlive():
@@ -362,7 +370,7 @@ def load(self, context):
     @register(context)
     class SpiritualHammer(CInteraction):
         def performAction(self, first, second):
-            damage = CDamage()
+            damage = spell_damage(first)
             strength = first.getStats().getNumericProperty("strength")
             damage.setNumericProperty("normal", 3 + first.getLevel() + strength // 3)
             second.hurt(damage)
@@ -370,7 +378,7 @@ def load(self, context):
     @register(context)
     class MelfsAcidArrow(CInteraction):
         def performAction(self, first, second):
-            damage = CDamage()
+            damage = spell_damage(first)
             damage.setNumericProperty("normal", 2 + randint(1, 4) + first.getLevel() // 2)
             second.hurt(damage)
 
@@ -393,7 +401,7 @@ def load(self, context):
             caster = effect.getCaster()
             if not caster:
                 return False
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("agility", -(2 + caster.getLevel() // 2))
             stats.setNumericProperty("hit", -(3 + caster.getLevel() // 3))
             stats.setNumericProperty("block", -4)
@@ -411,7 +419,7 @@ def load(self, context):
             caster = effect.getCaster()
             if not caster:
                 return False
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("hit", -(2 + caster.getLevel() // 3))
             effect.setBonus(stats)
             return True
@@ -422,7 +430,7 @@ def load(self, context):
             caster = effect.getCaster()
             if not caster:
                 return False
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("armor", -(2 + caster.getLevel() // 2))
             stats.setNumericProperty("block", -2)
             stats.setNumericProperty("hit", -2)
@@ -435,7 +443,7 @@ def load(self, context):
             caster = effect.getCaster()
             if not caster:
                 return False
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("agility", 3 + caster.getLevel() // 2)
             stats.setNumericProperty("hit", 3)
             stats.setNumericProperty("crit", 2)
@@ -448,7 +456,7 @@ def load(self, context):
             caster = effect.getCaster()
             if not caster:
                 return False
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("block", 15 + caster.getLevel() * 2)
             effect.setBonus(stats)
             return True
@@ -459,7 +467,7 @@ def load(self, context):
             caster = effect.getCaster()
             if not caster:
                 return False
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("armor", 6 + caster.getStats().getNumericProperty("armor") // 2)
             stats.setNumericProperty("normalResist", 5)
             effect.setBonus(stats)
@@ -471,7 +479,7 @@ def load(self, context):
             caster = effect.getCaster()
             if not caster:
                 return False
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("hit", 2 + caster.getLevel() // 4)
             stats.setNumericProperty("attack", 1)
             effect.setBonus(stats)
@@ -483,7 +491,7 @@ def load(self, context):
             caster = effect.getCaster()
             if not caster:
                 return False
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("armor", 3 + caster.getLevel() // 2)
             stats.setNumericProperty("normalResist", 3)
             stats.setNumericProperty("shadowResist", 3)
@@ -497,7 +505,7 @@ def load(self, context):
             if not caster:
                 return False
             boost = 2 + caster.getLevel() // 3
-            stats = CStats()
+            stats = bonus_stats(caster)
             stats.setNumericProperty("strength", boost)
             stats.setNumericProperty("agility", boost)
             stats.setNumericProperty("stamina", boost)


### PR DESCRIPTION
## Summary

The pybind bindings for `CDamage` and `CStats` define no Python constructor, so every `CDamage()` / `CStats()` call in `res/plugins` raised `TypeError` at runtime. `PY_SAFE` swallowed the error, with two silent consequences:

- `performAction` bodies dealt **zero typed damage** (the spell fizzled past its plain-attack component).
- A raising `configureEffect` **dropped the interaction's effect entirely** (no buff/debuff/DoT ever applied).

This fixes both the newly merged Baldur's Gate content (#1322) and the pre-existing spells (ElemStaff, ChaosBlast, FrostBolt, ShadowBolt, ExposeCorruption, SmugglersMark, and the effects of ArmorOfEndlessWinter, SanctifiedWard, WayfarersStride, AbyssalShadows) by constructing through shared `spell_damage()` / `bonus_stats()` helpers that use `creature.getGame().createObject("CDamage"/"CStats")` — the construction path the engine exposes to content and the pattern `test.py` already uses throughout. The now-unused `CDamage`/`CStats` imports are dropped.

## Validation

- `python3 scripts/validate_content.py --repo-root .` — passed
- `python3 -m unittest tests.test_content_validator` — 160 tests OK
- ctest `for_unit_tests` + `performance` labels — passed
- `python3 test.py --suite fast` and `--suite gameplay` — passed (map walkthroughs stay green with spells dealing their real damage; no rebalancing needed)
- Headless functional check: every interaction cast against live creatures — typed damage lands, stat bonuses attach, DoTs tick
- `black -l 120 --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FVGwTN4J3WiURLg7c3HJQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014FVGwTN4J3WiURLg7c3HJQ)_