### PR TITLE
Harden campaign manifest validation (non-string start, history delimiters, id traversal)

### DIFF
--- a/res/campaign.py
+++ b/res/campaign.py
@@ -77,8 +77,23 @@ def _require(condition, message):
         raise CampaignError(message)
 
 
+# CampaignStateStore.record_outcome serializes history as
+# "<scenario_id>:<outcome>" entries joined by ",". A scenario id or outcome key
+# containing either delimiter would corrupt that string (mis-split ids/outcomes
+# or fabricate entries), so reject them at validation time.
+_HISTORY_DELIMITERS = (",", ":")
+
+
+def _reject_history_delimiters(where, label, value):
+    _require(
+        not any(delimiter in value for delimiter in _HISTORY_DELIMITERS),
+        f'{where}: {label} must not contain "," or ":" (reserved for campaign history)',
+    )
+
+
 def _validate_scenario(campaign_id, scenario_id, scenario, scenario_ids):
     where = f'campaign "{campaign_id}" scenario "{scenario_id}"'
+    _reject_history_delimiters(where, f'scenario id "{scenario_id}"', scenario_id)
     _require(isinstance(scenario, dict), f"{where}: scenario must be an object")
     for key in SCENARIO_REQUIRED_KEYS:
         _require(key in scenario, f'{where}: missing required key "{key}"')
@@ -93,6 +108,7 @@ def _validate_scenario(campaign_id, scenario_id, scenario, scenario_ids):
     _require(isinstance(routes, dict), f'{where}: "next" must be an object mapping outcome to scenario id')
     for outcome, target in routes.items():
         _require(isinstance(outcome, str) and outcome, f'{where}: outcomes in "next" must be non-empty strings')
+        _reject_history_delimiters(where, f'outcome "{outcome}"', outcome)
         _require(
             isinstance(target, str) and target in scenario_ids,
             f'{where}: "next" target for outcome "{outcome}" must name a scenario in this campaign',
@@ -147,8 +163,9 @@ def validate_manifest(data):
         isinstance(scenarios, dict) and scenarios,
         f'campaign "{campaign_id}": "scenarios" must be a non-empty object',
     )
+    start_id = data["start"]
     _require(
-        data["start"] in scenarios,
+        isinstance(start_id, str) and start_id in scenarios,
         f'campaign "{campaign_id}": "start" must name a scenario in this campaign',
     )
     for scenario_id, scenario in scenarios.items():
@@ -189,6 +206,17 @@ def list_campaigns(root=None):
 
 
 def get_manifest(campaign_id, root=None):
+    # campaign_id can come from an untrusted save file (CampaignStateStore reads
+    # it as a dynamic player property), so refuse anything but a bare directory
+    # name to keep the manifest read inside campaigns_root().
+    _require(
+        isinstance(campaign_id, str)
+        and campaign_id
+        and "/" not in campaign_id
+        and "\\" not in campaign_id
+        and campaign_id not in (".", ".."),
+        f"invalid campaign id {campaign_id!r}: must be a bare campaign directory name",
+    )
     root = campaigns_root() if root is None else Path(root)
     manifest_path = root / campaign_id / CAMPAIGN_MANIFEST_NAME
     _require(manifest_path.is_file(), f'unknown campaign "{campaign_id}" (missing {manifest_path})')

--- a/tests/test_campaign_driver.py
+++ b/tests/test_campaign_driver.py
@@ -198,6 +198,32 @@ class ManifestTest(unittest.TestCase):
                 with self.assertRaises(campaign.CampaignError):
                     campaign.validate_manifest(data)
 
+    def test_validate_manifest_rejects_non_string_start(self):
+        # A non-string "start" must raise CampaignError, not an unguarded
+        # TypeError from the ``start in scenarios`` membership test.
+        for bad_start in ([], {}, 3, None):
+            with self.subTest(start=bad_start):
+                data = manifest_fixture()
+                data["start"] = bad_start
+                with self.assertRaises(campaign.CampaignError):
+                    campaign.validate_manifest(data)
+
+    def test_validate_manifest_rejects_history_delimiters(self):
+        # Scenario ids and outcome keys are serialized into campaign history as
+        # "<id>:<outcome>" entries joined by ",", so neither may contain those
+        # delimiters or the recorded history would be corrupted.
+        colon_id = manifest_fixture()
+        colon_id["scenarios"]["on:e"] = colon_id["scenarios"].pop("one")
+        colon_id["start"] = "on:e"
+
+        comma_outcome = manifest_fixture()
+        comma_outcome["scenarios"]["one"]["next"] = {"completed,extra": "two"}
+
+        for label, data in (("colon-in-id", colon_id), ("comma-in-outcome", comma_outcome)):
+            with self.subTest(case=label):
+                with self.assertRaises(campaign.CampaignError):
+                    campaign.validate_manifest(data)
+
     def test_list_campaigns_returns_sorted_manifests(self):
         root = self.make_root()
         second = manifest_fixture()
@@ -226,6 +252,16 @@ class ManifestTest(unittest.TestCase):
         self.assertEqual("Trial Campaign", manifest["title"])
         with self.assertRaises(campaign.CampaignError):
             campaign.get_manifest("unknown", root)
+
+    def test_get_manifest_rejects_path_traversal_ids(self):
+        # campaign_id can originate from an untrusted save; a traversal id must be
+        # refused before it is joined into the manifest filesystem path.
+        root = self.make_root()
+        self.write_campaign(root, manifest_fixture())
+        for bad_id in ("../trial", "a/b", "..", ".", "", "a\\b"):
+            with self.subTest(campaign_id=bad_id):
+                with self.assertRaises(campaign.CampaignError):
+                    campaign.get_manifest(bad_id, root)
 
     def test_shipped_campaigns_load_and_validate(self):
         manifests = campaign.list_campaigns()


### PR DESCRIPTION
## Summary

`res/campaign.py`'s `validate_manifest` is contracted to reject malformed manifests with `CampaignError`, but a proactive review of the newly-merged multilevel-campaign driver (#1301) surfaced three inputs that slip past. All three are verified with runnable reproductions and fixed with validation-only, backward-compatible guards.

### 1. Non-string `start` → uncaught `TypeError` (correctness)
`validate_manifest` tested `data["start"] in scenarios` without a type check. A manifest with `"start": []` (or `{}`) raises `TypeError: unhashable type` — and since `CampaignError` is a `ValueError`, that `TypeError` propagates uncaught out of `load_manifest`/`list_campaigns`/`get_manifest`/`start`, crashing callers that correctly catch `CampaignError`. Now type-guarded, mirroring the `next`-target check that already does `isinstance(target, str) and target in scenario_ids`.

### 2. History-delimiter injection in scenario ids / outcomes (correctness)
`CampaignStateStore.record_outcome` serializes history as `"<scenario_id>:<outcome>"` entries joined by `","`, and `history()` splits back on `,` then `:`. Validation allowed any non-empty string, so an id containing `:` or an outcome containing `,` corrupted the saved history (e.g. `history()` returning a 1-tuple → `ValueError` in `for scen, out in ...`). Now `,` and `:` are rejected in both scenario ids and outcome keys.

### 3. Path traversal via `campaign_id` in `get_manifest` (security hardening)
`get_manifest` joined `campaign_id` into the manifest path with no traversal guard, and `campaign_id` can originate from an untrusted save file (a dynamic player property read by `CampaignStateStore.campaign_id()`). A value like `../x` resolved outside `campaigns_root()`. Now ids containing `/`, `\`, or equal to `.`/`..`/empty are rejected before the path is built.

## Validation
- `python3 -m unittest tests.test_campaign_driver` → **26 tests, OK** (23 existing + 3 new regression tests).
- `python3 scripts/validate_content.py --repo-root .` → **Content validation passed** (shipped `fallOfNouraajd`/`wardensRoad` manifests unaffected).
- `git diff --check` clean; longest line ≤ 120.

Found during proactive correctness/security review of recently-merged code (same effort that produced the #1325 shell-injection fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_