### PR TITLE
[EPIC_02][STORY_01][SUBSTORY_05] Add resource provider isolation tests

### DIFF
--- a/tests/unit/test_resource.cpp
+++ b/tests/unit/test_resource.cpp
@@ -216,6 +216,74 @@ void test_load_game_creates_context_owned_providers() {
     expect_true(first_items != second_items, "separate game contexts should not share configuration provider caches");
 }
 
+void test_game_contexts_isolate_same_logical_config_id() {
+    auto singletonResources = CResourcesProvider::getInstance();
+    const auto itemsPath = std::filesystem::path(singletonResources->getPath("config/items.json"));
+    expect_true(!itemsPath.empty(), "items config should resolve before context-owned config isolation test");
+    if (itemsPath.empty()) {
+        return;
+    }
+    const auto configRoot = itemsPath.parent_path();
+
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const std::string logicalConfigId = "unit_ctx_isolation_" + std::to_string(nonce) + ".json";
+    const auto configPath = configRoot / logicalConfigId;
+    std::filesystem::remove(configPath);
+
+    // Publish the same logical id with the "alpha" value and let the first game context cache it.
+    expect_true(write_text_file(configPath, R"({"marker":"alpha"})"),
+                "context isolation fixture should be written with the initial value");
+    if (!std::filesystem::exists(configPath)) {
+        return;
+    }
+
+    auto firstGame = CGameLoader::loadGame();
+    auto secondGame = CGameLoader::loadGame();
+    expect_true(firstGame->getConfigurationProvider() != secondGame->getConfigurationProvider(),
+                "distinct game contexts must own distinct configuration providers");
+
+    auto firstAlpha = firstGame->getConfigurationProvider()->getConfiguration(logicalConfigId);
+    expect_true(json_string_value(firstAlpha, "marker") == "alpha",
+                "the first game context should load the initial config value under the shared logical id");
+
+    // Re-publish the same logical id with a different value; only a per-context cache keeps the two
+    // games serving different objects for one id.
+    expect_true(write_text_file(configPath, R"({"marker":"beta"})"),
+                "context isolation fixture should be rewritable with a second value");
+
+    auto secondBeta = secondGame->getConfigurationProvider()->getConfiguration(logicalConfigId);
+    expect_true(json_string_value(secondBeta, "marker") == "beta",
+                "a separate game context should read the current config value for the same logical id");
+
+    // The second context's load must not be visible in, or mutate, the first context's cache.
+    auto firstAlphaAgain = firstGame->getConfigurationProvider()->getConfiguration(logicalConfigId);
+    expect_true(firstAlphaAgain == firstAlpha,
+                "a game context should keep serving its own cached object for a given logical id");
+    expect_true(json_string_value(firstAlphaAgain, "marker") == "alpha",
+                "another context's load of the same id must not leak into or overwrite a context's cache");
+    expect_true(firstAlpha != secondBeta,
+                "two game contexts must resolve the same logical id to their own isolated objects");
+
+    // Static compatibility behavior stays separate: neither context load primes the process-wide cache.
+    auto legacyConfig = CConfigurationProvider::getConfig(logicalConfigId);
+    expect_true(json_string_value(legacyConfig, "marker") == "beta",
+                "context-owned loads must not populate the process-wide configuration provider cache");
+    expect_true(legacyConfig != firstAlpha && legacyConfig != secondBeta,
+                "the process-wide compatibility cache must stay distinct from context-owned caches");
+
+    // Unsafe-path rejection is unchanged for context-owned resource providers.
+    auto firstResources = firstGame->getResourcesProvider();
+    auto secondResources = secondGame->getResourcesProvider();
+    expect_true(firstResources->getPath("../config/items.json").empty(),
+                "context-owned providers must keep rejecting parent-traversal resource paths");
+    expect_true(secondResources->getPath("/etc/passwd").empty(),
+                "context-owned providers must keep rejecting absolute resource paths");
+    expect_true(!firstResources->getPath("config/items.json").empty(),
+                "context-owned providers must keep resolving safe in-root resource paths");
+
+    std::filesystem::remove(configPath);
+}
+
 void test_map_load_resolves_through_context_owned_providers() {
     auto singletonResources = CResourcesProvider::getInstance();
     const auto itemsPath = std::filesystem::path(singletonResources->getPath("config/items.json"));
@@ -334,6 +402,7 @@ int main() {
     test_resource_provider_save_uses_provider_root_when_cwd_changes();
     test_configuration_provider_instances_do_not_share_config_cache();
     test_load_game_creates_context_owned_providers();
+    test_game_contexts_isolate_same_logical_config_id();
     test_map_load_resolves_through_context_owned_providers();
     test_resource_plugin_trust_boundary_rejects_escapes();
 


### PR DESCRIPTION
## Summary

Adds a focused regression to `tests/unit/test_resource.cpp` that locks in resource-provider isolation across game contexts, per the substory's technical description ("create two CGame instances ... register different temporary config values with the same logical id and prove each game creates objects from its own provider/cache. Verify unsafe-path rejection remains unchanged").

The existing suite already proves that separate game contexts own distinct provider instances and parse configs into distinct objects, but every existing case serves identical file content to both games. The new test closes that gap by publishing the **same logical config id with different values** and proving each context resolves and caches its own object.

New test `test_game_contexts_isolate_same_logical_config_id`:
- Publishes logical id `X` with value `alpha`, has the first game context's configuration provider load and cache it.
- Re-publishes `X` with value `beta`, has a second game context load it and read `beta` (its own cache).
- Re-reads the first context and asserts it still serves `alpha` (same cached object): a second context's load of the same id neither leaks into nor mutates the first context's cache.
- Asserts the two contexts resolve one logical id to two distinct isolated objects (`alpha` != `beta`).
- Confirms static compatibility behavior stays separate: context-owned loads do not prime the process-wide `CConfigurationProvider::getConfig` cache.
- Re-asserts unsafe-path rejection is unchanged for context-owned resource providers (parent-traversal and absolute paths rejected; safe in-root path still resolves).

The isolation property locked in: two game contexts each serve and cache their own object for the same logical resource id, so one context can neither see nor mutate another context's cached resource, and provider resolution/rejection is deterministic and scoped per context. Static compatibility (process-wide) behavior remains covered separately.

No production code changed; test-only addition. Deterministic (unique-nonce temp fixture, no RNG or timing dependence).

## Tests

- `clang-format` clean, `git diff --check` clean.
- New native case `test_game_contexts_isolate_same_logical_config_id` registered in the `game_core` resource unit-test binary `main()`; validated in CI via `ctest` / `python3 test.py` (heavy native builds not run locally).

Worker implementation branch did not modify any queue workbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_