### PR TITLE
Add security invariant lock: no subprocess shell=True in project Python

### DIFF
--- a/tests/security/test_no_shell_true.py
+++ b/tests/security/test_no_shell_true.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# fall-of-nouraajd c++ dark fantasy game
+# Copyright (C) 2026  Andrzej Lis
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Invariant lock: project Python must never invoke a subprocess with
+``shell=True``.
+
+``shell=True`` runs the command through ``/bin/sh``, so any attacker-influenced
+value interpolated into the command string becomes shell-executable (the same
+command-injection class fixed in the ``subagent_registry`` sweep, which built an
+operator command from untrusted branch/worktree fields). Every subprocess call
+site in this repo already passes an explicit argv list; this test pins that so a
+``shell=True`` call cannot silently reappear. Prefer ``subprocess.run([...])``
+and, when composing a human-facing command string, ``shlex.join``/``shlex.quote``.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Directories that hold this project's own Python (the code we control). Excludes
+# submodules and build trees, which are not part of this repository's sources.
+SOURCE_DIRS = ("scripts", "res", "tests", "src")
+ROOT_MODULES = ("mcp.py", "test.py", "game_simulation.py", "play.py", "quest_state.py")
+
+SHELL_TRUE = re.compile(r"shell\s*=\s*True")
+
+
+def _iter_python_files():
+    seen: set[Path] = set()
+    for name in ROOT_MODULES:
+        path = REPO_ROOT / name
+        if path.is_file():
+            seen.add(path)
+    for directory in SOURCE_DIRS:
+        base = REPO_ROOT / directory
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*.py"):
+            seen.add(path)
+    return sorted(seen)
+
+
+class NoShellTrueTest(unittest.TestCase):
+    def test_no_project_python_uses_subprocess_shell_true(self):
+        this_file = Path(__file__).resolve()
+        offenders: list[str] = []
+        for path in _iter_python_files():
+            if path.resolve() == this_file:
+                # This file names the pattern in its regex/docstring on purpose.
+                continue
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            if SHELL_TRUE.search(text):
+                offenders.append(str(path.relative_to(REPO_ROOT)))
+        self.assertEqual(
+            [],
+            offenders,
+            "shell=True runs commands through the shell and makes any interpolated value "
+            "injectable; use subprocess.run([...]) with an argv list instead. Offending files: "
+            f"{offenders}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a preventive **security invariant lock**: project Python must never invoke a subprocess with `shell=True`.

`shell=True` runs the command through `/bin/sh`, so any attacker-influenced value interpolated into the command string becomes shell-executable — the same command-injection class fixed in the `subagent_registry` sweep (#1325), where an operator command was built from untrusted `branch`/`worktree` fields. Every subprocess call site in this repo already passes an explicit argv list; this test pins that property so a `shell=True` call cannot silently reappear.

## Change

- **`tests/security/test_no_shell_true.py`** — scans this project's own Python (`scripts/`, `src/`, `res/`, `tests/`, and the root modules `mcp.py`/`test.py`/`game_simulation.py`/`play.py`/`quest_state.py`) and asserts no `shell=True`. Excludes itself (it names the pattern in its regex/docstring). Modeled on the existing source-scanning security tests (`test_layout_no_script_eval.py`, `test_configure_supply_chain.py`).

## Validation

- `python3 -m unittest tests.security.test_no_shell_true` → **1 test, OK** (invariant holds today).
- Negative control: the regex `shell\s*=\s*True` matches a real `subprocess.run(..., shell=True)`, so the test **fails closed** if the invariant regresses.
- `py_compile` clean; `git diff --check` clean; lines ≤ 120.

Additive test only — no source or CI changes. Complements the proactive-review fixes (#1325 et al.) with a regression guard for that vulnerability class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXJFAGuL4Nfo18iFJMRnB8)_