### PR TITLE
Add regression test for the duplicate-JSON-key validator guard

### DIFF
--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -78,6 +78,25 @@ class ContentValidatorTest(unittest.TestCase):
             "previously defined at layers[1].objects[0]",
         )
 
+    def test_duplicate_json_object_keys_are_flagged(self):
+        root = self.make_fixture()
+        map_path = root / "res/maps/broken/map.json"
+        # Inject a literal duplicate key. Python's json keeps the last value, but
+        # the engine's strict C++ loader rejects the whole document, so the
+        # validator must flag it. write_json cannot emit duplicates -- patch raw text.
+        text = map_path.read_text(encoding="utf-8")
+        patched = text.replace('"layers":', '"width": 24,\n  "width": 24,\n  "layers":', 1)
+        self.assertNotEqual(text, patched, "expected to inject a duplicate key")
+        map_path.write_text(patched, encoding="utf-8")
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/map.json",
+            'duplicate JSON object key "width"',
+        )
+
     def _declare_map_assets(self, root, assets):
         map_path = root / "res/maps/broken/map.json"
         map_data = read_json(map_path)
@@ -4331,7 +4350,9 @@ class TypeRegistrationCoverageAuditTest(unittest.TestCase):
         # out passes the coverage audit and then fails at runtime when built by
         # name. iter_cpp_metadata_declarations already strips comments, so this
         # scan must too, or the two disagree.
-        self.assertEqual({"CFoo"}, iter_cpp_template_type_names("CTypes::register_type<CFoo, CBar>();", "register_type"))
+        self.assertEqual(
+            {"CFoo"}, iter_cpp_template_type_names("CTypes::register_type<CFoo, CBar>();", "register_type")
+        )
         self.assertEqual(set(), iter_cpp_template_type_names("// CTypes::register_type<CFoo>();", "register_type"))
         self.assertEqual(
             set(),


### PR DESCRIPTION
## Summary

The `hearthfall`, `gravemoor`, and `usurpergate` `map.json` files carried **literal duplicate `properties`/`propertytypes` keys**. Python's `json` silently keeps the last value (so `validate_content.py` passed), but the engine's strict C++ parser rejects the whole document — each map loaded **empty** at runtime, stranding the player at `(0,0,0)` with no start event or NPCs, which broke the hearthfall/gravemoor/usurpergate walkthrough tests.

**The map fix and the validator guard already landed on `main`** independently (via #1346 and #1353): the duplicate keys are gone and `scripts/validate_content.py` now rejects duplicate object keys. I verified on current `main` that all six hearthfall/gravemoor/usurpergate walkthroughs pass.

That guard shipped **without a test**, so this PR (rebased down to just that one gap) adds a regression test: it injects a literal duplicate key into a fixture map and asserts the validator flags `duplicate JSON object key "width"`.

## Validation

- `python3 -m unittest tests.test_content_validator` — 167 tests OK (incl. the new test)
- `python3 scripts/validate_content.py --repo-root .` — passed
- `black --check -l 120 tests/test_content_validator.py` — clean

## Separate pre-existing failure (not addressed here)

`GameTest.test_nouraajd_ritual_return_round_trip_preserves_persistent_state` fails on clean `main` too — an unrelated map-transition/event-ordering bug (the ritual `StartEvent`'s `ritual_initialized` flag isn't set when the map is entered via a `CMapTransitionRequest`, though it works on a direct load). Left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DYtaw1LH29TtZHvpz4eR