### PR TITLE
Stop player auto-path when an obstacle blocks the route

### DIFF
--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -740,6 +740,10 @@ std::shared_ptr<vstd::future<Coords, void>> CPlayerController::control(std::shar
     }
     return vstd::now([this, player]() {
         if (!canContinue(player)) {
+            // A path that can no longer be continued (finished, or its next step became blocked)
+            // is abandoned outright, so a later poll cannot silently resume a stale route after
+            // the obstacle moves away.
+            clearPath();
             return player->getCoords();
         }
         return path.at(currentStep);
@@ -785,7 +789,6 @@ void CPlayerController::interrupt(std::shared_ptr<CCreature>) { clearPath(); }
 
 void CPlayerController::onTurnEnded(std::shared_ptr<CCreature>) {}
 
-// TODO: add stopping when obstacle found
 std::pair<bool, Coords::Direction> CPlayerController::isOnPath(std::shared_ptr<CPlayer> player, Coords coords) {
     if (!isCompleted(player)) {
         for (auto it : path | std::views::filter([this](auto it) { return it.first >= currentStep - 1; })) {

--- a/tests/unit/test_controller.cpp
+++ b/tests/unit/test_controller.cpp
@@ -289,6 +289,46 @@ void test_player_controller_prefers_longer_lower_cost_route() {
     expect_true(controller->isCompleted(player), "player weighted detour should complete after the target step");
 }
 
+// An obstacle appearing on the player's pending auto-path must STOP the walk, not
+// pause it: the controller abandons the stored route when its next step becomes
+// impassable, so the route cannot silently resume after the obstacle moves away.
+// CMap::move() already interrupts a controller that yields no movement, but the
+// controller is also polled directly (GUI footprint rendering via isOnPath,
+// script-driven control), where a merely-paused path would linger and resume.
+void test_player_controller_stops_and_clears_path_when_obstacle_appears() {
+    auto game = std::make_shared<CGame>();
+    auto map = open_tile_map(game, 4, 1);
+    auto player = player_at(game, Coords(0, 0, 0));
+    auto controller = std::make_shared<CPlayerController>();
+    player->setController(controller);
+
+    controller->setTarget(player, Coords(2, 0, 0));
+    auto first_step = resolve_coords(controller->control(player));
+    expect_true(first_step == Coords(1, 0, 0), "player auto-path should start with the adjacent corridor step");
+    player->moveTo(first_step);
+    controller->onStepCommitted(player, first_step);
+    expect_true(controller->isOnPath(player, Coords(2, 0, 0)).first,
+                "the remaining route should render as path while it is still passable");
+
+    map->removeTile(2, 0, 0);
+    expect_true(map->addTile(tile(false), 2, 0, 0), "fixture should block the next path step");
+    expect_true(!map->canStep(Coords(2, 0, 0)), "fixture should make the next path step impassable");
+
+    auto blocked_step = resolve_coords(controller->control(player));
+    expect_true(blocked_step == Coords(1, 0, 0), "a blocked auto-path must not steer into the obstacle");
+    expect_true(controller->isCompleted(player), "a blocked auto-path counts as completed (stopped)");
+    expect_true(!controller->isOnPath(player, Coords(2, 0, 0)).first,
+                "a stopped auto-path must not keep rendering stale footprints");
+
+    map->removeTile(2, 0, 0);
+    expect_true(map->addTile(tile(true), 2, 0, 0), "fixture should clear the obstacle again");
+    auto after_unblock = resolve_coords(controller->control(player));
+    expect_true(after_unblock == Coords(1, 0, 0),
+                "an auto-path stopped by an obstacle must not resume after the obstacle clears");
+    expect_true(controller->isCompleted(player),
+                "the abandoned route stays abandoned until the player picks a new target");
+}
+
 void test_npc_random_controller_prefers_longer_lower_cost_route() {
     vstd::rng().seed(4);
     auto game = std::make_shared<CGame>();
@@ -1047,6 +1087,7 @@ int main() {
     test_npc_random_controller_clears_stale_blocked_path();
     test_ground_controller_ignores_stale_transition_generation();
     test_player_controller_prefers_longer_lower_cost_route();
+    test_player_controller_stops_and_clears_path_when_obstacle_appears();
     test_npc_random_controller_prefers_longer_lower_cost_route();
     test_target_controller_flow_field_prefers_longer_lower_cost_route();
     test_player_controller_prefers_cheap_navigation_edge_over_expensive_band();


### PR DESCRIPTION
## Summary
- `CPlayerController` had `// TODO: add stopping when obstacle found`. The stored path already refused to steer into a newly blocked step (`hasPendingPath` re-checks `canStep` every poll), but it only *paused*: the route stayed stored, and the next poll after the obstacle cleared silently resumed the walk — potentially many turns later.
- `CMap::move()` masked this inside the turn loop (it interrupts a controller that yields no movement, which clears the path), but the controller is also polled directly — GUI footprint rendering through `isOnPath` and script-driven `control()` — where the stale route lingered and resumed.
- `control()` now clears the path whenever it cannot be continued (finished, or next step blocked), so a blocked auto-path stops permanently, stale footprints stop rendering, and resumption requires an explicit new target. Also removes the now-resolved TODO marker.

## Regression test
- `test_player_controller_stops_and_clears_path_when_obstacle_appears` (tests/unit/test_controller.cpp): walks one committed step, blocks the next step, and pins that the controller (1) does not steer into the obstacle, (2) reports the walk completed, (3) stops rendering the stale route, and (4) does **not** resume after the obstacle clears. Verified failing without the engine change (`FAIL: an auto-path stopped by an obstacle must not resume after the obstacle clears`) and passing with it.

## Validation
- `cmake --build cmake-build-release --target _game for_unit_tests -j$(nproc)` — clean.
- `ctest --test-dir cmake-build-release -R for_unit_tests` — 100% tests passed, 0 tests failed out of 10.
- Full native matrix + coverage left to CI (`src/core/**` + `tests/unit/**` are coverage-relevant; the poller auto-requires the coverage step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)