### PR TITLE
[EPIC_04][STORY_03][SUBSTORY_05] Add map-local asset regression tests

### DIFF
--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -527,6 +527,8 @@ void init_game_module(py::module_ &m) {
         .def("getSceneManager", &CGame::getSceneManager, "Return the scene transition manager.")
         .def("getRngHandler", &CGame::getRngHandler, "Return the random encounter/loot handler.")
         .def("createObject", createObject, "Create an object by configured type id.")
+        .def("getResourcesProvider", &CGame::getResourcesProvider,
+             "Return the game's context-owned resources provider (map-scoped path resolution).")
         .def("getGui", &CGame::getGui, "Return the GUI root object.");
 
     py::class_<CGameGraphicsObject, CGameObject, std::shared_ptr<CGameGraphicsObject>>(
@@ -1088,7 +1090,11 @@ void init_game_module(py::module_ &m) {
              "Return the process-wide resource provider (compatibility facade for code without a game instance).")
         .def("getPath", &CResourcesProvider::getPath, "Resolve a resource path relative to the active resource root.")
         .def("load", &CResourcesProvider::load, "Load a resource file as text.")
-        .def("getFiles", &CResourcesProvider::getFiles, "List files under a resource path.");
+        .def("getFiles", &CResourcesProvider::getFiles, "List files under a resource path.")
+        .def("getActiveScope", &CResourcesProvider::getActiveScope,
+             "Return the active map scope name, or an empty string when no map scope is active.")
+        .def("getScopedRoots", &CResourcesProvider::getScopedRoots,
+             "Return the canonical roots of all currently-registered map scopes.");
 
     auto ceffect = py::class_<CEffect, CWrapper<CEffect>, std::shared_ptr<CEffect>, CGameObject>(
                        m, "CEffect", "Base status effect class.")

--- a/test.py
+++ b/test.py
@@ -5213,6 +5213,120 @@ class GameTest(unittest.TestCase):
         return True, ""
 
     @game_test
+    def test_map_local_assets_isolate_per_active_map(self):
+        # Regression for the map-local-assets story (E04/S03): two runtime maps may each
+        # declare a map-local asset under the SAME map-relative filename but with DIFFERENT
+        # content. loadNewMap registers and activates the loaded map's directory as the
+        # resource scope so the active map resolves its OWN copy of that bare name. The
+        # scope-bearing resolution lives on the game context's resources provider
+        # (CGame.getResourcesProvider()), distinct from the process-wide singleton whose base
+        # search path has no active scope. This test drives the runtime map switch and asserts
+        # that the active map's context provider resolves the bare asset name to that map's own
+        # copy (content "A" vs "B"), that the active scope tracks the current map, and that the
+        # bare name never leaks through the process-wide base search path. Complementary
+        # C++ coverage lives in tests/unit/test_resource.cpp
+        # (test_scoped_search_roots_resolve_active_map_assets,
+        # test_map_load_activates_scope_for_map_local_assets).
+        game = load_game_module()
+        nonce = "{}_{}".format(os.getpid(), time.time_ns())
+        asset_name = "localsprite_{}.png".format(nonce)
+        map_a = "unit_local_asset_a_{}".format(nonce)
+        map_b = "unit_local_asset_b_{}".format(nonce)
+        maps_root = Path.cwd() / "maps"
+        dir_a = maps_root / map_a
+        dir_b = maps_root / map_b
+
+        def write_map(map_dir, marker):
+            map_dir.mkdir(parents=True, exist_ok=True)
+            (map_dir / "config.json").write_text("{}")
+            (map_dir / "script.py").write_text("")
+            (map_dir / asset_name).write_text(marker)
+            (map_dir / "map.json").write_text(
+                json.dumps(
+                    {
+                        "type": "map",
+                        "orientation": "orthogonal",
+                        "width": 1,
+                        "height": 1,
+                        "tilewidth": 32,
+                        "tileheight": 32,
+                        "properties": {"x": "0", "y": "0", "z": "0"},
+                        "tilesets": [{"firstgid": 1, "tileproperties": {"0": {"type": "GrassTile"}}}],
+                        "layers": [
+                            {
+                                "type": "tilelayer",
+                                "name": "ground",
+                                "width": 1,
+                                "height": 1,
+                                "properties": {
+                                    "level": "0",
+                                    "default": "GrassTile",
+                                    "outOfBounds": "GrassTile",
+                                    "xBound": "1",
+                                    "yBound": "1",
+                                },
+                                "data": [1],
+                            }
+                        ],
+                    }
+                )
+            )
+
+        try:
+            write_map(dir_a, "A")
+            write_map(dir_b, "B")
+
+            provider = game.CResourcesProvider.getInstance()
+            # The bare map-local name must not resolve through the process-wide base search
+            # path: only a map's active scope (the context provider) can bind it.
+            self.assertEqual("", provider.getPath(asset_name))
+
+            g = game.CGameLoader.loadGame()
+            scoped = g.getResourcesProvider()
+
+            map_obj_a = game.CMapLoader.loadNewMap(g, map_a)
+            self.assertIsNotNone(map_obj_a)
+            self.assertEqual(map_a, g.getMap().mapName)
+            # Same relative filename, different content, each packaged inside its own map dir.
+            self.assertEqual("A", provider.load("maps/{}/{}".format(map_a, asset_name)))
+            # loadNewMap activated map A's scope on the context provider, so the bare name now
+            # resolves through it to map A's OWN copy of the asset.
+            self.assertEqual(map_a, scoped.getActiveScope())
+            resolved_a = scoped.getPath(asset_name)
+            self.assertTrue(resolved_a, "active map A should resolve its own map-local asset")
+            self.assertEqual("A", Path(resolved_a).read_text())
+
+            map_obj_b = game.CMapLoader.loadNewMap(g, map_b)
+            self.assertIsNotNone(map_obj_b)
+            self.assertEqual(map_b, g.getMap().mapName)
+            self.assertEqual("B", provider.load("maps/{}/{}".format(map_b, asset_name)))
+            # Switching to map B moves the active scope; the SAME bare name now resolves to map
+            # B's distinct copy, proving per-active-map isolation.
+            self.assertEqual(map_b, scoped.getActiveScope())
+            resolved_b = scoped.getPath(asset_name)
+            self.assertTrue(resolved_b, "active map B should resolve its own map-local asset")
+            self.assertEqual("B", Path(resolved_b).read_text())
+            self.assertNotEqual(resolved_a, resolved_b)
+
+            # Switching the active map does not collapse the two same-named assets: each
+            # map's own directory still holds its own copy.
+            self.assertEqual("A", provider.load("maps/{}/{}".format(map_a, asset_name)))
+            # And the bare name still never resolves through the base search path after loads.
+            self.assertEqual("", provider.getPath(asset_name))
+
+            report = {
+                "map_a": map_a,
+                "map_b": map_b,
+                "asset": asset_name,
+                "active_map": g.getMap().mapName,
+                "resolved_distinct": resolved_a != resolved_b,
+            }
+            return True, json.dumps(report, sort_keys=True)
+        finally:
+            shutil.rmtree(dir_a, ignore_errors=True)
+            shutil.rmtree(dir_b, ignore_errors=True)
+
+    @game_test
     def test_binding_validation_rejects_invalid_logger_and_dynamic_values(self):
         game = load_game_module()
 

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -198,6 +198,69 @@ class ContentValidatorTest(unittest.TestCase):
 
         self.assertIssueContains(issues, "assets[1].path", "duplicate asset declaration: shared.id")
 
+    def _reference_map_animation(self, root, animation):
+        # Add a map object whose ``properties.animation`` references a map-local asset by its
+        # bare, map-relative name -- exactly the reference site _iter_map_asset_reference_sites
+        # collects (``layers[].objects[].properties.animation``). The object carries no name so
+        # it stays clear of the placed-name / trigger-recognition checks.
+        map_path = root / "res/maps/broken/map.json"
+        map_data = read_json(map_path)
+        map_data["layers"][1]["objects"].append(
+            {
+                "id": 2,
+                "type": "StartEvent",
+                "x": 1,
+                "y": 1,
+                "width": 1,
+                "height": 1,
+                "properties": {"animation": animation},
+            }
+        )
+        write_json(map_path, map_data)
+        return map_path
+
+    def test_map_asset_reference_to_declared_animation_passes_validation(self):
+        root = self.make_fixture()
+        self._make_asset_files(root)
+        self._declare_map_assets(root, [{"path": "anim/walk", "kind": "animationRoot"}])
+        self._reference_map_animation(root, "anim/walk")
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
+    def test_map_asset_reference_to_undeclared_animation_is_flagged(self):
+        root = self.make_fixture()
+        self._make_asset_files(root)
+        # The map declares an unrelated asset, so the consistency check runs, but the
+        # referenced map-local animation ("anim/walk", which exists on disk as anim/walk.png)
+        # is never declared -- it would not be staged into the build, so it is flagged.
+        self._declare_map_assets(root, [{"path": "images/portrait.png", "kind": "file"}])
+        self._reference_map_animation(root, "anim/walk")
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/map.json",
+            "layers[1].objects[1].properties.animation",
+            "references map-local asset 'anim/walk' that is not declared in the map's 'assets' array",
+        )
+
+    def test_map_asset_reference_to_global_asset_is_not_flagged(self):
+        root = self.make_fixture()
+        # A global asset packaged independently of the map under res/. Even though the map
+        # declares an assets array (activating the consistency check), a reference that
+        # resolves through the base res/ search path must never be treated as map-local.
+        (root / "res/images").mkdir(parents=True, exist_ok=True)
+        (root / "res/images/global_sprite.png").write_text("png")
+        self._declare_map_assets(root, [{"path": "hero.combat.idle", "kind": "logicalId"}])
+        self._reference_map_animation(root, "images/global_sprite")
+
+        issues = validate_repo(root)
+
+        self.assertEqual([], [str(issue) for issue in issues])
+
     def _valid_class_profile(self):
         return {
             "warrior": {


### PR DESCRIPTION
## Summary

Regression tests completing the map-local-assets story (SS02 search roots → SS03 activation → SS04 validator/CMake → **SS05 tests**).

### Validator consistency tests (`tests/test_content_validator.py`, +3 tests)
Exercise the SS04 `_validate_map_asset_references` check against the real validator, using the existing `_declare_map_assets`/`_make_asset_files` harness:
- a map-local `animation` reference to a **declared** asset passes,
- a reference to an **undeclared** map-local asset is flagged at its object reference site,
- a **global** (`images/...`) reference is spared even while the map declares an `assets` array.

### Gameplay test (`test.py`)
`test_map_local_assets_isolate_per_active_map` creates two runtime maps declaring the **same** relative asset filename with **different** content, and asserts through the game context's resources provider that:
- the active map resolves the bare asset name to its **own** copy (`"A"` vs `"B"`),
- `getActiveScope()` tracks the loaded map across a `loadNewMap` switch,
- the two resolutions are distinct paths, and
- the bare name never resolves through the process-wide base search path.

### Python binding (`src/core/CModule.cpp`)
To make the scope behaviour observable from the gameplay test, bind `CGame::getResourcesProvider` (the context-owned, map-scoped provider — previously only the process-wide singleton was reachable) and `CResourcesProvider::getActiveScope` / `getScopedRoots`. Three standard `.def` bindings of already-registered types.

## Validation
- `python3 -m unittest tests.test_content_validator` — OK, 179 tests (+3)
- `python3 scripts/validate_content.py --repo-root .` — Content validation passed
- `test.py` parses; indentation multiple-of-4 verified
- Full C++ build + gameplay + coverage run in CI (first build of the new bindings + gameplay test)

Complementary C++ scope-resolution coverage already lives in `tests/unit/test_resource.cpp` (`test_scoped_search_roots_resolve_active_map_assets`, `test_map_load_activates_scope_for_map_local_assets`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b)_