### PR TITLE
Surface artifact-set membership in item tooltips

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -197,3 +197,8 @@ Set pieces are ordinary items re-classed to a `Set*` slot subclass (e.g.
 set-completion check. `res/config/slots.json` maps every equipment slot,
 including the `CShield` (LeftHand) and `CPants` (Legs) slots used by four-piece
 sets.
+
+For discoverability, each piece's `description` ends with `Part of the <set>
+set (<n> pieces).` and each combined artifact's ends with `Assembled from the
+<set> set.` — this text surfaces in the item tooltip so players can tell which
+items belong together.

--- a/res/config/armors.json
+++ b/res/config/armors.json
@@ -123,7 +123,7 @@
         }
       },
       "label": "Rib Cage",
-      "description": "Harness of lacquered beast ribs favored by grave-witches; the dead find its shape familiar and pass by.",
+      "description": "Harness of lacquered beast ribs favored by grave-witches; the dead find its shape familiar and pass by. Part of the Armor of the Damned set (4 pieces).",
       "power": 8
     }
   },
@@ -161,7 +161,7 @@
         }
       },
       "label": "Dragon Scale Armor",
-      "description": "Overlapping scales stripped from a red wyrm's flank; furnace heat and Pritscher claws alike slide off.",
+      "description": "Overlapping scales stripped from a red wyrm's flank; furnace heat and Pritscher claws alike slide off. Part of the Wrath of the Dragon Father set (4 pieces).",
       "power": 19
     }
   },

--- a/res/config/items.json
+++ b/res/config/items.json
@@ -175,7 +175,7 @@
         }
       },
       "label": "Skull Helmet",
-      "description": "Varnished troll skull worn as a cap by hedge-wizards; grim, but the dead brain-case keeps thoughts orderly.",
+      "description": "Varnished troll skull worn as a cap by hedge-wizards; grim, but the dead brain-case keeps thoughts orderly. Part of the Armor of the Damned set (4 pieces).",
       "power": 4
     }
   },
@@ -248,7 +248,7 @@
         }
       },
       "label": "Crown of Dragontooth",
-      "description": "Jagged diadem of dragon fangs set in red gold; whoever bears it speaks with a wyrm's authority over flame.",
+      "description": "Jagged diadem of dragon fangs set in red gold; whoever bears it speaks with a wyrm's authority over flame. Part of the Wrath of the Dragon Father set (4 pieces).",
       "power": 21
     }
   },
@@ -265,7 +265,7 @@
         }
       },
       "label": "Dragonbone Greaves",
-      "description": "Shin guards of split wyrm bone, light as ash wood and stubborn as old scars.",
+      "description": "Shin guards of split wyrm bone, light as ash wood and stubborn as old scars. Part of the Wrath of the Dragon Father set (4 pieces).",
       "power": 4
     }
   },
@@ -411,7 +411,7 @@
         }
       },
       "label": "Shield of the Yawning Dead",
-      "description": "A barrow-door hammered into a shield; the grave-cold face of it makes the dead hesitate to strike.",
+      "description": "A barrow-door hammered into a shield; the grave-cold face of it makes the dead hesitate to strike. Part of the Armor of the Damned set (4 pieces).",
       "power": 9
     }
   },
@@ -429,7 +429,7 @@
         }
       },
       "label": "Dragonscale Guards",
-      "description": "Thigh guards of overlapping wyrm scale, shrugging off both furnace heat and the claws of the deep.",
+      "description": "Thigh guards of overlapping wyrm scale, shrugging off both furnace heat and the claws of the deep. Part of the Wrath of the Dragon Father set (4 pieces).",
       "power": 7
     }
   },
@@ -460,7 +460,7 @@
         "2"
       ],
       "label": "Armor of the Damned",
-      "description": "Blackshard, barrow-shield, troll-skull and rib harness fused into one damned panoply; the grave answers to whoever wears it.",
+      "description": "Blackshard, barrow-shield, troll-skull and rib harness fused into one damned panoply; the grave answers to whoever wears it. Assembled from the Armor of the Damned set.",
       "power": 24,
       "tags": [
         "compound"
@@ -492,7 +492,7 @@
         "6"
       ],
       "label": "Wrath of the Dragon Father",
-      "description": "Crown, scale, greaves and guards welded into a single wyrm-panoply; the wearer speaks to fire as a father to a wayward child.",
+      "description": "Crown, scale, greaves and guards welded into a single wyrm-panoply; the wearer speaks to fire as a father to a wayward child. Assembled from the Wrath of the Dragon Father set.",
       "power": 30,
       "tags": [
         "compound"

--- a/res/config/weapons.json
+++ b/res/config/weapons.json
@@ -384,7 +384,7 @@
         }
       },
       "label": "Blackshard of the Dead Knight",
-      "description": "Night-black shard pried from a dead knight's barrow beneath the catacombs; it drinks lamplight like the grave.",
+      "description": "Night-black shard pried from a dead knight's barrow beneath the catacombs; it drinks lamplight like the grave. Part of the Armor of the Damned set (4 pieces).",
       "power": 7
     }
   },

--- a/test.py
+++ b/test.py
@@ -6149,6 +6149,28 @@ class GameTest(unittest.TestCase):
             "compound artifacts must never appear as random loot",
         )
 
+    def test_compound_artifact_set_membership_is_discoverable_in_tooltip(self):
+        import artifact_sets
+
+        game = load_game_module()
+        g, game_map, player = load_game_map_with_player("test")
+        runtime = artifact_sets.get_runtime()
+
+        for definition in runtime.all_sets():
+            for piece_id in definition["pieces"]:
+                piece = g.getObjectHandler().createObject(g, piece_id)
+                tooltip = game.CTooltipHandler.buildTooltip(piece)
+                self.assertIn(
+                    definition["label"],
+                    tooltip,
+                    f"piece {piece_id} tooltip should name its set",
+                )
+                self.assertIn("Part of the", tooltip)
+            combined = g.getObjectHandler().createObject(g, definition["combined"])
+            combined_tooltip = game.CTooltipHandler.buildTooltip(combined)
+            self.assertIn(definition["label"], combined_tooltip)
+            self.assertIn("Assembled from the", combined_tooltip)
+
     @game_test
     def test_crafting_runtime_applies_recipe(self):
         import crafting


### PR DESCRIPTION
## What

Follow-up to #1370 (compound artifacts). Adds in-game **discoverability** of artifact sets: players previously had no hint that certain items combine.

Each set piece's `description` now ends with `Part of the <set> set (<n> pieces).` and each combined artifact's ends with `Assembled from the <set> set.`. The existing tooltip renders the description (`CTooltipHandler`), so the membership is visible in-game with no engine change.

## Changes

- `res/config/{items,weapons,armors}.json`: appended the membership hint to the 8 set pieces and 2 combined artifacts (description text only).
- `test.py`: `test_compound_artifact_set_membership_is_discoverable_in_tooltip` asserts the hints appear in `CTooltipHandler.buildTooltip` output for every piece and combined artifact.
- `docs/content.md`: documented the convention.

Content validation and all four compound-artifact gameplay tests pass locally.

Note: `main`'s CI is currently red due to a pre-existing Warden's Road (gravemoor/hearthfall/usurpergate) map-loading regression (see main commit "Record observation: gravemoor/hearthfall native red root cause") — unrelated to this content-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JiWjyXWj22r4nZavLbXih

---
_Generated by [Claude Code](https://claude.ai/code/session_015JiWjyXWj22r4nZavLbXih)_