### PR TITLE
Record observation: gravemoor/hearthfall (#1301 maps) fail native walkthroughs — fleet-wide native CI red

### DIFF
--- a/planning/workflow_observations/records/20260703T050650Z-ctrl-vm-1693-2f224ca5-627cb614.json
+++ b/planning/workflow_observations/records/20260703T050650Z-ctrl-vm-1693-2f224ca5-627cb614.json
@@ -1,0 +1,43 @@
+{
+  "affectedPaths": [
+    "res/maps/gravemoor/script.py",
+    "res/maps/hearthfall/script.py"
+  ],
+  "category": "ci",
+  "controllerId": "ctrl-vm-1693-2f224ca5",
+  "createdAtUtc": "2026-07-03T05:06:50Z",
+  "details": "Native linux + windows jobs fail fleet-wide on two gameplay walkthrough tests\nfor the multilevel-campaign maps added by #1301, reddening native CI for every\nnative PR (e.g. PRs #1342, #1349 native jobs):\n\n1. test_stdio_map_walkthrough_gravemoor (McpServerTest) / _mcp_walkthrough_gravemoor:\n   \"Expected object handle for gravemoorStart\" -> _mcp_get_object_by_name returns\n   None. The object IS defined in content (res/maps/gravemoor/map.json name+type\n   \"gravemoorStart\"; res/maps/gravemoor/config.json \"gravemoorStart\" entry), so\n   this is a RUNTIME object-handle/registration issue, not missing content: the\n   named object is not resolvable by name via the MCP handle path at runtime.\n\n2. test_map_walkthrough_hearthfall (GameTest) / walkthrough_hearthfall_map:\n   \"Arrival should play the Hearthfall intro\" -> game_map.getBoolProperty(\n   \"hearthfall_intro\") is False after arrival. The intro logic EXISTS\n   (res/maps/hearthfall/script.py line ~38-40 gates on and sets\n   \"hearthfall_intro\"), so the trigger that should invoke it on map arrival is\n   not firing. Runtime trigger-wiring issue, not missing content.\n\nBoth are native-validated (the walkthrough tests require the built _game engine),\nso a fix cannot be validated in a submodule-restricted sandbox; whoever has a\nnative build should debug the gravemoor object-name registration and the\nhearthfall arrival/onEnter intro trigger. Prior fleet-wide gameplay red was\nfixed by #1274; this is a distinct, NEW red introduced with the #1301 maps.\n",
+  "evidence": [
+    {
+      "contentPresent": "map.json name+type gravemoorStart; config.json gravemoorStart",
+      "failure": "Expected object handle for gravemoorStart -> None",
+      "test": "test_stdio_map_walkthrough_gravemoor"
+    },
+    {
+      "contentPresent": "hearthfall/script.py sets hearthfall_intro (~L38-40)",
+      "failure": "Arrival should play the Hearthfall intro; hearthfall_intro False after arrival",
+      "test": "test_map_walkthrough_hearthfall"
+    },
+    {
+      "jobs": [
+        "linux",
+        "windows"
+      ],
+      "note": "distinct new red from the #1274-fixed gameplay red",
+      "reddenedPRs": [
+        1342,
+        1349
+      ]
+    }
+  ],
+  "fingerprint": "gravemoor-hearthfall-multilevel-map-walkthrough-native-red",
+  "id": "20260703T050650Z-ctrl-vm-1693-2f224ca5-627cb614",
+  "impact": "Every native PR's linux+windows jobs fail on gravemoor/hearthfall walkthroughs (NEW red distinct from #1274's fix); native CI cannot go green for any PR until the two #1301-map runtime bugs are fixed",
+  "phase": "validation",
+  "role": "controller",
+  "schemaVersion": 1,
+  "severity": "high",
+  "sourceCommit": "48a1ed6",
+  "suggestedImprovement": "With a native build: fix gravemoorStart object-name handle resolution (defined in map.json/config.json but _mcp_get_object_by_name returns None) and the hearthfall arrival intro trigger (script sets hearthfall_intro but it is False after arrival)",
+  "summary": "New multilevel maps gravemoor/hearthfall fail native walkthrough tests (runtime object-handle + arrival-trigger bugs, content present), reddening native linux+windows fleet-wide"
+}


### PR DESCRIPTION
Append-only workflow observation (single new record; no source/workbook changes).

Flags a **new, fleet-wide native-CI red** distinct from the #1274-fixed gameplay red: the two multilevel-campaign maps added by #1301 fail their native walkthrough tests, so `linux` + `windows` fail on every native PR (observed on #1342 and #1349).

- `test_stdio_map_walkthrough_gravemoor`: "Expected object handle for `gravemoorStart`" → `None`. The object **is** defined (`res/maps/gravemoor/map.json` name+type, `config.json` entry), so it's a runtime object-name **handle-resolution** issue, not missing content.
- `test_map_walkthrough_hearthfall`: "Arrival should play the Hearthfall intro" → `hearthfall_intro` is `False` after arrival. The intro logic **exists** (`res/maps/hearthfall/script.py` sets it), so the **arrival trigger** isn't firing.

Both require a native `_game` build to validate a fix, so they're out of reach in a submodule-restricted sandbox — surfaced here for a build-capable controller/human to fix the gravemoor object registration and the hearthfall arrival intro trigger.

`workflow_observations.py validate` → 0 errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_