### PR TITLE
[EPIC_07][STORY_01][SUBSTORY_02] Render player race and class labels

### DIFF
--- a/src/gui/panel/CGameCharacterPanel.cpp
+++ b/src/gui/panel/CGameCharacterPanel.cpp
@@ -47,6 +47,29 @@ CGameCharacterPanel::buildCharacterSheetLines(const std::shared_ptr<CPlayer> &pl
             }
         }
     }
+    // Identity rows: the player's race and class rendered as human-readable
+    // labels after the configured numeric / string rows. These come from the
+    // archetype *Label accessors and fail closed exactly like the rows above -
+    // an empty or throwing label is skipped so it can never escape the render
+    // loop or emit a blank row.
+    if (player) {
+        try {
+            std::string race = player->getArchetypeRaceLabel();
+            if (!race.empty()) {
+                lines.emplace_back("Race", race);
+            }
+        } catch (const std::exception &exception) {
+            vstd::logger::warning("Ignoring character sheet race label failure:", exception.what());
+        }
+        try {
+            std::string creatureClass = player->getArchetypeClassLabel();
+            if (!creatureClass.empty()) {
+                lines.emplace_back("Class", creatureClass);
+            }
+        } catch (const std::exception &exception) {
+            vstd::logger::warning("Ignoring character sheet class label failure:", exception.what());
+        }
+    }
     return lines;
 }
 

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -2225,6 +2225,53 @@ void test_character_panel_sheet_lines_build_without_rendering_and_fail_closed() 
                 "character sheet builder should return no rows for a missing player");
 }
 
+void test_character_panel_sheet_lines_render_race_and_class_labels() {
+    auto panel = std::make_shared<CGameCharacterPanel>();
+    auto charSheet = std::make_shared<CMapStringString>();
+    charSheet->setValues({{"Gold", "getGold"}});
+    panel->setCharSheet(charSheet);
+
+    auto player = std::make_shared<CPlayer>();
+    player->setBaseStats(player_stats());
+    player->setGold(50);
+    player->setTypeId("Harpy");
+    player->setLabel("Harpy Windcaller");
+
+    // The builder appends the archetype race / class identity rows after the
+    // configured rows, resolving them from the human-readable *Label accessors
+    // without any GUI/SDL rendering.
+    const auto lines = panel->buildCharacterSheetLines(player);
+    auto find_row = [&](const std::string &label) -> std::string {
+        for (const auto &[key, value] : lines) {
+            if (key == label) {
+                return value;
+            }
+        }
+        return "";
+    };
+    expect_true(lines.size() == 3, "builder should append the Race and Class rows after the configured rows");
+    expect_true(!lines.empty() && lines.front().first == "Gold",
+                "configured rows should still precede the appended identity rows");
+    expect_true(find_row("Race") == "Harpy Windcaller",
+                "character sheet builder should render the archetype race label");
+    expect_true(find_row("Class") == "Harpy Windcaller",
+                "character sheet builder should render the archetype class label");
+
+    // Fail-closed: with no label / type id / name the identity labels resolve
+    // empty and are skipped rather than emitting blank Race / Class rows.
+    auto anonymous = std::make_shared<CPlayer>();
+    anonymous->setBaseStats(player_stats());
+    anonymous->setGold(0);
+    const auto anonymousLines = panel->buildCharacterSheetLines(anonymous);
+    bool hasIdentityRow = false;
+    for (const auto &[key, value] : anonymousLines) {
+        if (key == "Race" || key == "Class") {
+            hasIdentityRow = true;
+        }
+    }
+    expect_true(!hasIdentityRow, "character sheet builder should skip empty race / class labels fail-closed");
+}
+
 } // namespace
 
 int main() {
@@ -2234,6 +2281,7 @@ int main() {
     test_widget_ignores_unarmed_non_left_clicks();
     test_widget_reflective_callbacks_fail_closed_on_bad_config();
     test_character_panel_sheet_lines_build_without_rendering_and_fail_closed();
+    test_character_panel_sheet_lines_render_race_and_class_labels();
     test_list_view_refreshes_from_generic_property_notifications();
     test_list_view_coalesces_property_refreshes_per_event_loop_tick();
     test_list_view_skips_queued_property_refresh_after_detach();


### PR DESCRIPTION
## Summary

Extends the render-free character sheet builder added in #1334 to also render the player's race and class as labeled rows.

- `CGameCharacterPanel::buildCharacterSheetLines` now appends a `Race` row and a `Class` row after the configured char-sheet rows, resolved from the human-readable archetype accessors `getArchetypeRaceLabel()` / `getArchetypeClassLabel()` (the `*Label` variants, not the `*Id` variants).
- The new rows follow the same fail-closed pattern already used in the builder: an empty or throwing label is skipped so it can never escape the render loop or emit a blank row. Existing numeric/string row ordering is preserved (identity rows are appended last).
- `renderObject` is unchanged and remains a pure join of the returned label/value rows, so nothing else about the render path changes.

## Tests

- Added `test_character_panel_sheet_lines_render_race_and_class_labels` in `tests/unit/test_gui.cpp` (registered in `main()`), asserting:
  - For a player with a known archetype (typeId + label set), the builder produces `Race` and `Class` rows with the human-readable label, without any GUI/SDL rendering.
  - Configured rows still precede the appended identity rows.
  - Fail-closed: for a player with no label/type id/name, the empty race/class labels are skipped rather than emitting blank rows.
- The existing `test_character_panel_sheet_lines_build_without_rendering_and_fail_closed` remains valid (its player has no label/type id/name, so the identity rows resolve empty and are skipped).

Files changed:
- `src/gui/panel/CGameCharacterPanel.cpp`
- `tests/unit/test_gui.cpp`

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_