### PR TITLE
Fix Warden's Road map corruption and cross-map StartEvent collision

### DIFF
--- a/res/maps/gravemoor/map.json
+++ b/res/maps/gravemoor/map.json
@@ -28,21 +28,6 @@
    "opacity": 1,
    "properties": {
     "default": "SwampTile",
-    "level": "0",
-    "xBound": "23",
-    "yBound": "23"
-   },
-   "propertytypes": {
-    "default": "string",
-    "level": "string",
-    "xBound": "string",
-    "yBound": "string"
-   },
-   "visible": true,
-   "x": 0,
-   "y": 0,
-   "properties": {
-    "default": "SwampTile",
     "outOfBounds": "MountainTile",
     "level": "0",
     "xBound": "23",
@@ -55,6 +40,9 @@
     "xBound": "string",
     "yBound": "string"
    },
+   "visible": true,
+   "x": 0,
+   "y": 0,
    "data": [
     12,
     12,
@@ -648,12 +636,6 @@
    "x": 0,
    "y": 0,
    "draworder": "topdown",
-   "properties": {
-    "level": "0"
-   },
-   "propertytypes": {
-    "level": "string"
-   },
    "objects": [
     {
      "height": 32,

--- a/res/maps/hearthfall/map.json
+++ b/res/maps/hearthfall/map.json
@@ -28,21 +28,6 @@
    "opacity": 1,
    "properties": {
     "default": "GrassTile",
-    "level": "0",
-    "xBound": "23",
-    "yBound": "23"
-   },
-   "propertytypes": {
-    "default": "string",
-    "level": "string",
-    "xBound": "string",
-    "yBound": "string"
-   },
-   "visible": true,
-   "x": 0,
-   "y": 0,
-   "properties": {
-    "default": "GrassTile",
     "outOfBounds": "MountainTile",
     "level": "0",
     "xBound": "23",
@@ -55,6 +40,9 @@
     "xBound": "string",
     "yBound": "string"
    },
+   "visible": true,
+   "x": 0,
+   "y": 0,
    "data": [
     12,
     12,
@@ -648,12 +636,6 @@
    "x": 0,
    "y": 0,
    "draworder": "topdown",
-   "properties": {
-    "level": "0"
-   },
-   "propertytypes": {
-    "level": "string"
-   },
    "objects": [
     {
      "height": 32,

--- a/res/maps/usurpergate/map.json
+++ b/res/maps/usurpergate/map.json
@@ -28,21 +28,6 @@
    "opacity": 1,
    "properties": {
     "default": "WastelandTile",
-    "level": "0",
-    "xBound": "23",
-    "yBound": "23"
-   },
-   "propertytypes": {
-    "default": "string",
-    "level": "string",
-    "xBound": "string",
-    "yBound": "string"
-   },
-   "visible": true,
-   "x": 0,
-   "y": 0,
-   "properties": {
-    "default": "WastelandTile",
     "outOfBounds": "MountainTile",
     "level": "0",
     "xBound": "23",
@@ -55,6 +40,9 @@
     "xBound": "string",
     "yBound": "string"
    },
+   "visible": true,
+   "x": 0,
+   "y": 0,
    "data": [
     12,
     12,
@@ -648,12 +636,6 @@
    "x": 0,
    "y": 0,
    "draworder": "topdown",
-   "properties": {
-    "level": "0"
-   },
-   "propertytypes": {
-    "level": "string"
-   },
    "objects": [
     {
      "height": 32,

--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -1373,6 +1373,20 @@ bool CPluginLoader::loadPlugin(const std::shared_ptr<CGame> &game, const std::st
         vstd::logger::warning("Rejected Python plugin outside trusted resource plugin paths:", path);
         return false;
     }
+    // A map's script.py registers its gameplay classes into the object handler as map-scoped
+    // bindings (see CObjectHandler::registerType); global plugins under plugins/ register
+    // authoritative bindings. isTrustedPluginPath already restricts a "script.py" filename to a
+    // valid maps/<name>/ directory, so the filename alone distinguishes the two here.
+    const auto normalizedPath = normalize_relative_resource_path(path);
+    const bool isMapScript = normalizedPath && std::filesystem::path(*normalizedPath).filename() == "script.py";
+    struct MapScriptScopeGuard {
+        std::shared_ptr<CObjectHandler> handler;
+        ~MapScriptScopeGuard() {
+            if (handler) {
+                handler->endMapScriptScope();
+            }
+        }
+    } scopeGuard;
     try {
         std::string code = game->getResourcesProvider()->load(path);
         pybind11::dict plugin_namespace;
@@ -1380,6 +1394,12 @@ bool CPluginLoader::loadPlugin(const std::shared_ptr<CGame> &game, const std::st
         plugin_namespace["__file__"] = path;
         plugin_namespace["__name__"] = vstd::join({"plugin_", vstd::to_hex_hash(path)}, "");
         pybind11::exec(code + "\n", plugin_namespace, plugin_namespace);
+        if (isMapScript) {
+            if (auto handler = game->getObjectHandler()) {
+                handler->beginMapScriptScope();
+                scopeGuard.handler = handler;
+            }
+        }
         plugin_namespace["load"](pybind11::none(), pybind11::cast(game));
         return true;
     } catch (const pybind11::error_already_set &exception) {

--- a/src/handler/CObjectHandler.cpp
+++ b/src/handler/CObjectHandler.cpp
@@ -72,8 +72,31 @@ std::shared_ptr<CGameObject> CObjectHandler::getType(const std::string &name) {
 }
 
 void CObjectHandler::registerType(std::string name, std::function<std::shared_ptr<CGameObject>()> constructor) {
-    constructors.insert(std::make_pair(name, constructor));
+    // A map's script.py is loaded (registering its classes) immediately before that map's objects
+    // are constructed from TMX, so a class name shared across maps -- e.g. every campaign map
+    // defines its own "StartEvent" -- must resolve to the map currently being loaded. The previous
+    // std::unordered_map::insert kept the first binding and silently dropped later ones, so the
+    // first map loaded in a session (the campaign start) owned a shared class name for every
+    // subsequent map: entering a later map constructed its start markers from the wrong map's class
+    // and skipped that map's arrival initialization.
+    //
+    // Registrations made while a map script is loading are therefore last-wins *among map scripts*,
+    // but must not clobber an authoritative binding registered outside map-script loading (native /
+    // config / global plugin, or an explicit tooling/test registration): those keep first priority
+    // so a globally injected class still overrides a map's same-named declaration.
+    if (loadingMapScript) {
+        if (externalConstructors.contains(name)) {
+            return;
+        }
+    } else {
+        externalConstructors.insert(name);
+    }
+    constructors.insert_or_assign(std::move(name), std::move(constructor));
 }
+
+void CObjectHandler::beginMapScriptScope() { loadingMapScript = true; }
+
+void CObjectHandler::endMapScriptScope() { loadingMapScript = false; }
 
 // TODO: add option to provide custom configuration from string
 std::shared_ptr<CGameObject> CObjectHandler::_createObject(std::shared_ptr<CGame> game, const std::string &type) {

--- a/src/handler/CObjectHandler.h
+++ b/src/handler/CObjectHandler.h
@@ -21,6 +21,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CGlobal.h"
 #include "core/CUtil.h"
 
+#include <unordered_set>
+
 #include "core/CSerialization.h"
 #include "object/CGameObject.h"
 
@@ -58,6 +60,13 @@ class CObjectHandler : public CGameObject {
 
     void registerType(std::string name, std::function<std::shared_ptr<CGameObject>()> constructor);
 
+    // Map-script loading window (see registerType). A map's script.py is executed immediately
+    // before that map's objects are constructed from TMX; the loader brackets that execution with
+    // these so registrations made by the script are treated as map-scoped rather than authoritative.
+    void beginMapScriptScope();
+
+    void endMapScriptScope();
+
     std::shared_ptr<CGameObject> getType(const std::string &name);
 
     std::shared_ptr<json> getConfig(const std::string &type);
@@ -70,6 +79,13 @@ class CObjectHandler : public CGameObject {
     std::shared_ptr<CGameObject> _clone(const std::shared_ptr<CGameObject> &object);
 
     std::unordered_map<std::string, std::function<std::shared_ptr<CGameObject>()>> constructors;
+
+    // Names registered outside a map-script load (native/config/global-plugin registration, or an
+    // explicit tooling/test registration). These are authoritative: a map script may not overwrite
+    // them, so a globally injected class keeps working even when a loading map declares the name.
+    std::unordered_set<std::string> externalConstructors;
+
+    bool loadingMapScript = false;
 
     std::unordered_map<std::string, std::shared_ptr<json>> objectConfig;
 };


### PR DESCRIPTION
## Summary

Two related fixes for map-loading correctness on `main`, uncovered while investigating four walkthrough/campaign CI failures.

### 1. Duplicate JSON keys broke three Warden's Road maps (`e865330`)

`hearthfall`, `gravemoor`, and `usurpergate` each had **duplicate `properties`/`propertytypes` keys** in their Map Layer and Object Layer (introduced by #1324). Python's tolerant parser keeps the last value, so `validate_content.py` passed — but the engine's **simdjson parser rejects any document with duplicate keys outright**, so those three maps failed to load in-game. Empty maps meant arrival events never fired.

Merged each layer's duplicate blocks into one, keeping the complete version (the one carrying `outOfBounds: MountainTile`), matching the format the already-passing `ninemarches` map uses. The maps round-trip cleanly at their native `indent=1` Tiled formatting, so the change is minimal (−60/+6 lines).

Fixes: `test_map_walkthrough_hearthfall`, `test_stdio_map_walkthrough_hearthfall`, `test_stdio_map_walkthrough_gravemoor`, `test_wardens_road_campaign_mercy_route`.

### 2. Cross-map `StartEvent` registration collision (`011ebd1`)

Every campaign map's `script.py` defines its own class named `StartEvent`. `registerType` used `unordered_map::insert`, which keeps the *first* binding and silently drops later ones — so the first map loaded in a session permanently owned each shared class name. Entering a later map constructed its start markers from the *wrong* map's class and skipped its arrival init (e.g. the `nouraajd → ritual` round trip lost ritual's intro).

Bracket a map's `script.py` `load()` with `begin/endMapScriptScope` (exception-safe RAII in the loader) so map-script registrations are **last-wins among map scripts**, while registrations made outside that window (native/config/global-plugin, or explicit tooling/test registrations) are recorded as **authoritative and never clobbered**. A loading map's shared class name now resolves to that map, but a globally injected class still overrides a map's same-named declaration.

This resolves a standing conflict between two tests that pin the opposite requirements — `test_nouraajd_ritual_return_round_trip_preserves_persistent_state` (needs the loading map's class) and `test_scene_manager_rejects_nested_transition_from_destination_entry` (needs an externally injected class) — which **both now pass**.

## Validation

- `python3 scripts/validate_content.py --repo-root .` — passed
- `python3 -m unittest tests.test_content_validator` — 160 tests OK
- ctest `for_unit_tests` — 10/10 pass; `performance` label — pass
- `python3 test.py --suite fast` and `--suite gameplay` — passed (0 failures; includes all walkthrough/campaign/transition tests and both previously-opposing tests)
- `clang-format --dry-run --Werror` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FVGwTN4J3WiURLg7c3HJQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014FVGwTN4J3WiURLg7c3HJQ)_