### PR TITLE
[EPIC_04][STORY_03][SUBSTORY_02] Add scoped resource search roots

### DIFF
--- a/src/core/CProvider.cpp
+++ b/src/core/CProvider.cpp
@@ -431,7 +431,65 @@ std::string CResourcesProvider::getPath(std::string path) {
             return candidate.string();
         }
     }
+
+    if (!activeScope.empty()) {
+        const auto scope = scopedRoots.find(activeScope);
+        if (scope != scopedRoots.end()) {
+            std::error_code errorCode;
+            const std::filesystem::path resourceRoot(scope->second.canonicalRoot);
+            const auto candidatePath = resourceRoot / requestedPath;
+            auto candidate = std::filesystem::weakly_canonical(candidatePath, errorCode);
+            if (!errorCode && isWithinResourceRoot(candidate, resourceRoot) && std::filesystem::exists(candidate)) {
+                return candidate.string();
+            }
+        }
+    }
     return {};
+}
+
+void CResourcesProvider::addScopedRoot(const std::string &scope, const std::string &root) {
+    auto existing = scopedRoots.find(scope);
+    if (existing != scopedRoots.end()) {
+        ++existing->second.refCount;
+        return;
+    }
+
+    std::error_code errorCode;
+    const auto canonicalRoot = std::filesystem::weakly_canonical(root, errorCode);
+    if (errorCode || root.empty() || !std::filesystem::is_directory(canonicalRoot, errorCode) || errorCode) {
+        vstd::logger::warning("Ignoring scoped resource root:", scope, "root:", root,
+                              "reason:", "root is not an existing directory");
+        return;
+    }
+
+    scopedRoots.emplace(scope, ScopedRoot{canonicalRoot.string(), 1});
+}
+
+void CResourcesProvider::releaseScopedRoot(const std::string &scope) {
+    auto existing = scopedRoots.find(scope);
+    if (existing == scopedRoots.end()) {
+        return;
+    }
+    if (--existing->second.refCount <= 0) {
+        scopedRoots.erase(existing);
+        if (activeScope == scope) {
+            activeScope.clear();
+        }
+    }
+}
+
+void CResourcesProvider::setActiveScope(const std::string &scope) { activeScope = scope; }
+
+std::string CResourcesProvider::getActiveScope() const { return activeScope; }
+
+std::vector<std::string> CResourcesProvider::getScopedRoots() const {
+    std::vector<std::string> roots;
+    roots.reserve(scopedRoots.size());
+    for (const auto &[scope, scopedRoot] : scopedRoots) {
+        roots.push_back(scopedRoot.canonicalRoot);
+    }
+    std::ranges::sort(roots);
+    return roots;
 }
 
 std::vector<std::string> CResourcesProvider::getFiles(const std::string &type) {

--- a/src/core/CProvider.h
+++ b/src/core/CProvider.h
@@ -120,6 +120,23 @@ class CResourcesProvider {
 
     bool save(std::string file, std::shared_ptr<json> data);
 
+    // Register (or ref-count up) a map-scoped search root. `root` must be an existing directory that
+    // canonicalizes successfully; empty/nonexistent roots are ignored with a warning. Adding the same
+    // scope again increments its reference count so a retained map keeps its root alive.
+    void addScopedRoot(const std::string &scope, const std::string &root);
+
+    // Ref-count down a scope; the root is dropped only when the count reaches zero (i.e. no retained
+    // map still owns objects from that scope).
+    void releaseScopedRoot(const std::string &scope);
+
+    // Select which registered scope resolution should consult. Empty string = no active scope.
+    void setActiveScope(const std::string &scope);
+
+    std::string getActiveScope() const;
+
+    // Inspection helper for tests: canonical roots of all currently-registered scopes, sorted.
+    std::vector<std::string> getScopedRoots() const;
+
     CResourcesProvider() = default;
 
   private:
@@ -130,12 +147,20 @@ class CResourcesProvider {
         std::source_location location;
     };
 
+    struct ScopedRoot {
+        std::string canonicalRoot;
+        int refCount;
+    };
+
     std::expected<std::string, LoadFailure>
     loadExpected(std::string path, std::source_location location = std::source_location::current());
 
     static void logLoadFailure(const LoadFailure &failure);
 
     static std::list<std::string> searchPath;
+
+    std::map<std::string, ScopedRoot> scopedRoots;
+    std::string activeScope;
 };
 
 class CConfigurationProvider {

--- a/tests/unit/test_resource.cpp
+++ b/tests/unit/test_resource.cpp
@@ -474,7 +474,7 @@ void test_scoped_search_roots_resolve_active_map_assets() {
                 "active scope mapA should resolve the asset inside tempRootA");
     {
         std::ifstream stream(resolvedA);
-        std::string contents(std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>());
+        std::string contents((std::istreambuf_iterator<char>(stream)), std::istreambuf_iterator<char>());
         expect_true(contents == "A", "active scope mapA should read the tempRootA copy of the asset");
     }
 
@@ -486,7 +486,7 @@ void test_scoped_search_roots_resolve_active_map_assets() {
                 "active scope mapB should resolve the asset inside tempRootB");
     {
         std::ifstream stream(resolvedB);
-        std::string contents(std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>());
+        std::string contents((std::istreambuf_iterator<char>(stream)), std::istreambuf_iterator<char>());
         expect_true(contents == "B", "active scope mapB should read the tempRootB copy of the asset");
     }
 

--- a/tests/unit/test_resource.cpp
+++ b/tests/unit/test_resource.cpp
@@ -31,6 +31,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <memory>
 #include <string>
 
@@ -431,6 +432,87 @@ void test_two_game_contexts_isolate_provider_cache_and_object_config() {
                 "context-owned providers must reject absolute resource paths");
 }
 
+void test_scoped_search_roots_resolve_active_map_assets() {
+    // Two maps register the SAME logical filename under DIFFERENT scoped roots; the active scope must
+    // decide which physical file resolves. A bare scoped filename must never resolve through the base
+    // (process-wide) search path, so nothing here can collide with the real resource tree.
+    const auto nonce = std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+    const std::string assetName = "scoped_asset_" + nonce + ".txt";
+
+    const auto tempRootA = std::filesystem::temp_directory_path() / ("scoped-root-a-" + nonce);
+    const auto tempRootB = std::filesystem::temp_directory_path() / ("scoped-root-b-" + nonce);
+    std::error_code errorCode;
+    std::filesystem::create_directories(tempRootA, errorCode);
+    std::filesystem::create_directories(tempRootB, errorCode);
+    expect_true(write_text_file(tempRootA / assetName, "A"), "scoped root A fixture should be written");
+    expect_true(write_text_file(tempRootB / assetName, "B"), "scoped root B fixture should be written");
+
+    const auto canonicalRootA = std::filesystem::weakly_canonical(tempRootA, errorCode).string();
+    const auto canonicalRootB = std::filesystem::weakly_canonical(tempRootB, errorCode).string();
+
+    auto provider = std::make_shared<CResourcesProvider>();
+
+    // Nothing is active yet, so a bare scoped filename must not resolve at the base search path.
+    expect_true(provider->getPath(assetName).empty(), "scoped asset must not resolve at base search path");
+
+    provider->addScopedRoot("mapA", tempRootA.string());
+    provider->addScopedRoot("mapB", tempRootB.string());
+    auto roots = provider->getScopedRoots();
+    expect_true(std::find(roots.begin(), roots.end(), canonicalRootA) != roots.end(),
+                "getScopedRoots should list the canonical root of mapA");
+    expect_true(std::find(roots.begin(), roots.end(), canonicalRootB) != roots.end(),
+                "getScopedRoots should list the canonical root of mapB");
+
+    // Registered but inactive scopes must not change base resolution.
+    expect_true(provider->getPath(assetName).empty(), "scoped asset must not resolve while no scope is active");
+
+    provider->setActiveScope("mapA");
+    const auto resolvedA = provider->getPath(assetName);
+    expect_true(!resolvedA.empty(), "active scope mapA should resolve the scoped asset");
+    expect_true(std::filesystem::weakly_canonical(std::filesystem::path(resolvedA).parent_path(), errorCode).string() ==
+                    canonicalRootA,
+                "active scope mapA should resolve the asset inside tempRootA");
+    {
+        std::ifstream stream(resolvedA);
+        std::string contents(std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>());
+        expect_true(contents == "A", "active scope mapA should read the tempRootA copy of the asset");
+    }
+
+    provider->setActiveScope("mapB");
+    const auto resolvedB = provider->getPath(assetName);
+    expect_true(!resolvedB.empty(), "active scope mapB should resolve the scoped asset");
+    expect_true(std::filesystem::weakly_canonical(std::filesystem::path(resolvedB).parent_path(), errorCode).string() ==
+                    canonicalRootB,
+                "active scope mapB should resolve the asset inside tempRootB");
+    {
+        std::ifstream stream(resolvedB);
+        std::string contents(std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>());
+        expect_true(contents == "B", "active scope mapB should read the tempRootB copy of the asset");
+    }
+
+    // Security: an active scope must never relax the traversal/absolute guards.
+    expect_true(provider->getPath("../escape.txt").empty(),
+                "parent-traversal paths must be rejected even with an active scope");
+    expect_true(provider->getPath("/etc/passwd").empty(), "absolute paths must be rejected even with an active scope");
+
+    // Ref-counting: a second add keeps the root alive across one release.
+    provider->addScopedRoot("mapA", tempRootA.string());
+    provider->releaseScopedRoot("mapA");
+    provider->setActiveScope("mapA");
+    expect_true(!provider->getPath(assetName).empty(), "mapA should still resolve while its refcount is positive");
+
+    provider->releaseScopedRoot("mapA");
+    auto rootsAfterRelease = provider->getScopedRoots();
+    expect_true(std::find(rootsAfterRelease.begin(), rootsAfterRelease.end(), canonicalRootA) ==
+                    rootsAfterRelease.end(),
+                "mapA root should be dropped once its refcount reaches zero");
+    expect_true(provider->getActiveScope().empty(), "releasing the active scope to zero should clear the active scope");
+    expect_true(provider->getPath(assetName).empty(), "mapA asset must not resolve after its scope is dropped");
+
+    std::filesystem::remove_all(tempRootA, errorCode);
+    std::filesystem::remove_all(tempRootB, errorCode);
+}
+
 } // namespace
 
 int main() {
@@ -443,6 +525,7 @@ int main() {
     test_map_load_resolves_through_context_owned_providers();
     test_two_game_contexts_isolate_provider_cache_and_object_config();
     test_resource_plugin_trust_boundary_rejects_escapes();
+    test_scoped_search_roots_resolve_active_map_assets();
 
     return finish_tests();
 }


### PR DESCRIPTION
## Summary

Extends the context-owned `CResourcesProvider` with **instance-level, ref-counted map-scoped search roots** so map-local assets can resolve through the active map's scope. `searchPath` is process-wide (`static`), so scopes are held per-provider — each game context owns its own scopes.

- `addScopedRoot(scope, root)` / `releaseScopedRoot(scope)` — ref-counted lifetime; a retained map keeps its root alive (dropped only when the count reaches zero).
- `setActiveScope(scope)` / `getActiveScope()` — selects which registered scope resolution consults.
- `getScopedRoots()` — inspection helper (sorted canonical roots).

`getPath` is unchanged for the base search path: the active scope is consulted only as a fallback, reusing the existing `isWithinResourceRoot` containment check and the top-of-function safe-relative-path guard, so scopes never weaken resource security. Traversal and absolute paths remain rejected. With no active scope, resolution is byte-for-byte unchanged.

Loader consumption (animations, etc.) is deliberately out of scope for this substory — it lands in SS03.

## Changes
- `src/core/CProvider.h` (+25): scoped-root API + private `ScopedRoot { canonicalRoot; refCount; }`, `scopedRoots` map, `activeScope`.
- `src/core/CProvider.cpp` (+58): scope-resolution fallback in `getPath`; the five method definitions.
- `tests/unit/test_resource.cpp` (+83): `test_scoped_search_roots_resolve_active_map_assets` — two scopes holding the same filename resolve differently by active scope, refcount lifetime, and traversal/absolute rejection with a scope active.

## Validation
- `python3 scripts/validate_content.py --repo-root .` — Content validation passed
- `python3 -m unittest tests.test_content_validator` — 176 OK
- `clang-format` — clean
- New C++ provider unit test; full C++ suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b)_