### PR TITLE
Add 15 Heroes III inspired adventure objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,7 @@ add_native_plugin(native_marker_plugin native_plugins/native_marker_plugin.cpp)
 add_native_plugin(native_gameplay native_plugins/native_gameplay.cpp)
 add_dependencies(_game ${NATIVE_PLUGIN_TARGETS})
 
+configure_file(res/config/adventure.json config/adventure.json)
 configure_file(res/config/armors.json config/armors.json)
 configure_file(res/config/classes.json config/classes.json)
 configure_file(res/config/races.json config/races.json)

--- a/res/config/adventure.json
+++ b/res/config/adventure.json
@@ -1,0 +1,131 @@
+{
+  "adventureLearningStone": {
+    "class": "AdventureLearningStone",
+    "properties": {
+      "animation": "images/ambient/stone_shrine",
+      "label": "Learning Stone",
+      "exp": 500
+    }
+  },
+  "campfire": {
+    "class": "Campfire",
+    "properties": {
+      "animation": "images/ambient/campfire_cauldron",
+      "label": "Campfire",
+      "gold": 100,
+      "value": 15
+    }
+  },
+  "fountainOfYouth": {
+    "class": "FountainOfYouth",
+    "properties": {
+      "animation": "images/ambient/stone_well",
+      "label": "Fountain of Youth",
+      "healing": 50
+    }
+  },
+  "magicWell": {
+    "class": "MagicWell",
+    "properties": {
+      "animation": "images/ambient/stone_well",
+      "label": "Magic Well"
+    }
+  },
+  "windmill": {
+    "class": "Windmill",
+    "properties": {
+      "animation": "images/ambient/hay_bales",
+      "label": "Windmill",
+      "gold": 250,
+      "cooldown": 50,
+      "turns": 50
+    }
+  },
+  "treeOfKnowledge": {
+    "class": "TreeOfKnowledge",
+    "properties": {
+      "animation": "images/ambient/dead_tree",
+      "label": "Tree of Knowledge",
+      "cost": 2000
+    }
+  },
+  "mercenaryCamp": {
+    "class": "MercenaryCamp",
+    "properties": {
+      "animation": "images/ambient/supply_pile",
+      "label": "Mercenary Camp",
+      "stat": "strength",
+      "bonus": 1
+    }
+  },
+  "marlettoTower": {
+    "class": "MarlettoTower",
+    "properties": {
+      "animation": "images/buildings/town_hall",
+      "label": "Marletto Tower",
+      "stat": "stamina",
+      "bonus": 1
+    }
+  },
+  "starAxis": {
+    "class": "StarAxis",
+    "properties": {
+      "animation": "images/ambient/brazier",
+      "label": "Star Axis",
+      "stat": "intelligence",
+      "bonus": 1
+    }
+  },
+  "adventureWitchHut": {
+    "class": "AdventureWitchHut",
+    "properties": {
+      "animation": "images/buildings/tavern",
+      "label": "Witch Hut",
+      "bonus": 1
+    }
+  },
+  "adventureObelisk": {
+    "class": "AdventureObelisk",
+    "properties": {
+      "animation": "images/ambient/notice_board",
+      "label": "Obelisk",
+      "text": "Weathered glyphs hint at a secret buried somewhere in Nouraajd."
+    }
+  },
+  "warriorsTomb": {
+    "class": "WarriorsTomb",
+    "properties": {
+      "animation": "images/ambient/gravestone_cluster",
+      "label": "Warrior's Tomb",
+      "enabled": true,
+      "value": 60,
+      "damage": 30
+    }
+  },
+  "sirens": {
+    "class": "Sirens",
+    "properties": {
+      "animation": "images/ambient/rubble_and_skulls",
+      "label": "Sirens",
+      "sacrifice": 30,
+      "expPerHp": 2
+    }
+  },
+  "keymastersTent": {
+    "class": "KeymastersTent",
+    "properties": {
+      "animation": "images/ambient/market_stall",
+      "label": "Keymaster's Tent",
+      "keyColor": "crimson"
+    }
+  },
+  "borderGuard": {
+    "class": "BorderGuard",
+    "properties": {
+      "animation": "images/misc/closed_door",
+      "label": "Border Guard",
+      "keyColor": "crimson",
+      "canStep": false
+    }
+  }
+}

--- a/res/plugins/object.py
+++ b/res/plugins/object.py
@@ -17,10 +17,28 @@
 
 def load(self, context):
     from game import randint
+    from game import claim_once
     from game import CBuilding
     from game import Coords
     from game import register
     from game import CScroll
+
+    def acting_player(event):
+        if not event:
+            return None
+        cause = event.getCause()
+        return cause if cause and cause.isPlayer() else None
+
+    def show_info(building, text):
+        if text and building.getMap():
+            building.getMap().getGame().getGuiHandler().showInfo(text, True)
+
+    def raise_base_stat(creature, stat, bonus):
+        base_stats = creature.getObjectProperty("baseStats")
+        if not base_stats:
+            return False
+        base_stats.setNumericProperty(stat, base_stats.getNumericProperty(stat) + bonus)
+        return True
 
     @register(context)
     class WayPoint(CBuilding):
@@ -139,6 +157,205 @@ def load(self, context):
                 self.getMap().addObject(mon)
                 mon.moveTo(location.x, location.y, location.z)
                 self.incProperty("monsters", -1)
+
+    # Heroes of Might and Magic III inspired adventure objects. Each visitable
+    # location keys its one-time rewards to the visiting player through
+    # claim_once, so per-player state survives saves via ordinary properties.
+    # The learning stone, witch hut, and obelisk carry an Adventure prefix
+    # because map scripts (ninemarches, sunderedmarch) already register
+    # map-local classes under the plain names.
+
+    @register(context)
+    class AdventureLearningStone(CBuilding):
+        def onEnter(self, event):
+            player = acting_player(event)
+            if not player:
+                return
+            if claim_once(player, "learningStone_" + self.getName()):
+                player.addExp(self.getNumericProperty("exp"))
+                show_info(self, "Ancient runes etched into the stone sharpen your mind. You gain experience.")
+
+    @register(context)
+    class Campfire(CBuilding):
+        def onEnter(self, event):
+            player = acting_player(event)
+            if not player:
+                return
+            player.addGold(self.getNumericProperty("gold"))
+            self.getGame().getRngHandler().addRandomLoot(player, self.getNumericProperty("value"))
+            show_info(self, "You scavenge supplies abandoned around a cold campfire.")
+            self.getMap().removeObjectByName(self.getName())
+
+    @register(context)
+    class FountainOfYouth(CBuilding):
+        def onEnter(self, event):
+            player = acting_player(event)
+            if player:
+                player.healProc(self.getNumericProperty("healing"))
+
+    @register(context)
+    class MagicWell(CBuilding):
+        def onEnter(self, event):
+            player = acting_player(event)
+            if player:
+                player.addManaProc(100)
+
+    @register(context)
+    class Windmill(CBuilding):
+        def onTurn(self, event):
+            if self.getNumericProperty("turns") < self.getNumericProperty("cooldown"):
+                self.incProperty("turns", 1)
+
+        def onEnter(self, event):
+            player = acting_player(event)
+            if not player:
+                return
+            if self.getNumericProperty("turns") >= self.getNumericProperty("cooldown"):
+                self.setNumericProperty("turns", 0)
+                player.addGold(self.getNumericProperty("gold"))
+                show_info(self, "The miller shares the profits of the last harvest with you.")
+
+    @register(context)
+    class TreeOfKnowledge(CBuilding):
+        def onEnter(self, event):
+            player = acting_player(event)
+            if not player:
+                return
+            claim = "treeOfKnowledge_" + self.getName()
+            if player.getBoolProperty(claim):
+                return
+            cost = self.getNumericProperty("cost")
+            if player.getGold() < cost:
+                show_info(self, "The tree whispers of enlightenment, but demands " + str(cost) + " gold as tribute.")
+                return
+            player.setBoolProperty(claim, True)
+            player.takeGold(cost)
+            level = player.getLevel()
+            exp_for_next_level = level * (level + 1) * 500
+            missing = exp_for_next_level - player.getNumericProperty("exp")
+            if missing > 0:
+                player.addExp(missing)
+            show_info(self, "You meditate beneath the Tree of Knowledge and reach a new level of understanding.")
+
+    @register(context)
+    class TrainingGround(CBuilding):
+        def onEnter(self, event):
+            player = acting_player(event)
+            if not player:
+                return
+            stat = self.getStringProperty("stat")
+            bonus = self.getNumericProperty("bonus")
+            if not stat or bonus <= 0:
+                return
+            if not player.getObjectProperty("baseStats"):
+                return
+            if not claim_once(player, "trained_" + self.getName()):
+                return
+            raise_base_stat(player, stat, bonus)
+            show_info(self, "The training pays off. Your " + stat + " permanently increases by " + str(bonus) + ".")
+
+    @register(context)
+    class MercenaryCamp(TrainingGround):
+        pass
+
+    @register(context)
+    class MarlettoTower(TrainingGround):
+        pass
+
+    @register(context)
+    class StarAxis(TrainingGround):
+        pass
+
+    @register(context)
+    class AdventureWitchHut(CBuilding):
+        def onEnter(self, event):
+            player = acting_player(event)
+            if not player:
+                return
+            bonus = self.getNumericProperty("bonus")
+            if bonus <= 0 or not player.getObjectProperty("baseStats"):
+                return
+            if not claim_once(player, "witchHut_" + self.getName()):
+                return
+            stats = ["strength", "agility", "stamina", "intelligence"]
+            stat = stats[randint(0, len(stats) - 1)]
+            raise_base_stat(player, stat, bonus)
+            show_info(self, "The witch brews a pungent draught. Your " + stat + " increases by " + str(bonus) + ".")
+
+    @register(context)
+    class AdventureObelisk(CBuilding):
+        def onEnter(self, event):
+            player = acting_player(event)
+            if not player:
+                return
+            if claim_once(player, "obelisk_" + self.getName()):
+                player.incProperty("obelisksVisited", 1)
+            show_info(self, self.getStringProperty("text"))
+
+    @register(context)
+    class WarriorsTomb(CBuilding):
+        def onEnter(self, event):
+            player = acting_player(event)
+            if not player:
+                return
+            if not self.getBoolProperty("enabled"):
+                show_info(self, "The tomb lies plundered and empty.")
+                return
+            self.setBoolProperty("enabled", False)
+            self.getGame().getRngHandler().addRandomLoot(player, self.getNumericProperty("value"))
+            # The guardian's toll bypasses armor and block, so it is applied
+            # straight to HP instead of through the combat damage pipeline.
+            toll = min(player.getHp() - 1, player.getHpMax() * self.getNumericProperty("damage") // 100)
+            if toll > 0:
+                player.setHp(player.getHp() - toll)
+            show_info(self, "You pry treasure from the warrior's tomb, but its restless guardian exacts a toll.")
+
+    @register(context)
+    class Sirens(CBuilding):
+        def onEnter(self, event):
+            player = acting_player(event)
+            if not player:
+                return
+            sacrifice = min(player.getHp() - 1, player.getHpMax() * self.getNumericProperty("sacrifice") // 100)
+            if sacrifice <= 0:
+                return
+            if not claim_once(player, "sirens_" + self.getName()):
+                return
+            # The song's toll cannot be armored or blocked away, so it is
+            # applied straight to HP instead of through the damage pipeline.
+            player.setHp(player.getHp() - sacrifice)
+            player.addExp(sacrifice * self.getNumericProperty("expPerHp"))
+            show_info(self, "The sirens' song drains your life, yet their secrets harden your resolve.")
+
+    @register(context)
+    class KeymastersTent(CBuilding):
+        def onEnter(self, event):
+            player = acting_player(event)
+            if not player:
+                return
+            color = self.getStringProperty("keyColor")
+            if not color:
+                return
+            claim = "borderPass_" + color
+            if not player.getBoolProperty(claim):
+                player.setBoolProperty(claim, True)
+                show_info(self, "The keymaster hands you the " + color + " pass.")
+
+    @register(context)
+    class BorderGuard(CBuilding):
+        def onTurn(self, event):
+            game_map = self.getMap()
+            if not game_map:
+                return
+            player = game_map.getPlayer()
+            color = self.getStringProperty("keyColor")
+            if not player or not color or not player.getBoolProperty("borderPass_" + color):
+                return
+            here = self.getCoords()
+            there = player.getCoords()
+            if here.z == there.z and abs(here.x - there.x) <= 1 and abs(here.y - there.y) <= 1:
+                show_info(self, "The border guard honors your " + color + " pass and stands aside.")
+                game_map.removeObjectByName(self.getName())
 
     @register(context)
     class TownPortalScroll(CScroll):

--- a/test.py
+++ b/test.py
@@ -5613,6 +5613,172 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_heroes3_adventure_objects_grant_their_rewards(self):
+        game = load_game_module()
+        g, game_map, player = load_game_map_with_player("test", "Warrior")
+
+        class FakeEvent:
+            def __init__(self, cause):
+                self.cause = cause
+
+            def getCause(self):
+                return self.cause
+
+        def place_object(type_id, name):
+            obj = g.createObject(type_id)
+            self.assertIsNotNone(obj, f"Expected adventure object '{type_id}' to be constructible.")
+            obj.name = name
+            game_map.addObject(obj)
+            coords = find_adjacent_walkable_tile(game_map, player.getCoords())
+            obj.moveTo(coords.x, coords.y, coords.z)
+            return obj
+
+        def stat(name):
+            return player.getStats().getNumericProperty(name)
+
+        event = FakeEvent(player)
+        infos = []
+        original_show_info = game.CGuiHandler.showInfo
+        game.CGuiHandler.showInfo = lambda self, message, centered=False: infos.append(message)
+        try:
+            # LearningStone: experience once per player.
+            stone = place_object("adventureLearningStone", "h3LearningStone")
+            exp_before = player.getNumericProperty("exp")
+            stone.onEnter(event)
+            self.assertEqual(exp_before + 500, player.getNumericProperty("exp"))
+            stone.onEnter(event)
+            self.assertEqual(exp_before + 500, player.getNumericProperty("exp"))
+
+            # Campfire: one-time gold plus loot, then it burns out.
+            campfire = place_object("campfire", "adventureCampfire")
+            gold_before = player.getGold()
+            items_before = len(player.getItems())
+            campfire.onEnter(event)
+            self.assertEqual(gold_before + 100, player.getGold())
+            self.assertGreater(len(player.getItems()), items_before)
+            self.assertIsNone(game_map.getObjectByName("adventureCampfire"))
+
+            # FountainOfYouth: heals half of max HP per visit.
+            fountain = place_object("fountainOfYouth", "adventureFountain")
+            player.setHp(1)
+            fountain.onEnter(event)
+            self.assertGreater(player.getHp(), 1)
+
+            # MagicWell: refills mana.
+            well = place_object("magicWell", "adventureMagicWell")
+            player.setMana(0)
+            well.onEnter(event)
+            self.assertGreater(player.getMana(), 0)
+
+            # Windmill: pays out, then needs its cooldown to elapse.
+            windmill = place_object("windmill", "adventureWindmill")
+            gold_before = player.getGold()
+            windmill.onEnter(event)
+            self.assertEqual(gold_before + 250, player.getGold())
+            windmill.onEnter(event)
+            self.assertEqual(gold_before + 250, player.getGold())
+            for _ in range(50):
+                windmill.onTurn(None)
+            windmill.onEnter(event)
+            self.assertEqual(gold_before + 500, player.getGold())
+
+            # Permanent stat trainers: each raises its stat once per player.
+            camp = place_object("mercenaryCamp", "adventureMercenaryCamp")
+            strength_before = stat("strength")
+            camp.onEnter(event)
+            camp.onEnter(event)
+            self.assertEqual(strength_before + 1, stat("strength"))
+
+            tower = place_object("marlettoTower", "adventureMarlettoTower")
+            stamina_before = stat("stamina")
+            tower.onEnter(event)
+            tower.onEnter(event)
+            self.assertEqual(stamina_before + 1, stat("stamina"))
+
+            axis = place_object("starAxis", "adventureStarAxis")
+            intelligence_before = stat("intelligence")
+            axis.onEnter(event)
+            axis.onEnter(event)
+            self.assertEqual(intelligence_before + 1, stat("intelligence"))
+
+            # WitchHut: raises one random stat once per player.
+            hut = place_object("adventureWitchHut", "h3WitchHut")
+            stat_names = ("strength", "agility", "stamina", "intelligence")
+            stats_before = sum(stat(name) for name in stat_names)
+            hut.onEnter(event)
+            hut.onEnter(event)
+            self.assertEqual(stats_before + 1, sum(stat(name) for name in stat_names))
+
+            # TreeOfKnowledge: pays gold for one level, once per player.
+            tree = place_object("treeOfKnowledge", "adventureTree")
+            player.addGold(2000)
+            gold_before = player.getGold()
+            level_before = player.getLevel()
+            tree.onEnter(event)
+            self.assertEqual(level_before + 1, player.getLevel())
+            self.assertEqual(gold_before - 2000, player.getGold())
+            tree.onEnter(event)
+            self.assertEqual(level_before + 1, player.getLevel())
+            self.assertEqual(gold_before - 2000, player.getGold())
+
+            # Obelisk: counts one visit per player and repeats its hint.
+            obelisk = place_object("adventureObelisk", "h3Obelisk")
+            hints_before = len(infos)
+            obelisk.onEnter(event)
+            obelisk.onEnter(event)
+            self.assertEqual(1, player.getNumericProperty("obelisksVisited"))
+            self.assertEqual(hints_before + 2, len(infos))
+
+            # WarriorsTomb: loot at a price, and only once.
+            tomb = place_object("warriorsTomb", "adventureTomb")
+            player.heal(0)
+            items_before = len(player.getItems())
+            hp_before = player.getHp()
+            tomb.onEnter(event)
+            self.assertGreater(len(player.getItems()), items_before)
+            self.assertLess(player.getHp(), hp_before)
+            self.assertTrue(player.isAlive())
+            items_before = len(player.getItems())
+            tomb.onEnter(event)
+            self.assertEqual(items_before, len(player.getItems()))
+
+            # Sirens: trade health for experience, once per player.
+            sirens = place_object("sirens", "adventureSirens")
+            player.heal(0)
+            hp_before = player.getHp()
+            exp_before = player.getNumericProperty("exp")
+            sirens.onEnter(event)
+            self.assertLess(player.getHp(), hp_before)
+            self.assertTrue(player.isAlive())
+            self.assertEqual(exp_before + (hp_before - player.getHp()) * 2, player.getNumericProperty("exp"))
+
+            # KeymastersTent hands out the pass the BorderGuard honors.
+            guard = place_object("borderGuard", "adventureBorderGuard")
+            guard_coords = guard.getCoords()
+            self.assertFalse(game_map.canStep(guard_coords))
+            guard.onTurn(None)
+            self.assertIsNotNone(game_map.getObjectByName("adventureBorderGuard"))
+            tent = place_object("keymastersTent", "adventureKeymastersTent")
+            tent.onEnter(event)
+            self.assertTrue(player.getBoolProperty("borderPass_crimson"))
+            guard.onTurn(None)
+            self.assertIsNone(game_map.getObjectByName("adventureBorderGuard"))
+            self.assertTrue(game_map.canStep(guard_coords))
+        finally:
+            game.CGuiHandler.showInfo = original_show_info
+
+        return True, json.dumps(
+            {
+                "exp": player.getNumericProperty("exp"),
+                "gold": player.getGold(),
+                "level": player.getLevel(),
+                "obelisks": player.getNumericProperty("obelisksVisited"),
+                "infos": len(infos),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_array_deserialize_skips_bad_entries_and_consumers_are_safe(self):
         game = load_game_module()
 
@@ -17258,10 +17424,7 @@ class GameTest(unittest.TestCase):
                 self.assertEqual(1, gui_log["trades"].count("victorMarket"))
                 self.assertEqual(-1, ctx["map"].getNumericProperty("VICTOR_COURTYARD_TURN"))
                 self.assertFalse(
-                    any(
-                        obj.getName() and obj.getName().startswith("victorCultist")
-                        for obj in ctx["map"].getObjects()
-                    ),
+                    any(obj.getName() and obj.getName().startswith("victorCultist") for obj in ctx["map"].getObjects()),
                     "victor: all victorCultist* runtime actors must be cleaned up with the reward.",
                 )
 


### PR DESCRIPTION
## Summary

Adds 15 Heroes of Might and Magic III inspired adventure objects as global `CBuilding` plugin classes in `res/plugins/object.py`, with spawnable config entries in a new `res/config/adventure.json` (staged through `CMakeLists.txt`):

| Object | Behavior |
|---|---|
| `adventureLearningStone` | +XP once per player |
| `campfire` | One-time gold + random loot, removes itself |
| `fountainOfYouth` | Heals a percentage of max HP per visit |
| `magicWell` | Refills mana per visit |
| `windmill` | Gold payout gated by a turn cooldown |
| `treeOfKnowledge` | Pay gold to reach the next level, once per player |
| `mercenaryCamp` / `marlettoTower` / `starAxis` | Permanent +1 strength / stamina / intelligence, once per player (shared `TrainingGround` base) |
| `adventureWitchHut` | Permanent +1 to a random stat, once per player |
| `adventureObelisk` | Lore hint + per-player `obelisksVisited` counter |
| `warriorsTomb` | One-time random loot at an unavoidable HP toll |
| `sirens` | Sacrifice a share of HP for experience, once per player |
| `keymastersTent` / `borderGuard` | Colored pass that opens an impassable border guard |

One-time rewards key off the visiting player via the existing `claim_once` helper, so per-player state persists through saves as ordinary properties. Permanent stat gains mutate the player's `baseStats`. The learning stone, witch hut, and obelisk classes carry an `Adventure` prefix because the `ninemarches`/`sunderedmarch` map scripts already register map-local classes under the plain names. All animations reuse already-staged art.

`test.py` gains `test_heroes3_adventure_objects_grant_their_rewards` covering every object (rewards, cooldowns, once-per-player claims, HP tolls, and the tent-to-guard unlock flow including the walkability flip), plus a black reformat of one pre-existing line required by the formatting gate.

## Validation

- `python3 scripts/validate_content.py --repo-root .` — passed
- `python3 -m unittest tests.test_content_validator` — 156 tests OK
- `ctest -R for_unit_tests` — 10/10 passed; `ctest -L performance` — 1/1 passed
- `python3 test.py` — full suite green (exit 0)
- `./scripts/run_coverage.sh` — 90.74% eligible lines (gate: 90%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DYtaw1LH29TtZHvpz4eR

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6DYtaw1LH29TtZHvpz4eR)_