### PR TITLE
[EPIC_03][STORY_04][SUBSTORY_05] Stage JSON primitive migration

### DIFF
--- a/res/config/panels.json
+++ b/res/config/panels.json
@@ -28,21 +28,16 @@
         }
       ],
       "charSheet": {
-        "class": "CMapStringString",
-        "properties": {
-          "values": {
-            "Class": "getPlayerClassId",
-            "Race": "getRaceId",
-            "Level": "getLevel",
-            "Experience": "getExp",
-            "Gold": "getGold",
-            "Mana": "getMana",
-            "Total Mana": "getManaMax",
-            "Mana Regeneration Rate": "getManaRegRate",
-            "Health Points": "getHp",
-            "Total Health Points": "getHpMax"
-          }
-        }
+        "Class": "getPlayerClassId",
+        "Race": "getRaceId",
+        "Level": "getLevel",
+        "Experience": "getExp",
+        "Gold": "getGold",
+        "Mana": "getMana",
+        "Total Mana": "getManaMax",
+        "Mana Regeneration Rate": "getManaRegRate",
+        "Health Points": "getHp",
+        "Total Health Points": "getHpMax"
       },
       "layout": {
         "class": "CCenteredLayout",

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -19,6 +19,12 @@ from pathlib import Path
 from typing import Any
 
 OBJECT_SCHEMA_KEYS = {"class", "ref", "properties"}
+# Registered primitive-collection wrapper classes (see src/core/CCoreTypeRegistration.cpp). A property
+# whose declared engine type is one of these may be authored either in the legacy schema-1 object-shape
+# ({"class": "CListString", "properties": {"values": [...]}}) or in the current flattened shape (a bare
+# JSON array for the list wrappers, a bare JSON object for the map wrappers). The validator accepts both.
+PRIMITIVE_LIST_WRAPPER_CLASSES = {"CListInt", "CListString"}
+PRIMITIVE_MAP_WRAPPER_CLASSES = {"CMapStringString", "CMapStringInt", "CMapIntString", "CMapIntInt"}
 # Recognised kinds for an optional map.json top-level "assets" declaration. Each declared asset
 # is a safe relative path under its own map directory; the kind documents how the entry resolves.
 MAP_ASSET_KINDS = {"file", "directory", "animationRoot", "logicalId"}
@@ -2539,6 +2545,21 @@ class ContentValidator:
         visible: dict[str, ConfigEntry],
         known_classes: set[str],
     ) -> None:
+        expected_base_class = expected_cpp_object_base_class(cpp_property.type_token)
+        # A primitive-collection wrapper property (EPIC_03/STORY_04) may use either the legacy
+        # object-shape ({"class": ..., "properties": {"values": ...}}) or the current flattened shape
+        # (a bare JSON array for list wrappers, a bare class-less JSON object for map wrappers). Accept
+        # the flattened shape here; the legacy object-shape (a dict carrying "class"/"ref") falls
+        # through to the standard object-node compatibility check below.
+        if expected_base_class in PRIMITIVE_LIST_WRAPPER_CLASSES and isinstance(value, list):
+            return
+        if (
+            expected_base_class in PRIMITIVE_MAP_WRAPPER_CLASSES
+            and isinstance(value, dict)
+            and "class" not in value
+            and "ref" not in value
+        ):
+            return
         expected_kind = expected_json_property_kind(cpp_property.type_token)
         if expected_kind is None:
             return
@@ -2550,7 +2571,6 @@ class ContentValidator:
                 f'property "{cpp_property.name}" for class "{class_name}" expected {expected_kind}; got {actual_kind}',
             )
             return
-        expected_base_class = expected_cpp_object_base_class(cpp_property.type_token)
         if expected_base_class is not None:
             self._validate_property_object_compatibility(
                 path,

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -261,6 +261,20 @@ class ContentValidatorTest(unittest.TestCase):
 
         self.assertEqual([], [str(issue) for issue in issues])
 
+    def test_panels_charsheet_uses_flattened_primitive_and_validates(self):
+        # EPIC_03/STORY_04/SUBSTORY_05: CGameCharacterPanel.charSheet (a CMapStringString wrapper) was
+        # migrated from the legacy schema-1 object-shape to the current flattened shape (a bare JSON
+        # object with no class/properties envelope). Confirm the real content is authored in the
+        # flattened form and that metadata-aware validation of the full repo accepts it -- i.e. the
+        # flattened primitive representation is a valid alternative to the legacy object-shape while
+        # every other resource file remains valid.
+        panels = json.loads((REPO_ROOT / "res/config/panels.json").read_text(encoding="utf-8"))
+        char_sheet = panels["characterPanel"]["properties"]["charSheet"]
+        self.assertNotIn("class", char_sheet)
+        self.assertNotIn("properties", char_sheet)
+        self.assertEqual("getPlayerClassId", char_sheet.get("Class"))
+        self.assertEqual([], [str(issue) for issue in validate_repo(REPO_ROOT)])
+
     def _valid_class_profile(self):
         return {
             "warrior": {


### PR DESCRIPTION
## Summary

First representative migration of a primitive-heavy config entry to the flattened form, now that serializer compatibility (SS03) accepts both encodings. Deliberately not a repo-wide rewrite.

- **`res/config/panels.json`**: `CGameCharacterPanel.charSheet` (a `CMapStringString`) migrated from the legacy schema-1 object-shape (`{"class": "CMapStringString", "properties": {"values": {…}}}`) to the current **flattened** shape (a bare JSON object).
- **`scripts/validate_content.py`**: teach metadata-aware property validation to accept the flattened primitive representation. A property whose declared engine type is a registered primitive-collection wrapper (`CListInt`/`CListString`/`CMapString*`/`CMapInt*`) may be authored as the legacy object-shape **or** as the flattened bare array (list wrappers) / bare class-less object (map wrappers). The legacy object-shape still falls through to the standard object-node compatibility check, and a scalar is still rejected.
- **`tests/test_content_validator.py`**: regression test asserting the migrated `charSheet` is authored in the flattened form and the full repo still validates.

Acceptance: at least one resource file (`panels.json`) now uses the flattened primitive representation, and all existing resource files remain valid. The engine loads the flattened `charSheet` into its declared `CMapStringString` property via the SS03 deserializer.

## Validation
- `python3 scripts/validate_content.py --repo-root .` — Content validation passed
- `python3 -m unittest tests.test_content_validator` — 180 OK
- Full gameplay/UI suite (loads `panels.json`) runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b)_