### PR TITLE
Fix crafting review findings and package Warden's Road maps into the build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,9 +103,12 @@ into the matching registration file or it won't be constructible from content.
   one or more `dialog*.json`, a per-map `config.json`, and a `script.py` that
   drives quest state (declares `QUEST_KEYS`/`QUEST_DEFAULTS`, uses
   `set_state`/`state_in`/`get_state`). Maps: `nouraajd`, `ritual`, `siege`,
-  `multilevel`, `test`.
+  `multilevel`, `ninemarches`, `hearthfall`, `gravemoor`, `usurpergate`,
+  `sunderedmarch`, `kadath`, `vhulmarn`, `test`.
 - **`res/plugins/*.py`** — Python gameplay plugins (crafting, interactions,
-  effects, potions, tiles, objects) declared in `res/plugins/manifest.json`.
+  effects, potions, tiles, objects). Every `.py` in the directory is
+  auto-discovered by `CPluginLoader`; `res/plugins/manifest.json` declares
+  native/dynamic plugin entries and optional per-map plugin lists.
 - **`res/game.py`** — the Python-side facade over `_game`; wraps native trace
   helpers and quest-state integration (`quest_state.py`).
 - Content schemas are documented in `docs/content.md`; the authoritative checker

--- a/docs/content.md
+++ b/docs/content.md
@@ -106,6 +106,25 @@ it may carry a `slots` object mapping slot ids to item ids.
 
 Unknown top-level keys in a profile are reported so typos are caught.
 
+## Crafting recipes (`res/config/crafting.json`)
+
+Each top-level key is a recipe id handled by the crafting plugin
+(`res/plugins/crafting.py`); `scripts/validate_content.py` enforces the schema.
+
+| Field           | Required | Type | Meaning |
+| --------------- | -------- | ---- | ------- |
+| `station`       | yes      | string | Must match some building's `craftingStationId` property. |
+| `inputs`        | no       | array of item entries | Reagents consumed by the craft. Each item id may appear only once — use `count` for multiples (the runtime merges duplicates defensively, but the validator rejects them). |
+| `output`        | yes*     | item entry | The crafted result. Exactly one of `output` / `outputs` must be present. |
+| `outputs`       | yes*     | non-empty array of item entries | Multi-item results. |
+| `gold`          | no       | non-negative integer | Gold cost, paid together with the reagents *before* the success roll — a failed craft still consumes its full cost. |
+| `successChance` | no       | integer 0–100 (default 100) | Chance the craft produces its output. |
+| `unlockFlag`    | no       | non-empty string | Boolean property gating the recipe; checked on the player first, then on the current map. |
+| `unlockHint`    | no       | non-empty string | Map-agnostic guidance shown while the recipe is locked. A map can override it per flag by setting an `unlockHint_<FLAG>` string property on its station instance (see `scribeDesk1` in `res/maps/nouraajd/config.json`). Without either, a generic "This recipe is locked." is shown — the raw flag name is never displayed. |
+
+An item entry is `{ "item": "<config id>", "count": <positive integer> }`
+(`count` defaults to 1). Item ids must exist in the global config.
+
 ## Gameplay tags (`"tags"`)
 
 Objects (items, effects, interactions, potions, …) may declare a `"tags"` array

--- a/res/config/crafting.json
+++ b/res/config/crafting.json
@@ -25,7 +25,8 @@
         ],
         "output": { "item": "TownPortalScroll", "count": 1 },
         "gold": 35,
-        "unlockFlag": "CAN_CRAFT_SCROLLS"
+        "unlockFlag": "CAN_CRAFT_SCROLLS",
+        "unlockHint": "Someone lettered must first grant you the scribe's craft."
     },
     "scribe_emergency_portal_scroll": {
         "station": "scribeDesk",
@@ -36,7 +37,8 @@
         "output": { "item": "TownPortalScroll", "count": 1 },
         "gold": 20,
         "successChance": 85,
-        "unlockFlag": "CAN_CRAFT_SCROLLS"
+        "unlockFlag": "CAN_CRAFT_SCROLLS",
+        "unlockHint": "Someone lettered must first grant you the scribe's craft."
     },
     "blend_greater_life_potion": {
         "station": "alchemyTable",
@@ -46,7 +48,8 @@
         "output": { "item": "GreaterLifePotion", "count": 1 },
         "gold": 45,
         "successChance": 90,
-        "unlockFlag": "CAN_BREW_GREATER_POTIONS"
+        "unlockFlag": "CAN_BREW_GREATER_POTIONS",
+        "unlockHint": "A master alchemist must first teach you greater brewing."
     },
     "blend_greater_mana_potion": {
         "station": "alchemyTable",
@@ -56,7 +59,8 @@
         "output": { "item": "GreaterManaPotion", "count": 1 },
         "gold": 45,
         "successChance": 90,
-        "unlockFlag": "CAN_BREW_GREATER_POTIONS"
+        "unlockFlag": "CAN_BREW_GREATER_POTIONS",
+        "unlockHint": "A master alchemist must first teach you greater brewing."
     },
     "brew_full_life_potion": {
         "station": "alchemyTable",
@@ -66,7 +70,8 @@
         "output": { "item": "FullLifePotion", "count": 1 },
         "gold": 90,
         "successChance": 85,
-        "unlockFlag": "CAN_BREW_GREATER_POTIONS"
+        "unlockFlag": "CAN_BREW_GREATER_POTIONS",
+        "unlockHint": "A master alchemist must first teach you greater brewing."
     },
     "brew_full_mana_potion": {
         "station": "alchemyTable",
@@ -76,6 +81,7 @@
         "output": { "item": "FullManaPotion", "count": 1 },
         "gold": 90,
         "successChance": 85,
-        "unlockFlag": "CAN_BREW_GREATER_POTIONS"
+        "unlockFlag": "CAN_BREW_GREATER_POTIONS",
+        "unlockHint": "A master alchemist must first teach you greater brewing."
     }
 }

--- a/res/maps/ninemarches/config.json
+++ b/res/maps/ninemarches/config.json
@@ -72,7 +72,10 @@
   },
   "gravewatchScribe": {
     "ref": "ScribeDesk",
-    "properties": {"animation": "images/buildings/chapel"}
+    "properties": {
+      "animation": "images/buildings/chapel",
+      "unlockHint_CAN_CRAFT_SCROLLS": "Study Gravewatch's learning stone until its drill-marks teach you the scribe's craft."
+    }
   },
   "learningStone": {
     "class": "LearningStone",

--- a/res/maps/ninemarches/script.py
+++ b/res/maps/ninemarches/script.py
@@ -89,9 +89,13 @@ def load(self, context):
             player.addGold(120)
             player.healProc(80)
             game_map.setBoolProperty("shrine_used", True)
+            # Gravewatch's scroll-crafting unlock: the crafting plugin reads this
+            # map flag through the scribe recipes' unlockFlag configuration.
+            game_map.setBoolProperty("CAN_CRAFT_SCROLLS", True)
             game.getGuiHandler().showMessage(
                 "You study Gravewatch's learning stone until the old drill-marks settle into your hands. You feel "
-                "steadier, and 120 gold in forgotten muster-pay falls from its hollow base."
+                "steadier, and 120 gold in forgotten muster-pay falls from its hollow base. Among the drill-marks "
+                "you learn the scribe's copying-craft - Gravewatch's scribe desk will serve you now."
             )
 
     @register(context)

--- a/res/maps/nouraajd/config.json
+++ b/res/maps/nouraajd/config.json
@@ -429,10 +429,16 @@
     }
   },
   "alchemyTable1": {
-    "ref": "AlchemyTable"
+    "ref": "AlchemyTable",
+    "properties": {
+      "unlockHint_CAN_BREW_GREATER_POTIONS": "Return the holy relic to Father Beren."
+    }
   },
   "scribeDesk1": {
-    "ref": "ScribeDesk"
+    "ref": "ScribeDesk",
+    "properties": {
+      "unlockHint_CAN_CRAFT_SCROLLS": "Deliver Mayor Irvin's sealed letter to Father Beren."
+    }
   },
   "gooby": {
     "ref": "Gooby",

--- a/res/plugins/crafting.py
+++ b/res/plugins/crafting.py
@@ -20,10 +20,9 @@ from game import randint
 
 LEAVE_OPTION = "Leave"
 
-UNLOCK_HINTS = {
-    "CAN_CRAFT_SCROLLS": "Deliver Mayor Irvin's sealed letter to Father Beren.",
-    "CAN_BREW_GREATER_POTIONS": "Return the holy relic to Father Beren.",
-}
+# Shown for a locked recipe when neither the recipe's unlockHint nor the
+# station's per-map override provides text. Never expose the raw flag name.
+DEFAULT_LOCKED_HINT = "This recipe is locked."
 
 
 def _status(ok, reason=""):
@@ -38,16 +37,27 @@ def _coerce_count(value, default=1):
 
 
 def _normalize_item_entries(entries):
+    # Entries listing the same item more than once are merged into a single
+    # requirement: verification and removal both treat each entry
+    # independently, so duplicates would otherwise pass the inventory check
+    # with fewer items than the recipe actually costs.
     normalized = []
+    index_by_item = {}
     for entry in entries or []:
         if isinstance(entry, str):
-            normalized.append({"item_id": entry, "count": 1})
-            continue
-        if isinstance(entry, dict):
+            item_id, count = entry, 1
+        elif isinstance(entry, dict):
             item_id = entry.get("item") or entry.get("item_id") or entry.get("itemId") or entry.get("id")
             if not item_id:
                 continue
-            normalized.append({"item_id": item_id, "count": _coerce_count(entry.get("count", 1), 1)})
+            count = _coerce_count(entry.get("count", 1), 1)
+        else:
+            continue
+        if item_id in index_by_item:
+            normalized[index_by_item[item_id]]["count"] += count
+        else:
+            index_by_item[item_id] = len(normalized)
+            normalized.append({"item_id": item_id, "count": count})
     return normalized
 
 
@@ -185,6 +195,7 @@ class CraftingRuntime:
             "gold": gold_cost,
             "success_chance": success_chance,
             "unlock": self._normalize_unlock_requirement(recipe_id, payload),
+            "unlock_hint": str(payload.get("unlockHint", "") or "").strip(),
             "display_name": self.get_item_label(primary_output),
         }
 
@@ -257,12 +268,18 @@ class CraftingRuntime:
                 missing.append(f"{gold_cost - held_gold}g")
         return missing
 
-    def recipe_unlock_hint(self, recipe):
+    def recipe_unlock_hint(self, recipe, station=None):
         unlock_state = recipe.get("unlock", {"type": "none", "value": None})
         if unlock_state["type"] != "flag":
             return ""
-        flag_name = unlock_state["value"]
-        return UNLOCK_HINTS.get(flag_name, f"Requires {flag_name}.")
+        # A map can tailor the guidance to its own quest line by setting an
+        # "unlockHint_<FLAG>" string property on its station instance; the
+        # recipe's unlockHint from crafting.json is the map-agnostic default.
+        if station is not None:
+            override = station.getStringProperty("unlockHint_" + unlock_state["value"])
+            if override:
+                return override
+        return recipe.get("unlock_hint") or DEFAULT_LOCKED_HINT
 
     def recipe_state(self, player, recipe):
         if not self.is_unlocked(player, recipe):
@@ -271,10 +288,10 @@ class CraftingRuntime:
             return "missing"
         return "ready"
 
-    def describe_recipe_for_player(self, player, recipe):
+    def describe_recipe_for_player(self, player, recipe, station=None):
         description = self.describe_recipe(recipe)
         if not self.is_unlocked(player, recipe):
-            return f"LOCKED - {description} | Unlock: {self.recipe_unlock_hint(recipe)}"
+            return f"LOCKED - {description} | Unlock: {self.recipe_unlock_hint(recipe, station)}"
         missing = self.missing_requirements(player, recipe)
         if not missing:
             return f"READY - {description}"
@@ -297,9 +314,9 @@ class CraftingRuntime:
     def available_recipes(self, player, station_id):
         return [recipe for recipe in self.station_recipes(station_id) if self.is_unlocked(player, recipe)]
 
-    def station_options(self, player, station_id):
+    def station_options(self, player, station_id, station=None):
         recipes = self.station_recipes(station_id)
-        option_map = {self.describe_recipe_for_player(player, recipe): recipe for recipe in recipes}
+        option_map = {self.describe_recipe_for_player(player, recipe, station): recipe for recipe in recipes}
         return recipes, option_map
 
     def execute_recipe(self, game_instance, player, recipe):
@@ -318,7 +335,7 @@ def get_runtime():
     return _RUNTIME
 
 
-def _format_result_message(runtime, recipe, result, player=None):
+def _format_result_message(runtime, recipe, result, player=None, station=None):
     if result["ok"]:
         output = recipe["outputs"][0]
         label = runtime.get_item_label(output["item_id"])
@@ -328,7 +345,7 @@ def _format_result_message(runtime, recipe, result, player=None):
         return f"You crafted {label}."
     reason = result.get("reason", "")
     if reason == "locked":
-        return f"That recipe is locked. {runtime.recipe_unlock_hint(recipe)}"
+        return f"That recipe is locked. {runtime.recipe_unlock_hint(recipe, station)}"
     if reason == "failed":
         return "The reagents fizzled and nothing was created."
     if reason == "missing:gold":
@@ -360,7 +377,7 @@ def open_crafting_station(station, player):
     handler = game_instance.getGuiHandler()
     station_label = station.getStringProperty("label") or station_id
     while True:
-        recipes, option_map = runtime.station_options(player, station_id)
+        recipes, option_map = runtime.station_options(player, station_id, station)
         if not recipes:
             handler.showInfo(f"No known recipes for {station_label}.", True)
             return
@@ -371,10 +388,10 @@ def open_crafting_station(station, player):
             break
         recipe = option_map[selection]
         if not runtime.is_unlocked(player, recipe):
-            handler.showInfo(_format_result_message(runtime, recipe, _status(False, "locked"), player), True)
+            handler.showInfo(_format_result_message(runtime, recipe, _status(False, "locked"), player, station), True)
             continue
         result = runtime.execute_recipe(game_instance, player, recipe)
-        handler.showInfo(_format_result_message(runtime, recipe, result, player), True)
+        handler.showInfo(_format_result_message(runtime, recipe, result, player, station), True)
 
 
 def craft_recipe(game_instance, player, recipe_id):

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -653,6 +653,12 @@ SCRIPT_PROPERTY_HYGIENE_ALLOWLIST = (
         reason="Crafting recipes read this player compatibility flag through unlockFlag configuration.",
     ),
     ScriptPropertyHygieneAllowance(
+        path="res/maps/ninemarches/script.py",
+        owner="map",
+        name="CAN_CRAFT_SCROLLS",
+        reason="Crafting recipes read this map flag through unlockFlag configuration.",
+    ),
+    ScriptPropertyHygieneAllowance(
         path="res/maps/multilevel/script.py",
         owner="map",
         name="used_stairs_up",
@@ -2158,7 +2164,9 @@ class ContentValidator:
             if scenario_id in finished or cycle_reported:
                 return
             if scenario_id in in_progress:
-                self._issue(path, "$.scenarios", "campaign scenario graph must be acyclic (transitions are forward-only)")
+                self._issue(
+                    path, "$.scenarios", "campaign scenario graph must be acyclic (transitions are forward-only)"
+                )
                 cycle_reported = True
                 return
             in_progress.add(scenario_id)
@@ -2725,7 +2733,7 @@ class ContentValidator:
                 self._issue(
                     context.map_path,
                     "properties (player entry)",
-                    f'player entry ({entry_x}, {entry_y}) sits on self-removing StartEvent '
+                    f"player entry ({entry_x}, {entry_y}) sits on self-removing StartEvent "
                     f'"{obj.get("name", type_name)}"; offset the entry so the event survives spawn',
                 )
 
@@ -2806,9 +2814,7 @@ class ContentValidator:
                 path, f"{profile_id}.baseStatContribution", profile.get("baseStatContribution"), required=True
             )
             self._validate_string_list(path, f"{profile_id}.traits", profile.get("traits"), required=False)
-            self._validate_int_valued_map(
-                path, f"{profile_id}.resistances", profile.get("resistances"), required=False
-            )
+            self._validate_int_valued_map(path, f"{profile_id}.resistances", profile.get("resistances"), required=False)
 
     def _validate_string_list(self, path: Path, location: str, value: Any, *, required: bool) -> None:
         if value is None:
@@ -3586,20 +3592,65 @@ class ContentValidator:
                 self._issue(crafting_path, f"{recipe_name}.station", f'unknown crafting station "{station}"')
             inputs = recipe.get("inputs", [])
             if isinstance(inputs, list):
+                seen_inputs: set[str] = set()
                 for index, item in enumerate(inputs):
-                    self._validate_recipe_item(crafting_path, f"{recipe_name}.inputs[{index}]", item)
+                    item_name = self._validate_recipe_item(crafting_path, f"{recipe_name}.inputs[{index}]", item)
+                    if item_name is None:
+                        continue
+                    # The crafting runtime verifies each entry independently, so a
+                    # duplicated item id would pass the inventory check with fewer
+                    # items than the recipe costs. The runtime now merges duplicates
+                    # defensively, but content should still declare each item once.
+                    if item_name in seen_inputs:
+                        self._issue(
+                            crafting_path,
+                            f"{recipe_name}.inputs[{index}].item",
+                            f'duplicate input item "{item_name}"; declare a single entry with the combined count',
+                        )
+                    seen_inputs.add(item_name)
             output = recipe.get("output")
-            self._validate_recipe_item(crafting_path, f"{recipe_name}.output", output)
+            outputs = recipe.get("outputs")
+            if output is not None and outputs is not None:
+                self._issue(crafting_path, recipe_name, 'recipe defines both "output" and "outputs"; use one')
+            if outputs is not None and output is None:
+                if isinstance(outputs, list) and outputs:
+                    for index, item in enumerate(outputs):
+                        self._validate_recipe_item(crafting_path, f"{recipe_name}.outputs[{index}]", item)
+                else:
+                    self._issue(crafting_path, f"{recipe_name}.outputs", "expected non-empty list of recipe items")
+            else:
+                self._validate_recipe_item(crafting_path, f"{recipe_name}.output", output)
+            self._validate_recipe_scalars(crafting_path, recipe_name, recipe)
 
-    def _validate_recipe_item(self, path: Path, location: str, item: Any) -> None:
+    def _validate_recipe_scalars(self, path: Path, recipe_name: str, recipe: dict) -> None:
+        gold = recipe.get("gold", recipe.get("gold_cost"))
+        if gold is not None and (not isinstance(gold, int) or isinstance(gold, bool) or gold < 0):
+            self._issue(path, f"{recipe_name}.gold", "expected non-negative integer gold cost")
+        chance = recipe.get("successChance", recipe.get("success_chance"))
+        if chance is not None and (not isinstance(chance, int) or isinstance(chance, bool) or not 0 <= chance <= 100):
+            self._issue(path, f"{recipe_name}.successChance", "expected integer success chance in 0..100")
+        unlock_flag = recipe.get("unlockFlag")
+        if unlock_flag is not None and (not isinstance(unlock_flag, str) or not unlock_flag.strip()):
+            self._issue(path, f"{recipe_name}.unlockFlag", "expected non-empty string flag name")
+        unlock_hint = recipe.get("unlockHint")
+        if unlock_hint is not None and (not isinstance(unlock_hint, str) or not unlock_hint.strip()):
+            self._issue(path, f"{recipe_name}.unlockHint", "expected non-empty string hint text")
+
+    def _validate_recipe_item(self, path: Path, location: str, item: Any) -> str | None:
         if not isinstance(item, dict):
             self._issue(path, location, "expected recipe item object")
-            return
+            return None
+        count = item.get("count")
+        if count is not None and (not isinstance(count, int) or isinstance(count, bool) or count < 1):
+            self._issue(path, f"{location}.count", "expected positive integer count")
         item_name = item.get("item")
-        if isinstance(item_name, str) and item_name not in self.global_entries:
-            self._issue(path, f"{location}.item", f'unknown recipe item "{item_name}"')
-        elif item_name is not None and not isinstance(item_name, str):
+        if isinstance(item_name, str):
+            if item_name not in self.global_entries:
+                self._issue(path, f"{location}.item", f'unknown recipe item "{item_name}"')
+            return item_name
+        if item_name is not None:
             self._issue(path, f"{location}.item", "expected string item id")
+        return None
 
     def _crafting_station_ids(self) -> set[str]:
         station_ids: set[str] = set()
@@ -4076,7 +4127,7 @@ class ContentValidator:
             self._issue(
                 path,
                 location,
-                f'expected a {CREATURE_RACE_STATS_SCHEMA_CLASS} object node '
+                f"expected a {CREATURE_RACE_STATS_SCHEMA_CLASS} object node "
                 f'(e.g. {{"class": "{CREATURE_RACE_STATS_SCHEMA_CLASS}", "properties": {{...}}}})',
             )
             return

--- a/tests/regression/test_crafting_gui_refresh.py
+++ b/tests/regression/test_crafting_gui_refresh.py
@@ -122,7 +122,7 @@ class FakeRuntime:
             "success_chance": 100,
         }
 
-    def station_options(self, player, station_id):
+    def station_options(self, player, station_id, station=None):
         self.station_option_calls += 1
         description = self.describe_recipe_for_player(player, self.recipe)
         return [self.recipe], {description: self.recipe}

--- a/tests/regression/test_crafting_unlock_hints.py
+++ b/tests/regression/test_crafting_unlock_hints.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# fall-of-nouraajd c++ dark fantasy game
+# Copyright (C) 2026  Andrzej Lis
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Regression: crafting unlock hints come from content, and duplicate recipe
+inputs are merged into one requirement.
+
+Hints used to live in a hardcoded UNLOCK_HINTS dict inside the plugin (with the
+raw flag name leaking into the fallback text), so a station on any map other
+than nouraajd showed guidance about NPCs that do not exist there. They now
+resolve station override -> recipe unlockHint -> generic text.
+
+Duplicate input entries used to be verified independently, so a recipe listing
+the same item twice would pass the inventory check with fewer items than it
+actually costs (removal silently no-ops when nothing matches).
+"""
+
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+RECIPES = {
+    "craft_scroll": {
+        "station": "scribeDesk",
+        "inputs": [{"item": "Scroll", "count": 1}],
+        "output": {"item": "TownPortalScroll", "count": 1},
+        "gold": 10,
+        "unlockFlag": "CAN_CRAFT_SCROLLS",
+        "unlockHint": "Someone lettered must first grant you the scribe's craft.",
+    },
+    "craft_scroll_no_hint": {
+        "station": "scribeDesk",
+        "inputs": [{"item": "Scroll", "count": 1}],
+        "output": {"item": "TownPortalScroll", "count": 1},
+        "unlockFlag": "CAN_CRAFT_SCROLLS",
+    },
+    "craft_duplicated_inputs": {
+        "station": "scribeDesk",
+        "inputs": [
+            {"item": "Scroll", "count": 1},
+            {"item": "Scroll", "count": 1},
+        ],
+        "output": {"item": "TownPortalScroll", "count": 1},
+    },
+}
+
+
+def load_crafting_with_fake_game():
+    fake_game = types.ModuleType("game")
+    fake_game.randint = lambda lower, upper: lower
+    fake_game.list_string = lambda game_instance, options: list(options)
+
+    class FakeResourcesProvider:
+        @classmethod
+        def getInstance(cls):
+            return cls()
+
+        def load(self, filename):
+            if filename == "config/crafting.json":
+                return json.dumps(RECIPES)
+            return "{}"
+
+    fake_game.CResourcesProvider = FakeResourcesProvider
+    old_game = sys.modules.get("game")
+    sys.modules["game"] = fake_game
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "crafting_under_test_unlock_hints", REPO_ROOT / "res" / "plugins" / "crafting.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if old_game is None:
+            sys.modules.pop("game", None)
+        else:
+            sys.modules["game"] = old_game
+
+
+class FakeStation:
+    def __init__(self, hints=None):
+        self.hints = hints or {}
+
+    def getStringProperty(self, key):
+        return self.hints.get(key, "")
+
+
+class FakePlayer:
+    def __init__(self, item_counts=None, gold=0):
+        self.item_counts = dict(item_counts or {})
+        self.gold = gold
+
+    def countItems(self, item_id):
+        return self.item_counts.get(item_id, 0)
+
+    def getNumericProperty(self, key):
+        return self.gold if key == "gold" else 0
+
+    def getBoolProperty(self, key):
+        return False
+
+    def getMap(self):
+        return None
+
+
+class CraftingUnlockHintTest(unittest.TestCase):
+    def setUp(self):
+        self.crafting = load_crafting_with_fake_game()
+        self.runtime = self.crafting.CraftingRuntime()
+
+    def test_recipe_unlock_hint_defaults_to_content_hint(self):
+        recipe = self.runtime.get_recipe("craft_scroll")
+        self.assertEqual(
+            "Someone lettered must first grant you the scribe's craft.",
+            self.runtime.recipe_unlock_hint(recipe),
+        )
+
+    def test_station_override_wins_over_recipe_hint(self):
+        recipe = self.runtime.get_recipe("craft_scroll")
+        station = FakeStation({"unlockHint_CAN_CRAFT_SCROLLS": "Study Gravewatch's learning stone."})
+        self.assertEqual(
+            "Study Gravewatch's learning stone.",
+            self.runtime.recipe_unlock_hint(recipe, station),
+        )
+
+    def test_missing_hint_falls_back_without_leaking_flag_name(self):
+        recipe = self.runtime.get_recipe("craft_scroll_no_hint")
+        hint = self.runtime.recipe_unlock_hint(recipe, FakeStation())
+        self.assertEqual(self.crafting.DEFAULT_LOCKED_HINT, hint)
+        self.assertNotIn("CAN_CRAFT_SCROLLS", hint)
+
+    def test_locked_description_uses_station_override(self):
+        recipe = self.runtime.get_recipe("craft_scroll")
+        station = FakeStation({"unlockHint_CAN_CRAFT_SCROLLS": "Study Gravewatch's learning stone."})
+        description = self.runtime.describe_recipe_for_player(FakePlayer(), recipe, station)
+        self.assertIn("LOCKED", description)
+        self.assertIn("Study Gravewatch's learning stone.", description)
+
+
+class CraftingDuplicateInputTest(unittest.TestCase):
+    def setUp(self):
+        self.crafting = load_crafting_with_fake_game()
+        self.runtime = self.crafting.CraftingRuntime()
+
+    def test_duplicate_entries_merge_into_combined_count(self):
+        recipe = self.runtime.get_recipe("craft_duplicated_inputs")
+        self.assertEqual([{"item_id": "Scroll", "count": 2}], recipe["inputs"])
+
+    def test_single_item_no_longer_satisfies_duplicated_requirement(self):
+        recipe = self.runtime.get_recipe("craft_duplicated_inputs")
+        player = FakePlayer({"Scroll": 1})
+        status = self.crafting.verify_inventory_requirements(player, recipe["inputs"])
+        self.assertFalse(status["ok"])
+        self.assertEqual("missing:Scroll", status["reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -254,7 +254,9 @@ class ContentValidatorTest(unittest.TestCase):
 
         issues = validate_repo(root)
 
-        self.assertIssueContains(issues, "res/config/races.json", "human.baseStatContribution.strength", "expected integer")
+        self.assertIssueContains(
+            issues, "res/config/races.json", "human.baseStatContribution.strength", "expected integer"
+        )
         self.assertIssueContains(issues, "human.traits[1]", "expected non-empty string")
         self.assertIssueContains(issues, "human.resistances.fire", "expected integer")
 
@@ -2766,9 +2768,7 @@ class ContentValidatorTest(unittest.TestCase):
     def test_creature_race_unknown_base_stats_key_is_reported(self):
         root = self.make_fixture()
         self.write_creature_race_stats_fixture(root)
-        self._write_creature_race(
-            root, {"baseStats": {"class": "CStats", "properties": {"strenght": 5}}}
-        )
+        self._write_creature_race(root, {"baseStats": {"class": "CStats", "properties": {"strenght": 5}}})
 
         issues = validate_repo(root)
 
@@ -3147,6 +3147,97 @@ class ContentValidatorTest(unittest.TestCase):
 
         self.assertIssueContains(
             issues, "res/maps/broken/script.py", "CAMPAIGN_OUTCOMES must be a literal tuple or list of outcome strings"
+        )
+
+    def _write_crafting_fixture(self, root, recipes):
+        write_json(
+            root / "res/config/buildings.json",
+            {
+                "AlchemyTable": {
+                    "class": "CBuilding",
+                    "properties": {"label": "Alchemist's Table", "craftingStationId": "alchemyTable"},
+                }
+            },
+        )
+        write_json(root / "res/config/crafting.json", recipes)
+
+    def _valid_recipe(self, **overrides):
+        recipe = {
+            "station": "alchemyTable",
+            "inputs": [{"item": "LifePotion", "count": 2}],
+            "output": {"item": "LifePotion", "count": 1},
+            "gold": 20,
+            "successChance": 90,
+        }
+        recipe.update(overrides)
+        return recipe
+
+    def test_crafting_valid_recipe_passes_validation(self):
+        root = self.make_fixture()
+        self._write_crafting_fixture(root, {"brew": self._valid_recipe()})
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
+    def test_crafting_outputs_list_is_validated(self):
+        root = self.make_fixture()
+        recipe = self._valid_recipe(outputs=[{"item": "LifePotion"}, {"item": "MissingItem"}])
+        del recipe["output"]
+        self._write_crafting_fixture(root, {"brew": recipe})
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues, "res/config/crafting.json", "brew.outputs[1].item", 'unknown recipe item "MissingItem"'
+        )
+
+    def test_crafting_output_and_outputs_together_are_flagged(self):
+        root = self.make_fixture()
+        recipe = self._valid_recipe(outputs=[{"item": "LifePotion"}])
+        self._write_crafting_fixture(root, {"brew": recipe})
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues, "res/config/crafting.json", 'recipe defines both "output" and "outputs"; use one'
+        )
+
+    def test_crafting_duplicate_input_items_are_flagged(self):
+        root = self.make_fixture()
+        recipe = self._valid_recipe(inputs=[{"item": "LifePotion", "count": 1}, {"item": "LifePotion", "count": 1}])
+        self._write_crafting_fixture(root, {"brew": recipe})
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/crafting.json",
+            "brew.inputs[1].item",
+            'duplicate input item "LifePotion"',
+        )
+
+    def test_crafting_scalar_fields_are_validated(self):
+        root = self.make_fixture()
+        recipe = self._valid_recipe(gold=-5, successChance=150, unlockFlag="   ", unlockHint="")
+        recipe["inputs"][0]["count"] = 0
+        self._write_crafting_fixture(root, {"brew": recipe})
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/config/crafting.json",
+            "brew.gold",
+            "expected non-negative integer gold cost",
+            "brew.successChance",
+            "expected integer success chance in 0..100",
+            "brew.unlockFlag",
+            "expected non-empty string flag name",
+            "brew.unlockHint",
+            "expected non-empty string hint text",
+            "brew.inputs[0].count",
+            "expected positive integer count",
         )
 
     def assertIssueContains(self, issues, *substrings):
@@ -4152,9 +4243,7 @@ class NouraajdCatacombsContentTest(unittest.TestCase):
         )
         reachable = self._reachable_tiles()
         adjacent = [
-            (cx + dx, cy + dy)
-            for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1))
-            if (cx + dx, cy + dy) in reachable
+            (cx + dx, cy + dy) for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)) if (cx + dx, cy + dy) in reachable
         ]
         self.assertTrue(
             adjacent,


### PR DESCRIPTION
## Summary

Fixes from a crafting-system review.

- **ninemarches scribe desk was permanently locked**: `CAN_CRAFT_SCROLLS` is only set by nouraajd's script and ninemarches is not part of any campaign, so the Gravewatch scribe desk showed only LOCKED recipes with hints about NPCs that don't exist on that map. Studying Gravewatch's learning stone now sets the flag (as a map bool, which recipe unlock checks already support).
- **Unlock hints move from code into content**: recipes declare a map-agnostic `unlockHint` in `crafting.json`, and a map can override it per flag with an `unlockHint_<FLAG>` string property on its station instance (nouraajd keeps its exact previous hint text). The hardcoded `UNLOCK_HINTS` dict is gone and the fallback no longer leaks raw flag names to the player.
- **Duplicate-input latent bug**: recipe normalization now merges repeated input item ids into one combined requirement. Previously each entry was verified independently, so a recipe listing the same item twice would pass the inventory check with fewer items than it costs (removal silently no-ops when nothing matches).
- **Validator hardened**: `validate_content.py` now validates the `outputs` list form, rejects `output`+`outputs` together, rejects duplicate input item ids, and checks `count`/`gold`/`successChance`/`unlockFlag`/`unlockHint` types and ranges. New hygiene allowance for the ninemarches map flag.
- New regression tests (`tests/regression/test_crafting_unlock_hints.py`) for hint resolution and duplicate merging; crafting recipe schema documented in `docs/content.md`; CLAUDE.md drift fixed (map list, plugin auto-discovery vs manifest).

> Note: an earlier revision of this PR also packaged the Warden's Road maps (hearthfall/gravemoor/usurpergate) into the CMake resource list and added their loader layer properties, as those tests were failing on main. Main received equivalent fixes independently (#1324 and the CMake packaging), so that commit was dropped during rebase and the merged diff is crafting-only.

## Validation

Rebased onto current main and re-verified before merge:

- `python3 scripts/validate_content.py --repo-root .` — passed
- `python3 -m unittest tests.test_content_validator` — 165 tests OK
- `python3 -m unittest discover -s tests -t .` — 646 tests OK
- Crafting integration tests, nouraajd + ninemarches walkthroughs, Tiled compatibility audit — OK
- Earlier pre-rebase runs: ctest unit + performance suites, full `python3 test.py` default suite, gameplay suite — all passed
- Changed-file black gate (`black --check -l 120`) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYnJA4n69FLiw7DAQJ9ozM