### PR TITLE
[EPIC_01][STORY_01][SUBSTORY_01] #614 Add durable controller transition reconciler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,16 @@ reconciliation against worktrees, `git rev-parse --verify` branch evidence, and 
 only recommends UNREACHABLE/ORPHANED transitions, which are applied with the explicit `mark` subcommand. The sweeper
 never deletes worktrees, kills processes, or mutates the workbook.
 
+After a restart or container suspension, derive the single deterministic next action per issue with the read-only
+`scripts/controller_reconciler.py` (`snapshot`/`reconcile`/`next-action` over a JSON evidence blob). It correlates the
+XLSX row, claim ID, claim PR, implementation PR/CI, and terminal PR by exact identity into one lifecycle state
+(`claim_selected`, `claim_pr_open`, `claim_pr_merged`, `worktree_ready`, `worker_running`, `implementation_pr_open`,
+`ci_pending`/`ci_passed`/`ci_failed`, `implementation_merged`, `terminal_pr_open`, `done`, `blocked`,
+`recovery_required`) and attaches an idempotency key (exact claim ID plus transition) to every write action so a
+restarted controller never duplicates a claim, PR, merge, or DONE write. It is strictly read-only — it never touches the
+workbook, git, or GitHub — and contradictory evidence fails closed to `recovery_required` rather than guessing a write.
+See `docs/codex-agent-queue.md` for the evidence schema and states.
+
 Scarce local resources shared between concurrent controllers (heavy build/test/coverage jobs, Xvfb displays, TCP
 ports, build directories, memory budgets, MCP server slots) are coordinated through the resource broker built into the
 same script. `python3 scripts/controller_resource_audit.py probe` reports read-only availability

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -464,6 +464,35 @@ python3 scripts/subagent_registry.py sweep --repo . --workbook planning/fall_of_
 recommendations with the exact `mark` command to apply each transition explicitly. It never deletes worktrees, kills
 processes, mutates the workbook, or rewrites the registry file.
 
+## Durable controller transition reconciler
+
+A controller's per-issue state is spread across the XLSX row, its claim ID, the worktree, the branch, the workbook-only
+**claim PR**, the implementation PR and its CI, and the terminal status PR. After a restart or container suspension the
+controller must decide what to do next without redoing a transition it already performed (a duplicate claim,
+worktree, implementation PR, merge, or DONE write). `scripts/controller_reconciler.py` derives one deterministic
+controller state and the single next action from a JSON evidence blob and prints JSON. It is strictly read-only: it
+never touches the workbook, git, or GitHub, so `snapshot`/`reconcile`/`next-action` can never themselves duplicate a
+transition. It reuses `pr_review_audit` for queue/PR/check normalization.
+
+```bash
+python3 scripts/controller_reconciler.py next-action --evidence-file evidence.json   # or pipe JSON on stdin
+python3 scripts/controller_reconciler.py reconcile < evidence.json
+```
+
+The evidence blob carries `issueName` (required), `claimId`, `owner`, the `queue` row, and optional `claimPr`,
+`implementationPr`, `terminalPr`, `worktreeReady`, and `workerRunning` records. The derived state is one of
+`claim_selected`, `claim_pr_open`, `claim_pr_merged`, `worktree_ready`, `worker_running`, `implementation_pr_open`,
+`ci_pending`, `ci_passed`, `ci_failed`, `implementation_merged`, `terminal_pr_open`, `done`, `blocked`, or
+`recovery_required`. Correlation is by exact identity (claim ID, issue name, owner, branch/head SHA, PR number); title
+matching alone is never authoritative. Every write action (`create_worktree`, `run_worker`, `open_implementation_pr`,
+`merge_implementation`, `mark_done`) carries an idempotency key of the exact claim ID plus the transition, so
+re-deriving the same state after a restart yields the same key and a caller that records applied keys skips work it
+already did — e.g. a merged claim PR and a freshly selected claim both resolve to the same `create_worktree` key.
+Contradictory evidence (a merged claim PR against an unclaimed row, a DONE row with an open implementation PR, a PR whose
+claim ID does not match) fails closed to `recovery_required` with the conflicting evidence instead of guessing a write;
+`reconcile` then exits non-zero so callers can branch. Read-only `snapshot`, `reconcile`, and `next-action` never call
+workbook save, git write commands, or GitHub mutations.
+
 ## Structured worker reports and restart handoffs
 
 Worker milestone and end-of-task reports use the versioned JSON schema in `scripts/worker_report.py` (schema version 1,

--- a/scripts/controller_reconciler.py
+++ b/scripts/controller_reconciler.py
@@ -26,6 +26,8 @@ Evidence schema (all fields optional unless noted; extra keys are ignored)::
         "claimId": "abc-123",                # required for any write transition
         "queue": { "status": "IN_PROGRESS", "owner": "...", "claimId": "...",
             "issueName": "...", "stale": false },
+        "claimPr": { "number": 11, "claimId": "...", "issueName": "...",
+            "owner": "...", "merged": false },   # workbook-only claim PR
         "implementationPr": { "number": 12, "claimId": "...", "issueName": "...",
             "owner": "...", "headSha": "...", "branch": "...",
             "merged": false, "mergeableState": "clean",
@@ -52,6 +54,8 @@ except ImportError:  # pragma: no cover - used when imported as scripts.controll
 # Controller lifecycle states (durable evidence only; worktree/worker states are
 # supplied as local evidence by the subagent registry, not inferred here).
 STATE_CLAIM_SELECTED = "claim_selected"
+STATE_CLAIM_PR_OPEN = "claim_pr_open"
+STATE_CLAIM_PR_MERGED = "claim_pr_merged"
 STATE_WORKTREE_READY = "worktree_ready"
 STATE_WORKER_RUNNING = "worker_running"
 STATE_IMPLEMENTATION_PR_OPEN = "implementation_pr_open"
@@ -123,6 +127,7 @@ class _Facts:
     claimId: str
     owner: str
     queue: dict[str, Any]
+    claimPr: dict[str, Any] | None
     implementationPr: dict[str, Any] | None
     terminalPr: dict[str, Any] | None
     worktreeReady: bool
@@ -185,6 +190,7 @@ def buildFacts(evidence: dict[str, Any]) -> _Facts:
     queue = _asDict(evidence.get("queue"))
     claimId = _str(evidence.get("claimId")) or _str(audit.firstValue(queue, "claimId", "claim_id", default=""))
     owner = _str(evidence.get("owner")) or audit.queueOwner(queue)
+    claim = evidence.get("claimPr")
     impl = evidence.get("implementationPr")
     term = evidence.get("terminalPr")
     facts = _Facts(
@@ -192,6 +198,7 @@ def buildFacts(evidence: dict[str, Any]) -> _Facts:
         claimId=claimId,
         owner=owner,
         queue=queue,
+        claimPr=claim if isinstance(claim, dict) else None,
         implementationPr=impl if isinstance(impl, dict) else None,
         terminalPr=term if isinstance(term, dict) else None,
         worktreeReady=audit.truthy(evidence.get("worktreeReady")),
@@ -206,6 +213,8 @@ def buildFacts(evidence: dict[str, Any]) -> _Facts:
     if claimId and queueClaim:
         _mismatch(facts, "queue claim id", claimId, queueClaim)
 
+    if facts.claimPr is not None:
+        _correlatePr(facts, facts.claimPr, "claim")
     if facts.implementationPr is not None:
         _correlatePr(facts, facts.implementationPr, "implementation")
     if facts.terminalPr is not None:
@@ -215,10 +224,15 @@ def buildFacts(evidence: dict[str, Any]) -> _Facts:
 
 def _deriveState(facts: _Facts) -> str:
     queueStatus = audit.queueStatus(facts.queue)
+    claimMerged = facts.claimPr is not None and audit.truthy(audit.firstValue(facts.claimPr, "merged", default=False))
     implMerged = facts.implementationPr is not None and audit.truthy(
         audit.firstValue(facts.implementationPr, "merged", default=False)
     )
 
+    # Contradiction: the claim PR merged (the issue is claimed on the remote) but
+    # the queue row still shows it as never claimed -> merged-but-unmarked recovery.
+    if claimMerged and queueStatus in {"not_started", ""}:
+        facts.contradictions.append("claim PR merged but queue row is not claimed")
     # Contradiction: implementation merged but the queue row was never claimed.
     if implMerged and queueStatus in {"not_started", ""}:
         facts.contradictions.append("implementation PR merged but queue row is not claimed")
@@ -262,6 +276,13 @@ def _deriveState(facts: _Facts) -> str:
         return STATE_WORKER_RUNNING
     if facts.worktreeReady:
         return STATE_WORKTREE_READY
+    # Claim-PR phase: the workbook-only claim PR gates implementation. A merged
+    # claim PR means the claim is durable and the worktree is what remains next; an
+    # open claim PR means the controller is still waiting for the concurrency guard.
+    if facts.claimPr is not None:
+        if claimMerged:
+            return STATE_CLAIM_PR_MERGED
+        return STATE_CLAIM_PR_OPEN
     if queueStatus == "in_progress":
         return STATE_CLAIM_SELECTED
     # No claim, no PR, no local evidence: nothing selected for this issue.
@@ -276,6 +297,15 @@ def _nextAction(state: str, facts: _Facts) -> str:
     if state == STATE_BLOCKED:
         return ACTION_NONE
     if state == STATE_CLAIM_SELECTED:
+        return ACTION_CREATE_WORKTREE
+    if state == STATE_CLAIM_PR_OPEN:
+        # The concurrency guard has not merged yet; keep waiting, never re-open a
+        # duplicate claim PR.
+        return ACTION_WAIT_FOR_CI
+    if state == STATE_CLAIM_PR_MERGED:
+        # Claim is durable; the next durable write is the worktree. This is the
+        # same action (and idempotency key) claim_selected produces, so a restart
+        # between "claim merged" and "worktree created" never duplicates work.
         return ACTION_CREATE_WORKTREE
     if state == STATE_WORKTREE_READY:
         return ACTION_RUN_WORKER

--- a/tests/test_controller_reconciler.py
+++ b/tests/test_controller_reconciler.py
@@ -39,10 +39,46 @@ class ControllerReconcilerStateMatrixTest(unittest.TestCase):
     def test_claim_selected_recommends_worktree(self) -> None:
         self.assertState(evidence(), reconciler.STATE_CLAIM_SELECTED, reconciler.ACTION_CREATE_WORKTREE)
 
-    def test_worktree_ready_recommends_worker(self) -> None:
-        self.assertState(
-            evidence(worktreeReady=True), reconciler.STATE_WORKTREE_READY, reconciler.ACTION_RUN_WORKER
+    def test_claim_pr_open_waits(self) -> None:
+        ev = evidence(claimPr={"claimId": "claim-1", "issueName": ISSUE, "merged": False})
+        snapshot = self.assertState(ev, reconciler.STATE_CLAIM_PR_OPEN, reconciler.ACTION_WAIT_FOR_CI)
+        # Waiting is a read action; it must never carry a write idempotency key.
+        self.assertIsNone(snapshot.idempotencyKey)
+
+    def test_claim_pr_merged_recommends_worktree(self) -> None:
+        ev = evidence(claimPr={"claimId": "claim-1", "issueName": ISSUE, "merged": True})
+        snapshot = self.assertState(ev, reconciler.STATE_CLAIM_PR_MERGED, reconciler.ACTION_CREATE_WORKTREE)
+        # A merged claim and a freshly selected claim converge on the same write, so
+        # a restart in between cannot duplicate the worktree transition.
+        self.assertEqual("claim-1:create_worktree", snapshot.idempotencyKey)
+        self.assertEqual(reconciler.reconcile(evidence()).idempotencyKey, snapshot.idempotencyKey)
+
+    def test_claim_pr_merged_but_row_unmarked_is_recovery(self) -> None:
+        ev = evidence(
+            queue={"status": "NOT_STARTED", "issueName": ISSUE},
+            claimPr={"claimId": "claim-1", "issueName": ISSUE, "merged": True},
         )
+        snapshot = reconciler.reconcile(ev)
+        self.assertEqual(reconciler.STATE_RECOVERY_REQUIRED, snapshot.state)
+        self.assertTrue(any("claim PR merged" in c for c in snapshot.contradictions))
+
+    def test_claim_pr_claim_id_mismatch_is_recovery(self) -> None:
+        ev = evidence(claimPr={"claimId": "other-claim", "issueName": ISSUE, "merged": False})
+        snapshot = reconciler.reconcile(ev)
+        self.assertEqual(reconciler.STATE_RECOVERY_REQUIRED, snapshot.state)
+        self.assertTrue(any("claim PR claim id mismatch" in c for c in snapshot.contradictions))
+
+    def test_worktree_ready_wins_over_open_claim_pr(self) -> None:
+        # A later lifecycle stage (worktree ready) takes precedence over an
+        # earlier one whose PR record lingers in the evidence blob.
+        ev = evidence(
+            worktreeReady=True,
+            claimPr={"claimId": "claim-1", "issueName": ISSUE, "merged": True},
+        )
+        self.assertState(ev, reconciler.STATE_WORKTREE_READY, reconciler.ACTION_RUN_WORKER)
+
+    def test_worktree_ready_recommends_worker(self) -> None:
+        self.assertState(evidence(worktreeReady=True), reconciler.STATE_WORKTREE_READY, reconciler.ACTION_RUN_WORKER)
 
     def test_worker_running_recommends_open_pr(self) -> None:
         self.assertState(


### PR DESCRIPTION
## Summary

Completes the durable, read-only controller transition reconciler (`scripts/controller_reconciler.py`) so it models the full controller lifecycle the acceptance criteria enumerate. The prior foundation modeled the implementation PR and terminal PR phases but omitted the workbook-only **claim PR** stage that gates implementation; this PR adds it additively.

- Adds two lifecycle states — `claim_pr_open` and `claim_pr_merged` — plus a `claimPr` evidence record correlated by exact identity (claim id / issue name / owner), exactly like the implementation and terminal PR records. Title matching is never authoritative.
- A merged claim PR resolves to the **same** `create_worktree` action and idempotency key (`<claimId>:create_worktree`) as a freshly selected claim, so a restart between "claim PR merged" and "worktree created" cannot duplicate work.
- A merged claim PR against a still-unclaimed queue row fails closed to `recovery_required` (merged-but-unmarked detection) with the conflicting evidence, rather than guessing a write.
- Documents the reconciler command, evidence schema, and full state list in `docs/codex-agent-queue.md` and references it from `AGENTS.md`, matching the existing doc style.

The reconciler remains strictly read-only: `snapshot` / `reconcile` / `next-action` consume a JSON evidence blob and print JSON, never calling workbook save, git write commands, or GitHub mutations. `reconcile` exits non-zero on `recovery_required` so callers can branch. Correlation reuses `pr_review_audit` for queue/PR/check normalization.

## Tests

`tests/test_controller_reconciler.py` (extends the existing fixture matrix; 28 tests, all passing). New cases:
- `test_claim_pr_open_waits` — open claim PR waits, carries no write idempotency key.
- `test_claim_pr_merged_recommends_worktree` — merged claim PR yields `create_worktree` with the same idempotency key as a freshly selected claim.
- `test_claim_pr_merged_but_row_unmarked_is_recovery` — merged-but-unmarked fails closed to `recovery_required`.
- `test_claim_pr_claim_id_mismatch_is_recovery` — claim-PR identity mismatch fails closed.
- `test_worktree_ready_wins_over_open_claim_pr` — later lifecycle stage takes precedence over a lingering claim-PR record.

Verification run locally: `python3 -m unittest tests.test_controller_reconciler` (OK, 28), `python3 -m unittest tests.test_pr_review_audit tests.test_controller_reconciler` (OK, 69), `python3 -m py_compile`, `black -l 120 --check`, and `git diff --check` all clean. Tests use only synthetic fixtures — no live workbook.

## Compatibility

Additive only. Existing `workbook_queue.py` subcommands, output schema, and claim/lease semantics are untouched. The reconciler's existing states, actions, evidence keys, and output payload are unchanged; evidence blobs without a `claimPr` key behave byte-identically to before (all pre-existing tests pass unmodified in behavior). No breaking changes to shared fleet tooling.

Worker implementation branch did not modify any queue workbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_