### PR TITLE
[EPIC_01][STORY_01][SUBSTORY_01] #614 Add read-only controller transition reconciler (foundation)

### DIFF
--- a/scripts/controller_reconciler.py
+++ b/scripts/controller_reconciler.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Durable, read-only controller transition reconciler.
+
+Controller state is spread across the XLSX queue row, claim IDs, worktrees,
+branches, the implementation pull request, its CI, and the terminal workbook
+pull request. After a restart a controller must decide what to do next WITHOUT
+re-doing a transition it already performed (a duplicate claim, a duplicate
+implementation PR, a duplicate terminal/DONE write).
+
+This module derives a single deterministic controller state from a snapshot of
+that evidence and returns the next action plus an idempotency key for the write
+that action would perform. It is strictly read-only: it consumes a JSON evidence
+blob and returns JSON. It never touches the workbook, git, or GitHub, so running
+`snapshot`/`reconcile`/`next-action` can never itself duplicate a transition.
+
+Correlation is by exact identity (claim ID, issue name, owner, branch, head SHA,
+PR number). Title matching alone is never authoritative. When the evidence
+contradicts itself the reconciler returns ``recovery_required`` with the
+conflicting evidence rather than guessing a write.
+
+Evidence schema (all fields optional unless noted; extra keys are ignored)::
+
+    {
+      "issueName": "[EPIC_..]..",          # required
+      "owner": "controller/ctrl-x/subagent-1",
+      "claimId": "abc-123",                # required for any write transition
+      "queue": { "status": "IN_PROGRESS", "owner": "...", "claimId": "...",
+                 "issueName": "...", "stale": false },
+      "implementationPr": { "number": 12, "claimId": "...", "issueName": "...",
+                 "owner": "...", "headSha": "...", "branch": "...",
+                 "merged": false, "mergeableState": "clean",
+                 "statusCheckRollup": [ ... ] },   # normalized by pr_review_audit
+      "terminalPr": { "number": 13, "claimId": "...", "merged": false },
+      "worktreeReady": true,               # local evidence (subagent registry)
+      "workerRunning": true
+    }
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+
+try:
+    import pr_review_audit as audit
+except ImportError:  # pragma: no cover - used when imported as scripts.controller_reconciler
+    from scripts import pr_review_audit as audit
+
+# Controller lifecycle states (durable evidence only; worktree/worker states are
+# supplied as local evidence by the subagent registry, not inferred here).
+STATE_CLAIM_SELECTED = "claim_selected"
+STATE_WORKTREE_READY = "worktree_ready"
+STATE_WORKER_RUNNING = "worker_running"
+STATE_IMPLEMENTATION_PR_OPEN = "implementation_pr_open"
+STATE_CI_PENDING = "ci_pending"
+STATE_CI_PASSED = "ci_passed"
+STATE_CI_FAILED = "ci_failed"
+STATE_IMPLEMENTATION_MERGED = "implementation_merged"
+STATE_TERMINAL_PR_OPEN = "terminal_pr_open"
+STATE_DONE = "done"
+STATE_BLOCKED = "blocked"
+STATE_RECOVERY_REQUIRED = "recovery_required"
+
+# Deterministic next actions. Each maps to exactly one write a controller would
+# perform; NONE / WAIT_FOR_CI / RECOVERY_REQUIRED perform no write.
+ACTION_NONE = "none"
+ACTION_CREATE_WORKTREE = "create_worktree"
+ACTION_RUN_WORKER = "run_worker"
+ACTION_OPEN_IMPLEMENTATION_PR = "open_implementation_pr"
+ACTION_WAIT_FOR_CI = "wait_for_ci"
+ACTION_FIX_CI = "fix_ci"
+ACTION_MERGE_IMPLEMENTATION = "merge_implementation"
+ACTION_MARK_DONE = "mark_done"
+ACTION_RECLAIM_OR_RECOVER = "reclaim_or_recover"
+ACTION_RECOVERY_REQUIRED = "recovery_required"
+
+# Actions that perform a durable write and therefore carry an idempotency key.
+_WRITE_ACTIONS = frozenset(
+    {
+        ACTION_CREATE_WORKTREE,
+        ACTION_RUN_WORKER,
+        ACTION_OPEN_IMPLEMENTATION_PR,
+        ACTION_MERGE_IMPLEMENTATION,
+        ACTION_MARK_DONE,
+    }
+)
+
+
+class ReconcilerError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ControllerSnapshot:
+    issueName: str
+    claimId: str
+    owner: str
+    state: str
+    nextAction: str
+    idempotencyKey: str | None
+    contradictions: tuple[str, ...] = ()
+    evidence: tuple[str, ...] = ()
+
+    def toPayload(self) -> dict[str, Any]:
+        return {
+            "issueName": self.issueName,
+            "claimId": self.claimId,
+            "owner": self.owner,
+            "state": self.state,
+            "nextAction": self.nextAction,
+            "idempotencyKey": self.idempotencyKey,
+            "contradictions": list(self.contradictions),
+            "evidence": list(self.evidence),
+        }
+
+
+@dataclass
+class _Facts:
+    issueName: str
+    claimId: str
+    owner: str
+    queue: dict[str, Any]
+    implementationPr: dict[str, Any] | None
+    terminalPr: dict[str, Any] | None
+    worktreeReady: bool
+    workerRunning: bool
+    contradictions: list[str] = field(default_factory=list)
+    evidence: list[str] = field(default_factory=list)
+
+
+def idempotencyKey(claimId: str, transition: str) -> str:
+    """Stable key for a write transition: exact claim ID + transition type.
+
+    Re-deriving the same state after a restart yields the same key, so a caller
+    that records applied keys can skip a transition it already performed.
+    """
+    if not claimId:
+        raise ReconcilerError("idempotency key requires a non-empty claim id")
+    return f"{claimId}:{transition}"
+
+
+def _asDict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _str(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _prField(record: dict[str, Any], *names: str) -> Any:
+    return audit.firstValue(record, *names, default=None)
+
+
+def _mismatch(facts: _Facts, label: str, expected: str, actual: str) -> None:
+    if expected and actual and expected != actual:
+        facts.contradictions.append(f"{label} mismatch: expected {expected!r}, saw {actual!r}")
+
+
+def _correlatePr(facts: _Facts, record: dict[str, Any], role: str) -> None:
+    """Verify a PR record belongs to this claim/issue/owner by exact identity."""
+    prClaim = _str(_prField(record, "claimId", "claim_id"))
+    prIssue = _str(_prField(record, "issueName", "issue", "linkedIssue"))
+    prOwner = _str(_prField(record, "owner", "author"))
+    _mismatch(facts, f"{role} PR claim id", facts.claimId, prClaim)
+    _mismatch(facts, f"{role} PR issue name", facts.issueName, prIssue)
+    # Owner is advisory (a PR may be opened by a bot account); only flag when the
+    # PR explicitly records a controller owner that differs from this claim's.
+    if prOwner.startswith("controller/"):
+        _mismatch(facts, f"{role} PR owner", facts.owner, prOwner)
+
+
+def _ciState(record: dict[str, Any]) -> audit.CheckSummary:
+    return audit.checkSummary(record)
+
+
+def buildFacts(evidence: dict[str, Any]) -> _Facts:
+    if not isinstance(evidence, dict):
+        raise ReconcilerError("evidence must be a JSON object")
+    issueName = _str(evidence.get("issueName"))
+    if not issueName:
+        raise ReconcilerError("evidence.issueName is required")
+    queue = _asDict(evidence.get("queue"))
+    claimId = _str(evidence.get("claimId")) or _str(audit.firstValue(queue, "claimId", "claim_id", default=""))
+    owner = _str(evidence.get("owner")) or audit.queueOwner(queue)
+    impl = evidence.get("implementationPr")
+    term = evidence.get("terminalPr")
+    facts = _Facts(
+        issueName=issueName,
+        claimId=claimId,
+        owner=owner,
+        queue=queue,
+        implementationPr=impl if isinstance(impl, dict) else None,
+        terminalPr=term if isinstance(term, dict) else None,
+        worktreeReady=audit.truthy(evidence.get("worktreeReady")),
+        workerRunning=audit.truthy(evidence.get("workerRunning")),
+    )
+
+    # Queue row must describe this issue; a row for a different issue is a
+    # correlation error, not a guessable transition.
+    queueIssue = _str(audit.firstValue(queue, "issueName", "issue", default=""))
+    _mismatch(facts, "queue issue name", issueName, queueIssue)
+    queueClaim = _str(audit.firstValue(queue, "claimId", "claim_id", default=""))
+    if claimId and queueClaim:
+        _mismatch(facts, "queue claim id", claimId, queueClaim)
+
+    if facts.implementationPr is not None:
+        _correlatePr(facts, facts.implementationPr, "implementation")
+    if facts.terminalPr is not None:
+        _correlatePr(facts, facts.terminalPr, "terminal")
+    return facts
+
+
+def _deriveState(facts: _Facts) -> str:
+    queueStatus = audit.queueStatus(facts.queue)
+    implMerged = facts.implementationPr is not None and audit.truthy(
+        audit.firstValue(facts.implementationPr, "merged", default=False)
+    )
+
+    # Contradiction: implementation merged but the queue row was never claimed.
+    if implMerged and queueStatus in {"not_started", ""}:
+        facts.contradictions.append("implementation PR merged but queue row is not claimed")
+    # Contradiction: queue marked DONE while an implementation PR is still open.
+    if queueStatus == "done" and facts.implementationPr is not None and not implMerged:
+        facts.contradictions.append("queue row is DONE but implementation PR is still open")
+
+    if facts.contradictions:
+        return STATE_RECOVERY_REQUIRED
+
+    if queueStatus == "done":
+        return STATE_DONE
+    if queueStatus == "blocked":
+        return STATE_BLOCKED
+
+    if facts.implementationPr is not None:
+        if implMerged:
+            # Merged implementation but the row isn't DONE yet -> terminal/DONE
+            # reconciliation is what remains.
+            if facts.terminalPr is not None and not audit.truthy(
+                audit.firstValue(facts.terminalPr, "merged", default=False)
+            ):
+                return STATE_TERMINAL_PR_OPEN
+            return STATE_IMPLEMENTATION_MERGED
+        ci = _ciState(facts.implementationPr)
+        if ci.ambiguous:
+            facts.contradictions.append(f"ambiguous CI identity: {', '.join(ci.ambiguous)}")
+            return STATE_RECOVERY_REQUIRED
+        if ci.state == "failure":
+            return STATE_CI_FAILED
+        if ci.state in {"pending", "unknown"}:
+            return STATE_CI_PENDING
+        if ci.state == "success":
+            return STATE_CI_PASSED
+        return STATE_IMPLEMENTATION_PR_OPEN
+
+    # No implementation PR yet: decide by claim / local evidence.
+    if audit.queueClaimIsStale(facts.queue):
+        return STATE_RECOVERY_REQUIRED
+    if facts.workerRunning:
+        return STATE_WORKER_RUNNING
+    if facts.worktreeReady:
+        return STATE_WORKTREE_READY
+    if queueStatus == "in_progress":
+        return STATE_CLAIM_SELECTED
+    # No claim, no PR, no local evidence: nothing selected for this issue.
+    return STATE_CLAIM_SELECTED
+
+
+def _nextAction(state: str, facts: _Facts) -> str:
+    if state == STATE_RECOVERY_REQUIRED:
+        return ACTION_RECOVERY_REQUIRED
+    if state == STATE_DONE:
+        return ACTION_NONE
+    if state == STATE_BLOCKED:
+        return ACTION_NONE
+    if state == STATE_CLAIM_SELECTED:
+        return ACTION_CREATE_WORKTREE
+    if state == STATE_WORKTREE_READY:
+        return ACTION_RUN_WORKER
+    if state == STATE_WORKER_RUNNING:
+        return ACTION_OPEN_IMPLEMENTATION_PR
+    if state == STATE_CI_PENDING or state == STATE_IMPLEMENTATION_PR_OPEN:
+        return ACTION_WAIT_FOR_CI
+    if state == STATE_CI_FAILED:
+        return ACTION_FIX_CI
+    if state == STATE_CI_PASSED:
+        # Only merge when the PR is actually mergeable; a dirty/blocked state is
+        # not a merge signal.
+        merge = audit.mergeState(facts.implementationPr or {})
+        if merge in {"dirty", "blocked", "behind"}:
+            return ACTION_FIX_CI
+        return ACTION_MERGE_IMPLEMENTATION
+    if state == STATE_IMPLEMENTATION_MERGED:
+        return ACTION_MARK_DONE
+    if state == STATE_TERMINAL_PR_OPEN:
+        return ACTION_WAIT_FOR_CI
+    return ACTION_NONE
+
+
+def reconcile(evidence: dict[str, Any]) -> ControllerSnapshot:
+    facts = buildFacts(evidence)
+    state = _deriveState(facts)
+    action = _nextAction(state, facts)
+    key: str | None = None
+    if action in _WRITE_ACTIONS:
+        if not facts.claimId:
+            # A write transition without a claim id cannot be made idempotent, so
+            # refuse to recommend it rather than risk a duplicate.
+            facts.contradictions.append(f"action {action} requires a claim id for idempotency")
+            state = STATE_RECOVERY_REQUIRED
+            action = ACTION_RECOVERY_REQUIRED
+        else:
+            key = idempotencyKey(facts.claimId, action)
+    return ControllerSnapshot(
+        issueName=facts.issueName,
+        claimId=facts.claimId,
+        owner=facts.owner,
+        state=state,
+        nextAction=action,
+        idempotencyKey=key,
+        contradictions=tuple(facts.contradictions),
+        evidence=tuple(facts.evidence),
+    )
+
+
+def snapshot(evidence: dict[str, Any]) -> ControllerSnapshot:
+    """Alias for reconcile(): both derive the read-only snapshot deterministically."""
+    return reconcile(evidence)
+
+
+def _loadEvidence(path: str | None) -> dict[str, Any]:
+    if path and path != "-":
+        with open(path, encoding="utf-8") as handle:
+            raw = handle.read()
+    else:
+        raw = sys.stdin.read()
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ReconcilerError(f"evidence is not valid JSON: {exc}") from exc
+
+
+def parseArgs(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("snapshot", "reconcile", "next-action"):
+        p = sub.add_parser(name, help=f"Read-only {name} over a controller evidence blob.")
+        p.add_argument("--evidence-file", help="Path to a JSON evidence blob; '-' or omitted reads stdin.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parseArgs(sys.argv[1:] if argv is None else argv)
+    try:
+        evidence = _loadEvidence(args.evidence_file)
+        result = reconcile(evidence)
+    except ReconcilerError as exc:
+        print(f"controller_reconciler: {exc}", file=sys.stderr)
+        return 2
+    if args.command == "next-action":
+        payload: dict[str, Any] = {"nextAction": result.nextAction, "idempotencyKey": result.idempotencyKey}
+    else:
+        payload = result.toPayload()
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    # A required recovery is a non-zero, non-crash signal so callers can branch.
+    return 1 if result.state == STATE_RECOVERY_REQUIRED else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_controller_reconciler.py
+++ b/tests/test_controller_reconciler.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from scripts import controller_reconciler as reconciler
+
+ISSUE = "[EPIC_01][STORY_01][SUBSTORY_01] #614 Add durable controller transition reconciler"
+
+
+def rollup(name: str, status: str, conclusion: str | None = None) -> list[dict[str, object]]:
+    check: dict[str, object] = {"name": name, "status": status}
+    if conclusion is not None:
+        check["conclusion"] = conclusion
+    return [check]
+
+
+def evidence(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "issueName": ISSUE,
+        "claimId": "claim-1",
+        "owner": "controller/ctrl-1/subagent-1",
+        "queue": {"status": "IN_PROGRESS", "issueName": ISSUE, "claimId": "claim-1"},
+    }
+    base.update(overrides)
+    return base
+
+
+class ControllerReconcilerStateMatrixTest(unittest.TestCase):
+    def assertState(self, ev: dict[str, object], state: str, action: str) -> reconciler.ControllerSnapshot:
+        snapshot = reconciler.reconcile(ev)
+        self.assertEqual(state, snapshot.state)
+        self.assertEqual(action, snapshot.nextAction)
+        return snapshot
+
+    def test_claim_selected_recommends_worktree(self) -> None:
+        self.assertState(evidence(), reconciler.STATE_CLAIM_SELECTED, reconciler.ACTION_CREATE_WORKTREE)
+
+    def test_worktree_ready_recommends_worker(self) -> None:
+        self.assertState(
+            evidence(worktreeReady=True), reconciler.STATE_WORKTREE_READY, reconciler.ACTION_RUN_WORKER
+        )
+
+    def test_worker_running_recommends_open_pr(self) -> None:
+        self.assertState(
+            evidence(workerRunning=True),
+            reconciler.STATE_WORKER_RUNNING,
+            reconciler.ACTION_OPEN_IMPLEMENTATION_PR,
+        )
+
+    def test_ci_pending_waits(self) -> None:
+        ev = evidence(
+            implementationPr={
+                "claimId": "claim-1",
+                "issueName": ISSUE,
+                "statusCheckRollup": rollup("linux", "IN_PROGRESS"),
+            }
+        )
+        self.assertState(ev, reconciler.STATE_CI_PENDING, reconciler.ACTION_WAIT_FOR_CI)
+
+    def test_ci_failed_fixes(self) -> None:
+        ev = evidence(
+            implementationPr={
+                "claimId": "claim-1",
+                "issueName": ISSUE,
+                "statusCheckRollup": rollup("linux", "COMPLETED", "FAILURE"),
+            }
+        )
+        self.assertState(ev, reconciler.STATE_CI_FAILED, reconciler.ACTION_FIX_CI)
+
+    def test_ci_passed_clean_merges(self) -> None:
+        ev = evidence(
+            implementationPr={
+                "claimId": "claim-1",
+                "issueName": ISSUE,
+                "mergeableState": "clean",
+                "statusCheckRollup": rollup("linux", "COMPLETED", "SUCCESS"),
+            }
+        )
+        snapshot = self.assertState(ev, reconciler.STATE_CI_PASSED, reconciler.ACTION_MERGE_IMPLEMENTATION)
+        self.assertEqual("claim-1:merge_implementation", snapshot.idempotencyKey)
+
+    def test_ci_passed_but_dirty_does_not_merge(self) -> None:
+        ev = evidence(
+            implementationPr={
+                "claimId": "claim-1",
+                "issueName": ISSUE,
+                "mergeableState": "dirty",
+                "statusCheckRollup": rollup("linux", "COMPLETED", "SUCCESS"),
+            }
+        )
+        self.assertState(ev, reconciler.STATE_CI_PASSED, reconciler.ACTION_FIX_CI)
+
+    def test_implementation_merged_marks_done(self) -> None:
+        ev = evidence(implementationPr={"claimId": "claim-1", "issueName": ISSUE, "merged": True})
+        self.assertState(ev, reconciler.STATE_IMPLEMENTATION_MERGED, reconciler.ACTION_MARK_DONE)
+
+    def test_terminal_pr_open_waits(self) -> None:
+        ev = evidence(
+            implementationPr={"claimId": "claim-1", "issueName": ISSUE, "merged": True},
+            terminalPr={"claimId": "claim-1", "issueName": ISSUE, "merged": False},
+        )
+        self.assertState(ev, reconciler.STATE_TERMINAL_PR_OPEN, reconciler.ACTION_WAIT_FOR_CI)
+
+    def test_done_is_terminal(self) -> None:
+        ev = evidence(queue={"status": "DONE", "issueName": ISSUE})
+        self.assertState(ev, reconciler.STATE_DONE, reconciler.ACTION_NONE)
+
+    def test_blocked_is_terminal(self) -> None:
+        ev = evidence(queue={"status": "BLOCKED", "issueName": ISSUE})
+        self.assertState(ev, reconciler.STATE_BLOCKED, reconciler.ACTION_NONE)
+
+    def test_stale_claim_requires_recovery(self) -> None:
+        ev = evidence(queue={"status": "IN_PROGRESS", "issueName": ISSUE, "stale": True})
+        self.assertState(ev, reconciler.STATE_RECOVERY_REQUIRED, reconciler.ACTION_RECOVERY_REQUIRED)
+
+
+class ControllerReconcilerContradictionTest(unittest.TestCase):
+    def test_done_row_with_open_implementation_pr_is_recovery(self) -> None:
+        ev = evidence(
+            queue={"status": "DONE", "issueName": ISSUE},
+            implementationPr={"claimId": "claim-1", "issueName": ISSUE, "merged": False},
+        )
+        snapshot = reconciler.reconcile(ev)
+        self.assertEqual(reconciler.STATE_RECOVERY_REQUIRED, snapshot.state)
+        self.assertTrue(any("DONE" in c for c in snapshot.contradictions))
+
+    def test_merged_implementation_without_claim_is_recovery(self) -> None:
+        ev = evidence(
+            queue={"status": "NOT_STARTED", "issueName": ISSUE},
+            implementationPr={"claimId": "claim-1", "issueName": ISSUE, "merged": True},
+        )
+        snapshot = reconciler.reconcile(ev)
+        self.assertEqual(reconciler.STATE_RECOVERY_REQUIRED, snapshot.state)
+
+    def test_pr_claim_id_mismatch_is_recovery(self) -> None:
+        ev = evidence(implementationPr={"claimId": "other-claim", "issueName": ISSUE})
+        snapshot = reconciler.reconcile(ev)
+        self.assertEqual(reconciler.STATE_RECOVERY_REQUIRED, snapshot.state)
+        self.assertTrue(any("claim id mismatch" in c for c in snapshot.contradictions))
+
+    def test_queue_issue_mismatch_is_recovery(self) -> None:
+        ev = evidence(queue={"status": "IN_PROGRESS", "issueName": "[EPIC_09][STORY_09][SUBSTORY_09] other"})
+        snapshot = reconciler.reconcile(ev)
+        self.assertEqual(reconciler.STATE_RECOVERY_REQUIRED, snapshot.state)
+
+    def test_write_action_without_claim_id_refuses(self) -> None:
+        ev = {"issueName": ISSUE, "queue": {"status": "IN_PROGRESS", "issueName": ISSUE}}
+        snapshot = reconciler.reconcile(ev)
+        # A worktree write with no claim id cannot be made idempotent -> recovery.
+        self.assertEqual(reconciler.STATE_RECOVERY_REQUIRED, snapshot.state)
+        self.assertIsNone(snapshot.idempotencyKey)
+
+
+class ControllerReconcilerIdempotencyTest(unittest.TestCase):
+    def test_write_actions_carry_a_stable_key_and_reads_do_not(self) -> None:
+        write = reconciler.reconcile(evidence(worktreeReady=True))
+        self.assertEqual("claim-1:run_worker", write.idempotencyKey)
+        wait = reconciler.reconcile(
+            evidence(
+                implementationPr={
+                    "claimId": "claim-1",
+                    "issueName": ISSUE,
+                    "statusCheckRollup": rollup("linux", "IN_PROGRESS"),
+                }
+            )
+        )
+        self.assertIsNone(wait.idempotencyKey)
+
+    def test_duplicate_evidence_yields_identical_snapshot(self) -> None:
+        ev = evidence(worktreeReady=True)
+        first = reconciler.reconcile(ev)
+        second = reconciler.reconcile(json.loads(json.dumps(ev)))
+        self.assertEqual(first.toPayload(), second.toPayload())
+
+    def test_idempotency_key_requires_claim(self) -> None:
+        self.assertEqual("c9:mark_done", reconciler.idempotencyKey("c9", "mark_done"))
+        with self.assertRaises(reconciler.ReconcilerError):
+            reconciler.idempotencyKey("", "mark_done")
+
+
+class ControllerReconcilerCliTest(unittest.TestCase):
+    def test_malformed_evidence_raises(self) -> None:
+        with self.assertRaises(reconciler.ReconcilerError):
+            reconciler.buildFacts([])  # type: ignore[arg-type]
+        with self.assertRaises(reconciler.ReconcilerError):
+            reconciler.buildFacts({"claimId": "x"})  # missing issueName
+
+    def test_next_action_command_emits_action_and_key(self) -> None:
+        stdout = io.StringIO()
+        payload = json.dumps(evidence(worktreeReady=True))
+        with redirect_stdout(stdout):
+            with mock.patch("sys.stdin", io.StringIO(payload)):
+                exit_code = reconciler.main(["next-action"])
+        self.assertEqual(0, exit_code)
+        result = json.loads(stdout.getvalue())
+        self.assertEqual(reconciler.ACTION_RUN_WORKER, result["nextAction"])
+        self.assertEqual("claim-1:run_worker", result["idempotencyKey"])
+
+    def test_recovery_exit_code_is_one(self) -> None:
+        stdout = io.StringIO()
+        payload = json.dumps(evidence(queue={"status": "IN_PROGRESS", "issueName": ISSUE, "stale": True}))
+        with redirect_stdout(stdout):
+            with mock.patch("sys.stdin", io.StringIO(payload)):
+                exit_code = reconciler.main(["reconcile"])
+        self.assertEqual(1, exit_code)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Foundation increment of **#614** (EPIC_01/STORY_01/SUBSTORY_01). After a restart a controller can duplicate transitions — a second claim, a duplicate implementation PR, a duplicate DONE/terminal write — because its state is spread across the queue row, claim id, worktree, branch, implementation PR, its CI, and the terminal PR.

Adds **`scripts/controller_reconciler.py`**: a strictly **read-only** reconciler that consumes a JSON evidence blob and derives one deterministic controller state, the next action, and an idempotency key for the write that action would perform.

- **States**: `claim_selected`, `worktree_ready`, `worker_running`, `implementation_pr_open`, `ci_pending` / `ci_passed` / `ci_failed`, `implementation_merged`, `terminal_pr_open`, `done`, `blocked`, `recovery_required`.
- **Idempotency**: every write action carries a key of `exact claim id + transition type`, so a restart that re-derives the same state emits the same key and a caller that records applied keys skips the duplicate. Read actions (`wait_for_ci`, `none`) carry no key.
- **Read-only**: it only reads the passed dict and returns JSON — never the workbook, git, or GitHub — so `snapshot`/`reconcile`/`next-action` can't themselves duplicate a transition.
- **Correlation by exact identity** (claim id, issue name, controller owner, PR identity); title matching is never authoritative. **Contradictory evidence returns `recovery_required` with the conflicts** (e.g. queue DONE but implementation PR still open; PR claim-id mismatch; merged implementation on an unclaimed row; a write action with no claim id) rather than a guessed write.
- **Reuses** `pr_review_audit`'s PR/check/queue normalization (`checkSummary`, `mergeState`, `queueStatus`, `queueClaimIsStale`, `controllerOwned`).

## Scope / blast radius

Additive: one new module + its test suite. No existing file changes, and **nothing consumes it yet** (zero runtime blast radius). It is not a CI-authority or `#1300` control-plane file. Wiring it into the controller prompts / queue tooling, and the `#623` duplicate-PR preflight / `#622` heartbeat-recovery consumers, are follow-up increments of #614 (so the row stays in progress after this lands).

## Validation

- `python3 -m unittest tests.test_controller_reconciler tests.test_pr_review_audit` → **64 tests, OK**. The new suite is a fixture matrix over every state, duplicate/stale evidence, merged-without-terminal, and each contradiction.
- `py_compile` clean; `git diff --check` clean; longest line ≤ 120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_