### PR TITLE
[codex] Fix dialog option display order

### DIFF
--- a/src/gui/panel/CGameDialogPanel.cpp
+++ b/src/gui/panel/CGameDialogPanel.cpp
@@ -113,7 +113,7 @@ void CGameDialogPanel::reload() {
 
 std::shared_ptr<CDialogOption> CGameDialogPanel::getOption(int option) { return getCurrentOptions()[option]; }
 
-std::map<int, std::shared_ptr<CDialogOption>, std::greater<>> CGameDialogPanel::getCurrentOptions() {
+std::map<int, std::shared_ptr<CDialogOption>> CGameDialogPanel::getCurrentOptions() {
     // TODO: make this generic and in vstd
     struct OptionComparator {
         bool operator()(const std::shared_ptr<CDialogOption> &a, const std::shared_ptr<CDialogOption> &b) const {
@@ -138,7 +138,7 @@ std::map<int, std::shared_ptr<CDialogOption>, std::greater<>> CGameDialogPanel::
         }
     }
 
-    std::map<int, std::shared_ptr<CDialogOption>, std::greater<>> return_value;
+    std::map<int, std::shared_ptr<CDialogOption>> return_value;
     int index = 0;
     for (const auto &option : options) {
         return_value[index++] = option;

--- a/src/gui/panel/CGameDialogPanel.h
+++ b/src/gui/panel/CGameDialogPanel.h
@@ -35,6 +35,10 @@ class CGameDialogPanel : public CGamePanel {
 
     bool keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i) override;
 
+#ifdef GAME_UNIT_TESTS
+    std::map<int, std::shared_ptr<CDialogOption>> getCurrentOptionsForTest() { return getCurrentOptions(); }
+#endif
+
   private:
     std::shared_ptr<CDialog> dialog;
     std::string currentStateId = "ENTRY";
@@ -45,5 +49,5 @@ class CGameDialogPanel : public CGamePanel {
 
     void selectOption(const std::shared_ptr<CDialogOption> &option);
 
-    std::map<int, std::shared_ptr<CDialogOption>, std::greater<>> getCurrentOptions();
+    std::map<int, std::shared_ptr<CDialogOption>> getCurrentOptions();
 };

--- a/test.py
+++ b/test.py
@@ -21044,6 +21044,11 @@ class XvfbGameplayProcessTest(unittest.TestCase):
             root = assert_runtime_rect(self, "dialogPanel dense", panel, ROOT_800_600)
             widgets = sorted(find_descendants_by_type(panel, "CTextWidget"), key=lambda child: resolved_rect(child)[1])
             self.assertEqual(1 + len(dense_options), len(widgets))
+            self.assertEqual(
+                ["Dense dialog state with enough options to exercise proportional option layout."]
+                + [f"{index + 1}: {text}" for index, text in enumerate(dense_options)],
+                [widget.text for widget in widgets],
+            )
             previous = None
             for widget in widgets:
                 widget_rect = resolved_rect(widget)

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -38,9 +38,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/panel/CGameFightPanel.h"
 #include "gui/panel/CGameInventoryPanel.h"
 #include "gui/panel/CGamePanel.h"
+#define GAME_UNIT_TESTS
+#include "gui/panel/CGameDialogPanel.h"
+#undef GAME_UNIT_TESTS
 #include "gui/panel/CListView.h"
 #include "handler/CObjectHandler.h"
 #include "object/CCreature.h"
+#include "object/CDialog.h"
 #include "object/CInteraction.h"
 #include "object/CItem.h"
 #include "object/CPlayer.h"
@@ -51,6 +55,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <chrono>
 #include <limits>
+#include <vector>
 #include <utility>
 
 namespace {
@@ -2272,6 +2277,37 @@ void test_character_panel_sheet_lines_render_race_and_class_labels() {
     expect_true(!hasIdentityRow, "character sheet builder should skip empty race / class labels fail-closed");
 }
 
+void test_dialog_panel_current_options_preserve_numeric_display_order() {
+    auto make_option = [](int number, const std::string &text) {
+        auto option = std::make_shared<CDialogOption>();
+        option->setNumber(number);
+        option->setText(text);
+        return option;
+    };
+
+    auto state = std::make_shared<CDialogState>();
+    state->setStateId("ENTRY");
+    state->setOptions({
+        make_option(2, "third"),
+        make_option(0, "first"),
+        make_option(1, "second"),
+    });
+
+    auto dialog = std::make_shared<CDialog>();
+    dialog->setStates({state});
+
+    auto panel = std::make_shared<CGameDialogPanel>();
+    panel->setDialog(dialog);
+
+    std::vector<std::string> displayedOptions;
+    for (const auto &[index, option] : panel->getCurrentOptionsForTest()) {
+        displayedOptions.push_back(std::to_string(index + 1) + ": " + option->getText());
+    }
+
+    expect_true(displayedOptions == std::vector<std::string>({"1: first", "2: second", "3: third"}),
+                "dialog panel should display options from lowest dialog number to highest");
+}
+
 } // namespace
 
 int main() {
@@ -2282,6 +2318,7 @@ int main() {
     test_widget_reflective_callbacks_fail_closed_on_bad_config();
     test_character_panel_sheet_lines_build_without_rendering_and_fail_closed();
     test_character_panel_sheet_lines_render_race_and_class_labels();
+    test_dialog_panel_current_options_preserve_numeric_display_order();
     test_list_view_refreshes_from_generic_property_notifications();
     test_list_view_coalesces_property_refreshes_per_event_loop_tick();
     test_list_view_skips_queued_property_refresh_after_detach();


### PR DESCRIPTION
## What changed
- Changed `CGameDialogPanel::getCurrentOptions()` to return options in ascending display index order instead of iterating the generated indices in descending order.
- Added a native GUI unit regression for numeric dialog option display ordering.
- Extended the existing Xvfb dense dialog layout test to assert visible top-to-bottom option text order.

## Why
Dialog options were sorted by their dialog `number`, then inserted into a `std::map` keyed from `0..n`, but the map used `std::greater<>`. Rendering iterated that map directly, so the visible option list appeared reversed.

## Validation
- `cmake --build cmake-build-release --target _game -j$(nproc)`
- `cmake --build cmake-build-release --target gui_unit_tests -j$(nproc)`
- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests.gui_unit_tests`
- `python3 -m py_compile test.py`

## Notes
- Focused Xvfb wrapper command was attempted with `GAME_XVFB_ONLY_CHILD_TESTS=test_choice_panel_layouts_and_hitboxes python3 test.py XvfbGameplayTest.test_keyboard_gameplay_under_xvfb`, but it skipped locally because SDL x11 is unavailable under xvfb in this environment.