### PR TITLE
Strip C++ comments before counting register_type<> in the content gate

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -1641,7 +1641,9 @@ class ContentValidator:
             library = path.stem
             for entry, body in iter_cpp_function_bodies(text):
                 classes = iter_cpp_template_type_names(body, "register_type")
-                for helper_name in re.findall(r"\bnative_plugin::(register_[A-Za-z_]\w*)\s*\(", body):
+                for helper_name in re.findall(
+                    r"\bnative_plugin::(register_[A-Za-z_]\w*)\s*\(", strip_cpp_comments(body)
+                ):
                     classes.update(helper_classes.get(helper_name, set()))
                 if classes:
                     entry_helpers[(library, entry)] = classes
@@ -4395,6 +4397,12 @@ def iter_cpp_function_bodies(text: str) -> list[tuple[str, str]]:
 
 def iter_cpp_template_type_names(text: str, call_name: str) -> set[str]:
     names: set[str] = set()
+    # Strip comments first so a commented-out (runtime-disabled) registration is
+    # not counted as a live one. Without this, iter_cpp_metadata_declarations
+    # (which strips comments) would omit a commented V_META while this scan still
+    # honored a commented register_type<...>, letting an unregistered reflected
+    # type pass the coverage audit and then fail at runtime when built by name.
+    text = strip_cpp_comments(text)
     pattern = re.compile(rf"\b{re.escape(call_name)}\s*<\s*([^,;\n]+)")
     for match in pattern.finditer(text):
         name = normalize_cpp_type(match.group(1))

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -30,6 +30,7 @@ from scripts.validate_content import (
     ScriptPropertyHygieneAllowance,
     classify_creature_templates,
     inventory_creature_overrides,
+    iter_cpp_template_type_names,
     report_legacy_class_checks,
     report_unmigrated_creatures,
     tile_types_by_id,
@@ -4234,6 +4235,22 @@ class TypeRegistrationCoverageAuditTest(unittest.TestCase):
         validator._validate_type_registration_coverage()
         self.assertFalse([issue for issue in validator.issues if "CItem" in issue.message])
         self.assertFalse([issue for issue in validator.issues if '"CCustomTrigger"' in issue.message])
+
+    def test_commented_registration_is_not_counted_as_registration(self):
+        # A commented-out (runtime-disabled) registration must NOT be treated as a
+        # live one; otherwise a reflected type whose only registration is commented
+        # out passes the coverage audit and then fails at runtime when built by
+        # name. iter_cpp_metadata_declarations already strips comments, so this
+        # scan must too, or the two disagree.
+        self.assertEqual({"CFoo"}, iter_cpp_template_type_names("CTypes::register_type<CFoo, CBar>();", "register_type"))
+        self.assertEqual(set(), iter_cpp_template_type_names("// CTypes::register_type<CFoo>();", "register_type"))
+        self.assertEqual(
+            set(),
+            iter_cpp_template_type_names("/* CTypes::register_type<CFoo, CBar>(); */", "register_type"),
+        )
+        # A live registration next to a commented one still resolves to the live type only.
+        mixed = "CTypes::register_type<CLive, CBase>();\n// CTypes::register_type<CDisabled, CBase>();\n"
+        self.assertEqual({"CLive"}, iter_cpp_template_type_names(mixed, "register_type"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The exhaustive `V_META` registration-coverage audit added by #1256 exists to catch reflected engine types that are neither registered nor excluded (so the loader can't be asked to build a type by name and fail at runtime). A proactive review found a **false pass**: the audit can be defeated by a comment.

`iter_cpp_metadata_declarations` strips comments before scanning for `V_META`, but `iter_cpp_template_type_names` scanned **raw** text for `register_type<...>` / `register_type_metadata<...>`. So a registration that is **commented out** — a realistic way to runtime-disable a type while leaving its `V_META` in the header — was still counted as a live registration. The reflected-but-unregistered type then passed the audit green and would fail at runtime when the loader builds it by name.

**Verified repro** (real functions against a temp repo): a `*TypeRegistration.cpp` whose only registration of `CFoo` is `// CTypes::register_type<CFoo, CGameObject>();` collected `static_registered = ['CFoo']` and the audit did **not** flag `CFoo`; a control type with no registration anywhere was correctly flagged — isolating the comment as the cause. Both `//` and `/* ... */` forms trigger it.

## Fix

Strip comments inside `iter_cpp_template_type_names` (which also covers both native-plugin `register_type` scans that route through it), and strip comments before the `native_plugin::register_*` helper-call `findall`. This makes the registration scan consistent with the metadata scan.

## Validation

- `python3 -m unittest tests.test_content_validator` → **161 tests, OK** (adds `test_commented_registration_is_not_counted_as_registration`).
- `python3 scripts/validate_content.py --repo-root .` → **Content validation passed** — confirming no *live* registration in the tree was hidden inside a comment (the fix introduces no false positive).
- `git diff --check` clean.

## Deliberately out of scope

The subagent also noted a **latent** single-template-argument parse limitation in the same helper (`register_type<CNewRoot>()` isn't parsed). It is currently harmless (the only single-arg registration is `register_type<CGameObject>()`, a builtin) and the safe fix requires balanced-angle-bracket handling to avoid breaking the real `register_type<CWrapper<T>>` pattern — so it is left untouched rather than risk a regression in a heavily-relied-upon parser.

Found during the same proactive review that produced #1325 and #1328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_