### PR TITLE
Authorize MCP handle method against allowlist before dereferencing it

### DIFF
--- a/mcp.py
+++ b/mcp.py
@@ -1262,6 +1262,19 @@ class EngineMcpServer:
             }
 
         target = self.handles[handle]
+        # Authorize against the allowlist BEFORE dereferencing the client-supplied
+        # method name. Doing getattr(target, method) first would fire the getter of
+        # any non-allowlisted property/descriptor, and the ordering also leaked a
+        # method-existence oracle (missing -> "Unknown method", present-but-denied
+        # -> "not exported"). Fail closed: anything not allowlisted is uniformly
+        # rejected as not exported before the object is touched.
+        if method not in self._allowed_handle_methods_for(target):
+            result = {"error": f"Method `{method}` is not exported for handle calls"}
+            return {
+                "content": [{"type": "text", "text": json.dumps(result, ensure_ascii=False)}],
+                "structuredContent": result,
+                "isError": True,
+            }
         try:
             method_callable = getattr(target, method)
         except AttributeError:
@@ -1274,13 +1287,6 @@ class EngineMcpServer:
 
         if not callable(method_callable):
             result = {"error": f"Attribute `{method}` on handle `{handle}` is not callable"}
-            return {
-                "content": [{"type": "text", "text": json.dumps(result, ensure_ascii=False)}],
-                "structuredContent": result,
-                "isError": True,
-            }
-        if method not in self._allowed_handle_methods_for(target):
-            result = {"error": f"Method `{method}` is not exported for handle calls"}
             return {
                 "content": [{"type": "text", "text": json.dumps(result, ensure_ascii=False)}],
                 "structuredContent": result,

--- a/tests/security/test_mcp_hardening.py
+++ b/tests/security/test_mcp_hardening.py
@@ -87,6 +87,23 @@ class McpHardeningTest(unittest.TestCase):
         for name in mutation_surface:
             self.assertNotIn(name, body)
 
+    def test_handle_call_authorizes_before_dereferencing_method(self):
+        # engine_handle_call must reject a non-allowlisted method BEFORE it does
+        # getattr(target, method): dereferencing first would fire a non-allowlisted
+        # property's getter and leaks a method-existence oracle. The allowlist
+        # check must therefore appear ahead of the client-controlled getattr.
+        source = self.mcp_source
+        allowlist_pos = source.find("if method not in self._allowed_handle_methods_for(target):")
+        getattr_pos = source.find("method_callable = getattr(target, method)")
+        self.assertNotEqual(-1, allowlist_pos, "allowlist check not found")
+        self.assertNotEqual(-1, getattr_pos, "client getattr not found")
+        self.assertLess(
+            allowlist_pos,
+            getattr_pos,
+            "allowlist authorization must precede getattr(target, method) so a "
+            "non-allowlisted method is rejected before the object is dereferenced",
+        )
+
     def test_transport_limits_and_trace_redaction_are_present(self):
         self.assertIn("MAX_MCP_MESSAGE_BYTES = 1024 * 1024", self.mcp_source)
         self.assertIn("MAX_HTTP_SESSIONS", self.mcp_source)


### PR DESCRIPTION
## Summary

Defense-in-depth hardening of the MCP handle-call security boundary, found during a security audit that otherwise verified the boundary sound (exact allowlist membership, sibling-isolated MRO union, safe string-keyed handle resolution, read-only race invariant enforced, no `eval`/`exec`, working pathfinding + map-dir traversal guards).

`engine_handle_call` performed `getattr(target, method)` on the **client-supplied** method name **before** checking it against `MCP_ALLOWED_HANDLE_METHODS`. Two consequences of that ordering:

1. **Dereference-before-authorize**: `getattr` fires the getter of any non-allowlisted property/descriptor before the call is rejected. (No live exploit today — the only properties exposed on handle-able objects are side-effect-free `def_readonly`/`def_readwrite` data members — but it's a latent footgun if a side-effecting property is ever bound.)
2. **Method-existence oracle**: a missing method returned `Unknown method` while a present-but-denied method returned `not exported`, letting a client enumerate which methods exist on an engine object via a handle.

## Fix

Move the allowlist authorization ahead of the `getattr`, so anything not allowlisted is uniformly rejected as `not exported` **before the object is dereferenced** (fail closed / authorize-before-dereference; also collapses the oracle to a single message).

## Compatibility

Behavior is unchanged for every existing test case: `_`-prefixed names are still caught by the earlier `method.startswith("_")` guard, and a present-but-denied method (e.g. `getController`, `__getattribute__`) still returns `not exported`. The only changed case — a *non-existent* + non-allowlisted name — now returns `not exported` instead of `Unknown method`, which is exactly the oracle removal and is not asserted anywhere.

## Validation

- `python3 -m unittest tests.security.test_mcp_hardening` → **6 tests, OK** (adds `test_handle_call_authorizes_before_dereferencing_method`, a source-ordering guard in the suite's established static-assertion style).
- Re-checked the two `test.py` `McpServerTest` runtime assertions (`__getattribute__`, `getController` → "not exported"): both remain satisfied.
- `py_compile` clean; `git diff --check` clean.

Part of the same proactive review that produced #1325, #1328, and #1336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_