### PR TITLE
Parse register_type<> first template arg with balanced angle brackets

### DIFF
--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -4463,6 +4463,36 @@ def iter_cpp_function_bodies(text: str) -> list[tuple[str, str]]:
     return functions
 
 
+def _first_template_argument(text: str, start: int) -> str | None:
+    """Return the first top-level template argument beginning at ``text[start]``
+    (just past the opening ``<``), honoring nested ``<...>``.
+
+    Returns None for a malformed/unterminated template. Unlike a ``[^,;\\n]``
+    capture, this stops the first argument at the matching top-level ``>`` or
+    ``,``, so a single-argument registration (``register_type<CFoo>()``) and a
+    nested wrapper (``register_type<CWrapper<CInner>>()``) are captured correctly
+    instead of swallowing the trailing ``>()`` and being rejected.
+    """
+    depth = 0
+    chars: list[str] = []
+    for ch in text[start:]:
+        if ch == "<":
+            depth += 1
+            chars.append(ch)
+        elif ch == ">":
+            if depth == 0:
+                return "".join(chars)
+            depth -= 1
+            chars.append(ch)
+        elif ch == "," and depth == 0:
+            return "".join(chars)
+        elif ch in ";\n":
+            return None
+        else:
+            chars.append(ch)
+    return None
+
+
 def iter_cpp_template_type_names(text: str, call_name: str) -> set[str]:
     names: set[str] = set()
     # Strip comments first so a commented-out (runtime-disabled) registration is
@@ -4471,9 +4501,12 @@ def iter_cpp_template_type_names(text: str, call_name: str) -> set[str]:
     # honored a commented register_type<...>, letting an unregistered reflected
     # type pass the coverage audit and then fail at runtime when built by name.
     text = strip_cpp_comments(text)
-    pattern = re.compile(rf"\b{re.escape(call_name)}\s*<\s*([^,;\n]+)")
+    pattern = re.compile(rf"\b{re.escape(call_name)}\s*<")
     for match in pattern.finditer(text):
-        name = normalize_cpp_type(match.group(1))
+        argument = _first_template_argument(text, match.end())
+        if argument is None:
+            continue
+        name = normalize_cpp_type(argument)
         if is_concrete_cpp_class_name(name):
             names.add(name)
     return names

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -4341,6 +4341,23 @@ class TypeRegistrationCoverageAuditTest(unittest.TestCase):
         mixed = "CTypes::register_type<CLive, CBase>();\n// CTypes::register_type<CDisabled, CBase>();\n"
         self.assertEqual({"CLive"}, iter_cpp_template_type_names(mixed, "register_type"))
 
+    def test_single_argument_and_nested_wrapper_registrations_are_detected(self):
+        # The first template argument is bounded by the matching top-level `>` or
+        # `,`, honoring nested `<...>`. A single-argument (base-less) registration
+        # and a nested wrapper must both be detected -- a plain `[^,;]` capture
+        # swallowed the trailing `>()` and dropped these, so a future
+        # `register_type<CNewRoot>()` would be falsely flagged as unregistered.
+        def names(src):
+            return iter_cpp_template_type_names(src, "register_type")
+
+        self.assertEqual({"CGameObject"}, names("register_type<CGameObject>();"))
+        self.assertEqual({"CRoot"}, names("CTypes::register_type<CRoot>(host);"))
+        self.assertEqual({"CInner"}, names("register_type<CWrapper<CInner>>();"))
+        self.assertEqual({"CInner"}, names("register_type<CWrapper<CInner>, CBase>();"))
+        self.assertEqual({"CSpaced"}, names("register_type< CSpaced >();"))
+        # Multi-argument detection is unchanged (first argument only).
+        self.assertEqual({"CDerived"}, names("register_type<CDerived, CBase>();"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Completes the latent false-positive I deliberately deferred in #1336. The content gate's `iter_cpp_template_type_names` captured the first template argument with `[^,;\n]+`, which swallows a single-argument registration's trailing `>()`. As a result:

- `register_type<CGameObject>()` → parsed as `CGameObject>()` → **dropped**
- `register_type<CWrapper<CInner>>()` → **dropped**
- only comma-terminated multi-arg forms (`register_type<CDerived, CBase>()`) parsed.

Today this is harmless (the only single-arg registration is `register_type<CGameObject>()`, a builtin), but a future base-less reflected type registered as `register_type<CNewRoot>()` would be **falsely flagged as unregistered and block an otherwise-valid PR**.

## Fix

Replace the capture with a balanced-angle-bracket parse (`_first_template_argument`) that bounds the first argument at the matching **top-level** `>` or `,`, honoring nested `<...>`. This handles single-arg, nested-wrapper, spaced, and multi-arg forms uniformly.

## No-regression evidence

Compared the real-repo collected registration sets before/after:

```
static:   added=['CGameObject']   removed=[]
native:   added=[]                removed=[]
metadata: added=[]                removed=[]
```

The parse only **gains** the previously-missed `CGameObject` (already registered/excluded) and **drops nothing** — so detection is strictly more complete with zero behavior change.

## Validation

- `python3 -m unittest tests.test_content_validator` → **167 tests, OK** (adds `test_single_argument_and_nested_wrapper_registrations_are_detected`).
- `python3 scripts/validate_content.py --repo-root .` → **Content validation passed**.
- `git diff --check` clean; changed lines ≤ black `-l 120`.

Part of the same proactive-review effort as #1325, #1328, #1336, #1341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_