### PR TITLE
Correct CLAUDE.md type-registration guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,10 +91,22 @@ The engine uses a reflection macro from the **`vstd`** submodule: `V_META(Class,
 Base, ...properties)` with `V_PROPERTY(...)` declarations (see any header in
 `src/object/` or `src/gui/object/`). This drives JSON (de)serialization —
 objects are constructed by type name from JSON and their properties round-trip
-through the meta system. Each source area registers its types via
-`register*Types()` (declared in `src/core/CTypeRegistration.h`, implemented in the
-`C*TypeRegistration.cpp` files). When adding a new engine object type, wire it
-into the matching registration file or it won't be constructible from content.
+through the meta system. Registration is split across two mechanisms:
+- **Core/GUI framework types** register via `register*Types()` (declared in
+  `src/core/CTypeRegistration.h`, implemented in the `C*TypeRegistration.cpp`
+  files).
+- **Gameplay object types** (`src/object/`: creatures, items, effects,
+  interactions, tiles, dialogs, quests, controllers, …) register via the
+  `native_plugin::register_*` helpers in `src/plugin/NativePlugin.cpp`, invoked
+  through the `native_gameplay*` dynamic-plugin entry points
+  (`native_plugins/native_gameplay*.cpp`, `*_load_v1`) declared in
+  `res/plugins/manifest.json`. `registerObjectTypes()` registers only the
+  `CGameObject` base.
+
+When adding a new gameplay object type, wire it into the matching
+`register_*` function in `src/plugin/NativePlugin.cpp`; core/GUI types go into
+the matching `C*TypeRegistration.cpp` file. Either way, an unregistered type
+won't be constructible from content.
 
 ### Content pipeline (`res/`)
 - **`res/config/*.json`** — global definitions (items, weapons, armors, monsters,


### PR DESCRIPTION
## Summary
- CLAUDE.md told contributors to wire new engine object types into the matching `C*TypeRegistration.cpp` file, but that path only covers core/GUI framework types — `registerObjectTypes()` registers just the `CGameObject` base.
- Every gameplay type (`CCreature`, `CItem`, `CEffect`, `CDialog`, `CQuest`, controllers, …) is actually registered by the `native_plugin::register_*` helpers in `src/plugin/NativePlugin.cpp`, invoked through the `native_gameplay*` dynamic-plugin `*_load_v1` entry points declared in `res/plugins/manifest.json`.
- Following the old guidance for a gameplay type would silently do nothing. Updated the section to describe both mechanisms and where each kind of type belongs, per the doc's own trust-the-code rule.

## Validation
- Docs-only change; verified the described registration flow directly in `src/object/CObjectTypeRegistration.cpp`, `src/plugin/NativePlugin.cpp`, `native_plugins/native_gameplay*.cpp`, and `res/plugins/manifest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)