### PR TITLE
[EPIC_03][STORY_04][SUBSTORY_03] Reject scalars for primitive collection wrappers on deserialize

### DIFF
--- a/src/core/CSerialization.cpp
+++ b/src/core/CSerialization.cpp
@@ -129,6 +129,46 @@ std::shared_ptr<json> primitiveObjectConfig(const std::shared_ptr<CGame> &game, 
     return primitiveObjectConfig<CMapIntInt>(game, property, value);
 }
 
+// The registered primitive wrappers (CList*/CMap*) all expose their value through a "values"
+// collection (a std::set or std::map). A flattened primitive therefore always deserializes from a
+// JSON array or object; a bare scalar can never be a valid flattened form for such a property.
+bool isPrimitiveCollectionValueType(std::type_index valueType) {
+    return valueType != std::type_index(typeid(int)) && valueType != std::type_index(typeid(std::string)) &&
+           valueType != std::type_index(typeid(bool));
+}
+
+template <typename T> bool isPrimitiveCollectionPointer(std::type_index property) {
+    if (property != std::type_index(typeid(std::shared_ptr<T>)) || !CTypes::isPrimitiveType<T>()) {
+        return false;
+    }
+    auto valueType = CTypes::primitiveValueType<T>();
+    return valueType && isPrimitiveCollectionValueType(*valueType);
+}
+
+bool isPrimitiveCollectionPointer(std::type_index property) {
+    return isPrimitiveCollectionPointer<CListString>(property) || isPrimitiveCollectionPointer<CListInt>(property) ||
+           isPrimitiveCollectionPointer<CMapStringString>(property) ||
+           isPrimitiveCollectionPointer<CMapStringInt>(property) ||
+           isPrimitiveCollectionPointer<CMapIntString>(property) || isPrimitiveCollectionPointer<CMapIntInt>(property);
+}
+
+// Guards scalar-to-collection coercion for primitive-wrapper properties. Returns true when the
+// scalar has been handled (rejected) and the caller must not attempt the underlying scalar
+// assignment. In strict mode an incompatible scalar raises a specific error; otherwise it is
+// skipped so the property keeps its default value instead of being silently mis-typed.
+bool rejectScalarForPrimitiveCollection(std::type_index property, const std::string &key) {
+    if (!isPrimitiveCollectionPointer(property)) {
+        return false;
+    }
+    const std::string message = "Cannot deserialize scalar value for property '" + key +
+                                "' which expects a primitive collection wrapper (a JSON array or object is required)";
+    if (CSerialization::isStrict()) {
+        throw std::runtime_error(message);
+    }
+    vstd::logger::warning(message);
+    return true;
+}
+
 class CGameObjectPointerSerializer : public CSerializerBase {
   public:
     std::any serialize(std::any object) final {
@@ -228,7 +268,7 @@ void CSerialization::setObjectProperty(const std::shared_ptr<CGameObject> &objec
 void CSerialization::setNumericProperty(const std::shared_ptr<CGameObject> &object, const std::string &key, int value) {
     if (isString(object, key)) {
         object->setStringProperty(key, vstd::str(value));
-    } else {
+    } else if (!rejectScalarForPrimitiveCollection(getProperty(object, key), key)) {
         object->setNumericProperty(key, value);
     }
 }
@@ -237,7 +277,7 @@ void CSerialization::setBooleanProperty(const std::shared_ptr<CGameObject> &obje
                                         bool value) {
     if (isString(object, key)) {
         object->setStringProperty(key, vstd::str(value));
-    } else {
+    } else if (!rejectScalarForPrimitiveCollection(getProperty(object, key), key)) {
         object->setBoolProperty(key, value);
     }
 }
@@ -246,7 +286,9 @@ void CSerialization::setStringProperty(const std::shared_ptr<CGameObject> &objec
                                        const std::string &value) {
     auto coerced = coerceStringProperty(getProperty(object, key), value);
     if (std::holds_alternative<std::string>(coerced)) {
-        object->setStringProperty(key, std::get<std::string>(coerced));
+        if (!rejectScalarForPrimitiveCollection(getProperty(object, key), key)) {
+            object->setStringProperty(key, std::get<std::string>(coerced));
+        }
     } else if (std::holds_alternative<int>(coerced)) {
         setNumericProperty(object, key, std::get<int>(coerced));
     } else if (std::holds_alternative<bool>(coerced)) {

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -928,7 +928,7 @@ void test_legacy_and_flattened_primitive_wrappers_deserialize_and_reject_scalars
     auto legacy_config = std::make_shared<json>();
     (*legacy_config)["class"] = PrimitiveSerializationHolder::static_meta()->name();
     (*legacy_config)["properties"]["listValues"]["class"] = CListString::static_meta()->name();
-    (*legacy_config)["properties"]["listValues"]["properties"]["values"] = {"north", "south"};
+    (*legacy_config)["properties"]["listValues"]["properties"]["values"] = json::array({"north", "south"});
     (*legacy_config)["properties"]["mapValues"]["class"] = CMapStringString::static_meta()->name();
     (*legacy_config)["properties"]["mapValues"]["properties"]["values"]["confirm"] = "enter";
 
@@ -945,7 +945,7 @@ void test_legacy_and_flattened_primitive_wrappers_deserialize_and_reject_scalars
     // for maps) with no class/properties envelope.
     auto flattened_config = std::make_shared<json>();
     (*flattened_config)["class"] = PrimitiveSerializationHolder::static_meta()->name();
-    (*flattened_config)["properties"]["listValues"] = {"east", "west"};
+    (*flattened_config)["properties"]["listValues"] = json::array({"east", "west"});
     (*flattened_config)["properties"]["mapValues"]["cancel"] = "escape";
 
     auto flattened = std::dynamic_pointer_cast<PrimitiveSerializationHolder>(
@@ -963,7 +963,7 @@ void test_legacy_and_flattened_primitive_wrappers_deserialize_and_reject_scalars
     auto mixed_config = std::make_shared<json>();
     (*mixed_config)["class"] = PrimitiveSerializationHolder::static_meta()->name();
     (*mixed_config)["properties"]["listValues"]["class"] = CListString::static_meta()->name();
-    (*mixed_config)["properties"]["listValues"]["properties"]["values"] = {"up", "down"};
+    (*mixed_config)["properties"]["listValues"]["properties"]["values"] = json::array({"up", "down"});
     (*mixed_config)["properties"]["mapValues"]["confirm"] = "enter";
     (*mixed_config)["properties"]["mapValues"]["inventory"] = "i";
 

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -912,6 +912,104 @@ void test_nested_primitive_wrappers_serialize_direct_values_and_round_trip() {
                 "integer-key maps should skip empty and unparsable JSON object keys");
 }
 
+void test_legacy_and_flattened_primitive_wrappers_deserialize_and_reject_scalars() {
+    CTypes::register_type_metadata<PrimitiveSerializationHolder, CGameObject>();
+
+    auto game = std::make_shared<CGame>();
+    game->getObjectHandler()->registerType(PrimitiveSerializationHolder::static_meta()->name(),
+                                           []() { return std::make_shared<PrimitiveSerializationHolder>(); });
+    game->getObjectHandler()->registerType(CListString::static_meta()->name(),
+                                           []() { return std::make_shared<CListString>(); });
+    game->getObjectHandler()->registerType(CMapStringString::static_meta()->name(),
+                                           []() { return std::make_shared<CMapStringString>(); });
+
+    // (a) Legacy object-shaped primitive: the wrapper is spelled out with its class and nested
+    // "values" property, exactly as older saves and configs stored it.
+    auto legacy_config = std::make_shared<json>();
+    (*legacy_config)["class"] = PrimitiveSerializationHolder::static_meta()->name();
+    (*legacy_config)["properties"]["listValues"]["class"] = CListString::static_meta()->name();
+    (*legacy_config)["properties"]["listValues"]["properties"]["values"] = {"north", "south"};
+    (*legacy_config)["properties"]["mapValues"]["class"] = CMapStringString::static_meta()->name();
+    (*legacy_config)["properties"]["mapValues"]["properties"]["values"]["confirm"] = "enter";
+
+    auto legacy = std::dynamic_pointer_cast<PrimitiveSerializationHolder>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game, legacy_config));
+    expect_true(legacy && legacy->getListValues() &&
+                    legacy->getListValues()->getValues() == std::set<std::string>({"north", "south"}),
+                "legacy object-shaped CListString should deserialize into the primitive wrapper property");
+    expect_true(legacy && legacy->getMapValues() &&
+                    legacy->getMapValues()->getValues() == std::map<std::string, std::string>({{"confirm", "enter"}}),
+                "legacy object-shaped CMapStringString should deserialize into the primitive wrapper property");
+
+    // (b) New flattened primitive: the wrapper is stored as its bare value (array for lists, object
+    // for maps) with no class/properties envelope.
+    auto flattened_config = std::make_shared<json>();
+    (*flattened_config)["class"] = PrimitiveSerializationHolder::static_meta()->name();
+    (*flattened_config)["properties"]["listValues"] = {"east", "west"};
+    (*flattened_config)["properties"]["mapValues"]["cancel"] = "escape";
+
+    auto flattened = std::dynamic_pointer_cast<PrimitiveSerializationHolder>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game, flattened_config));
+    expect_true(flattened && flattened->getListValues() &&
+                    flattened->getListValues()->getValues() == std::set<std::string>({"east", "west"}),
+                "flattened CListString array should deserialize into the primitive wrapper property");
+    expect_true(flattened && flattened->getMapValues() &&
+                    flattened->getMapValues()->getValues() ==
+                        std::map<std::string, std::string>({{"cancel", "escape"}}),
+                "flattened CMapStringString object should deserialize into the primitive wrapper property");
+
+    // (c) Mixed nesting: one property uses the legacy envelope while the sibling uses the flattened
+    // form in the same object.
+    auto mixed_config = std::make_shared<json>();
+    (*mixed_config)["class"] = PrimitiveSerializationHolder::static_meta()->name();
+    (*mixed_config)["properties"]["listValues"]["class"] = CListString::static_meta()->name();
+    (*mixed_config)["properties"]["listValues"]["properties"]["values"] = {"up", "down"};
+    (*mixed_config)["properties"]["mapValues"]["confirm"] = "enter";
+    (*mixed_config)["properties"]["mapValues"]["inventory"] = "i";
+
+    auto mixed = std::dynamic_pointer_cast<PrimitiveSerializationHolder>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game, mixed_config));
+    expect_true(mixed && mixed->getListValues() &&
+                    mixed->getListValues()->getValues() == std::set<std::string>({"up", "down"}),
+                "mixed nesting should honor the legacy object-shaped list property");
+    expect_true(mixed && mixed->getMapValues() &&
+                    mixed->getMapValues()->getValues() ==
+                        std::map<std::string, std::string>({{"confirm", "enter"}, {"inventory", "i"}}),
+                "mixed nesting should honor the flattened map sibling property");
+
+    // (d) Invalid scalar-to-collection coercion: a bare scalar for a collection wrapper is rejected
+    // in strict mode and skipped (property stays unset) in lenient mode.
+    auto scalar_config = std::make_shared<json>();
+    (*scalar_config)["class"] = PrimitiveSerializationHolder::static_meta()->name();
+    (*scalar_config)["properties"]["listValues"] = 42;
+
+    expect_runtime_error(
+        [&]() {
+            CSerialization::StrictScope strict;
+            CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game, scalar_config);
+        },
+        "strict deserialization should reject a bare numeric scalar for a primitive collection property");
+
+    auto lenient = std::dynamic_pointer_cast<PrimitiveSerializationHolder>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game, scalar_config));
+    expect_true(lenient && !lenient->getListValues(),
+                "lenient deserialization should skip an incompatible scalar without setting the collection property");
+
+    // A non-numeric string scalar for a map wrapper is rejected the same way once coercion fails to
+    // yield an array or object.
+    auto scalar_string_config = std::make_shared<json>();
+    (*scalar_string_config)["class"] = PrimitiveSerializationHolder::static_meta()->name();
+    (*scalar_string_config)["properties"]["mapValues"] = "north";
+
+    expect_runtime_error(
+        [&]() {
+            CSerialization::StrictScope strict;
+            CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game,
+                                                                                                  scalar_string_config);
+        },
+        "strict deserialization should reject a bare string scalar for a primitive collection property");
+}
+
 void test_nested_property_notification_batches_emit_one_deterministic_signal() {
     CTypes::register_type_metadata<PropertyChangeProbe, CGameObject>();
 
@@ -2507,6 +2605,7 @@ int main() {
     test_map_domain_signals_emit_for_tile_and_object_changes();
     test_reviewed_value_wrappers_have_explicit_primitive_metadata();
     test_nested_primitive_wrappers_serialize_direct_values_and_round_trip();
+    test_legacy_and_flattened_primitive_wrappers_deserialize_and_reject_scalars();
     test_nested_property_notification_batches_emit_one_deterministic_signal();
     test_object_deserialization_batches_property_notifications();
     test_bulk_object_deserialization_notifications_stay_batched();


### PR DESCRIPTION
## Summary

Adds a strict-mode guard in `CSerialization` so that a scalar JSON value supplied for a property whose type is a primitive collection wrapper (`CListInt`, `CListString`, `CMapStringString`, `CMapStringInt`, `CMapIntString`, `CMapIntInt`) is **rejected with a clear error** instead of being silently coerced through the numeric/boolean/string setters.

- In **strict mode** (e.g. save loading, `StrictScope`) the scalar is rejected with `std::runtime_error` naming the property and explaining that a JSON array or object is required.
- In **lenient mode** the scalar is warned about and skipped, preserving forward-compatible loading.
- Legacy object-shape wrappers and the flattened forms (bare JSON array for lists, bare JSON object for maps) continue to deserialize unchanged — the guard keys purely off the property's registered primitive-collection type.

## Changes

- `src/core/CSerialization.cpp` (+48): anonymous-namespace helpers `isPrimitiveCollectionValueType` / `isPrimitiveCollectionPointer` and `rejectScalarForPrimitiveCollection(property, key)`, wired into `setNumericProperty` / `setBooleanProperty` / `setStringProperty`.
- `tests/unit/test_core.cpp` (+99): `test_legacy_and_flattened_primitive_wrappers_deserialize_and_reject_scalars` covering legacy object-shape, flattened, mixed nesting, and invalid-scalar coercion under both `StrictScope` (throws) and lenient (skips) modes.

## Validation

- `python3 scripts/validate_content.py --repo-root .` — OK
- `python3 -m unittest tests.test_content_validator` — 176 OK
- `clang-format` — clean
- C++ unit test added; full C++ suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b)_