### PR TITLE
[EPIC_02][STORY_01][SUBSTORY_01] #618 Add change-kind taxonomy to the CI classifier

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -218,6 +218,15 @@ steps and Windows jobs are skipped after focused workflow validation. The workfl
 `linux-coverage` job that runs `./scripts/run_coverage.sh` when changed paths match the coverage rule; because it is
 path-gated, do not configure it as an always-present branch-protection check.
 
+Alongside the `native-needed` / `coverage-needed` gate outputs, `scripts/ci_change_classifier.py` also emits an
+additive change-**kind** taxonomy consumed by the workflow and poller: `coverage-relevant`, `native-gui`,
+`native-engine`, `content-json-python`, `workflow-python`, `prompts-docs`, and `queue-state-only`. Each changed path is
+assigned exactly one primary kind (GUI C++ before generic engine code, `res/` content before tooling), and **every
+`src/gui/**` descendant is coverage-relevant** so GUI C++ never skips coverage. `queue-state-only` is true only when the
+entire diff is workbook/observation state. These booleans do not change native/coverage need (still taken from the
+`NATIVE`/`COVERAGE` pattern sets); they let the workflow route jobs by kind and are covered by a path-matrix test in
+`tests/test_ci_change_classifier.py`.
+
 The campaign-specific PR gates run inside `linux` when native validation is required. Full-route campaign scenarios are
 scheduled, manual, or label-selected gates inside the same job, so they do not add a separate always-present branch
 protection check.

--- a/scripts/ci_change_classifier.py
+++ b/scripts/ci_change_classifier.py
@@ -85,6 +85,68 @@ LIGHTWEIGHT_PATH_PATTERNS = (
 )
 
 
+# Disjoint change-KIND taxonomy consumed by the workflow and poller. Each changed
+# path is assigned exactly one primary kind by _path_kind() (first match wins, in
+# the order below), so GUI C++ is never mis-bucketed as generic engine code and a
+# res/ content change is never mis-bucketed as an engine change. The workflow can
+# gate expensive jobs from the presence booleans; native/coverage need is still
+# taken from the existing NATIVE/COVERAGE pattern sets (unchanged) for safety.
+GUI_NATIVE_KIND_PATTERNS = ("src/gui/*",)
+ENGINE_NATIVE_KIND_PATTERNS = (
+    "src/*",
+    "native_plugins/*",
+    "random-dungeon-generator/*",
+    "vstd/*",
+    "CMakeLists.txt",
+    "cmake/*",
+    "configure.sh",
+    "configure.bat",
+    "vcpkg.json",
+    "test.py",
+    "tests/unit/*",
+    "tests/fixtures/*",
+    "tests/regression/*",
+)
+CONTENT_KIND_PATTERNS = ("res/*",)
+WORKFLOW_PYTHON_KIND_PATTERNS = (
+    ".github/*",
+    "scripts/*.py",
+    "scripts/*.sh",
+    "tests/test_*.py",
+    "tests/security/*.py",
+)
+QUEUE_STATE_KIND_PATTERNS = (
+    "planning/*.xlsx",
+    "planning/workflow_observations/records/*.json",
+    "planning/workflow_observations/resolutions/*.json",
+)
+PROMPTS_DOCS_KIND_PATTERNS = (
+    "AGENTS.md",
+    "CLAUDE.md",
+    "README.md",
+    "*.md",
+    "docs/*",
+    "prompts/*",
+)
+
+
+def _path_kind(path: str) -> str:
+    """Assign one primary KIND to a changed path (first match wins)."""
+    if matchesAny(path, GUI_NATIVE_KIND_PATTERNS):
+        return "native-gui"
+    if matchesAny(path, ENGINE_NATIVE_KIND_PATTERNS):
+        return "native-engine"
+    if matchesAny(path, CONTENT_KIND_PATTERNS):
+        return "content-json-python"
+    if matchesAny(path, WORKFLOW_PYTHON_KIND_PATTERNS):
+        return "workflow-python"
+    if matchesAny(path, QUEUE_STATE_KIND_PATTERNS):
+        return "queue-state"
+    if matchesAny(path, PROMPTS_DOCS_KIND_PATTERNS):
+        return "prompts-docs"
+    return "unclassified"
+
+
 @dataclass(frozen=True)
 class ChangeClassification:
     paths: tuple[str, ...]
@@ -93,6 +155,16 @@ class ChangeClassification:
     nativeReasons: tuple[str, ...]
     authorityChange: bool = False
     authorityPaths: tuple[str, ...] = ()
+    # Additive KIND taxonomy (presence booleans over the changed set). These do
+    # not alter native/coverage need; they let the workflow route jobs by change
+    # kind and let tests pin the classification of each path category.
+    coverageRelevant: bool = False
+    nativeGui: bool = False
+    nativeEngine: bool = False
+    contentJsonPython: bool = False
+    workflowPython: bool = False
+    promptsDocs: bool = False
+    queueStateOnly: bool = False
 
     @property
     def humanReviewRequired(self) -> bool:
@@ -142,6 +214,9 @@ def classifyPaths(paths: Sequence[str], *, forceNative: bool = False) -> ChangeC
         elif not matchesAny(path, LIGHTWEIGHT_PATH_PATTERNS):
             nativeReasons.append(f"unclassified:{path}")
 
+    kinds = [_path_kind(path) for path in changed]
+    coverageRelevant = any(matchesAny(path, COVERAGE_PATH_PATTERNS) for path in changed)
+
     return ChangeClassification(
         paths=changed,
         coverageNeeded=coverageNeeded,
@@ -149,6 +224,13 @@ def classifyPaths(paths: Sequence[str], *, forceNative: bool = False) -> ChangeC
         nativeReasons=tuple(dict.fromkeys(nativeReasons)),
         authorityChange=authorityChange,
         authorityPaths=authorityPaths,
+        coverageRelevant=coverageRelevant,
+        nativeGui="native-gui" in kinds,
+        nativeEngine="native-engine" in kinds,
+        contentJsonPython="content-json-python" in kinds,
+        workflowPython="workflow-python" in kinds,
+        promptsDocs="prompts-docs" in kinds,
+        queueStateOnly=bool(kinds) and all(kind == "queue-state" for kind in kinds),
     )
 
 
@@ -191,11 +273,23 @@ def changedPaths(base: str, head: str) -> tuple[str, ...]:
 
 
 def writeGithubOutput(path: Path, classification: ChangeClassification) -> None:
+    def line(key: str, value: bool) -> str:
+        return f"{key}={str(value).lower()}\n"
+
     with path.open("a", encoding="utf-8") as handle:
-        handle.write(f"coverage-needed={str(classification.coverageNeeded).lower()}\n")
-        handle.write(f"native-needed={str(classification.nativeNeeded).lower()}\n")
-        handle.write(f"authority-change={str(classification.authorityChange).lower()}\n")
-        handle.write(f"human-review-required={str(classification.humanReviewRequired).lower()}\n")
+        handle.write(line("coverage-needed", classification.coverageNeeded))
+        handle.write(line("native-needed", classification.nativeNeeded))
+        handle.write(line("authority-change", classification.authorityChange))
+        handle.write(line("human-review-required", classification.humanReviewRequired))
+        # Additive KIND taxonomy outputs (available to the workflow for finer job
+        # routing; existing native-needed/coverage-needed gating is unchanged).
+        handle.write(line("coverage-relevant", classification.coverageRelevant))
+        handle.write(line("native-gui", classification.nativeGui))
+        handle.write(line("native-engine", classification.nativeEngine))
+        handle.write(line("content-json-python", classification.contentJsonPython))
+        handle.write(line("workflow-python", classification.workflowPython))
+        handle.write(line("prompts-docs", classification.promptsDocs))
+        handle.write(line("queue-state-only", classification.queueStateOnly))
 
 
 def parseArgs(argv: Sequence[str]) -> argparse.Namespace:
@@ -242,11 +336,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             {
                 "authorityChange": classification.authorityChange,
                 "authorityPaths": list(classification.authorityPaths),
+                "contentJsonPython": classification.contentJsonPython,
                 "coverageNeeded": classification.coverageNeeded,
+                "coverageRelevant": classification.coverageRelevant,
                 "humanReviewRequired": classification.humanReviewRequired,
+                "nativeEngine": classification.nativeEngine,
+                "nativeGui": classification.nativeGui,
                 "nativeNeeded": classification.nativeNeeded,
                 "nativeReasons": list(classification.nativeReasons),
                 "paths": list(classification.paths),
+                "promptsDocs": classification.promptsDocs,
+                "queueStateOnly": classification.queueStateOnly,
+                "workflowPython": classification.workflowPython,
             },
             indent=2,
             sort_keys=True,

--- a/tests/test_ci_change_classifier.py
+++ b/tests/test_ci_change_classifier.py
@@ -101,7 +101,9 @@ class CiChangeClassifierTest(unittest.TestCase):
             ci_change_classifier.writeGithubOutput(output, classification)
 
             self.assertEqual(
-                "coverage-needed=true\nnative-needed=true\nauthority-change=false\nhuman-review-required=false\n",
+                "coverage-needed=true\nnative-needed=true\nauthority-change=false\nhuman-review-required=false\n"
+                "coverage-relevant=true\nnative-gui=true\nnative-engine=false\ncontent-json-python=false\n"
+                "workflow-python=false\nprompts-docs=false\nqueue-state-only=false\n",
                 output.read_text(encoding="utf-8"),
             )
 
@@ -125,9 +127,78 @@ class CiChangeClassifierTest(unittest.TestCase):
                     "native-needed": "false",
                     "authority-change": "false",
                     "human-review-required": "false",
+                    "coverage-relevant": "false",
+                    "native-gui": "false",
+                    "native-engine": "false",
+                    "content-json-python": "false",
+                    "workflow-python": "true",
+                    "prompts-docs": "false",
+                    "queue-state-only": "false",
                 },
                 values,
             )
+
+    def test_kind_taxonomy_partitions_representative_paths(self) -> None:
+        booleans = (
+            "nativeGui",
+            "nativeEngine",
+            "contentJsonPython",
+            "workflowPython",
+            "promptsDocs",
+            "queueStateOnly",
+            "coverageRelevant",
+        )
+        matrix = {
+            "docs/testing.md": {"promptsDocs"},
+            "AGENTS.md": {"promptsDocs"},
+            "prompts/codex-queue-controller.md": {"promptsDocs"},
+            ".github/workflows/other.yml": {"workflowPython"},
+            "scripts/pr_review_audit.py": {"workflowPython"},
+            "scripts/run_coverage.sh": {"workflowPython", "coverageRelevant"},
+            "planning/board.xlsx": {"queueStateOnly"},
+            "res/config/monsters.json": {"contentJsonPython"},
+            "res/maps/nouraajd/script.py": {"contentJsonPython"},
+            "src/gui/panel/CListView.cpp": {"nativeGui", "coverageRelevant"},
+            "src/gui/CAnimation.cpp": {"nativeGui", "coverageRelevant"},
+            "src/core/CGame.cpp": {"nativeEngine", "coverageRelevant"},
+            "native_plugins/foo.cpp": {"nativeEngine", "coverageRelevant"},
+            "tests/unit/test_core.cpp": {"nativeEngine", "coverageRelevant"},
+        }
+        for path, expected in matrix.items():
+            with self.subTest(path=path):
+                classification = ci_change_classifier.classifyPaths([path])
+                actual = {name for name in booleans if getattr(classification, name)}
+                self.assertEqual(expected, actual)
+
+    def test_every_gui_descendant_requires_native_and_coverage(self) -> None:
+        for path in (
+            "src/gui/CAnimation.cpp",
+            "src/gui/panel/CListView.cpp",
+            "src/gui/widget/deep/nested/Foo.cpp",
+        ):
+            with self.subTest(path=path):
+                classification = ci_change_classifier.classifyPaths([path])
+                self.assertTrue(classification.nativeGui)
+                self.assertTrue(classification.coverageRelevant)
+                self.assertTrue(classification.coverageNeeded)
+                self.assertTrue(classification.nativeNeeded)
+
+    def test_queue_state_only_requires_the_whole_change_to_be_queue_state(self) -> None:
+        pure = ci_change_classifier.classifyPaths(["planning/board.xlsx"])
+        self.assertTrue(pure.queueStateOnly)
+        mixed = ci_change_classifier.classifyPaths(["planning/board.xlsx", "docs/x.md"])
+        self.assertFalse(mixed.queueStateOnly)
+        self.assertTrue(mixed.promptsDocs)
+
+    def test_mixed_diff_unions_kinds_and_validation_needs(self) -> None:
+        classification = ci_change_classifier.classifyPaths(
+            ["src/gui/CAnimation.cpp", "docs/x.md", "res/config/monsters.json"]
+        )
+        self.assertTrue(classification.nativeGui)
+        self.assertTrue(classification.promptsDocs)
+        self.assertTrue(classification.contentJsonPython)
+        self.assertTrue(classification.nativeNeeded)
+        self.assertTrue(classification.coverageNeeded)
 
     def test_main_returns_clean_error_when_git_executable_is_missing(self) -> None:
         def raise_missing_git(*_args: object, **_kwargs: object) -> None:


### PR DESCRIPTION
## Summary

Implements **#618** (EPIC_02/STORY_01/SUBSTORY_01). The single change classifier consumed by `build.yml` (the `linux-fast` gate) and `poll_pr_checks.py` exposed only `native-needed`/`coverage-needed`. This adds the **granular change-KIND taxonomy** #618 asks for, so the workflow/poller can route by change kind and GUI C++ never skips coverage.

The headline "verified problem" (GUI C++ missing coverage) is actually already satisfied — `src/gui/*` has been in `COVERAGE_PATH_PATTERNS` since #898 and fnmatch's `*` crosses `/`, so `src/gui/**` descendants already require native+coverage (empirically confirmed). This PR delivers the remaining, untested piece: the tested granular taxonomy, and **pins** the GUI-coverage invariant so it can't silently regress.

## Changes

- **`scripts/ci_change_classifier.py`** — additive booleans on `ChangeClassification`: `coverageRelevant`, `nativeGui`, `nativeEngine`, `contentJsonPython`, `workflowPython`, `promptsDocs`, `queueStateOnly`. A new `_path_kind()` assigns each changed path exactly one primary kind (first match wins: GUI C++ → `native-gui` before generic engine; `res/` → `content-json-python` before tooling; etc.). `queue-state-only` is true only when the whole diff is workbook/observation state. Emitted as GitHub `--github-output` lines and in the JSON payload.
- **`tests/test_ci_change_classifier.py`** — path-matrix test across docs / workflow-python / queue-state / content / GUI / engine / native-plugin / tests-unit / coverage-script / mixed; a `src/gui/**`-coverage lock test; a mixed-diff union test; and updates to the two exact-output assertions.
- **`docs/testing.md`** — documents the taxonomy and the GUI-coverage guarantee.

## Safety / blast radius

`native-needed` and `coverage-needed` keep their existing `NATIVE`/`COVERAGE`-pattern computation, so `build.yml`'s job gating is **unchanged** — this is strictly additive, near-zero runtime blast radius. No `build.yml` job-graph rewrite. The already-correct gating plus this enrichment satisfies every acceptance criterion, now pinned by tests:

- GUI C++ requires native **and** coverage ✓
- workflow-only / docs / queue-state changes skip native ✓
- required checks reach terminal states (unchanged `linux-fast` always-terminal gate) ✓
- mixed diffs use strict union of kinds and needs ✓

## Validation

- `python3 -m unittest tests.test_ci_change_classifier tests.test_poll_pr_checks tests.test_prompt_inventory` → **74 tests, OK**.
- `python3 scripts/ci_change_classifier.py --path src/gui/panel/CListView.cpp` → `nativeGui=true, coverageRelevant=true, coverageNeeded=true, nativeNeeded=true`.
- `git diff --check` clean.

> Note: this touches `ci_change_classifier.py`, a CI-authority file, so by the poller's own rule the PR is `human-review-required` and forces native+coverage — intentional; it should get human review before merge rather than auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_