### PR TITLE
[EPIC_60][STORY_02][SUBSTORY_05] Monster fight controller ranks interactions by weakening value

### DIFF
--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -556,6 +556,30 @@ bool heal_preserves_combatant(const std::shared_ptr<CCreature> &me, const std::s
     }
     return strongest_heal_estimate(me) > incoming;
 }
+
+// Deterministic estimate of how much a single cast weakens the opponent, used to
+// rank a caster's interactions. Every castable interaction is credited with the
+// caster's expected landed hit on the opponent (expected_incoming_hit in the
+// attacking direction: caster's top damage plus flat bonus, mitigated by the
+// opponent's normal resist and armor, with the block dice deliberately excluded
+// so the estimate stays stable). An interaction that also routes a non-buff
+// effect onto the opponent keeps weakening it for the effect's whole duration,
+// so credit that hit once more per lingering turn. Mana cost is intentionally
+// not part of the value: the previous selector maximized mana cost, which made
+// casters spend their priciest spell instead of their most weakening one.
+int weakening_estimate(const std::shared_ptr<CInteraction> &interaction, const std::shared_ptr<CCreature> &me,
+                       const std::shared_ptr<CCreature> &opponent) {
+    const int hit = expected_incoming_hit(opponent, me);
+    int value = hit;
+    const auto effect = interaction->getEffect();
+    if (effect && !interaction->effectRoutesToCaster(effect) && !effect->hasTag(CTag::Buff)) {
+        // A lingering debuff/stun weakens even a caster with no melee damage, so
+        // floor the per-turn value at 1 to keep such effects ranked above an
+        // interaction that merely lands the same hit once.
+        value += std::max(hit, 1) * std::max(effect->getDuration(), 1);
+    }
+    return value;
+}
 } // namespace
 
 bool CMonsterFightController::control(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent) {
@@ -576,7 +600,7 @@ bool CMonsterFightController::control(std::shared_ptr<CCreature> me, std::shared
             return true;
         }
     }
-    if (auto action = selectInteraction(me)) {
+    if (auto action = selectInteraction(me, opponent)) {
         me->useAction(action, opponent);
         return true;
     }
@@ -600,20 +624,32 @@ std::shared_ptr<CItem> CMonsterFightController::getLeastPowerfulItemWithTag(std:
 }
 
 // TODO: use buffs
-std::shared_ptr<CInteraction> CMonsterFightController::selectInteraction(std::shared_ptr<CCreature> cr) {
+std::shared_ptr<CInteraction> CMonsterFightController::selectInteraction(std::shared_ptr<CCreature> me,
+                                                                         std::shared_ptr<CCreature> opponent) {
     std::function<bool(std::shared_ptr<CInteraction>)> pFunction = [](const std::shared_ptr<CInteraction> &it) {
         return !it->hasTag(CTag::Buff);
     };
-    std::function<bool(std::shared_ptr<CInteraction>)> pFunction2 = [cr](const std::shared_ptr<CInteraction> &it) {
-        return it->getManaCost() <= cr->getMana();
+    std::function<bool(std::shared_ptr<CInteraction>)> pFunction2 = [me](const std::shared_ptr<CInteraction> &it) {
+        return it->getManaCost() <= me->getMana();
     };
     std::function<bool(std::shared_ptr<CInteraction>)> pFunction3 = [](const std::shared_ptr<CInteraction> &it) {
         return !it->getEffect() || (it->getEffect() && !it->getEffect()->hasTag(CTag::Buff));
     };
-    auto pred = [](const std::shared_ptr<CInteraction> &a, const std::shared_ptr<CInteraction> &b) {
-        return a->getManaCost() < b->getManaCost();
+    // Rank affordable, non-buff interactions by how much they weaken the current
+    // opponent rather than by mana cost. Ties break toward the cheaper spell, then
+    // by name, so the choice is deterministic regardless of container ordering.
+    auto pred = [me, opponent](const std::shared_ptr<CInteraction> &a, const std::shared_ptr<CInteraction> &b) {
+        const int wa = weakening_estimate(a, me, opponent);
+        const int wb = weakening_estimate(b, me, opponent);
+        if (wa != wb) {
+            return wa < wb;
+        }
+        if (a->getManaCost() != b->getManaCost()) {
+            return a->getManaCost() > b->getManaCost();
+        }
+        return a->getName() > b->getName();
     };
-    std::set<std::shared_ptr<CInteraction>> interactions = cr->getInteractions();
+    std::set<std::shared_ptr<CInteraction>> interactions = me->getInteractions();
     auto rng =
         interactions | std::views::filter(pFunction) | std::views::filter(pFunction2) | std::views::filter(pFunction3);
     auto max = std::ranges::max_element(rng, pred);

--- a/src/core/CController.h
+++ b/src/core/CController.h
@@ -97,7 +97,7 @@ class CMonsterFightController : public CFightController {
     bool control(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent) override;
 
   private:
-    std::shared_ptr<CInteraction> selectInteraction(std::shared_ptr<CCreature> cr);
+    std::shared_ptr<CInteraction> selectInteraction(std::shared_ptr<CCreature> me, std::shared_ptr<CCreature> opponent);
 
     std::shared_ptr<CItem> getLeastPowerfulItemWithTag(std::shared_ptr<CCreature> cr, CTag tag);
 };

--- a/tests/unit/test_controller.cpp
+++ b/tests/unit/test_controller.cpp
@@ -29,6 +29,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/panel/CGameFightPanel.h"
 #include "handler/CObjectHandler.h"
 #include "object/CCreature.h"
+#include "object/CEffect.h"
 #include "object/CInteraction.h"
 #include "object/CItem.h"
 #include "object/CMapObject.h"
@@ -830,6 +831,59 @@ void test_monster_fight_controller_heals_when_next_hit_would_kill() {
                 "monster fight controller should heal when it would otherwise die to the next hit");
 }
 
+std::shared_ptr<CInteraction> caster_interaction(const std::shared_ptr<CGame> &game, int manaCost,
+                                                 std::shared_ptr<CEffect> effect) {
+    auto interaction = std::make_shared<CInteraction>();
+    interaction->setGame(game);
+    interaction->setManaCost(manaCost);
+    if (effect) {
+        interaction->setEffect(effect);
+    }
+    return interaction;
+}
+
+std::shared_ptr<CEffect> opponent_debuff(const std::shared_ptr<CGame> &game, int duration) {
+    auto effect = std::make_shared<CEffect>();
+    effect->setGame(game);
+    effect->setDuration(duration);
+    return effect;
+}
+
+void test_monster_fight_controller_ranks_interactions_by_weakening() {
+    auto game = fight_fixture_game();
+    auto monster = creature_at(0, 0, 0);
+    monster->setGame(game);
+    // A single landed hit lands 10 damage; the opponent has no armor/resist.
+    monster->getBaseStats()->setStamina(10);
+    monster->getBaseStats()->setDmgMax(10);
+    monster->setHp(monster->getHpMax());
+    // Enough mana for the strong (10) and weak (50) spells, but not the debuff bomb (100).
+    monster->getBaseStats()->setIntelligence(100);
+    monster->setMana(60);
+
+    auto opponent = creature_at(1, 0, 0);
+    opponent->setGame(game);
+    opponent->getBaseStats()->setStamina(10);
+
+    // Weak but expensive: no lingering effect, so its weakening value is just the hit.
+    auto weakPricey = caster_interaction(game, 50, nullptr);
+    // Strong but cheap: a 3-turn opponent debuff makes it the most weakening cast.
+    auto strongCheap = caster_interaction(game, 10, opponent_debuff(game, 3));
+    // Strongest on paper (5-turn debuff) but unaffordable, so it must be skipped.
+    auto strongestUnaffordable = caster_interaction(game, 100, opponent_debuff(game, 5));
+    monster->addAction(weakPricey);
+    monster->addAction(strongCheap);
+    monster->addAction(strongestUnaffordable);
+
+    auto controller = std::make_shared<CMonsterFightController>();
+    expect_true(controller->control(monster, opponent), "monster fight controller should cast a weakening interaction");
+    // Casting spends the chosen spell's mana: 60 - 10 uniquely identifies the cheap,
+    // strongly-weakening spell over the pricey weak one (would leave 10) and proves the
+    // unaffordable debuff bomb (needs 100) was filtered out by mana affordability.
+    expect_true(monster->getMana() == 50,
+                "monster fight controller should pick the most weakening affordable interaction, not the priciest");
+}
+
 } // namespace
 
 int main() {
@@ -855,6 +909,7 @@ int main() {
     test_monster_fight_controller_attacks_hard_hitter_instead_of_wasting_heal();
     test_monster_fight_controller_heals_when_heal_outpaces_incoming_damage();
     test_monster_fight_controller_heals_when_next_hit_would_kill();
+    test_monster_fight_controller_ranks_interactions_by_weakening();
 
     return finish_tests();
 }


### PR DESCRIPTION
## Summary

`CMonsterFightController::selectInteraction` previously chose which spell/interaction a caster monster used by taking the affordable, non-buff interaction with the **highest mana cost** (`std::ranges::max_element` over `getManaCost()`). That is a crude tactical proxy: casters burned their priciest spell rather than the one that most weakens the opponent.

This PR replaces the mana-cost criterion with a deterministic **weakening estimate** ranked against the current opponent, in the closed-form style of `heal_preserves_combatant` (#1337):

- Every castable interaction is credited with the caster's **expected landed hit** on the opponent — reusing `expected_incoming_hit` in the attacking direction (top of the caster's damage range plus the flat damage bonus, mitigated by the opponent's normal resist and armor, with the block dice deliberately excluded so the estimate stays stable / RNG-free).
- An interaction that also routes a **non-buff effect onto the opponent** (a debuff/stun, not a self-buff) keeps weakening it for the effect's whole duration, so it is credited that hit once more per lingering turn (per-turn value floored at 1 so lingering debuffs still outrank a plain equal hit even for a zero-melee caster).
- **Mana cost is no longer part of the tactical value.** Ties break toward the cheaper spell, then by name, so the selection is deterministic regardless of container ordering.

The heal / mana-item gating from #1337 and non-caster behavior are unchanged; only the interaction-selection branch is affected. `selectInteraction` now takes the opponent so it can score against the actual target.

Old criterion: highest mana cost among affordable non-buff interactions → New criterion: highest deterministic weakening value (expected hit + sustained opponent debuff over its duration), ties broken toward the cheaper spell.

## Tests

- Added `test_monster_fight_controller_ranks_interactions_by_weakening` in `tests/unit/test_controller.cpp` (registered in `main()`): a caster holding a pricey-but-weak interaction (mana 50, no effect), a cheap-but-strong one (mana 10, 3-turn opponent debuff), and an unaffordable stronger one (mana 100, 5-turn debuff) with only 60 mana must cast the cheap strongly-weakening spell — asserted via the exact post-cast mana (60 → 50), which simultaneously proves the priciest weak spell is not chosen and that the strongest-but-unaffordable spell is filtered out by mana affordability.
- Existing controller tests (heal/mana gating, single-interaction fallback) remain green: a lone candidate is still selected, preserving prior behavior.

Worker implementation branch did not modify any queue workbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_