### PR TITLE
Add 30 Heroes of Might and Magic 3 inspired items and potions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,21 @@ configure_file(res/maps/sunderedmarch/dialog.json maps/sunderedmarch/dialog.json
 configure_file(res/maps/sunderedmarch/map.json maps/sunderedmarch/map.json)
 configure_file(res/maps/sunderedmarch/script.py maps/sunderedmarch/script.py)
 
+configure_file(res/maps/gravemoor/config.json maps/gravemoor/config.json)
+configure_file(res/maps/gravemoor/dialog.json maps/gravemoor/dialog.json)
+configure_file(res/maps/gravemoor/map.json maps/gravemoor/map.json)
+configure_file(res/maps/gravemoor/script.py maps/gravemoor/script.py)
+
+configure_file(res/maps/hearthfall/config.json maps/hearthfall/config.json)
+configure_file(res/maps/hearthfall/dialog.json maps/hearthfall/dialog.json)
+configure_file(res/maps/hearthfall/map.json maps/hearthfall/map.json)
+configure_file(res/maps/hearthfall/script.py maps/hearthfall/script.py)
+
+configure_file(res/maps/usurpergate/config.json maps/usurpergate/config.json)
+configure_file(res/maps/usurpergate/dialog.json maps/usurpergate/dialog.json)
+configure_file(res/maps/usurpergate/map.json maps/usurpergate/map.json)
+configure_file(res/maps/usurpergate/script.py maps/usurpergate/script.py)
+
 configure_file(res/maps/test/config.json maps/test/config.json)
 configure_file(res/maps/test/map.json maps/test/map.json)
 configure_file(res/maps/test/script.py maps/test/script.py)

--- a/res/config/armors.json
+++ b/res/config/armors.json
@@ -91,5 +91,97 @@
         "cursed"
       ]
     }
+  },
+  "BreastplateOfPetrifiedWood": {
+    "class": "CArmor",
+    "properties": {
+      "animation": "images/items/armors/leatherarmor",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "armor": 40,
+          "intelligence": 2,
+          "stamina": 3
+        }
+      },
+      "label": "Breastplate of Petrified Wood",
+      "description": "Boards of stone-hard fossil oak strapped over quilted cloth; a humble ward that turns aside the odd claw.",
+      "power": 3
+    }
+  },
+  "RibCage": {
+    "class": "CArmor",
+    "properties": {
+      "animation": "images/items/armors/leatherarmor",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "armor": 100,
+          "intelligence": 6,
+          "shadowResist": 10,
+          "stamina": 4
+        }
+      },
+      "label": "Rib Cage",
+      "description": "Harness of lacquered beast ribs favored by grave-witches; the dead find its shape familiar and pass by.",
+      "power": 8
+    }
+  },
+  "ArmorOfWonder": {
+    "class": "CArmor",
+    "properties": {
+      "animation": "images/items/armors/robe",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "agility": 5,
+          "armor": 130,
+          "intelligence": 5,
+          "stamina": 5,
+          "strength": 5
+        }
+      },
+      "label": "Armor of Wonder",
+      "description": "Shimmering mail of no known forge that fits every wearer as if measured; every virtue rises a little beneath it.",
+      "power": 10
+    }
+  },
+  "DragonScaleArmor": {
+    "class": "CArmor",
+    "properties": {
+      "animation": "images/items/armors/platearmor",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "agility": 5,
+          "armor": 320,
+          "fireResist": 30,
+          "stamina": 12,
+          "strength": 10
+        }
+      },
+      "label": "Dragon Scale Armor",
+      "description": "Overlapping scales stripped from a red wyrm's flank; furnace heat and Pritscher claws alike slide off.",
+      "power": 19
+    }
+  },
+  "TitansCuirass": {
+    "class": "CArmor",
+    "properties": {
+      "animation": "images/items/armors/chestplateofnorth",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "armor": 430,
+          "intelligence": 12,
+          "stamina": 16,
+          "strength": 14,
+          "thunderResist": 20
+        }
+      },
+      "label": "Titan's Cuirass",
+      "description": "Storm-blued plate hammered for a giant's chest and cut down by Victor's smiths; thunder rolls off it like rain.",
+      "power": 23
+    }
   }
 }

--- a/res/config/items.json
+++ b/res/config/items.json
@@ -161,5 +161,239 @@
         "cursed"
       ]
     }
+  },
+  "SkullHelmet": {
+    "class": "CHelmet",
+    "properties": {
+      "animation": "images/items/helmets/crownofnightmares",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "armor": 45,
+          "intelligence": 4,
+          "stamina": 2
+        }
+      },
+      "label": "Skull Helmet",
+      "description": "Varnished troll skull worn as a cap by hedge-wizards; grim, but the dead brain-case keeps thoughts orderly.",
+      "power": 4
+    }
+  },
+  "HelmOfTheAlabasterUnicorn": {
+    "class": "CHelmet",
+    "properties": {
+      "animation": "images/items/helmets/crownofnightmares",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "armor": 70,
+          "intelligence": 6,
+          "stamina": 3
+        }
+      },
+      "label": "Helm of the Alabaster Unicorn",
+      "description": "White-lacquered helm crowned with a spiral horn; a relic of gentler heraldry that still steadies the mind.",
+      "power": 6
+    }
+  },
+  "CrownOfTheSupremeMagi": {
+    "class": "CHelmet",
+    "properties": {
+      "animation": "images/items/helmets/crownofnightmares",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "armor": 90,
+          "crit": 2,
+          "intelligence": 9,
+          "stamina": 3
+        }
+      },
+      "label": "Crown of the Supreme Magi",
+      "description": "Three interlocking circlets once worn by a magi triumvirate; under them spells come quicker and colder.",
+      "power": 9
+    }
+  },
+  "ThunderHelmet": {
+    "class": "CHelmet",
+    "properties": {
+      "animation": "images/items/helmets/crownofnightmares",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "armor": 170,
+          "intelligence": 12,
+          "stamina": 6,
+          "strength": 4,
+          "thunderResist": 25
+        }
+      },
+      "label": "Thunder Helmet",
+      "description": "Giant-forged warhelm that mutters with distant storms; hair stands on end beneath it.",
+      "power": 14
+    }
+  },
+  "CrownOfDragontooth": {
+    "class": "CHelmet",
+    "properties": {
+      "animation": "images/items/helmets/crownofnightmares",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "armor": 260,
+          "crit": 4,
+          "fireResist": 20,
+          "intelligence": 14,
+          "stamina": 10
+        }
+      },
+      "label": "Crown of Dragontooth",
+      "description": "Jagged diadem of dragon fangs set in red gold; whoever bears it speaks with a wyrm's authority over flame.",
+      "power": 21
+    }
+  },
+  "DragonboneGreaves": {
+    "class": "CBoots",
+    "properties": {
+      "animation": "images/items/boots/eradicatorsboots",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "armor": 50,
+          "intelligence": 3,
+          "stamina": 2
+        }
+      },
+      "label": "Dragonbone Greaves",
+      "description": "Shin guards of split wyrm bone, light as ash wood and stubborn as old scars.",
+      "power": 4
+    }
+  },
+  "BootsOfSpeed": {
+    "class": "CBoots",
+    "properties": {
+      "animation": "images/items/boots/eradicatorsboots",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "agility": 12,
+          "armor": 60,
+          "stamina": 4
+        }
+      },
+      "label": "Boots of Speed",
+      "description": "Courier boots stitched with wind-runes; roads seem to shorten beneath them.",
+      "power": 8
+    }
+  },
+  "SandalsOfTheSaint": {
+    "class": "CBoots",
+    "properties": {
+      "animation": "images/items/boots/eradicatorsboots",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "agility": 8,
+          "armor": 230,
+          "block": 4,
+          "intelligence": 10,
+          "stamina": 10,
+          "strength": 8
+        }
+      },
+      "label": "Sandals of the Saint",
+      "description": "Rope sandals a nameless saint wore into martyrdom; grace clings to whoever walks in them.",
+      "power": 20
+    }
+  },
+  "EquestriansGloves": {
+    "class": "CGloves",
+    "properties": {
+      "animation": "images/items/gloves/glovesoftheassasin",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "agility": 9,
+          "armor": 55,
+          "stamina": 3
+        }
+      },
+      "label": "Equestrian's Gloves",
+      "description": "Supple riding gloves from the old horse-fairs; hands move at a canter in them.",
+      "power": 6
+    }
+  },
+  "GauntletsOfTheStillEye": {
+    "class": "CGloves",
+    "properties": {
+      "animation": "images/items/gloves/glovesoftheassasin",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "agility": 2,
+          "armor": 30,
+          "block": 2,
+          "crit": 2
+        }
+      },
+      "label": "Gauntlets of the Still Eye",
+      "description": "Thin gauntlets set with a dragon's dead eye at each cuff; the steady gaze quiets trembling hands.",
+      "power": 3
+    }
+  },
+  "GirdleOfVitality": {
+    "class": "CBelt",
+    "properties": {
+      "animation": "images/items/belts/undestructiblebelt",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "armor": 40,
+          "stamina": 9
+        }
+      },
+      "label": "Girdle of Vitality",
+      "description": "Physician's broad belt lined with tonic herbs; the heart beats surer beneath it.",
+      "power": 5
+    }
+  },
+  "SashOfCourage": {
+    "class": "CBelt",
+    "properties": {
+      "animation": "images/items/belts/undestructiblebelt",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "armor": 55,
+          "block": 5,
+          "stamina": 6,
+          "strength": 4
+        }
+      },
+      "label": "Sash of Courage",
+      "description": "Campaign sash awarded for holding the gates; fear finds no purchase on the one who wears it.",
+      "power": 7
+    }
+  },
+  "ShacklesOfWar": {
+    "class": "CBelt",
+    "properties": {
+      "animation": "images/items/belts/undestructiblebelt",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "agility": -8,
+          "block": -6,
+          "stamina": 10,
+          "strength": 12
+        }
+      },
+      "label": "Shackles of War",
+      "description": "Iron war-fetters that lock about the waist and choose the field for you: no retreat and no surrender until the curse is struck off.",
+      "power": 13,
+      "tags": [
+        "cursed"
+      ]
+    }
   }
 }

--- a/res/config/potions.json
+++ b/res/config/potions.json
@@ -154,5 +154,85 @@
         "mana"
       ]
     }
+  },
+  "FountainOfYouthTonic": {
+    "class": "LifePotion",
+    "properties": {
+      "animation": "images/items/potions/life",
+      "label": "Fountain of Youth Tonic",
+      "description": "Bottled from a hidden spring that smooths scars and stiff joints, though the youth it returns never lasts.",
+      "power": 2,
+      "singleUse": true,
+      "tags": [
+        "heal"
+      ]
+    }
+  },
+  "MagicWellDraught": {
+    "class": "ManaPotion",
+    "properties": {
+      "animation": "images/items/potions/mana",
+      "label": "Magic Well Draught",
+      "description": "Drawn at midnight from the old well behind the chapel, it returns a modest measure of spent sorcery.",
+      "power": 2,
+      "singleUse": true,
+      "tags": [
+        "mana"
+      ]
+    }
+  },
+  "OasisWater": {
+    "class": "RejuvenationPotion",
+    "properties": {
+      "animation": "images/items/potions/bless",
+      "label": "Oasis Water",
+      "description": "Clear water carried in wax-sealed skins from a far oasis, easing wounds and weary minds alike.",
+      "power": 3,
+      "singleUse": true,
+      "tags": [
+        "heal",
+        "mana"
+      ]
+    }
+  },
+  "PhoenixFeatherTonic": {
+    "class": "LifePotion",
+    "properties": {
+      "animation": "images/items/potions/life",
+      "label": "Phoenix Feather Tonic",
+      "description": "Crimson tonic steeped with a molted phoenix feather; the drinker's wounds close in a wash of gentle flame.",
+      "power": 4,
+      "singleUse": true,
+      "tags": [
+        "heal"
+      ]
+    }
+  },
+  "MagicSpringPhial": {
+    "class": "ManaPotion",
+    "properties": {
+      "animation": "images/items/potions/mana",
+      "label": "Magic Spring Phial",
+      "description": "Azure water from a mountain spring said to double a caster's reserves; it hums against the glass.",
+      "power": 6,
+      "singleUse": true,
+      "tags": [
+        "mana"
+      ]
+    }
+  },
+  "ElixirOfLife": {
+    "class": "RejuvenationPotion",
+    "properties": {
+      "animation": "images/items/potions/bless",
+      "label": "Elixir of Life",
+      "description": "The alchemists' grail: a golden elixir that knits flesh, refills the wellspring of magic, and mocks death itself.",
+      "power": 6,
+      "singleUse": true,
+      "tags": [
+        "heal",
+        "mana"
+      ]
+    }
   }
 }

--- a/res/config/weapons.json
+++ b/res/config/weapons.json
@@ -349,5 +349,123 @@
         "cursed"
       ]
     }
+  },
+  "CentaursAxe": {
+    "class": "CWeapon",
+    "properties": {
+      "animation": "images/items/weapons/broadsword",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "dmgMax": 13,
+          "dmgMin": 9,
+          "stamina": 1,
+          "strength": 3
+        }
+      },
+      "label": "Centaur's Axe",
+      "description": "Plainswrought axe traded up from centaur herds long since scattered; its balance still favors a charging swing.",
+      "power": 3
+    }
+  },
+  "BlackshardOfTheDeadKnight": {
+    "class": "CWeapon",
+    "properties": {
+      "animation": "images/items/weapons/shadowblade",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "agility": 3,
+          "dmgMax": 25,
+          "dmgMin": 19,
+          "shadowResist": 5,
+          "stamina": 4,
+          "strength": 5
+        }
+      },
+      "label": "Blackshard of the Dead Knight",
+      "description": "Night-black shard pried from a dead knight's barrow beneath the catacombs; it drinks lamplight like the grave.",
+      "power": 7
+    }
+  },
+  "OgresClubOfHavoc": {
+    "class": "CWeapon",
+    "properties": {
+      "animation": "images/items/weapons/shortstaff",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "dmgMax": 39,
+          "dmgMin": 28,
+          "stamina": 7,
+          "strength": 13
+        }
+      },
+      "label": "Ogre's Club of Havoc",
+      "description": "Knotted ogre cudgel banded in siege iron; every blow lands with the weight of a falling gate.",
+      "power": 12
+    }
+  },
+  "SwordOfHellfire": {
+    "class": "CWeapon",
+    "properties": {
+      "animation": "images/items/weapons/chaossword",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "crit": 4,
+          "dmgMax": 45,
+          "dmgMin": 36,
+          "fireResist": 15,
+          "stamina": 6,
+          "strength": 10
+        }
+      },
+      "label": "Sword of Hellfire",
+      "description": "Forged in a furnace stoked with cult pyres, its edge sheds sparks that scar stone.",
+      "power": 16
+    }
+  },
+  "TitansGladius": {
+    "class": "CWeapon",
+    "properties": {
+      "animation": "images/items/weapons/valkyrie",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "agility": 10,
+          "block": -4,
+          "crit": 5,
+          "dmgMax": 63,
+          "dmgMin": 56,
+          "stamina": 12,
+          "strength": 16
+        }
+      },
+      "label": "Titan's Gladius",
+      "description": "Storm-forged giant's blade sized down for mortal hands; it demands attack over guard and punishes hesitation.",
+      "power": 24
+    }
+  },
+  "SwordOfJudgement": {
+    "class": "CWeapon",
+    "properties": {
+      "animation": "images/items/weapons/void",
+      "bonus": {
+        "class": "CStats",
+        "properties": {
+          "agility": 12,
+          "crit": 3,
+          "dmgMax": 66,
+          "dmgMin": 58,
+          "intelligence": 12,
+          "stamina": 12,
+          "strength": 12
+        }
+      },
+      "label": "Sword of Judgement",
+      "description": "The old kings' arbiter blade, said to weigh a soul with every stroke; none it finds wanting rise again.",
+      "power": 26
+    }
   }
 }

--- a/res/maps/gravemoor/map.json
+++ b/res/maps/gravemoor/map.json
@@ -26,6 +26,18 @@
    "height": 24,
    "width": 24,
    "opacity": 1,
+   "properties": {
+    "default": "SwampTile",
+    "level": "0",
+    "xBound": "23",
+    "yBound": "23"
+   },
+   "propertytypes": {
+    "default": "string",
+    "level": "string",
+    "xBound": "string",
+    "yBound": "string"
+   },
    "visible": true,
    "x": 0,
    "y": 0,
@@ -612,6 +624,12 @@
    "type": "objectgroup",
    "name": "Object Layer",
    "opacity": 1,
+   "properties": {
+    "level": "0"
+   },
+   "propertytypes": {
+    "level": "string"
+   },
    "visible": true,
    "x": 0,
    "y": 0,

--- a/res/maps/hearthfall/map.json
+++ b/res/maps/hearthfall/map.json
@@ -26,6 +26,18 @@
    "height": 24,
    "width": 24,
    "opacity": 1,
+   "properties": {
+    "default": "GrassTile",
+    "level": "0",
+    "xBound": "23",
+    "yBound": "23"
+   },
+   "propertytypes": {
+    "default": "string",
+    "level": "string",
+    "xBound": "string",
+    "yBound": "string"
+   },
    "visible": true,
    "x": 0,
    "y": 0,
@@ -612,6 +624,12 @@
    "type": "objectgroup",
    "name": "Object Layer",
    "opacity": 1,
+   "properties": {
+    "level": "0"
+   },
+   "propertytypes": {
+    "level": "string"
+   },
    "visible": true,
    "x": 0,
    "y": 0,

--- a/res/maps/usurpergate/map.json
+++ b/res/maps/usurpergate/map.json
@@ -26,6 +26,18 @@
    "height": 24,
    "width": 24,
    "opacity": 1,
+   "properties": {
+    "default": "WastelandTile",
+    "level": "0",
+    "xBound": "23",
+    "yBound": "23"
+   },
+   "propertytypes": {
+    "default": "string",
+    "level": "string",
+    "xBound": "string",
+    "yBound": "string"
+   },
    "visible": true,
    "x": 0,
    "y": 0,
@@ -612,6 +624,12 @@
    "type": "objectgroup",
    "name": "Object Layer",
    "opacity": 1,
+   "properties": {
+    "level": "0"
+   },
+   "propertytypes": {
+    "level": "string"
+   },
    "visible": true,
    "x": 0,
    "y": 0,

--- a/res/plugins/potion.py
+++ b/res/plugins/potion.py
@@ -28,3 +28,10 @@ def load(self, context):
         def onUse(self, event):
             power = self.getNumericProperty("power")
             event.getCause().addManaProc(power * 20)
+
+    @register(context)
+    class RejuvenationPotion(CPotion):
+        def onUse(self, event):
+            power = self.getNumericProperty("power")
+            event.getCause().healProc(power * 20)
+            event.getCause().addManaProc(power * 20)


### PR DESCRIPTION
## Summary

Adds 30 new Heroes of Might and Magic 3 inspired items spanning treasure-tier (power 2) through relic-tier (power 26), including 6 new potions. All items reuse existing art, follow Nouraajd lore in their descriptions, and enter the RNG loot pool via their `power` rating.

- **weapons.json (6):** Centaur's Axe (3), Blackshard of the Dead Knight (7), Ogre's Club of Havoc (12), Sword of Hellfire (16), Titan's Gladius (24, trades block for attack like the H3 original), Sword of Judgement (26)
- **armors.json (5):** Breastplate of Petrified Wood (3), Rib Cage (8), Armor of Wonder (10), Dragon Scale Armor (19), Titan's Cuirass (23)
- **items.json (13):** Skull Helmet (4), Helm of the Alabaster Unicorn (6), Crown of the Supreme Magi (9), Thunder Helmet (14), Crown of Dragontooth (21), Dragonbone Greaves (4), Boots of Speed (8), Sandals of the Saint (20), Gauntlets of the Still Eye (3), Equestrian's Gloves (6), Girdle of Vitality (5), Sash of Courage (7), and the cursed Shackles of War (13)
- **potions.json (6):** Fountain of Youth Tonic (2), Magic Well Draught (2), Oasis Water (3), Phoenix Feather Tonic (4), Magic Spring Phial (6), Elixir of Life (6)
- **res/plugins/potion.py:** new `RejuvenationPotion` class (restores both health and mana) backing Oasis Water and Elixir of Life

## Pre-existing test failures fixed

The full suite was red on `main` because of the three newest maps; fixed both causes so validation runs green:

- **CMakeLists.txt:** `gravemoor`, `hearthfall`, and `usurpergate` map resources were never wired into the build-dir copy, failing their walkthroughs, the Warden's Road campaign tests, and `test_config_entries_create_in_global_and_map_contexts` (10 failures total).
- **map.json metadata:** the same maps' layers were missing the legacy object-style `properties` blocks (`level`, `default`, `xBound`, `yBound`) required by `CMapLoader`, which silently skipped their tile layers and failed `test_map_json_tiled_compatibility`. Added the same metadata every other map carries, with each map's dominant terrain as the default tile.

## Validation

- `python3 scripts/validate_content.py --repo-root .` — passed
- `python3 -m unittest tests.test_content_validator` — 160 tests OK
- `ctest -R for_unit_tests` — 10/10 passed; `ctest -L performance` — 1/1 passed
- `python3 test.py` — exit 0, all shards OK (previously 10 failures on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYtPr2qHrT8FpC6qu3PkW7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYtPr2qHrT8FpC6qu3PkW7)_