### PR TITLE
[EPIC_05][STORY_03][SUBSTORY_02] Migrate direct RenderCopy call sites

### DIFF
--- a/src/gui/CRenderContext.cpp
+++ b/src/gui/CRenderContext.cpp
@@ -76,6 +76,7 @@ bool CRenderContext::copy(SDL_Texture *texture, const SDL_Rect *sourceRect, cons
         ++stats.failedCopies;
         return false;
     }
+    // Single sanctioned direct SDL_RenderCopy site; all call sites route texture blits through this wrapper.
     return finishCopy(SDL_RenderCopy(renderer, texture, sourceRect, &normalizedTarget), "CRenderContext::copy");
 }
 
@@ -95,6 +96,7 @@ bool CRenderContext::copyEx(SDL_Texture *texture, const SDL_Rect *sourceRect, co
         ++stats.failedCopies;
         return false;
     }
+    // Single sanctioned direct SDL_RenderCopyEx site; all rotated/flipped blits route through this wrapper.
     return finishCopy(SDL_RenderCopyEx(renderer, texture, sourceRect, &normalizedTarget, angle, center, flip),
                       "CRenderContext::copyEx");
 }

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -2194,6 +2194,44 @@ void test_render_context_rejects_null_texture_and_copies_valid_texture() {
     expect_true(stats.failedCopies == 0, "render context should not count failed copies for valid smoke path");
 }
 
+void test_render_context_copy_ex_rotates_and_tracks_stats() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto &renderContext = gui->getRenderContext();
+    renderContext.resetStats();
+
+    // copyEx must fail closed on missing texture, exactly like copy().
+    SDL_Rect target = {2, 3, 4, 5};
+    expect_true(!renderContext.copyEx(nullptr, nullptr, &target, 90.0, nullptr, SDL_FLIP_NONE),
+                "render context copyEx should reject null textures");
+
+    auto surface = fn::sdl::SurfacePtr(SDL_SAFE(SDL_CreateRGBSurfaceWithFormat(0, 2, 2, 32, SDL_PIXELFORMAT_RGBA32)));
+    expect_true(surface != nullptr, "render context copyEx smoke test should create an SDL surface");
+    if (!surface) {
+        return;
+    }
+    SDL_SAFE(SDL_FillRect(surface.get(), nullptr, SDL_MapRGBA(surface->format, 0, 255, 0, 255)));
+    auto texture = fn::sdl::TexturePtr(SDL_SAFE(SDL_CreateTextureFromSurface(gui->getRenderer(), surface.get())));
+    expect_true(texture != nullptr, "render context copyEx smoke test should create an SDL texture");
+    if (!texture) {
+        return;
+    }
+
+    // Negative extents must be normalized before reaching SDL, mirroring copy().
+    SDL_Rect flippedTarget = {10, 12, -4, -5};
+    SDL_Rect clip = {0, 0, 8, 8};
+    expect_true(renderContext.copyEx(texture.get(), nullptr, &flippedTarget, 45.0, nullptr, SDL_FLIP_HORIZONTAL, &clip),
+                "render context copyEx should rotate and copy valid textures");
+
+    const auto &stats = renderContext.getStats();
+    expect_true(stats.attemptedCopies == 2, "render context copyEx should count attempted copies");
+    expect_true(stats.successfulCopies == 1, "render context copyEx should count successful copies");
+    expect_true(stats.skippedCopies == 1, "render context copyEx should count skipped copies for null texture");
+    expect_true(stats.failedCopies == 0, "render context copyEx should not count failed copies for valid smoke path");
+}
+
 void test_widget_reflective_callbacks_fail_closed_on_bad_config() {
     SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
@@ -2427,6 +2465,7 @@ int main() {
     test_render_traversal_stops_after_detach();
     test_texture_cache_without_gui_fails_closed();
     test_render_context_rejects_null_texture_and_copies_valid_texture();
+    test_render_context_copy_ex_rotates_and_tracks_stats();
     test_minimap_bounds_extreme_metadata_fails_closed();
     test_minimap_bounds_overflow_prone_extents_fail_closed();
     test_minimap_bounds_sparse_coordinates_fail_closed();


### PR DESCRIPTION
## Summary

This substory migrates the remaining direct `SDL_RenderCopy` / `SDL_RenderCopyEx` call sites onto the `CRenderContext::copy` / `copyEx` wrapper introduced by the prior substory.

Investigation finding: on current `main` the migration is already fully complete. A repo-wide search (`grep -rn "RenderCopy"`) returns exactly two occurrences, both inside the wrapper's own implementation (`src/gui/CRenderContext.cpp`). Every texture blit call site already routes through the wrapper:

- `src/gui/CAnimation.cpp:52` -> `getRenderContext().copy(...)`
- `src/gui/CAnimation.cpp:54` -> `getRenderContext().copyEx(...)` (rotated sprite)
- `src/gui/CAnimation.cpp:126` -> `getRenderContext().copy(...)`
- `src/gui/object/CMinimapGraphicsObject.cpp:398` -> `getRenderContext().copy(...)`
- `src/gui/object/CGameGraphicsObject.cpp:289` -> `getRenderContext().copy(...)`
- `src/gui/CTextManager.cpp:122,136,158` -> `getRenderContext().copy(...)`

The remaining raw-renderer uses (`SDL_RenderFillRect`, `SDL_RenderClear`, `SDL_RenderPresent`, `SDL_RenderReadPixels`) are not texture-copy blits and are out of scope for this substory.

Because there were no direct call sites left to migrate, this PR locks in the completed migration with a minimal, behavior-preserving change instead of forcing a fake substitution:

- Mark the wrapper's two `SDL_RenderCopy` / `SDL_RenderCopyEx` calls as the single sanctioned direct sites so future blits keep routing through the wrapper (comment-only, no behavior change).
- Add `copyEx` unit coverage. The wrapper's `copyEx` path (used by the migrated `CAnimation` rotated-sprite call site) previously had no test; the existing test only exercised `copy`.

## Tests

- Extended `tests/unit/test_gui.cpp` with `test_render_context_copy_ex_rotates_and_tracks_stats`, exercising the wrapper's rotated/flipped path: null-texture rejection, negative-extent normalization, clip-guard, and stats counters (attempted/successful/skipped/failed). Registered in the GUI test runner.
- Relies on existing rendering tests + CI for the mechanical call-site coverage, since no call-site substitution was required.

Worker implementation branch did not modify any queue workbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_