### PR TITLE
[codex] Fix grouped trade stack selling

### DIFF
--- a/src/gui/panel/CGameTradePanel.cpp
+++ b/src/gui/panel/CGameTradePanel.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CTextureCache.h"
 
 #include <algorithm>
+#include <map>
 
 CListView::collection_pointer CGameTradePanel::inventoryCollection(std::shared_ptr<CGui> gui) {
     auto player = gui && gui->getGame() && gui->getGame()->getMap() ? gui->getGame()->getMap()->getPlayer() : nullptr;
@@ -33,13 +34,15 @@ CListView::collection_pointer CGameTradePanel::inventoryCollection(std::shared_p
 
 void CGameTradePanel::inventoryCallback(std::shared_ptr<CGui> gui, int index,
                                         std::shared_ptr<CGameObject> _newSelection) {
-    this->selectInventory(vstd::cast<CItem>(_newSelection));
+    this->selectInventory(gui, vstd::cast<CItem>(_newSelection));
     refreshViews();
 }
 
 bool CGameTradePanel::inventorySelect(std::shared_ptr<CGui> gui, int index, std::shared_ptr<CGameObject> object) {
-    return std::any_of(selectedInventory.begin(), selectedInventory.end(),
-                       [object](const auto &selection) { return CGameObject::sameInstance(selection.lock(), object); });
+    auto item = vstd::cast<CItem>(object);
+    auto stack = getSellableInventoryStack(gui, item);
+    return !stack.empty() && std::all_of(stack.begin(), stack.end(),
+                                         [this](const auto &stackItem) { return isInventorySelected(stackItem); });
 }
 
 CListView::collection_pointer CGameTradePanel::marketCollection(std::shared_ptr<CGui> gui) {
@@ -114,11 +117,19 @@ void CGameTradePanel::finalizeBuy(std::shared_ptr<CGui> gui) {
     }
 }
 
-std::set<std::string> CGameTradePanel::getItemNames(std::list<std::weak_ptr<CItem>> items) {
-    return vstd::functional::map<std::set<std::string>>(items, [](std::weak_ptr<CItem> ob) {
+std::vector<std::string> CGameTradePanel::getItemNames(std::list<std::weak_ptr<CItem>> items) {
+    std::map<std::string, int> counts;
+    for (const auto &ob : items) {
         auto item = ob.lock();
-        return item ? item->getLabel() : std::string();
-    });
+        if (item) {
+            counts[item->getLabel()]++;
+        }
+    }
+    std::vector<std::string> names;
+    for (const auto &[label, count] : counts) {
+        names.push_back(count > 1 ? vstd::str(count) + "x " + label : label);
+    }
+    return names;
 }
 
 int CGameTradePanel::getTotalSellCost() {
@@ -155,18 +166,52 @@ void CGameTradePanel::selectMarket(std::weak_ptr<CItem> selection) {
     }
 }
 
-void CGameTradePanel::selectInventory(std::weak_ptr<CItem> selection) {
-    if (selection.lock() && !selection.lock()->hasTag(CTag::Quest)) {
-        auto selected = selection.lock();
-        auto selectionIt =
-            std::find_if(selectedInventory.begin(), selectedInventory.end(),
-                         [selected](const auto &item) { return CGameObject::sameInstance(item.lock(), selected); });
-        if (selectionIt != selectedInventory.end()) {
-            selectedInventory.erase(selectionIt);
-        } else {
-            selectedInventory.push_back(selection);
+void CGameTradePanel::selectInventory(std::shared_ptr<CGui> gui, std::weak_ptr<CItem> selection) {
+    auto selected = selection.lock();
+    auto stack = getSellableInventoryStack(gui, selected);
+    if (stack.empty()) {
+        return;
+    }
+
+    const bool allSelected = std::all_of(stack.begin(), stack.end(),
+                                         [this](const auto &stackItem) { return isInventorySelected(stackItem); });
+    if (allSelected) {
+        selectedInventory.remove_if([&stack](const auto &item) {
+            auto selectedItem = item.lock();
+            return !selectedItem || std::any_of(stack.begin(), stack.end(), [selectedItem](const auto &stackItem) {
+                return CGameObject::sameInstance(selectedItem, stackItem);
+            });
+        });
+    } else {
+        selectedInventory.remove_if([](const auto &item) { return item.expired(); });
+        for (const auto &stackItem : stack) {
+            if (!isInventorySelected(stackItem)) {
+                selectedInventory.push_back(stackItem);
+            }
         }
     }
+}
+
+std::vector<std::shared_ptr<CItem>> CGameTradePanel::getSellableInventoryStack(std::shared_ptr<CGui> gui,
+                                                                               std::shared_ptr<CItem> selection) {
+    std::vector<std::shared_ptr<CItem>> stack;
+    auto player = gui && gui->getGame() && gui->getGame()->getMap() ? gui->getGame()->getMap()->getPlayer() : nullptr;
+    if (!player || !selection) {
+        return stack;
+    }
+    const auto typeId = selection->getTypeId();
+    for (const auto &item : player->getItems()) {
+        if (item && item->getTypeId() == typeId && !item->hasTag(CTag::Quest)) {
+            stack.push_back(item);
+        }
+    }
+    return stack;
+}
+
+bool CGameTradePanel::isInventorySelected(std::shared_ptr<CItem> item) {
+    return item && std::any_of(selectedInventory.begin(), selectedInventory.end(), [item](const auto &selection) {
+               return CGameObject::sameInstance(selection.lock(), item);
+           });
 }
 
 void CGameTradePanel::setMarket(std::shared_ptr<CMarket> _market) { market = _market; }

--- a/src/gui/panel/CGameTradePanel.h
+++ b/src/gui/panel/CGameTradePanel.h
@@ -20,10 +20,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "CGamePanel.h"
 #include "object/CPlayer.h"
 
+#include <vector>
+
 class CGameTradePanel : public CGamePanel {
     V_META(CGameTradePanel, CGamePanel,
            // TODO: unify this with CGameInventoryPanel
-           // TODO: allow selecting couple of grouped objects
            V_PROPERTY(CGameTradePanel, std::shared_ptr<CMarket>, market, getMarket, setMarket),
            V_METHOD(CGameTradePanel, inventoryCollection, CListView::collection_pointer, std::shared_ptr<CGui>),
            V_METHOD(CGameTradePanel, inventoryCallback, void, std::shared_ptr<CGui>, int, std::shared_ptr<CGameObject>),
@@ -78,8 +79,12 @@ class CGameTradePanel : public CGamePanel {
 
     void selectMarket(std::weak_ptr<CItem> selection);
 
-    void selectInventory(std::weak_ptr<CItem> selection);
+    void selectInventory(std::shared_ptr<CGui> gui, std::weak_ptr<CItem> selection);
 
-    // TODO: should be not unique collection. items get merged
-    std::set<std::string> getItemNames(std::list<std::weak_ptr<CItem>> items);
+    std::vector<std::shared_ptr<CItem>> getSellableInventoryStack(std::shared_ptr<CGui> gui,
+                                                                  std::shared_ptr<CItem> selection);
+
+    bool isInventorySelected(std::shared_ptr<CItem> item);
+
+    std::vector<std::string> getItemNames(std::list<std::weak_ptr<CItem>> items);
 };

--- a/test.py
+++ b/test.py
@@ -1684,6 +1684,7 @@ XVFB_GAMEPLAY_CHILD_TESTS = (
     "test_inventory_drag_close_or_modal_panel_cancels_without_equip",
     "test_inventory_equipped_selection_resets_inventory_selection",
     "test_inventory_quest_item_selection_is_ignored",
+    "test_trade_grouped_inventory_sell_selects_all_sellable_copies",
     "test_fight_quest_item_selection_is_ignored",
     "test_cave_loss_does_not_reopen_fight_panel",
     "test_fight_panel_select_interaction_cancels_on_sdl_quit",
@@ -1740,6 +1741,7 @@ XVFB_GAMEPLAY_CHILD_DURATION_HINTS = {
     "test_inventory_drag_close_or_modal_panel_cancels_without_equip": 6,
     "test_inventory_equipped_selection_resets_inventory_selection": 6,
     "test_inventory_quest_item_selection_is_ignored": 6,
+    "test_trade_grouped_inventory_sell_selects_all_sellable_copies": 6,
     "test_fight_quest_item_selection_is_ignored": 6,
     "test_cave_loss_does_not_reopen_fight_panel": 6,
     "test_fight_panel_select_interaction_cancels_on_sdl_quit": 6,
@@ -20530,6 +20532,56 @@ class XvfbGameplayProcessTest(unittest.TestCase):
         weapon_after = player.getWeapon().getTypeId() if player.getWeapon() else None
         self.assertEqual(1, player.countItems("letterToBeren"))
         self.assertEqual(weapon_before, weapon_after)
+
+    def test_trade_grouped_inventory_sell_selects_all_sellable_copies(self):
+        game, g, _, player = create_xvfb_gameplay_session(self)
+        player.setItems(set())
+        for index in range(2):
+            scroll = g.createObject("Scroll")
+            scroll.name = f"groupedTradeSellScroll{index}"
+            player.addItem(scroll)
+        quest_scroll = g.createObject("Scroll")
+        quest_scroll.name = "groupedTradeSellQuestScroll"
+        quest_scroll.addTag(game.CTag.QUEST)
+        player.addItem(quest_scroll)
+        market = g.createObject("CMarket")
+
+        trade = open_panel_for_screenshot(self, g, "tradePanel", "CGameTradePanel")
+        trade.setMarket(market)
+        pump_event_loop(3)
+        player_list = find_list_view(trade, "inventoryCollection")
+        scroll_column, scroll_row, _ = find_visible_list_cell_by_type(player_list, g.getGui(), "Scroll")
+
+        activate_list_cell(player_list, g.getGui(), scroll_column, scroll_row)
+        pump_event_loop(5)
+        self.assertEqual(1, get_panel_selection_box_counts_by_collection(trade).get("inventoryCollection", 0))
+        self.assertGreater(trade.getTotalSellCost(), 0)
+
+        captured_question = {}
+
+        def answer_and_capture():
+            panel = find_top_level_panel(g, "CGameQuestionPanel")
+            if panel is None:
+                game.event_loop.instance().invoke(answer_and_capture)
+                return
+            panel_data = json.loads(game.jsonify(panel))
+            captured_question["text"] = panel_data.get("properties", {}).get("question", "")
+            buttons = sorted(find_descendants_by_type(panel, "CButton"), key=lambda child: resolved_rect(child)[0])
+            activate_widget(buttons[0], g.getGui())
+
+        game.event_loop.instance().invoke(answer_and_capture)
+        buttons = {button.text: button for button in find_descendants_by_type(trade, "CButton")}
+        activate_widget(buttons["SELL"], g.getGui())
+        self.assertTrue(pump_event_loop_until(lambda: "text" in captured_question, timeout=2.0))
+        pump_event_loop(5)
+
+        self.assertIn("2x Scroll", captured_question.get("text", ""))
+        self.assertEqual(1, player.countItems("Scroll"))
+        self.assertTrue(player.hasItem(lambda item: item.getName() == quest_scroll.getName() and item.hasTag("quest")))
+        market_scrolls = [item for item in market.getItems() if item.getTypeId() == "Scroll"]
+        self.assertEqual(2, len(market_scrolls))
+        self.assertFalse(any(item.hasTag(game.CTag.QUEST) for item in market_scrolls))
+        self.assertEqual(0, trade.getTotalSellCost())
 
     def test_fight_quest_item_selection_is_ignored(self):
         game, g, _, player = create_xvfb_gameplay_session(self, map_name="nouraajd")


### PR DESCRIPTION
## What changed

- Expanded trade-panel inventory clicks so a grouped row selects every sellable player inventory item with the clicked `typeId`.
- Kept quest-tagged copies excluded from sell selection and made stack toggling atomic.
- Counted duplicate labels in trade confirmation text, e.g. `2x Scroll`.
- Added an Xvfb regression covering two sellable scrolls grouped with a quest-tagged scroll.

## Why

Grouped inventory rows previously toggled only the representative item returned by the list view. That meant a duplicate stack sold one copy at a time, and a quest-tagged representative could prevent sellable copies in the same grouped row from being selected.

## Validation

- `clang-format -i src/gui/panel/CGameTradePanel.cpp src/gui/panel/CGameTradePanel.h`
- `black -l 120 test.py`
- `python3 -m py_compile test.py`
- `git diff --check`
- `GAME_XVFB_ONLY_CHILD_TESTS=test_trade_grouped_inventory_sell_selects_all_sellable_copies python3 test.py XvfbGameplayTest.test_keyboard_gameplay_under_xvfb` skipped locally because SDL x11 was unavailable under xvfb.

## Known limitations

- Local Xvfb could not execute in this environment; native build, full Python/Xvfb, and coverage evidence will come from the GitHub Actions `build / linux` check.