### PR TITLE
[EPIC_06][STORY_02][SUBSTORY_03] Migrate player creation compatibility

### DIFF
--- a/test.py
+++ b/test.py
@@ -18854,6 +18854,70 @@ class GameTest(unittest.TestCase):
         return True, json.dumps(results, sort_keys=True)
 
     @game_test
+    def test_legacy_player_ids_create_configured_players_with_class_properties(self):
+        # [EPIC_06][STORY_02][SUBSTORY_03] Player-creation compatibility for the class/race
+        # separation. Selecting any of the historical character ids through
+        # CGameLoader.startGameWithPlayer must still build the existing configured CPlayer, set
+        # its class identity (getPlayerClassId) accordingly, expose a race identity (getRaceId),
+        # and surface the class-granted actions now sourced from the res/config/creature_classes
+        # profile the template references (monsters.json creatureClass ref -> <Name>Class). The
+        # legacy config entries must all remain present -- including the historical "Assasin"
+        # spelling preserved as a resource id -- so old character selection and saves keep working
+        # while the class/race properties become available.
+        game = load_game_module()
+
+        # The runtime menu is the source of truth for selectable templates, so this list stays in
+        # sync with the config rather than hard-coding it. Every historical legacy id -- including
+        # the preserved "Assasin" spelling -- must still be offered (config entries were not
+        # removed during the class/race separation).
+        options_game = game.CGameLoader.loadGame()
+        template_ids = set(game.player_class_options(options_game).values())
+        for legacy_id in ("Warrior", "Sorcerer", "Assasin", "Inquisitor", "Wayfarer"):
+            self.assertIn(legacy_id, template_ids, f"legacy template {legacy_id} was removed")
+
+        def action_type_ids(actions):
+            return sorted(action.getTypeId() for action in actions)
+
+        results = {}
+        for player_type in sorted(template_ids):
+            g = game.CGameLoader.loadGame()
+            game.CGameLoader.startGameWithPlayer(g, "test", player_type)
+            game_map = g.getMap()
+            self.assertIsNotNone(game_map, player_type)
+            player = game_map.getPlayer()
+
+            # Still the existing configured CPlayer: created, of the selected type, alive and
+            # controllable exactly as before the class/race split.
+            self.assertIsNotNone(player, player_type)
+            self.assertEqual(player_type, player.getTypeId(), player_type)
+            self.assertIsNotNone(get_player_controller(player), player_type)
+            self.assertTrue(player.isAlive(), player_type)
+
+            # playerClassId is set accordingly and a non-empty race identity is exposed, so the
+            # class/race properties are available on the freshly created player.
+            self.assertEqual(player_type, player.getPlayerClassId(), player_type)
+            self.assertTrue(player.getRaceId(), player_type)
+
+            # The referenced class profile is wired through creation: the composed effective
+            # interactions surface the class-granted baseline action ("Attack" from each
+            # <Name>Class.actions), proving the class content reaches the player. This is
+            # level-independent -- class starting actions are ungated -- so it holds for a
+            # fresh (level 0) character.
+            effective = action_type_ids(player.getEffectiveInteractions())
+            self.assertIn("Attack", effective, player_type)
+
+            results[player_type] = {
+                "typeId": player.getTypeId(),
+                "playerClassId": player.getPlayerClassId(),
+                "raceId": player.getRaceId(),
+                "effectiveActions": effective,
+            }
+
+        # Every offered template produced a distinct configured player.
+        self.assertEqual(len(template_ids), len(results))
+        return True, json.dumps(results, sort_keys=True)
+
+    @game_test
     def test_one_time_reward_paths_grant_exactly_once_and_clean_up_actors(self):
         # [EPIC_07][STORY_02][SUBSTORY_04] Data-driven regression over every one-time
         # (claim_once-guarded) reward path in res/maps/nouraajd/script.py and


### PR DESCRIPTION
## Summary

Delivers the player-creation compatibility guarantee for EPIC_06 / STORY_02 ("Separate player class from race while preserving stable IDs").

The production mechanism already exists from SUBSTORY_02: the player templates in `res/config/monsters.json` reference their extracted class profile via `creatureClass: {ref: <Name>Class}` (`res/config/creature_classes.json`), and `CPlayer::getPlayerClassId()` / `getRaceId()` derive stable identities (type id → class id, default race). This substory **locks that compatibility contract with the regression tests the issue mandates** — "Tests for every current player template through `CGameLoader.startGameWithPlayer`".

## What the test asserts

`test_legacy_player_ids_create_configured_players_with_class_properties` drives every currently offered player template (enumerated from the runtime `player_class_options` menu, so it stays in sync with the config) through the 3-argument `CGameLoader.startGameWithPlayer` and verifies:

- Every historical legacy id — **`Warrior`, `Sorcerer`, `Assasin` (historical spelling preserved as a resource id), `Inquisitor`, `Wayfarer`** — is still offered, i.e. the config entries were not removed during the class/race separation.
- Selecting each id still builds the existing configured `CPlayer` (correct type id, alive, controllable).
- `getPlayerClassId()` is set accordingly (== the selected id) and `getRaceId()` exposes a non-empty race identity, so the class/race properties are available.
- The referenced class profile is wired through creation: the composed effective interactions surface the class-granted baseline `Attack` action (level-independent — class starting actions are ungated), proving the class content reaches a freshly created character.

## Behavior / risk

Test-only, additive. No production or content files change, so current character selection and old saves behave exactly as before; the test cannot regress gameplay and only pins the compatibility contract.

## Validation

- `python3 scripts/validate_content.py --repo-root .` → passed
- `python3 -c "import ast; ast.parse(open('test.py').read())"` → OK; no tab indentation
- Full gameplay suite / coverage via CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b)_