### PR TITLE
Scope map-script class registration so map transitions run the destination map's classes

### DIFF
--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -1482,6 +1482,24 @@ bool CPluginLoader::loadMapPlugins(const std::shared_ptr<CGame> &game, const std
         return false;
     }
 
+    // Mark every class registration performed while this map's script/plugins load as map-scoped, so
+    // a transition destination's classes override an earlier map's identically named classes without
+    // clobbering core types or explicit overrides. The guard restores the flag even if a plugin
+    // throws mid-load.
+    struct MapScriptScopeGuard {
+        std::shared_ptr<CObjectHandler> handler;
+        explicit MapScriptScopeGuard(std::shared_ptr<CObjectHandler> handler) : handler(std::move(handler)) {
+            if (this->handler) {
+                this->handler->beginMapScriptScope();
+            }
+        }
+        ~MapScriptScopeGuard() {
+            if (handler) {
+                handler->endMapScriptScope();
+            }
+        }
+    } mapScriptScopeGuard(game->getObjectHandler());
+
     bool loadedAll = true;
     std::set<std::string> loadedPythonPlugins;
     std::set<std::string> loadedDynamicPlugins;

--- a/src/handler/CObjectHandler.cpp
+++ b/src/handler/CObjectHandler.cpp
@@ -72,8 +72,30 @@ std::shared_ptr<CGameObject> CObjectHandler::getType(const std::string &name) {
 }
 
 void CObjectHandler::registerType(std::string name, std::function<std::shared_ptr<CGameObject>()> constructor) {
-    constructors.insert(std::make_pair(name, constructor));
+    if (mapScriptScopeActive) {
+        // A map script is registering this class. Several maps legitimately define the same class
+        // name (e.g. StartEvent), and a map may be loaded while another map is still active during a
+        // transition. Override an existing registration only when it too was owned by a map script,
+        // so the destination map runs its own class instead of the previously loaded map's -- e.g.
+        // entering the ritual map after Nouraajd must build ritualStart from the ritual StartEvent,
+        // not Nouraajd's. Persistent registrations (core types, native/global plugins, or explicit
+        // manual registerType overrides made outside a map scope) are left untouched.
+        const bool alreadyPersistent = constructors.contains(name) && !mapScopedTypes.contains(name);
+        if (alreadyPersistent) {
+            return;
+        }
+        constructors.insert_or_assign(name, std::move(constructor));
+        mapScopedTypes.insert(std::move(name));
+        return;
+    }
+    // Persistent registration path: keep first-registration-wins so core types (registered first at
+    // game init) and explicit test/manual overrides cannot be clobbered by later registrations.
+    constructors.insert(std::make_pair(std::move(name), std::move(constructor)));
 }
+
+void CObjectHandler::beginMapScriptScope() { mapScriptScopeActive = true; }
+
+void CObjectHandler::endMapScriptScope() { mapScriptScopeActive = false; }
 
 // TODO: add option to provide custom configuration from string
 std::shared_ptr<CGameObject> CObjectHandler::_createObject(std::shared_ptr<CGame> game, const std::string &type) {

--- a/src/handler/CObjectHandler.h
+++ b/src/handler/CObjectHandler.h
@@ -58,6 +58,16 @@ class CObjectHandler : public CGameObject {
 
     void registerType(std::string name, std::function<std::shared_ptr<CGameObject>()> constructor);
 
+    // Map-script registration scope. Class names registered while the scope is active (i.e. while a
+    // map's script.py is being loaded) are treated as map-scoped: a later map-scoped registration of
+    // the same name overrides an earlier map-scoped one, so a transition destination runs its own
+    // class rather than a previously loaded map's identically named class. Persistent registrations
+    // (core types, native/global plugins, and manual registerType calls made outside this scope) are
+    // never overridden by a map script, preserving core-type protection and explicit test overrides.
+    void beginMapScriptScope();
+
+    void endMapScriptScope();
+
     std::shared_ptr<CGameObject> getType(const std::string &name);
 
     std::shared_ptr<json> getConfig(const std::string &type);
@@ -70,6 +80,11 @@ class CObjectHandler : public CGameObject {
     std::shared_ptr<CGameObject> _clone(const std::shared_ptr<CGameObject> &object);
 
     std::unordered_map<std::string, std::function<std::shared_ptr<CGameObject>()>> constructors;
+
+    // Names whose current constructor was registered by a map script (see beginMapScriptScope).
+    std::unordered_set<std::string> mapScopedTypes;
+
+    bool mapScriptScopeActive = false;
 
     std::unordered_map<std::string, std::shared_ptr<json>> objectConfig;
 };


### PR DESCRIPTION
## Summary

Fixes the pre-existing failure of `test_nouraajd_ritual_return_round_trip_preserves_persistent_state` on `main`.

### Root cause

`CObjectHandler` stored class constructors in a single global, **first-registration-wins** registry (`constructors.insert(...)`) with no per-map cleanup. Six map scripts legitimately register the same class name `StartEvent` (plus other shared names like `ChangeMap`). When a map is loaded while another is still active during a **transition**, the destination map silently reused the previously loaded map's identically named class.

Concretely: entering the ritual map after Nouraajd built its entry object `ritualStart` (map.json `type: StartEvent`) from **Nouraajd's** `StartEvent`. Nouraajd's `onEnter` resets Nouraajd quest state and removes itself, but never sets `ritual_initialized` — so the flag stayed `False`. The earlier fix (#1338) only added a test-side step-off/step-back dance, which could never work because the entry StartEvent had already been consumed by Nouraajd's `onEnter` during entry placement (`attachPlayer` → `moveTo`).

### Fix

Track a **map-script registration scope** on `CObjectHandler`. Names registered while a map's `script.py`/plugins load (`loadMapPlugins`) are marked map-scoped. A later map-scoped registration overrides an earlier map-scoped one, so the active map runs its own class. Persistent registrations — core types (registered first at game init), native/global plugins, and explicit manual `registerType` overrides made outside a map scope — are never clobbered by a map script.

This preserves two contracts at once:
- **ritual round-trip:** ritual's `StartEvent` now overrides Nouraajd's → `ritual_initialized` is set. ✅
- **`test_scene_manager_rejects_nested_transition_from_destination_entry`:** its manually pre-registered `StartEvent` override (persistent, registered outside a map scope) is still honored and not clobbered by ritual's script. ✅

An RAII guard around `loadMapPlugins` restores the scope flag even if a plugin throws mid-load.

## Validation

- `python3 scripts/validate_content.py --repo-root .` — passed
- `ctest -R for_unit_tests` — 10/10; `ctest -L performance` — 1/1
- `python3 test.py` (full suite) — **exit 0, all OK** (previously 1 failure on `main`)
- Verified the two mutually-constraining tests (`ritual_return_round_trip` and `rejects_nested_transition_from_destination_entry`) both pass together

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYtPr2qHrT8FpC6qu3PkW7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYtPr2qHrT8FpC6qu3PkW7)_