### PR TITLE
[EPIC_04][STORY_03][SUBSTORY_04] Update validator and CMake for map assets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,73 @@ configure_file(res/config/weapons.json config/weapons.json)
 configure_file(res/config/artifact_sets.json config/artifact_sets.json)
 configure_file(res/config/graphics.json config/graphics.json)
 
+# Stage a map's DECLARED map-local assets (from its map.json "assets" array) into the build tree,
+# alongside the explicit per-file configure_file() lines below. Most maps declare no "assets" at all,
+# so this is a no-op for them today; it becomes active only when a map declares map-local assets.
+# It is intentionally defensive: a missing map.json, a missing/malformed "assets" array, or an
+# unreadable entry is logged via message(STATUS ...) and skipped -- never a fatal error, because a
+# broken configure fails all of CI. string(JSON ...) requires CMake >= 3.19 (we require >= 3.20).
+function(stage_map_declared_assets map_name)
+    set(_map_dir "res/maps/${map_name}")
+    set(_map_json "${CMAKE_CURRENT_SOURCE_DIR}/${_map_dir}/map.json")
+    if (NOT EXISTS "${_map_json}")
+        return()
+    endif ()
+    if (CMAKE_VERSION VERSION_LESS 3.19)
+        message(STATUS "stage_map_declared_assets: CMake < 3.19 lacks string(JSON); skipping ${map_name}")
+        return()
+    endif ()
+    file(READ "${_map_json}" _map_contents)
+    string(JSON _assets_type ERROR_VARIABLE _assets_type_err TYPE "${_map_contents}" assets)
+    if (_assets_type_err OR NOT _assets_type STREQUAL "ARRAY")
+        # No "assets" array (the common case) or a malformed one: nothing to stage.
+        return()
+    endif ()
+    string(JSON _assets_len ERROR_VARIABLE _assets_len_err LENGTH "${_map_contents}" assets)
+    if (_assets_len_err OR _assets_len EQUAL 0)
+        return()
+    endif ()
+    math(EXPR _assets_last "${_assets_len} - 1")
+    foreach (_i RANGE ${_assets_last})
+        string(JSON _asset_path ERROR_VARIABLE _path_err GET "${_map_contents}" assets ${_i} path)
+        if (_path_err OR _asset_path STREQUAL "")
+            message(STATUS "stage_map_declared_assets: ${map_name} assets[${_i}] has no readable 'path'; skipping")
+            continue ()
+        endif ()
+        string(JSON _asset_kind ERROR_VARIABLE _kind_err GET "${_map_contents}" assets ${_i} kind)
+        if (_kind_err)
+            set(_asset_kind "")
+        endif ()
+        set(_src "${CMAKE_CURRENT_SOURCE_DIR}/${_map_dir}/${_asset_path}")
+        set(_rel_src "${_map_dir}/${_asset_path}")
+        set(_rel_dst "maps/${map_name}/${_asset_path}")
+        if (_asset_kind STREQUAL "logicalId")
+            # Logical handle, not a filesystem path: nothing to copy.
+            continue ()
+        elseif (_asset_kind STREQUAL "directory")
+            if (IS_DIRECTORY "${_src}")
+                get_filename_component(_dst_parent "${_rel_dst}" DIRECTORY)
+                file(COPY "${_src}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/${_dst_parent}")
+            else ()
+                message(STATUS "stage_map_declared_assets: ${map_name} directory asset '${_asset_path}' missing; skipping")
+            endif ()
+        else ()
+            # file / animationRoot / unspecified: stage the concrete file if present, otherwise the
+            # "<path>.png" sprite an animationRoot resolves to, otherwise the directory form.
+            if (EXISTS "${_src}" AND NOT IS_DIRECTORY "${_src}")
+                configure_file("${_rel_src}" "${_rel_dst}" COPYONLY)
+            elseif (EXISTS "${_src}.png")
+                configure_file("${_rel_src}.png" "${_rel_dst}.png" COPYONLY)
+            elseif (IS_DIRECTORY "${_src}")
+                get_filename_component(_dst_parent "${_rel_dst}" DIRECTORY)
+                file(COPY "${_src}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/${_dst_parent}")
+            else ()
+                message(STATUS "stage_map_declared_assets: ${map_name} asset '${_asset_path}' (kind '${_asset_kind}') not found; skipping")
+            endif ()
+        endif ()
+    endforeach ()
+endfunction()
+
 configure_file(res/maps/nouraajd/config.json maps/nouraajd/config.json)
 configure_file(res/maps/nouraajd/dialog.json maps/nouraajd/dialog.json)
 configure_file(res/maps/nouraajd/dialog2.json maps/nouraajd/dialog2.json)
@@ -354,6 +421,16 @@ configure_file(res/maps/usurpergate/config.json maps/usurpergate/config.json)
 configure_file(res/maps/usurpergate/dialog.json maps/usurpergate/dialog.json)
 configure_file(res/maps/usurpergate/map.json maps/usurpergate/map.json)
 configure_file(res/maps/usurpergate/script.py maps/usurpergate/script.py)
+
+# Stage every map's declared map-local assets (see stage_map_declared_assets above). This is a
+# no-op for every map today because none declare an "assets" array; it activates automatically the
+# moment a map adds one.
+set(GAME_STAGED_MAPS
+    nouraajd siege ritual vhulmarn kadath ninemarches sunderedmarch gravemoor
+    hearthfall usurpergate test multilevel)
+foreach (_staged_map ${GAME_STAGED_MAPS})
+    stage_map_declared_assets(${_staged_map})
+endforeach ()
 
 configure_file(res/plugins/effect.py plugins/effect.py)
 configure_file(res/plugins/interaction.py plugins/interaction.py)

--- a/docs/content.md
+++ b/docs/content.md
@@ -11,11 +11,16 @@ python3 scripts/validate_content.py --repo-root .
 
 Each map lives in `res/maps/<name>/` and is described by a Tiled-style
 `map.json`. A map may additionally declare the local assets it owns through an
-**optional** top-level `assets` array. The declaration is descriptive metadata:
-it documents and validates which files, directories, and logical resources a map
-depends on. Undeclared assets are not loaded or staged differently yet — engine
-loading and CMake staging rules are introduced separately — so adding `assets`
-is safe and purely additive for existing maps.
+**optional** top-level `assets` array. The declaration documents and validates
+which files, directories, and logical resources a map owns. It is now also
+load-bearing: engine loading treats the map's own directory as an active scoped
+search root (so map-local animations/textures resolve), and the CMake build
+**stages each declared asset into the build tree**. A map-local asset that an
+animation/background field references but does not declare would therefore not be
+packaged — so declared assets and referenced assets must stay consistent (see
+**Reference consistency and staging** below). Adding `assets` remains safe and
+purely additive for existing maps: they declare no `assets` and reference only
+global (`res/`-wide) resources, so nothing changes for them.
 
 ### Shape
 
@@ -67,6 +72,33 @@ within it. The validator rejects a declaration when its `path`:
 
 A `path` may not be declared more than once within a single map's `assets`
 array.
+
+### Reference consistency and staging
+
+Once a map declares an `assets` array, the validator additionally enforces that
+every **map-local** animation/background reference the map makes is declared.
+Concretely, it walks the map's own object layers (`map.json` object
+`properties.animation` / `properties.background`) and the map's local config
+entries (per-map `config.json` / `dialog*.json` `properties.animation` /
+`properties.background`), and for each referenced value:
+
+- If the value resolves to a **global** asset under `res/` (as a directory, a
+  file, or a `<value>.png` sprite), it is packaged independently of the map and
+  is left alone — this is how the existing maps reference shared `images/...`
+  animations.
+- If the value resolves **only** under the map's own directory (map-local) but
+  is **not** matched by a declared `assets` entry, the validator reports an
+  error: an undeclared map-local asset would not be staged, so the map would
+  break on a fresh build. Declare it with kind `file`, `directory`, or
+  `animationRoot` (an `animationRoot` at `path` matches a reference to `path`,
+  and a `file` at `path.png` matches a reference to `path`). `logicalId` entries
+  are logical handles and never satisfy a filesystem reference.
+
+On the build side, `CMakeLists.txt` reads each map's `map.json`, and for every
+declared entry stages it into the build tree next to the map: `file` and
+`animationRoot` (`<path>.png` form) are copied with `configure_file(... COPYONLY)`,
+`directory` and directory-form `animationRoot` entries are copied wholesale, and
+`logicalId` entries are skipped. Maps without an `assets` array are a no-op.
 
 ## Player class and race profiles (`res/config/classes.json`, `res/config/races.json`)
 

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -2768,6 +2768,7 @@ class ContentValidator:
             self._issue(context.map_path, "assets", "expected array")
             return
         seen_paths: set[str] = set()
+        declared_keys: set[str] = set()
         for index, entry in enumerate(assets):
             location = f"assets[{index}]"
             if not isinstance(entry, dict):
@@ -2797,6 +2798,8 @@ class ContentValidator:
                 )
                 continue
             self._validate_map_asset_target(context, location, path_value, kind)
+            declared_keys.update(self._map_asset_reference_keys(path_value, kind))
+        self._validate_map_asset_references(context, declared_keys)
 
     def _validate_profile_configs(self) -> None:
         for path, data in self.global_files.items():
@@ -2904,6 +2907,121 @@ class ContentValidator:
                     f"{location}.path",
                     f"declared animation root resolves to neither a directory nor a '<path>.png' file: {path_value}",
                 )
+
+    @staticmethod
+    def _map_asset_reference_keys(path_value: str, kind: str) -> set[str]:
+        """Normalized reference keys under which a declared asset can be referenced.
+
+        Animation/background fields reference an asset by its map-relative path *without* the
+        ``.png`` extension the engine appends when resolving a ``<path>.png`` sprite, so a declared
+        ``file``/``animationRoot`` that points at a PNG must also be matchable by its extension-less
+        form. Directories are referenced verbatim. ``logicalId`` entries are logical handles, not
+        filesystem paths, so they never satisfy a map-local reference and are excluded here.
+        """
+        keys: set[str] = set()
+        if kind == "logicalId":
+            return keys
+        normalized = path_value.rstrip("/")
+        keys.add(normalized)
+        if kind in ("file", "animationRoot") and normalized.endswith(".png"):
+            keys.add(normalized[: -len(".png")])
+        if kind == "animationRoot":
+            keys.add(f"{normalized}.png")
+        return keys
+
+    @staticmethod
+    def _map_asset_path_exists(base: Path, value: str) -> bool:
+        """True when ``value`` resolves under ``base`` as a directory, a file, or a ``<value>.png`` sprite."""
+        target = base / value
+        if target.is_dir() or target.is_file():
+            return True
+        return (base / f"{value}.png").is_file()
+
+    def _iter_map_asset_reference_sites(self, context: MapContext) -> list[tuple[Path, str, str]]:
+        """Collect ``(path, location, value)`` for every animation/background reference owned by a map.
+
+        Reference sites are the map's own object layers (``map.json`` object ``properties.animation`` /
+        ``properties.background``), the map-level ``properties.background``, and the map's local config
+        entries (per-map ``config.json``/``dialog*.json`` ``properties.animation`` / ``properties.background``).
+        Only literal strings authored inside the map directory are collected; values inherited from
+        global templates via ``ref`` are not (they live outside the map and are packaged globally).
+        """
+        sites: list[tuple[Path, str, str]] = []
+        reference_fields = ("animation", "background")
+        data = context.map_data
+        if isinstance(data, dict):
+            map_props = data.get("properties")
+            if isinstance(map_props, dict):
+                background = map_props.get("background")
+                if isinstance(background, str) and background:
+                    sites.append((context.map_path, "properties.background", background))
+            layers = data.get("layers")
+            if isinstance(layers, list):
+                for layer_index, layer in enumerate(layers):
+                    if not isinstance(layer, dict) or layer.get("type") != "objectgroup":
+                        continue
+                    objects = layer.get("objects")
+                    if not isinstance(objects, list):
+                        continue
+                    for object_index, obj in enumerate(objects):
+                        if not isinstance(obj, dict):
+                            continue
+                        props = obj.get("properties")
+                        if not isinstance(props, dict):
+                            continue
+                        base = f"layers[{layer_index}].objects[{object_index}].properties"
+                        for field in reference_fields:
+                            value = props.get(field)
+                            if isinstance(value, str) and value:
+                                sites.append((context.map_path, f"{base}.{field}", value))
+        for key, entry in context.config_entries.items():
+            entry_data = entry.data
+            if not isinstance(entry_data, dict):
+                continue
+            props = entry_data.get("properties")
+            if not isinstance(props, dict):
+                continue
+            for field in reference_fields:
+                value = props.get(field)
+                if isinstance(value, str) and value:
+                    sites.append((entry.path, f"{key}.properties.{field}", value))
+        return sites
+
+    def _validate_map_asset_references(self, context: MapContext, declared_keys: set[str]) -> None:
+        """Ensure every map-local animation/background reference is a declared (hence staged) asset.
+
+        Runs only for maps that declare an ``assets`` array. A reference is treated as *map-local*
+        when it resolves under the map directory *and* is not already satisfied by a global asset
+        under ``res/`` (global animations/backgrounds are packaged independently and must stay valid).
+        A map-local reference with no matching declared asset would not be staged into the build, so
+        it is flagged. This deliberately never fires for the existing maps: they declare no ``assets``
+        (so this method returns immediately) and reference only global ``images/...`` assets.
+        """
+        if not declared_keys and not self._map_declares_assets(context):
+            return
+        res_root = self.repo_root / "res"
+        for path, location, value in self._iter_map_asset_reference_sites(context):
+            normalized = value.strip().rstrip("/")
+            if not normalized or not is_safe_map_relative_path(normalized):
+                continue
+            if self._map_asset_path_exists(res_root, normalized):
+                # Satisfied by a global asset; packaged independently of the map, so it is fine.
+                continue
+            if not self._map_asset_path_exists(context.directory, normalized):
+                # Neither global nor map-local: an unrelated/unresolved reference other checks own.
+                continue
+            if normalized not in declared_keys:
+                self._issue(
+                    path,
+                    location,
+                    f"references map-local asset '{value}' that is not declared in the map's 'assets' array; "
+                    "declare it (kind file/directory/animationRoot) so it is validated and staged into the build",
+                )
+
+    @staticmethod
+    def _map_declares_assets(context: MapContext) -> bool:
+        data = context.map_data
+        return isinstance(data, dict) and isinstance(data.get("assets"), list)
 
     def _validate_tile_layer(
         self,


### PR DESCRIPTION
## Summary

Completes the map-local-assets tooling: the content validator now enforces that map-local animation/background references are declared, and CMake stages declared assets into the build tree so new map assets package correctly on fresh builds.

### Validator (`scripts/validate_content.py`)
For a map that declares an `assets` array, `_validate_map_asset_references` walks every animation/background reference the map itself authors — object-layer `properties.{animation,background}`, map-level `properties.background`, and per-map config entries (`config.json`/`dialog*.json`). A reference satisfied by a **global** asset under `res/` is ignored (existing maps reference only `images/...` globals); a **map-local** reference (resolving only under the map directory) with no matching declared asset is flagged, since it would not be staged/packaged. Extension-less animation references match `animationRoot`/PNG declarations via normalized keys. Maps that declare no `assets` — every current map — are entirely unaffected.

### CMake (`CMakeLists.txt`)
`stage_map_declared_assets(map_name)` reads a map's `map.json` `assets` array via `string(JSON ...)` (CMake ≥3.19; project requires 3.20) and stages declared `file`/`animationRoot`/`directory` assets into the build tree (`logicalId` skipped). Fully defensive: a missing `map.json` or missing/malformed `assets` array is skipped with a `message(STATUS ...)` — configure never fails. It is a **verified no-op** for the current asset-less maps and activates automatically when a map declares assets (validated in isolation via `cmake -P`).

### Docs (`docs/content.md`)
Updates the map-assets section to state engine loading (active map scope) and CMake staging of declared assets are now implemented.

## Validation
- `python3 scripts/validate_content.py --repo-root .` — Content validation passed (no new errors on the 12 existing maps)
- `python3 -m unittest tests.test_content_validator` — 176 OK
- `python3 -m py_compile scripts/validate_content.py` — clean
- CMake staging function exercised via `cmake -P` for all four kinds + the asset-less no-op path
- Full build/configure runs in CI (first real `cmake configure` of the new function)

Map-local reference regression tests and a test map that declares assets land in the follow-up substory (SS05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b)_