### PR TITLE
Remove dead CCustomAnimation branch from CAnimationProvider

### DIFF
--- a/src/core/CProvider.cpp
+++ b/src/core/CProvider.cpp
@@ -585,7 +585,7 @@ bool CResourcesProvider::save(std::string file, std::shared_ptr<json> data) {
 }
 
 std::shared_ptr<CAnimation> CAnimationProvider::getAnimation(const std::shared_ptr<CGame> &game,
-                                                             const std::shared_ptr<CGameObject> &object, bool custom) {
+                                                             const std::shared_ptr<CGameObject> &object) {
     if (!game || !object) {
         return nullptr;
     }
@@ -595,8 +595,7 @@ std::shared_ptr<CAnimation> CAnimationProvider::getAnimation(const std::shared_p
     if (!resolvedAnimationPath.empty() && std::filesystem::is_directory(resolvedAnimationPath)) {
         animation = game->createObject<CDynamicAnimation>("CDynamicAnimation");
     } else if (std::filesystem::is_regular_file(game->getResourcesProvider()->getPath(animationPath + ".png"))) {
-        animation = custom ? game->createObject<CAnimation>("CCustomAnimation")
-                           : game->createObject<CStaticAnimation>("CStaticAnimation");
+        animation = game->createObject<CStaticAnimation>("CStaticAnimation");
     } else {
         // TODO: if the path wasnt empty load text instead, requires changes in text
         // manager
@@ -610,15 +609,14 @@ std::shared_ptr<CAnimation> CAnimationProvider::getAnimation(const std::shared_p
     return animation;
 }
 
-std::shared_ptr<CAnimation> CAnimationProvider::getAnimation(const std::shared_ptr<CGame> &game, std::string path,
-                                                             bool custom) {
+std::shared_ptr<CAnimation> CAnimationProvider::getAnimation(const std::shared_ptr<CGame> &game, std::string path) {
     std::shared_ptr<CGameObject> object = game->createObject<CGameObject>();
     if (!object) {
         vstd::logger::warning("Skipping animation path with unregistered CGameObject type:", path);
         return nullptr;
     }
     object->setAnimation(std::move(path));
-    auto animation = getAnimation(game, object, custom);
+    auto animation = getAnimation(game, object);
     if (animation) {
         animation->setOwnedObject(object);
     }

--- a/src/core/CProvider.h
+++ b/src/core/CProvider.h
@@ -188,8 +188,7 @@ class CConfigurationProvider {
 class CAnimationProvider {
   public:
     static std::shared_ptr<CAnimation> getAnimation(const std::shared_ptr<CGame> &game,
-                                                    const std::shared_ptr<CGameObject> &object, bool custom = false);
+                                                    const std::shared_ptr<CGameObject> &object);
 
-    static std::shared_ptr<CAnimation> getAnimation(const std::shared_ptr<CGame> &game, std::string path,
-                                                    bool custom = false);
+    static std::shared_ptr<CAnimation> getAnimation(const std::shared_ptr<CGame> &game, std::string path);
 };


### PR DESCRIPTION
## Summary
- `CAnimationProvider::getAnimation(..., bool custom = false)` had a `custom ? createObject<CAnimation>("CCustomAnimation") : ...` branch, but `CCustomAnimation` exists nowhere in the codebase — no class, no type registration, no config entry. Had any caller passed `custom=true` for a regular-file animation, construction would have failed type resolution.
- Every call site (engine, GUI, tests) uses the defaulted form, so the parameter and branch were dead. Removed the `custom` parameter from both overloads; regular-file paths now always construct `CStaticAnimation`, which is the only behavior that ever executed.
- `CAnimationProvider` is not exposed through the pybind module, so there is no Python-facing signature change.

## Validation
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` — clean build.
- `ctest --test-dir cmake-build-release -R for_unit_tests` — 100% tests passed, 0 tests failed out of 10.
- Full native matrix + coverage left to CI (`src/core/**` is coverage-relevant, poller auto-requires the coverage step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)