### PR TITLE
[EPIC_60][STORY_02][SUBSTORY_04] Gate monster auto-heal on tempo instead of a fixed hp threshold

### DIFF
--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -513,11 +513,56 @@ void CRangeController::setDistance(int distance) { this->distance = distance; }
 
 int CRangeController::getDistance() { return distance; }
 
+namespace {
+// Deterministic, pessimistic estimate of one landed opponent hit: the top of the
+// damage range plus the flat damage bonus (CCreature::getDmg() without the
+// miss/crit dice), mitigated by normal resist and armor exactly the way
+// CCreature::hurt()/takeDamage() mitigate a normal-damage strike. Block is a
+// dice roll and is deliberately not credited, keeping the estimate stable and
+// erring toward survival.
+int expected_incoming_hit(const std::shared_ptr<CCreature> &me, const std::shared_ptr<CCreature> &opponent) {
+    auto attack = opponent->getStats();
+    const int raw = std::max(std::max(attack->getDmgMin(), attack->getDmgMax()), 0) + std::max(attack->getDamage(), 0);
+    auto defense = me->getStats();
+    const int afterResist = raw * (100 - defense->getNormalResist()) / 100.0;
+    const int afterArmor = afterResist * ((100 - defense->getArmor()) / 100.0);
+    return std::max(afterArmor, 0);
+}
+
+// Heal items restore getPower() * 20% of max hp (res/plugins/potion.py), capped
+// by the hp actually missing. Returns the estimate for the strongest heal item
+// carried, i.e. the best single-turn hp swing a heal turn could buy.
+int strongest_heal_estimate(const std::shared_ptr<CCreature> &me) {
+    int bestPower = 0;
+    for (const auto &item : me->getItems()) {
+        if (item && item->hasTag(CTag::Heal)) {
+            bestPower = std::max(bestPower, item->getPower());
+        }
+    }
+    const int uncapped = bestPower * me->getHpMax() / 5;
+    return std::min(uncapped, me->getHpMax() - me->getHp());
+}
+
+// A heal turn is only worth its tempo when it actually preserves the combatant:
+// either the creature would not survive the next landed hit anyway (a heal is
+// the only move with a chance to keep it alive), or the strongest heal carried
+// restores more hp than that hit removes (net gain). Healing reflexively at a
+// fixed hp threshold made monsters chain-drink potions against hard hitters
+// while losing more hp per turn than each potion restored.
+bool heal_preserves_combatant(const std::shared_ptr<CCreature> &me, const std::shared_ptr<CCreature> &opponent) {
+    const int incoming = expected_incoming_hit(me, opponent);
+    if (me->getHp() <= incoming) {
+        return true;
+    }
+    return strongest_heal_estimate(me) > incoming;
+}
+} // namespace
+
 bool CMonsterFightController::control(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent) {
     if (!me || !opponent) {
         return false;
     }
-    if (me->getHpRatio() < 75) {
+    if (me->getHpRatio() < 75 && heal_preserves_combatant(me, opponent)) {
         auto object = getLeastPowerfulItemWithTag(me, CTag::Heal);
         if (object) {
             me->useItem(object);

--- a/tests/unit/test_controller.cpp
+++ b/tests/unit/test_controller.cpp
@@ -29,6 +29,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/panel/CGameFightPanel.h"
 #include "handler/CObjectHandler.h"
 #include "object/CCreature.h"
+#include "object/CInteraction.h"
 #include "object/CItem.h"
 #include "object/CMapObject.h"
 #include "object/CPlayer.h"
@@ -745,6 +746,90 @@ void test_monster_fight_controller_uses_mana_item_when_mana_is_low() {
     expect_true(monster->getItems().empty(), "used disposable mana item should be removed from inventory");
 }
 
+std::shared_ptr<CGame> fight_fixture_game() {
+    auto game = std::make_shared<CGame>();
+    auto map = std::make_shared<CMap>();
+    game->setMap(map);
+    map->setGame(game);
+    return game;
+}
+
+std::shared_ptr<CCreature> fight_fixture_monster(const std::shared_ptr<CGame> &game, int stamina, int hp) {
+    auto monster = creature_at(0, 0, 0);
+    monster->setGame(game);
+    monster->getBaseStats()->setStamina(stamina);
+    monster->setHp(hp);
+    return monster;
+}
+
+std::shared_ptr<CCreature> fight_fixture_hitter(const std::shared_ptr<CGame> &game, int dmg) {
+    auto opponent = creature_at(1, 0, 0);
+    opponent->setGame(game);
+    opponent->getBaseStats()->setDmgMin(dmg);
+    opponent->getBaseStats()->setDmgMax(dmg);
+    return opponent;
+}
+
+std::shared_ptr<CPotion> heal_potion(const std::shared_ptr<CGame> &game, int power) {
+    auto potion = std::make_shared<CPotion>();
+    potion->setGame(game);
+    potion->setPower(power);
+    potion->addTag(CTag::Heal);
+    return potion;
+}
+
+void test_monster_fight_controller_attacks_hard_hitter_instead_of_wasting_heal() {
+    auto game = fight_fixture_game();
+    // hpMax 70, hp 35 (50%): the old fixed 75% threshold healed reflexively here.
+    auto monster = fight_fixture_monster(game, 10, 35);
+    // One expected landed hit removes 20 hp; the best heal restores ~14 (power 1 -> 20% of 70).
+    auto opponent = fight_fixture_hitter(game, 20);
+    monster->addItem(heal_potion(game, 1));
+    monster->addAction(std::make_shared<CInteraction>());
+
+    auto controller = std::make_shared<CMonsterFightController>();
+    expect_true(controller->control(monster, opponent),
+                "monster fight controller should attack a hard hitter instead of wasting the turn");
+    expect_true(monster->getItems().size() == 1,
+                "monster should not spend a heal that is outpaced by one expected enemy hit");
+}
+
+void test_monster_fight_controller_heals_when_heal_outpaces_incoming_damage() {
+    auto game = fight_fixture_game();
+    // hpMax 70, hp 20 (28%): hurt, but the expected 2 hp hit is not lethal.
+    auto monster = fight_fixture_monster(game, 10, 20);
+    auto opponent = fight_fixture_hitter(game, 2);
+    // The strongest heal (power 5, capped by missing hp to 50) clearly outpaces the hit.
+    auto weak = heal_potion(game, 1);
+    auto strong = heal_potion(game, 5);
+    monster->addItem(weak);
+    monster->addItem(strong);
+    monster->addAction(std::make_shared<CInteraction>());
+
+    auto controller = std::make_shared<CMonsterFightController>();
+    expect_true(controller->control(monster, opponent),
+                "monster fight controller should heal when the heal is a net gain at low hp");
+    expect_true(monster->getItems().size() == 1, "monster fight controller should use only one heal item per turn");
+    expect_true(monster->hasItem(strong) && !monster->hasItem(weak),
+                "monster fight controller should spend the least powerful heal item first");
+}
+
+void test_monster_fight_controller_heals_when_next_hit_would_kill() {
+    auto game = fight_fixture_game();
+    // hpMax 70, hp 10: the expected 25 hp hit is lethal, so healing is the only play
+    // even though the best heal (~14) restores less than the hit removes.
+    auto monster = fight_fixture_monster(game, 10, 10);
+    auto opponent = fight_fixture_hitter(game, 25);
+    monster->addItem(heal_potion(game, 1));
+    monster->addAction(std::make_shared<CInteraction>());
+
+    auto controller = std::make_shared<CMonsterFightController>();
+    expect_true(controller->control(monster, opponent),
+                "monster fight controller should act when the next hit would kill");
+    expect_true(monster->getItems().empty(),
+                "monster fight controller should heal when it would otherwise die to the next hit");
+}
+
 } // namespace
 
 int main() {
@@ -767,6 +852,9 @@ int main() {
     test_player_fight_controller_start_is_idempotent_and_guards_invalid_encounters();
     test_player_fight_controller_end_is_idempotent_and_guards_invalid_encounters();
     test_monster_fight_controller_uses_mana_item_when_mana_is_low();
+    test_monster_fight_controller_attacks_hard_hitter_instead_of_wasting_heal();
+    test_monster_fight_controller_heals_when_heal_outpaces_incoming_damage();
+    test_monster_fight_controller_heals_when_next_hit_would_kill();
 
     return finish_tests();
 }


### PR DESCRIPTION
## Summary

`CMonsterFightController::control` drank a heal potion whenever `getHpRatio() < 75`, which wasted turns against hard hitters: each turn spent healing restored less hp than the opponent's next hit removed, so the monster lost tempo and hp simultaneously.

The heal branch is now gated on a net-gain decision (`heal_preserves_combatant` in `src/core/CController.cpp`):

- **Emergency**: heal when current hp would not survive one expected landed hit (`hp <= expected incoming`), because a heal is the only move with a chance to keep the combatant alive.
- **Net gain**: otherwise heal only when the strongest heal item carried restores more hp than one expected landed hit removes.
- Against a hard hitter that outpaces every heal (and while hp still survives the hit), the controller attacks instead of reflexively drinking.

Supporting estimates (deterministic on purpose so the AI decision is stable):

- `expected_incoming_hit`: top of the opponent's damage range plus flat damage bonus (mirroring `CCreature::getDmg()` without the miss/crit dice), mitigated by normal resist and armor exactly like `CCreature::hurt()`/`takeDamage()`; block dice are not credited, erring toward survival.
- `strongest_heal_estimate`: heal items restore `getPower() * 20%` of max hp (the `res/plugins/potion.py` convention), capped by the hp actually missing.

Unchanged behavior: the `getHpRatio() < 75` "hurt enough to consider" gate, one heal item per turn, and least-powerful-heal-first item economy (the existing python test `test_monster_fight_controller_uses_only_one_heal_item_per_turn` still passes through the emergency branch).

## Tests

New unit tests in `tests/unit/test_controller.cpp`:

- `test_monster_fight_controller_attacks_hard_hitter_instead_of_wasting_heal` — at 50% hp (where the old threshold healed reflexively) against a 20-damage hitter with only a ~14 hp heal available, the controller attacks and keeps the potion.
- `test_monster_fight_controller_heals_when_heal_outpaces_incoming_damage` — at low hp against a light hitter, the controller heals, consumes exactly one item per turn, and spends the least powerful heal first.
- `test_monster_fight_controller_heals_when_next_hit_would_kill` — when the next expected hit is lethal, the controller heals even though the heal is smaller than the hit.

Worker implementation branch did not modify any queue workbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_