### PR TITLE
Handle name collisions in CSerialization::generateName

### DIFF
--- a/src/core/CSerialization.cpp
+++ b/src/core/CSerialization.cpp
@@ -19,8 +19,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CGame.h"
 #include "core/CJsonUtil.h"
 #include "core/CList.h"
+#include "core/CMap.h"
 #include "core/CTypes.h"
 
+#include <atomic>
+#include <cstdint>
 #include <stdexcept>
 
 std::shared_ptr<CSerializerBase> CSerialization::serializer(std::pair<std::type_index, std::type_index> key) {
@@ -427,11 +430,11 @@ std::shared_ptr<CGameObject> object_deserialize(const std::shared_ptr<CGame> &ga
     } else if (CJsonUtil::isType(config)) {
         object = game->getObjectHandler()->getType((*config)["class"].get<std::string>());
         if (object) {
+            object->setGame(game);
             if (vstd::is_empty(object->getName())) {
                 object->setName(CSerialization::generateName(object));
             }
             object->setType((*config)["class"].get<std::string>());
-            object->setGame(game);
         }
     }
     if (!object && CSerialization::isStrict()) {
@@ -463,9 +466,29 @@ std::shared_ptr<CGameObject> object_deserialize(const std::shared_ptr<CGame> &ga
     return object;
 }
 
-// TODO: handle collisions
 std::string CSerialization::generateName(const std::shared_ptr<CGameObject> &object) {
-    return vstd::to_hex_hash(to_hex(object), vstd::rand());
+    return generateName(object, [&object](const std::string &candidate) {
+        auto game = object ? object->getGame() : nullptr;
+        auto map = game ? game->getMap() : nullptr;
+        return map && map->getObjectByName(candidate) != nullptr;
+    });
+}
+
+std::string CSerialization::generateName(const std::shared_ptr<CGameObject> &object,
+                                         const std::function<bool(const std::string &)> &isNameTaken) {
+    // A colliding generated name silently drops the newcomer from name-keyed registries such as
+    // CMap::mapObjects, so candidates are re-rolled until free. The sequence counter keeps hash
+    // inputs distinct even when the allocator reuses an object address and the RNG repeats.
+    static std::atomic<std::uint64_t> sequence{0};
+    constexpr int maxAttempts = 256;
+    for (int attempt = 0; attempt < maxAttempts; attempt++) {
+        auto candidate = vstd::to_hex_hash(to_hex(object), vstd::rand(), sequence.fetch_add(1));
+        if (!isNameTaken || !isNameTaken(candidate)) {
+            return candidate;
+        }
+    }
+    throw std::runtime_error("Failed to generate a unique object name after " + std::to_string(maxAttempts) +
+                             " attempts");
 }
 
 std::shared_ptr<json> map_serialize(const std::map<std::string, std::shared_ptr<CGameObject>> &object) {

--- a/src/core/CSerialization.h
+++ b/src/core/CSerialization.h
@@ -245,6 +245,9 @@ class CSerialization {
 
     static std::string generateName(const std::shared_ptr<CGameObject> &object);
 
+    static std::string generateName(const std::shared_ptr<CGameObject> &object,
+                                    const std::function<bool(const std::string &)> &isNameTaken);
+
     static bool isStrict();
 
     static bool setStrict(bool value);

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -2572,6 +2572,44 @@ void test_creature_composed_main_stat_selection() {
                 "an empty creatureClass main stat falls back to creature.baseStats");
 }
 
+// CSerialization::generateName must never hand out a name its uniqueness
+// predicate rejects: name-keyed registries treat a colliding name as a
+// duplicate and silently drop the newcomer (CMap::addObject "Ignoring
+// duplicate map object"), so the generator has to re-roll instead. Pins:
+//   * a rejected candidate is never returned (the collision-retry loop);
+//   * candidates offered to the predicate are all distinct (the sequence
+//     counter keeps hash inputs unique even under allocator address reuse
+//     and RNG repeats);
+//   * a predicate that rejects every candidate fails loudly with
+//     std::runtime_error instead of returning a known-colliding name;
+//   * repeated default-overload calls on the same object stay distinct.
+void test_generate_name_collision_retry() {
+    auto object = std::make_shared<CGameObject>();
+
+    std::set<std::string> rejected;
+    auto reject_first_three = [&rejected](const std::string &candidate) {
+        if (rejected.size() < 3) {
+            rejected.insert(candidate);
+            return true;
+        }
+        return false;
+    };
+    auto name = CSerialization::generateName(object, reject_first_three);
+    expect_true(!name.empty(), "generateName returns a non-empty name once the predicate accepts");
+    expect_true(rejected.count(name) == 0, "generateName never returns a candidate its predicate rejected");
+    expect_true(rejected.size() == 3, "generateName offers distinct fresh candidates until one is accepted");
+
+    std::set<std::string> names;
+    for (int i = 0; i < 64; i++) {
+        names.insert(CSerialization::generateName(object));
+    }
+    expect_true(names.size() == 64, "repeated generateName calls on the same object yield distinct names");
+
+    expect_runtime_error(
+        [&object]() { CSerialization::generateName(object, [](const std::string &) { return true; }); },
+        "generateName throws instead of returning a name when every candidate collides");
+}
+
 } // namespace
 
 int main() {
@@ -2620,6 +2658,7 @@ int main() {
     test_save_format_codec_validation();
     test_save_format_bounds_crafted_documents();
     test_serialization_collection_and_error_helpers();
+    test_generate_name_collision_retry();
     test_creature_effective_stats_baseline_capture();
     test_creature_effective_actions_baseline_capture();
     test_interaction_self_target_property_round_trip();


### PR DESCRIPTION
## Summary
- `CSerialization::generateName` carried a `// TODO: handle collisions` and returned `to_hex_hash(to_hex(object), rand())` with no uniqueness handling. Generated names key `CMap::mapObjects`, and `CMap::addObject` silently drops a newcomer whose name is already taken — so a collision loses a cloned (`CObjectHandler::_clone`) or freshly deserialized object.
- `generateName` now retries fresh candidates through an injectable `isNameTaken` predicate; the default overload checks the owning game's active-map registry (`CMap::getObjectByName`). A process-wide atomic sequence counter is mixed into the hash so candidate inputs stay distinct even when the allocator reuses an object address and the RNG repeats. After 256 rejected candidates it throws instead of returning a known-colliding name.
- `object_deserialize` now calls `setGame(game)` before assigning the generated name (previously after), so the default predicate can consult the registry; `setGame` is a plain field assignment, so the reorder has no other effect.

## Regression test
- `test_generate_name_collision_retry` (tests/unit/test_core.cpp) pins: rejected candidates are never returned, candidates offered are distinct, an always-rejecting predicate throws `std::runtime_error`, and 64 consecutive default-overload calls on one object yield 64 distinct names. The collision-retry surface did not exist before this change, and the existing clone-uniqueness pin in `test_creature_clone_preserves_composed_archetypes` still passes.

## Validation
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` — clean.
- `ctest --test-dir cmake-build-release -R for_unit_tests` — 100% tests passed, 0 tests failed out of 10.
- Full native matrix + coverage left to CI (`src/core/**` + `tests/unit/**` are coverage-relevant; the poller auto-requires the coverage step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)