### PR TITLE
[EPIC_04][STORY_03][SUBSTORY_03] Use scoped provider for animations and textures

### DIFF
--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -59,6 +59,8 @@ std::set<std::string> get_saved_map_dependencies(const std::shared_ptr<CGame> &g
 
 void load_map_resources(const std::shared_ptr<CGame> &game, const std::string &mapName);
 
+void activate_map_scope(const std::shared_ptr<CGame> &game, const std::string &mapName);
+
 namespace {
 constexpr const char *PLUGIN_MANIFEST_PATH = "plugins/manifest.json";
 constexpr const char *DYNAMIC_PLUGIN_DEFAULT_ENTRY = "game_plugin_load_v1";
@@ -630,6 +632,9 @@ restore_save_document(const std::shared_ptr<CGame> &game, const CSaveFormat::Dec
                 load_map_resources(game, requiredMap);
             }
         }
+        // Activate the primary saved map's scope last so dependency maps loaded above for their
+        // config/quest data do not leave their scope active.
+        activate_map_scope(game, saveDocument.mapName);
     }
 
     const auto saveConfigKey = CSaveFormat::savedMapConfigKey(slotName);
@@ -1014,11 +1019,31 @@ void load_map_resources(const std::shared_ptr<CGame> &game, const std::string &m
     game->getObjectHandler()->registerConfig(getConfigPaths(game->getResourcesProvider(), mapName));
 }
 
+// Register the map's directory as a scoped search root and make it the active scope so that
+// map-local assets (animations/textures declared by a bare name) resolve through it. Global
+// assets keep their precedence: the base search path is always consulted first, and the scope
+// only adds map-local names that are not found globally. Absolute/traversal paths remain rejected
+// by the provider's existing safe-path guard. Called for the map that becomes active after a load;
+// dependency maps loaded only for config/quest data do not steal the active scope.
+void activate_map_scope(const std::shared_ptr<CGame> &game, const std::string &mapName) {
+    const auto provider = game->getResourcesProvider();
+    if (!provider) {
+        return;
+    }
+    const auto mapRoot = provider->getPath("maps/" + mapName);
+    if (mapRoot.empty()) {
+        return;
+    }
+    provider->addScopedRoot(mapName, mapRoot);
+    provider->setActiveScope(mapName);
+}
+
 std::shared_ptr<CMap> CMapLoader::loadNewMap(const std::shared_ptr<CGame> &game, const std::string &mapName) {
     if (std::shared_ptr<json> mapc = game->getConfigurationProvider()->getConfiguration(getMapPath(mapName))) {
         std::shared_ptr<CMap> map = game->getObjectHandler()->createObject<CMap>(game);
         game->setMap(map);
         load_map_resources(game, mapName);
+        activate_map_scope(game, mapName);
         loadFromTmx(map, mapc);
         map->setMapName(mapName);
         return map;

--- a/src/core/CProvider.cpp
+++ b/src/core/CProvider.cpp
@@ -401,6 +401,10 @@ std::shared_ptr<json> CResourcesProvider::loadJson(std::string path) {
 }
 
 std::string CResourcesProvider::getPath(std::string path) {
+    // Resolution precedence: the process-wide base search path is always consulted first, so global
+    // assets keep their meaning; only if nothing matches there does the active map scope (if any)
+    // get a chance to resolve a map-local asset of the same relative name. The safe-relative-path
+    // guard below rejects absolute and traversal paths before any root — base or scoped — is tried.
     if (!isSafeRelativeResourcePath(path)) {
         vstd::logger::warning("Rejected unsafe resource path:", path);
         return {};

--- a/tests/unit/test_resource.cpp
+++ b/tests/unit/test_resource.cpp
@@ -513,6 +513,63 @@ void test_scoped_search_roots_resolve_active_map_assets() {
     std::filesystem::remove_all(tempRootB, errorCode);
 }
 
+void test_map_load_activates_scope_for_map_local_assets() {
+    // Loading a map must register and activate that map's directory as a scoped search root, so a
+    // map-local asset (e.g. an animation frame declared by a bare name) resolves through the active
+    // scope while global assets keep resolving through the base search path. This is what the
+    // animation/texture cache relies on, since both resolve through the game's resources provider.
+    auto singletonResources = CResourcesProvider::getInstance();
+    const auto itemsPath = std::filesystem::path(singletonResources->getPath("config/items.json"));
+    expect_true(!itemsPath.empty(), "items config should resolve before the map-local asset scope test");
+    if (itemsPath.empty()) {
+        return;
+    }
+    const auto resourceRoot = itemsPath.parent_path().parent_path();
+
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const std::string mapName = "unit_scope_map_" + std::to_string(nonce);
+    const auto mapDir = resourceRoot / "maps" / mapName;
+    std::filesystem::create_directories(mapDir);
+    const auto mapConfigPath = mapDir / "map.json";
+    const std::string localAssetName = "unit_scope_sprite_" + std::to_string(nonce) + ".png";
+    const auto localAssetPath = mapDir / localAssetName;
+
+    const bool fixtureWritten =
+        write_text_file(mapConfigPath, R"({"marker":"scope","properties":{"x":0,"y":0,"z":0},"layers":[]})") &&
+        write_text_file(localAssetPath, "png");
+    expect_true(fixtureWritten, "temporary map fixture and map-local asset should be written");
+    if (!std::filesystem::exists(mapConfigPath) || !std::filesystem::exists(localAssetPath)) {
+        std::filesystem::remove_all(mapDir);
+        return;
+    }
+
+    auto game = CGameLoader::loadGame();
+    auto provider = game->getResourcesProvider();
+
+    // Before the map loads, the map-local asset must NOT resolve by its bare name (no active scope).
+    expect_true(provider->getPath(localAssetName).empty(),
+                "a map-local asset must not resolve by bare name before its map is loaded");
+
+    auto map = CMapLoader::loadNewMap(game, mapName);
+    expect_true(map && map->getMapName() == mapName, "loadNewMap should load the authored map");
+
+    expect_true(provider->getActiveScope() == mapName, "loadNewMap should activate the loaded map's scope");
+
+    // The map-local asset now resolves by its bare name, inside the map directory.
+    const auto resolvedLocal = provider->getPath(localAssetName);
+    expect_true(!resolvedLocal.empty(), "the map-local asset should resolve through the active map scope");
+    std::error_code errorCode;
+    expect_true(std::filesystem::weakly_canonical(std::filesystem::path(resolvedLocal).parent_path(), errorCode) ==
+                    std::filesystem::weakly_canonical(mapDir, errorCode),
+                "the map-local asset should resolve inside the loaded map's directory");
+
+    // Global assets keep their precedence: a base-path asset still resolves after a scope is active.
+    expect_true(!provider->getPath("config/items.json").empty(),
+                "global assets must still resolve through the base search path with a map scope active");
+
+    std::filesystem::remove_all(mapDir);
+}
+
 } // namespace
 
 int main() {
@@ -526,6 +583,7 @@ int main() {
     test_two_game_contexts_isolate_provider_cache_and_object_config();
     test_resource_plugin_trust_boundary_rejects_escapes();
     test_scoped_search_roots_resolve_active_map_assets();
+    test_map_load_activates_scope_for_map_local_assets();
 
     return finish_tests();
 }


### PR DESCRIPTION
## Summary

Wires the scoped-search-root capability from SS02 into map loading so map-local animation/texture assets actually resolve, without weakening global resolution.

- New `activate_map_scope(game, mapName)` in `CLoader`: when a map becomes active — `CMapLoader::loadNewMap`, and the **primary** map of a restored save — its directory is registered as a scoped search root (`addScopedRoot`) and set as the active scope (`setActiveScope`). Dependency maps loaded only for config/quest data (the `restore_save_document` loop) do **not** steal the active scope; the primary map is activated last.
- The animation/texture resolution chain already resolves through the game's context provider (`CTextureCache::loadTexture`, `CDynamicAnimation`, `CAnimationProvider::getAnimation` all use `game->getResourcesProvider()` / `getConfigurationProvider()`), so once the scope is active, a map-local asset declared by a bare name resolves through it. Global assets keep base-search-path precedence (base is consulted first; the scope only adds map-local names). Absolute/traversal paths remain rejected.
- Documented the resolution precedence on `CResourcesProvider::getPath`.

Retained-map return without a reload keeps the previously-activated scope; full scope switching for retained-map returns is left to the later substories in this story.

## Changes
- `src/core/CLoader.cpp` (+25): `activate_map_scope` helper + forward decl; wired into `loadNewMap` and `restore_save_document`.
- `src/core/CProvider.cpp` (+4): precedence doc-comment on `getPath`.
- `tests/unit/test_resource.cpp` (+58): `test_map_load_activates_scope_for_map_local_assets` — a map-local asset resolves by bare name only after the map loads (scope activated), resolves inside the map dir, and global assets still resolve.

## Validation
- `clang-format` — clean (all 3 files)
- `python3 scripts/validate_content.py --repo-root .` — passed
- `python3 -m unittest tests.test_content_validator` — OK
- New resource unit test; full C++ + gameplay suites run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b)_