### PR TITLE
Fix docstring indentation in controller_reconciler to unblock test_indentation

### DIFF
--- a/scripts/controller_reconciler.py
+++ b/scripts/controller_reconciler.py
@@ -21,18 +21,18 @@ conflicting evidence rather than guessing a write.
 Evidence schema (all fields optional unless noted; extra keys are ignored)::
 
     {
-      "issueName": "[EPIC_..]..",          # required
-      "owner": "controller/ctrl-x/subagent-1",
-      "claimId": "abc-123",                # required for any write transition
-      "queue": { "status": "IN_PROGRESS", "owner": "...", "claimId": "...",
-                 "issueName": "...", "stale": false },
-      "implementationPr": { "number": 12, "claimId": "...", "issueName": "...",
-                 "owner": "...", "headSha": "...", "branch": "...",
-                 "merged": false, "mergeableState": "clean",
-                 "statusCheckRollup": [ ... ] },   # normalized by pr_review_audit
-      "terminalPr": { "number": 13, "claimId": "...", "merged": false },
-      "worktreeReady": true,               # local evidence (subagent registry)
-      "workerRunning": true
+        "issueName": "[EPIC_..]..",          # required
+        "owner": "controller/ctrl-x/subagent-1",
+        "claimId": "abc-123",                # required for any write transition
+        "queue": { "status": "IN_PROGRESS", "owner": "...", "claimId": "...",
+            "issueName": "...", "stale": false },
+        "implementationPr": { "number": 12, "claimId": "...", "issueName": "...",
+            "owner": "...", "headSha": "...", "branch": "...",
+            "merged": false, "mergeableState": "clean",
+            "statusCheckRollup": [ ... ] },   # normalized by pr_review_audit
+        "terminalPr": { "number": 13, "claimId": "...", "merged": false },
+        "worktreeReady": true,               # local evidence (subagent registry)
+        "workerRunning": true
     }
 """
 


### PR DESCRIPTION
`test_indentation` (test.py) requires every line in a git-tracked `*.py` file to have leading spaces in multiples of 4. `scripts/controller_reconciler.py` carries a JSON example in its module docstring indented at 6 and 17 spaces, which fails that check and turns the gameplay suite red on every run (it is the sole failure in [run 2986](https://github.com/lisu188/fall-of-nouraajd/actions/runs/28639816106), on both linux and windows).

Reindents the docstring example to multiples of 4 — whitespace-only, no logic change. The file still parses (`ast.parse` OK) and a full sweep of git-tracked `*.py` files reports zero indentation offenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxyPhWoHXUxZ6YSXx4a2Vp

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxyPhWoHXUxZ6YSXx4a2Vp)_