### PR TITLE
[EPIC_07][STORY_01][SUBSTORY_01] Extract character sheet text builder from render path

### DIFF
--- a/src/gui/panel/CGameCharacterPanel.cpp
+++ b/src/gui/panel/CGameCharacterPanel.cpp
@@ -19,12 +19,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CJsonUtil.h"
 #include "core/CMap.h"
 #include "gui/CTextManager.h"
+#include "object/CPlayer.h"
 
 #include <exception>
 
-void CGameCharacterPanel::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int i) {
-    std::string text;
-    std::shared_ptr<CPlayer> player = gui->getGame()->getMap()->getPlayer();
+std::vector<std::pair<std::string, std::string>>
+CGameCharacterPanel::buildCharacterSheetLines(const std::shared_ptr<CPlayer> &player) {
+    std::vector<std::pair<std::string, std::string>> lines;
+    if (!charSheet) {
+        return lines;
+    }
     for (auto [key, value] : charSheet->getValues()) {
         if (value.empty() || !player) {
             continue;
@@ -34,14 +38,23 @@ void CGameCharacterPanel::renderObject(std::shared_ptr<CGui> gui, std::shared_pt
         // shown directly; string accessors (e.g. class / race identity) fall back to a
         // string invocation so they render as their text value rather than being skipped.
         try {
-            text += key + ": " + vstd::str(player->meta()->invoke_method<int>(value, player)) + "\n";
+            lines.emplace_back(key, vstd::str(player->meta()->invoke_method<int>(value, player)));
         } catch (const std::exception &) {
             try {
-                text += key + ": " + player->meta()->invoke_method<std::string>(value, player) + "\n";
+                lines.emplace_back(key, player->meta()->invoke_method<std::string>(value, player));
             } catch (const std::exception &exception) {
                 vstd::logger::warning("Ignoring character sheet value callback failure:", value, exception.what());
             }
         }
+    }
+    return lines;
+}
+
+void CGameCharacterPanel::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int i) {
+    std::string text;
+    std::shared_ptr<CPlayer> player = gui->getGame()->getMap()->getPlayer();
+    for (const auto &[label, value] : buildCharacterSheetLines(player)) {
+        text += label + ": " + value + "\n";
     }
     gui->getTextManager()->drawText(text, rect->x, rect->y, rect->w);
 }

--- a/src/gui/panel/CGameCharacterPanel.h
+++ b/src/gui/panel/CGameCharacterPanel.h
@@ -20,6 +20,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CGamePanel.h"
 #include "core/CList.h"
 
+#include <string>
+#include <utility>
+#include <vector>
+
+class CPlayer;
+
 class CGameCharacterPanel : public CGamePanel {
     V_META(CGameCharacterPanel, CGamePanel,
            V_PROPERTY(CGameCharacterPanel, std::shared_ptr<CMapStringString>, charSheet, getCharSheet, setCharSheet),
@@ -28,6 +34,13 @@ class CGameCharacterPanel : public CGamePanel {
     void renderObject(std::shared_ptr<CGui> shared_ptr, std::shared_ptr<SDL_Rect> rect, int i) override;
 
   public:
+    // Render-free text assembly for the character sheet: resolves the configured
+    // charSheet accessors against the player and returns the ordered label/value
+    // rows renderObject draws. Kept separate from rendering so the panel text is
+    // unit-testable without SDL and so later identity rows (race / class labels)
+    // can extend the row list in one place.
+    std::vector<std::pair<std::string, std::string>> buildCharacterSheetLines(const std::shared_ptr<CPlayer> &player);
+
     std::shared_ptr<CMapStringString> getCharSheet();
 
     void setCharSheet(std::shared_ptr<CMapStringString> charSheet);

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -34,6 +34,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/object/CGameGraphicsObject.h"
 #include "gui/object/CMinimapGraphicsObject.h"
 #include "gui/object/CWidget.h"
+#include "gui/panel/CGameCharacterPanel.h"
 #include "gui/panel/CGameFightPanel.h"
 #include "gui/panel/CGameInventoryPanel.h"
 #include "gui/panel/CGamePanel.h"
@@ -2185,6 +2186,45 @@ void test_widget_reflective_callbacks_fail_closed_on_bad_config() {
     expect_true(panel->clicks == 1, "valid widget click callback should still fire");
 }
 
+void test_character_panel_sheet_lines_build_without_rendering_and_fail_closed() {
+    auto panel = std::make_shared<CGameCharacterPanel>();
+    auto player = std::make_shared<CPlayer>();
+    player->setBaseStats(player_stats());
+    player->setLevel(4);
+    player->setGold(123);
+    player->setRaceId("harpy");
+
+    // No configured charSheet: the builder must fail closed with no rows.
+    expect_true(panel->buildCharacterSheetLines(player).empty(),
+                "character sheet builder should return no rows without a configured charSheet");
+
+    auto charSheet = std::make_shared<CMapStringString>();
+    charSheet->setValues({{"Gold", "getGold"},
+                          {"Level", "getLevel"},
+                          {"Race", "getRaceId"},
+                          {"Broken", "notARealAccessor"},
+                          {"Empty", ""}});
+    panel->setCharSheet(charSheet);
+
+    // The builder resolves the reflective accessors without any GUI/SDL rendering,
+    // keeps the configured (map-ordered) rows, and skips bad or empty accessor
+    // names fail-closed instead of throwing out of the panel.
+    const auto lines = panel->buildCharacterSheetLines(player);
+    expect_true(lines.size() == 3,
+                "character sheet builder should keep resolvable rows and skip bad / empty accessors");
+    if (lines.size() == 3) {
+        expect_true(lines[0].first == "Gold" && lines[0].second == "123",
+                    "character sheet builder should resolve numeric accessors without rendering");
+        expect_true(lines[1].first == "Level" && lines[1].second == "4",
+                    "character sheet builder should preserve the charSheet row ordering");
+        expect_true(lines[2].first == "Race" && lines[2].second == "harpy",
+                    "character sheet builder should fall back to string accessors for identity rows");
+    }
+
+    expect_true(panel->buildCharacterSheetLines(nullptr).empty(),
+                "character sheet builder should return no rows for a missing player");
+}
+
 } // namespace
 
 int main() {
@@ -2193,6 +2233,7 @@ int main() {
     test_layout_runtime_overrides_preserve_serialized_percentage_layouts();
     test_widget_ignores_unarmed_non_left_clicks();
     test_widget_reflective_callbacks_fail_closed_on_bad_config();
+    test_character_panel_sheet_lines_build_without_rendering_and_fail_closed();
     test_list_view_refreshes_from_generic_property_notifications();
     test_list_view_coalesces_property_refreshes_per_event_loop_tick();
     test_list_view_skips_queued_property_refresh_after_detach();


### PR DESCRIPTION
## Summary

Extracts the character-sheet text assembly out of `CGameCharacterPanel::renderObject` into a render-free, unit-testable builder so the panel text can be verified without SDL/rendering.

- `CGameCharacterPanel::buildCharacterSheetLines(player)` (new public method, `src/gui/panel/CGameCharacterPanel.h/.cpp`) resolves the configured `charSheet` accessors against the player and returns the ordered label/value rows. It preserves the exact existing semantics: same labels, same map ordering, empty accessor names and missing players are skipped, int invocation first with a string-invocation fallback (class/race identity accessors), and double-failure logs a warning and skips the row (fail closed) instead of throwing out of the render loop.
- `renderObject` now just joins the returned rows as `label + ": " + value + "\n"` and draws them, so the numeric charSheet output is byte-for-byte unchanged.
- The builder returns label/value pairs (rather than a pre-joined string) so the upcoming race/class label-row substory can extend the row list in one place.
- New unit test `test_character_panel_sheet_lines_build_without_rendering_and_fail_closed` in `tests/unit/test_gui.cpp` (registered in `main()`): asserts numeric rows (`getGold`, `getLevel`) resolve for a known player without any rendering, the string fallback resolves `getRaceId`, ordering is preserved, and a bad accessor (`notARealAccessor`), an empty accessor, a missing charSheet, and a null player are all skipped fail-closed without throwing.

## Validation

- `clang-format -i` run on all changed C++ files; `git diff --check` clean.
- CI (for_unit_tests) validates the build and the new test.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_