### PR TITLE
Fix duplicate layer properties in Warden's Road map JSON

### DIFF
--- a/res/maps/gravemoor/map.json
+++ b/res/maps/gravemoor/map.json
@@ -28,21 +28,6 @@
    "opacity": 1,
    "properties": {
     "default": "SwampTile",
-    "level": "0",
-    "xBound": "23",
-    "yBound": "23"
-   },
-   "propertytypes": {
-    "default": "string",
-    "level": "string",
-    "xBound": "string",
-    "yBound": "string"
-   },
-   "visible": true,
-   "x": 0,
-   "y": 0,
-   "properties": {
-    "default": "SwampTile",
     "outOfBounds": "MountainTile",
     "level": "0",
     "xBound": "23",
@@ -55,6 +40,9 @@
     "xBound": "string",
     "yBound": "string"
    },
+   "visible": true,
+   "x": 0,
+   "y": 0,
    "data": [
     12,
     12,
@@ -648,12 +636,6 @@
    "x": 0,
    "y": 0,
    "draworder": "topdown",
-   "properties": {
-    "level": "0"
-   },
-   "propertytypes": {
-    "level": "string"
-   },
    "objects": [
     {
      "height": 32,

--- a/res/maps/hearthfall/map.json
+++ b/res/maps/hearthfall/map.json
@@ -28,21 +28,6 @@
    "opacity": 1,
    "properties": {
     "default": "GrassTile",
-    "level": "0",
-    "xBound": "23",
-    "yBound": "23"
-   },
-   "propertytypes": {
-    "default": "string",
-    "level": "string",
-    "xBound": "string",
-    "yBound": "string"
-   },
-   "visible": true,
-   "x": 0,
-   "y": 0,
-   "properties": {
-    "default": "GrassTile",
     "outOfBounds": "MountainTile",
     "level": "0",
     "xBound": "23",
@@ -55,6 +40,9 @@
     "xBound": "string",
     "yBound": "string"
    },
+   "visible": true,
+   "x": 0,
+   "y": 0,
    "data": [
     12,
     12,
@@ -648,12 +636,6 @@
    "x": 0,
    "y": 0,
    "draworder": "topdown",
-   "properties": {
-    "level": "0"
-   },
-   "propertytypes": {
-    "level": "string"
-   },
    "objects": [
     {
      "height": 32,

--- a/res/maps/usurpergate/map.json
+++ b/res/maps/usurpergate/map.json
@@ -28,21 +28,6 @@
    "opacity": 1,
    "properties": {
     "default": "WastelandTile",
-    "level": "0",
-    "xBound": "23",
-    "yBound": "23"
-   },
-   "propertytypes": {
-    "default": "string",
-    "level": "string",
-    "xBound": "string",
-    "yBound": "string"
-   },
-   "visible": true,
-   "x": 0,
-   "y": 0,
-   "properties": {
-    "default": "WastelandTile",
     "outOfBounds": "MountainTile",
     "level": "0",
     "xBound": "23",
@@ -55,6 +40,9 @@
     "xBound": "string",
     "yBound": "string"
    },
+   "visible": true,
+   "x": 0,
+   "y": 0,
    "data": [
     12,
     12,
@@ -648,12 +636,6 @@
    "x": 0,
    "y": 0,
    "draworder": "topdown",
-   "properties": {
-    "level": "0"
-   },
-   "propertytypes": {
-    "level": "string"
-   },
    "objects": [
     {
      "height": 32,


### PR DESCRIPTION
## Summary

Two squash merges — #1324 (Warden's Road map layer properties) and #1327 (Heroes 3 items) — each independently added a legacy object-style `properties`/`propertytypes` block to the tile and object layers of the `gravemoor`, `hearthfall`, and `usurpergate` maps. The merged result left every layer in those three maps with **duplicate `properties` and `propertytypes` keys**.

Python's `json` module tolerates duplicate keys (last one wins), so `scripts/validate_content.py` and the content-validator unit tests stayed green. But the engine parses map JSON with **simdjson**, which rejects documents with duplicate object keys (`TAPE_ERROR`). At runtime `CMapLoader` therefore failed to load all three maps, breaking:

- `test_map_walkthrough_{gravemoor,hearthfall,usurpergate}`
- `test_stdio_map_walkthrough_{gravemoor,hearthfall,usurpergate}`
- `test_wardens_road_campaign_mercy_route` and `test_wardens_road_campaign_wrath_route_clamps_gold`
- `test_config_entries_create_in_global_and_map_contexts`
- `test_map_json_tiled_compatibility`

## Fix

Collapse each layer back to a single `properties`/`propertytypes` block, keeping the richer variant from #1324 that also declares the `outOfBounds` tile. Net change is 3 files, removing the duplicated blocks only.

## Validation

- `python3 scripts/validate_content.py --repo-root .` — passed
- Clean rebuild + the 10 previously-failing tests above — all pass
- Verified via `json.load(object_pairs_hook=...)` that no layer object retains duplicate keys

> Note: `main` currently has an unrelated, pre-existing CI failure (`test_nouraajd_ritual_return_round_trip_preserves_persistent_state`) that predates this branch and is independent of these map files. This PR neither causes nor fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYtPr2qHrT8FpC6qu3PkW7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYtPr2qHrT8FpC6qu3PkW7)_