### PR TITLE
Scale GUI panels with the resizable window

### DIFF
--- a/res/config/panels.json
+++ b/res/config/panels.json
@@ -42,8 +42,10 @@
       "layout": {
         "class": "CCenteredLayout",
         "properties": {
-          "h": "600",
-          "w": "800"
+          "h": "55.56%",
+          "minH": 600,
+          "minW": 800,
+          "w": "41.67%"
         }
       }
     }
@@ -89,7 +91,7 @@
       "layout": {
         "class": "CLayout",
         "properties": {
-          "h": "200",
+          "h": "66.67%",
           "horizontal": "PARENT",
           "vertical": "UP"
         }
@@ -150,8 +152,10 @@
       "layout": {
         "class": "CCenteredLayout",
         "properties": {
-          "h": "300",
-          "w": "400"
+          "h": "27.78%",
+          "minH": 300,
+          "minW": 400,
+          "w": "20.84%"
         }
       }
     }
@@ -190,10 +194,10 @@
             "layout": {
               "class": "CLayout",
               "properties": {
-                "h": "300",
-                "w": "200",
-                "x": "150",
-                "y": "100"
+                "h": "50%",
+                "w": "25%",
+                "x": "18.75%",
+                "y": "16.67%"
               }
             }
           }
@@ -228,10 +232,10 @@
             "layout": {
               "class": "CLayout",
               "properties": {
-                "h": "300",
-                "w": "200",
-                "x": "450",
-                "y": "100"
+                "h": "50%",
+                "w": "25%",
+                "x": "56.25%",
+                "y": "16.67%"
               }
             }
           }
@@ -327,8 +331,10 @@
       "layout": {
         "class": "CCenteredLayout",
         "properties": {
-          "h": "600",
-          "w": "800"
+          "h": "55.56%",
+          "minH": 600,
+          "minW": 800,
+          "w": "41.67%"
         }
       }
     }
@@ -351,8 +357,10 @@
       "layout": {
         "class": "CCenteredLayout",
         "properties": {
-          "h": "300",
-          "w": "400"
+          "h": "27.78%",
+          "minH": 300,
+          "minW": 400,
+          "w": "20.84%"
         }
       }
     }
@@ -425,8 +433,10 @@
       "layout": {
         "class": "CCenteredLayout",
         "properties": {
-          "h": "600",
-          "w": "800"
+          "h": "55.56%",
+          "minH": 600,
+          "minW": 800,
+          "w": "41.67%"
         }
       }
     }
@@ -437,8 +447,10 @@
       "layout": {
         "class": "CCenteredLayout",
         "properties": {
-          "h": "600",
-          "w": "800"
+          "h": "55.56%",
+          "minH": 600,
+          "minW": 800,
+          "w": "41.67%"
         }
       }
     }
@@ -449,7 +461,7 @@
       "layout": {
         "class": "CLayout",
         "properties": {
-          "h": "100",
+          "h": "33.34%",
           "horizontal": "PARENT",
           "vertical": "DOWN"
         }
@@ -462,8 +474,10 @@
       "layout": {
         "class": "CCenteredLayout",
         "properties": {
-          "h": "300",
-          "w": "400"
+          "h": "27.78%",
+          "minH": 300,
+          "minW": 400,
+          "w": "20.84%"
         }
       },
       "children": [
@@ -493,8 +507,10 @@
       "layout": {
         "class": "CCenteredLayout",
         "properties": {
-          "h": "600",
-          "w": "800"
+          "h": "55.56%",
+          "minH": 600,
+          "minW": 800,
+          "w": "41.67%"
         }
       }
     }
@@ -510,10 +526,10 @@
             "layout": {
               "class": "CLayout",
               "properties": {
-                "h": "100",
-                "w": "200",
-                "x": "200",
-                "y": "500"
+                "h": "16.67%",
+                "vertical": "DOWN",
+                "w": "25%",
+                "x": "25%"
               }
             },
             "text": "SELL"
@@ -526,10 +542,10 @@
             "layout": {
               "class": "CLayout",
               "properties": {
-                "h": "100",
-                "w": "200",
-                "x": "400",
-                "y": "500"
+                "h": "16.67%",
+                "vertical": "DOWN",
+                "w": "25%",
+                "x": "50%"
               }
             },
             "text": "BUY"
@@ -541,9 +557,9 @@
             "layout": {
               "class": "CLayout",
               "properties": {
-                "h": "200",
-                "w": "200",
-                "x": "200",
+                "h": "33.34%",
+                "w": "25%",
+                "x": "25%",
                 "y": "0"
               }
             },
@@ -556,9 +572,9 @@
             "layout": {
               "class": "CLayout",
               "properties": {
-                "h": "200",
-                "w": "200",
-                "x": "400",
+                "h": "33.34%",
+                "w": "25%",
+                "x": "50%",
                 "y": "0"
               }
             },
@@ -618,8 +634,10 @@
       "layout": {
         "class": "CCenteredLayout",
         "properties": {
-          "h": "600",
-          "w": "800"
+          "h": "55.56%",
+          "minH": 600,
+          "minW": 800,
+          "w": "41.67%"
         }
       }
     }
@@ -630,8 +648,10 @@
       "layout": {
         "class": "CCenteredLayout",
         "properties": {
-          "h": "600",
-          "w": "800"
+          "h": "55.56%",
+          "minH": 600,
+          "minW": 800,
+          "w": "41.67%"
         }
       }
     }

--- a/src/gui/CLayout.cpp
+++ b/src/gui/CLayout.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/object/CProxyGraphicsObject.h"
 
 #include <algorithm>
+#include <cmath>
 #include <optional>
 
 namespace {
@@ -32,6 +33,21 @@ std::optional<int> parseLayoutInt(const std::string &value) {
         size_t parsed = 0;
         int result = std::stoi(value, &parsed);
         if (parsed == value.size()) {
+            return result;
+        }
+    } catch (...) {
+    }
+    return std::nullopt;
+}
+
+std::optional<double> parseLayoutDouble(const std::string &value) {
+    if (value.empty()) {
+        return std::nullopt;
+    }
+    try {
+        size_t parsed = 0;
+        double result = std::stod(value, &parsed);
+        if (parsed == value.size() && std::isfinite(result)) {
             return result;
         }
     } catch (...) {
@@ -111,6 +127,14 @@ void CLayout::clearRuntimeRect() {
     clearRuntimeH();
 }
 
+int CLayout::getMinW() { return minW; }
+
+void CLayout::setMinW(int _minW) { minW = std::max(_minW, 0); }
+
+int CLayout::getMinH() { return minH; }
+
+void CLayout::setMinH(int _minH) { minH = std::max(_minH, 0); }
+
 void CLayout::setHorizontal(std::string horizontal) { CLayout::horizontal = horizontal; }
 
 std::string CLayout::getHorizontal() { return horizontal; }
@@ -119,9 +143,9 @@ void CLayout::setVertical(std::string vertical) { CLayout::vertical = vertical; 
 
 std::string CLayout::getVertical() { return vertical; }
 
-std::pair<CLayout::TYPE, int> CLayout::parseValue(std::string value) {
+std::pair<CLayout::TYPE, double> CLayout::parseValue(std::string value) {
     if (vstd::ends_with(value, "%")) {
-        auto parsed = parseLayoutInt(value.substr(0, value.length() - 1));
+        auto parsed = parseLayoutDouble(value.substr(0, value.length() - 1));
         if (parsed) {
             return std::make_pair(PERCENT, *parsed);
         }
@@ -132,7 +156,7 @@ std::pair<CLayout::TYPE, int> CLayout::parseValue(std::string value) {
     return std::make_pair(SIMPLE, 0);
 }
 
-int CLayout::parseValue(std::pair<TYPE, int> value, int parentValue) {
+int CLayout::parseValue(std::pair<TYPE, double> value, int parentValue) {
     switch (value.first) {
     case SIMPLE:
         return value.second;
@@ -154,12 +178,14 @@ std::shared_ptr<SDL_Rect> CLayout::getRect(std::shared_ptr<CGameGraphicsObject> 
         w = *runtimeW;
     } else {
         w = horizontal == "PARENT" ? parent->w : parseValue(getW(), parent->w);
+        w = std::max(w, minW);
     }
     int h = 0;
     if (runtimeH) {
         h = *runtimeH;
     } else {
         h = vertical == "PARENT" ? parent->h : parseValue(getH(), parent->h);
+        h = std::max(h, minH);
     }
 
     if (horizontal == "LEFT" || horizontal == "PARENT") {

--- a/src/gui/CLayout.h
+++ b/src/gui/CLayout.h
@@ -27,16 +27,17 @@ class CLayout : public CGameObject {
            V_PROPERTY(CLayout, std::string, h, getH, setH), V_PROPERTY(CLayout, std::string, x, getX, setX),
            V_PROPERTY(CLayout, std::string, y, getY, setY),
            V_PROPERTY(CLayout, std::string, vertical, getVertical, setVertical),
-           V_PROPERTY(CLayout, std::string, horizontal, getHorizontal, setHorizontal))
+           V_PROPERTY(CLayout, std::string, horizontal, getHorizontal, setHorizontal),
+           V_PROPERTY(CLayout, int, minW, getMinW, setMinW), V_PROPERTY(CLayout, int, minH, getMinH, setMinH))
   public:
     virtual std::shared_ptr<SDL_Rect> getRect(std::shared_ptr<CGameGraphicsObject> object);
 
   private:
     enum TYPE { SIMPLE, PERCENT };
 
-    std::pair<TYPE, int> parseValue(std::string value);
+    std::pair<TYPE, double> parseValue(std::string value);
 
-    int parseValue(std::pair<TYPE, int> value, int parentValue);
+    int parseValue(std::pair<TYPE, double> value, int parentValue);
 
     int parseValue(std::string value, int parentValue);
 
@@ -86,6 +87,14 @@ class CLayout : public CGameObject {
 
     void clearRuntimeRect();
 
+    int getMinW();
+
+    void setMinW(int _minW);
+
+    int getMinH();
+
+    void setMinH(int _minH);
+
     std::string getVertical();
 
     void setVertical(std::string vertical);
@@ -101,6 +110,8 @@ class CLayout : public CGameObject {
     std::string y = "0";
     std::string vertical;
     std::string horizontal;
+    int minW = 0;
+    int minH = 0;
     std::optional<int> runtimeX;
     std::optional<int> runtimeY;
     std::optional<int> runtimeW;

--- a/src/gui/object/CProxyTargetGraphicsObject.cpp
+++ b/src/gui/object/CProxyTargetGraphicsObject.cpp
@@ -1,6 +1,6 @@
 /*
 fall-of-nouraajd c++ dark fantasy game
-Copyright (C) 2025  Andrzej Lis
+Copyright (C) 2025-2026  Andrzej Lis
 
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
@@ -25,7 +25,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 void CProxyTargetGraphicsObject::refresh() {
     vstd::with<void>(getGui(), [this](auto gui) {
-        constexpr int maxProxyCells = 4096;
+        // Must cover the largest resizable-window map grid: CGui clamps to 7680x4320,
+        // which at the minimum practical 50px tile size yields 155x87 = 13485 cells.
+        constexpr int maxProxyCells = 16384;
         int prevX = 0, prevY = 0;
         for (const auto &x_pair : proxyObjects) {
             prevX = std::max(prevX, x_pair.first + 1);

--- a/test.py
+++ b/test.py
@@ -2648,6 +2648,11 @@ def annotate_panel_layout(source_path, output_path, summary):
     annotated.save(output_path)
 
 
+def gui_logical_size(g):
+    gui = g.getGui()
+    return int(gui.getNumericProperty("width")), int(gui.getNumericProperty("height"))
+
+
 def capture_panel_layout(test_case, g, scenario, panel, regions=None, outside_tolerance=0):
     regions = regions or {}
     pump_event_loop(3)
@@ -2656,7 +2661,7 @@ def capture_panel_layout(test_case, g, scenario, panel, regions=None, outside_to
         data, width, height = capture_sdl_screenshot(screenshot_path, g.getGui())
     except RuntimeError as exc:
         test_case.skipTest(f"SDL renderer is not available for screenshot readback: {exc}")
-    test_case.assertEqual((GUI_WIDTH, GUI_HEIGHT), (width, height))
+    test_case.assertEqual(gui_logical_size(g), (width, height))
     panel_rect = resolved_rect(panel)
     objects = sorted((gui_object_record(obj) for obj in collect_gui_descendants(panel)), key=lambda item: item["rect"])
     summary = {
@@ -2716,7 +2721,7 @@ def assert_screenshot_has_rendered_pixels(test_case, g, name):
         test_case.skipTest(f"SDL renderer is not available for screenshot readback: {exc}")
 
     test_case.assertEqual(".png", screenshot_path.suffix)
-    test_case.assertEqual((GUI_WIDTH, GUI_HEIGHT), (width, height))
+    test_case.assertEqual(gui_logical_size(g), (width, height))
     test_case.assertTrue(screenshot_path.exists())
     test_case.assertGreater(screenshot_path.stat().st_size, 0)
     with Image.open(screenshot_path) as image:
@@ -2739,7 +2744,7 @@ def assert_minimap_has_rendered_pixels(test_case, g, name):
         test_case.skipTest(f"SDL renderer is not available for screenshot readback: {exc}")
     summary = screenshot_rect_summary(data, width, MINIMAP_RECT)
 
-    test_case.assertEqual((GUI_WIDTH, GUI_HEIGHT), (width, height))
+    test_case.assertEqual(gui_logical_size(g), (width, height))
     test_case.assertTrue(screenshot_path.exists())
     test_case.assertGreater(screenshot_path.stat().st_size, 0)
     with Image.open(screenshot_path) as image:
@@ -8099,9 +8104,7 @@ class GameTest(unittest.TestCase):
         self.assertIsNone(restored_map.getObjectByName("cave1"))
         self.assertIsNotNone(restored_map.getObjectByName("gooby1"))
         # The StartEvent markers removed on first entry stay removed on the reused session.
-        start_events = [
-            obj for obj in restored_map.getObjects() if obj.getStringProperty("type") == "StartEvent"
-        ]
+        start_events = [obj for obj in restored_map.getObjects() if obj.getStringProperty("type") == "StartEvent"]
         self.assertEqual([], start_events)
         # Post-return source-state equality (map flags, turn, quest-state machine, inventory) is
         # intentionally not asserted: reuseLoadedMap re-attaches the player at the map entry, and
@@ -11249,9 +11252,7 @@ class GameTest(unittest.TestCase):
                 reloaded_player = reloaded_map.getPlayer()
                 self.assertEqual(player_type, reloaded_player.getPlayerClassId(), player_type)
                 self.assertEqual(default_race, reloaded_player.getRaceId(), player_type)
-                snapshot_b = runtime_save_state_summary(
-                    normalize_save_snapshot(json.loads(game.jsonify(reloaded_map)))
-                )
+                snapshot_b = runtime_save_state_summary(normalize_save_snapshot(json.loads(game.jsonify(reloaded_map))))
                 self.assertEqual(snapshot_a, snapshot_b, player_type)
 
                 results[player_type] = {
@@ -11407,8 +11408,7 @@ class GameTest(unittest.TestCase):
             g.changeMap("ritual")
             self.assertTrue(
                 pump_event_loop_until(
-                    lambda gm=g, sm=scene_manager: gm.getMap().mapName == "ritual"
-                    and not sm.isTransitionPending(),
+                    lambda gm=g, sm=scene_manager: gm.getMap().mapName == "ritual" and not sm.isTransitionPending(),
                     timeout=2.0,
                     min_iterations=2,
                 ),
@@ -11422,8 +11422,7 @@ class GameTest(unittest.TestCase):
             g.changeMap("test")
             self.assertTrue(
                 pump_event_loop_until(
-                    lambda gm=g, sm=scene_manager: gm.getMap().mapName == "test"
-                    and not sm.isTransitionPending(),
+                    lambda gm=g, sm=scene_manager: gm.getMap().mapName == "test" and not sm.isTransitionPending(),
                     timeout=2.0,
                     min_iterations=2,
                 ),
@@ -13511,6 +13510,64 @@ class GameTest(unittest.TestCase):
                 "market_items": len(market.getItems()),
                 "player_swords": player.countItems("Sword"),
             },
+            sort_keys=True,
+        )
+
+    @game_test
+    def test_window_resize_scales_percent_panels(self):
+        # Panels use percent-of-window layouts with pixel minimums (res/config/panels.json):
+        # a window larger than the 1920x1080 design scales panels up, a smaller one floors
+        # them at their design size. Logical size is driven through the CGui width/height
+        # properties, which feed the root layout's runtime overrides.
+        game = load_game_module()
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.loadGui(g)
+        game.CGameLoader.startGameWithPlayer(g, "nouraajd", "Warrior")
+        gui = g.getGui()
+        gui_handler = g.getGuiHandler()
+
+        def open_inventory():
+            panel = gui_handler.openPanel("inventoryPanel")
+            pump_event_loop(3)
+            return panel
+
+        def close_panel(panel):
+            panel.close()
+            pump_event_loop(3)
+
+        gui.setNumericProperty("width", 2560)
+        gui.setNumericProperty("height", 1440)
+        self.assertEqual((0, 0, 2560, 1440), resolved_rect(gui))
+        minimap = next(iter(collect_gui_children(gui, "CMinimapGraphicsObject")))
+        self.assertEqual((2340, 1220, 220, 220), resolved_rect(minimap))
+
+        panel = open_inventory()
+        scaled_rect = resolved_rect(panel)
+        self.assertEqual((747, 320, 1066, 800), scaled_rect)
+        inventory_list = find_list_view(panel, "inventoryCollection")
+        equipped_list = find_list_view(panel, "equippedCollection")
+        self.assertEqual((747, 320, 266, 800), resolved_rect(inventory_list))
+        self.assertEqual((1546, 320, 266, 800), resolved_rect(equipped_list))
+        self.assertEqual((5, 16), list_runtime_grid(inventory_list, gui))
+        self.assertEqual((4, 2), list_runtime_grid(equipped_list, gui))
+        close_panel(panel)
+
+        gui.setNumericProperty("width", 1024)
+        gui.setNumericProperty("height", 768)
+        panel = open_inventory()
+        floored_rect = resolved_rect(panel)
+        self.assertEqual((112, 84, 800, 600), floored_rect)
+        close_panel(panel)
+
+        gui.setNumericProperty("width", 1920)
+        gui.setNumericProperty("height", 1080)
+        panel = open_inventory()
+        design_rect = resolved_rect(panel)
+        self.assertEqual((560, 240, 800, 600), design_rect)
+        close_panel(panel)
+
+        return True, json.dumps(
+            {"scaled": scaled_rect, "floored": floored_rect, "design": design_rect},
             sort_keys=True,
         )
 
@@ -20166,6 +20223,14 @@ class XvfbGameplayProcessTest(unittest.TestCase):
         self.assertEqual((0, 0, width, height), tuple(map_graph.getResolvedRect()))
         self.assertEqual(expected_proxy_count, len(map_graph.getChildren()))
         assert_rendered_map_proxy_cells(self, g)
+
+        panel = open_layout_panel(self, g, "inventoryPanel")
+        try:
+            self.assertEqual((0, 0, 800, 600), resolved_rect(panel))
+            self.assertEqual((4, 2), list_runtime_grid(find_list_view(panel, "equippedCollection"), gui))
+        finally:
+            panel.close()
+            pump_event_loop(3)
 
     def test_screenshot_readback_has_rendered_pixels(self):
         _, g, _, _ = create_xvfb_gameplay_session(self)

--- a/tests/security/test_layout_no_script_eval.py
+++ b/tests/security/test_layout_no_script_eval.py
@@ -32,7 +32,7 @@ class LayoutScriptEvaluationTest(unittest.TestCase):
     def test_invalid_layout_dimensions_fall_back_to_zero(self):
         layout_cpp = (REPO_ROOT / "src/gui/CLayout.cpp").read_text()
         parse_value = re.search(
-            r"std::pair<CLayout::TYPE, int> CLayout::parseValue\(std::string value\) \{(?P<body>.*?)\n\}",
+            r"std::pair<CLayout::TYPE, double> CLayout::parseValue\(std::string value\) \{(?P<body>.*?)\n\}",
             layout_cpp,
             re.DOTALL,
         )

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -407,6 +407,66 @@ void test_layout_runtime_overrides_preserve_serialized_percentage_layouts() {
                 "clearing parent runtime overrides should restore the serialized parent rectangle");
 }
 
+void test_layout_fractional_percentages_resolve_exact_design_pixels() {
+    auto parent = std::make_shared<CGameGraphicsObject>();
+    auto parentLayout = std::make_shared<CLayout>();
+    parentLayout->setRect(0, 0, 1920, 1080);
+    parent->setLayout(parentLayout);
+
+    auto child = std::make_shared<CGameGraphicsObject>();
+    auto childLayout = std::make_shared<CCenteredLayout>();
+    childLayout->setW("41.67%");
+    childLayout->setH("55.56%");
+    child->setLayout(childLayout);
+    parent->addChild(child);
+
+    expect_rect(childLayout->getRect(child), 560, 240, 800, 600,
+                "fractional percentages should reproduce the 800x600 design rect at 1920x1080");
+
+    parentLayout->setRuntimeRect(0, 0, 2560, 1440);
+    expect_rect(childLayout->getRect(child), 747, 320, 1066, 800,
+                "fractional percentages should scale panels with a larger root rectangle");
+
+    childLayout->setW("12.5");
+    expect_true(childLayout->getRect(child)->w == 0, "fractional plain pixel values should stay invalid");
+    childLayout->setW("nan%");
+    expect_true(childLayout->getRect(child)->w == 0, "non-finite percentages should stay invalid");
+}
+
+void test_layout_minimum_size_floors_percentage_panels() {
+    auto parent = std::make_shared<CGameGraphicsObject>();
+    auto parentLayout = std::make_shared<CLayout>();
+    parentLayout->setRect(0, 0, 1280, 720);
+    parent->setLayout(parentLayout);
+
+    auto child = std::make_shared<CGameGraphicsObject>();
+    auto childLayout = std::make_shared<CCenteredLayout>();
+    childLayout->setW("41.67%");
+    childLayout->setH("55.56%");
+    childLayout->setMinW(800);
+    childLayout->setMinH(600);
+    child->setLayout(childLayout);
+    parent->addChild(child);
+
+    expect_rect(childLayout->getRect(child), 240, 60, 800, 600,
+                "panels below the minimum size should be floored and stay centered");
+
+    parentLayout->setRuntimeRect(0, 0, 1920, 1080);
+    expect_rect(childLayout->getRect(child), 560, 240, 800, 600,
+                "the minimum floor should hand off exactly at the design resolution");
+
+    childLayout->setRuntimeW(320);
+    childLayout->setRuntimeH(200);
+    expect_rect(childLayout->getRect(child), 800, 440, 320, 200,
+                "runtime size overrides should bypass the minimum floor");
+
+    childLayout->clearRuntimeRect();
+    parentLayout->setRuntimeRect(0, 0, 1280, 720);
+    childLayout->setMinW(-50);
+    childLayout->setMinH(-50);
+    expect_rect(childLayout->getRect(child), 374, 160, 533, 400, "negative minimum sizes should be ignored");
+}
+
 void test_gui_window_is_resizable_and_guard_paths_fail_closed() {
     SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
@@ -2314,6 +2374,8 @@ int main() {
     pybind11::scoped_interpreter guard{};
 
     test_layout_runtime_overrides_preserve_serialized_percentage_layouts();
+    test_layout_fractional_percentages_resolve_exact_design_pixels();
+    test_layout_minimum_size_floors_percentage_panels();
     test_widget_ignores_unarmed_non_left_clicks();
     test_widget_reflective_callbacks_fail_closed_on_bad_config();
     test_character_panel_sheet_lines_build_without_rendering_and_fail_closed();

--- a/todo.txt
+++ b/todo.txt
@@ -4,7 +4,6 @@ the implementation backlog; docs/codebase-cleanup-plan.md sequences the cleanup
 work. Historical fix-by-fix notes live in docs/todo-worklog.md.
 
 Already queued — work the existing workbook items, do not re-propose:
-//TODO: resizing panels                                          [queued: EPIC_05_STORY_02]
 //TODO: migrate remaining global/static providers and UI/session services into CGameContext where safe [queued: EPIC_02_STORY_01]
 //TODO: encapsulate SDL_RenderCopy                               [queued: EPIC_05_STORY_03]
 //TODO: what if we return to oldMap after switch?                [queued: EPIC_02_STORY_03]


### PR DESCRIPTION
## Summary

Completes the "resizing panels" TODO (`EPIC_05_STORY_02`, queue workbook untouched per controller rules — no active claim existed). The window-resize core already landed; this makes the panels themselves adapt:

- **CLayout**: fractional percentages (`"41.67%"`) so percent layouts reproduce exact 1920×1080 design pixels under the existing truncation math, plus `minW`/`minH` properties that floor the resolved size (runtime overrides bypass the floor).
- **panels.json**: every centered panel is now percent-of-window with its design size as the minimum — larger windows scale panels up, smaller windows keep them at 800×600 / 400×300. Absolute-pixel interiors (fight creature cards, creature/stats views, trade SELL/BUY buttons and cost widgets) converted to percent/anchor equivalents that resolve to identical pixels at the design resolution, so all existing layout contracts hold unchanged.
- **CProxyTargetGraphicsObject**: `maxProxyCells` 4096 → 16384 so the map grid covers the full 7680×4320 window clamp at 50px tiles instead of vanishing above ~5K windows.
- **todo.txt**: drop the completed entry.

## Tests

- Native: `test_layout_fractional_percentages_resolve_exact_design_pixels`, `test_layout_minimum_size_floors_percentage_panels` (gui_unit_tests).
- Python: new `GameTest.test_window_resize_scales_percent_panels` asserts scaled (2560×1440), floored (1024×768) and design (1920×1080) panel rects, interior list rects, and list grid counts; the Xvfb resize child test now also asserts the floored panel fills an 800×600 window; screenshot size asserts derive from the live gui size instead of hardcoded 1920×1080.

## Local validation

- `ctest --test-dir cmake-build-release --output-on-failure -R for_unit_tests` — 10/10 pass
- `python3 test.py GameTest.test_window_resize_scales_percent_panels` — OK
- `python3 test.py PanelLayoutManifestTest` — OK
- Xvfb children (resize, panel root contracts, fight nested views, inventory/loot/trade, text-centric, choice panels, list capacity/paging) via `GAME_XVFB_ONLY_CHILD_TESTS` — all OK
- Visual check: real X11 window resized to 1280×720 with inventory open — HUD re-anchors, panel floors at 800×600 centered
- Heavy validation (full build matrix, full Python suite, coverage) delegated to CI polling per AGENTS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)