### PR TITLE
[EPIC_05][STORY_02][SUBSTORY_03] Add opt-in panel resize handles

### DIFF
--- a/src/gui/CGui.h
+++ b/src/gui/CGui.h
@@ -81,6 +81,7 @@ class CGui : public CGameGraphicsObject {
     // to decide drag-vs-click, so the rule lives in exactly one place.
     static bool isDragActive(const DragSession &session);
 
+    using CGameGraphicsObject::event;
     using CGameGraphicsObject::render;
 
     SDL_Renderer *getRenderer() const;

--- a/src/gui/object/CGameGraphicsObject.h
+++ b/src/gui/object/CGameGraphicsObject.h
@@ -134,10 +134,14 @@ class CGameGraphicsObject : public CGameObject {
 
     int getTileSize(const std::shared_ptr<CGameGraphicsObject> &object);
 
+  protected:
+    // Called by the parent before this object's own mouse/keyboard hooks; the default forwards to the
+    // children (highest priority first) and only then to this object. Overridable so a subclass can
+    // claim an event ahead of its children (e.g. a panel's resize handle under a covering child).
+    virtual bool event(std::shared_ptr<CGui> gui, SDL_Event *event);
+
   private:
     virtual void render(std::shared_ptr<CGui> renderer, int frameTime);
-
-    bool event(std::shared_ptr<CGui> gui, SDL_Event *event);
 
     int getTopPriority();
 

--- a/src/gui/panel/CGamePanel.cpp
+++ b/src/gui/panel/CGamePanel.cpp
@@ -16,14 +16,142 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "CGamePanel.h"
+#include "core/CUtil.h"
 #include "gui/CGui.h"
+#include "gui/CLayout.h"
 #include "gui/CTextureCache.h"
 #include "gui/object/CWidget.h"
+
+#include <algorithm>
 
 bool CGamePanel::keyboardEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, SDL_Keycode i) { return true; }
 
 bool CGamePanel::mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int button, int x, int y) {
+    if (button == SDL_BUTTON_LEFT) {
+        if (type == SDL_MOUSEBUTTONDOWN && beginResize(x, y)) {
+            // Capture the pointer so the resize keeps tracking even if the cursor leaves the panel rect.
+            if (sharedPtr) {
+                sharedPtr->capturePointer(this->ptr<CGameGraphicsObject>());
+            }
+            return true;
+        }
+        if (type == SDL_MOUSEBUTTONUP && isResizing()) {
+            endResize();
+            if (sharedPtr) {
+                sharedPtr->releasePointerCapture();
+            }
+            return true;
+        }
+    }
     return true;
+}
+
+bool CGamePanel::mouseMotionEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int x, int y, int xrel,
+                                  int yrel) {
+    if (isResizing()) {
+        updateResize(x, y);
+        return true;
+    }
+    return false;
+}
+
+void CGamePanel::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int frameTime) {
+    // Only opted-in panels paint a grab handle; everything else renders exactly as before.
+    if (!resizable || !gui || !rect || rect->w <= 0 || rect->h <= 0) {
+        return;
+    }
+    auto renderer = gui->getRenderer();
+    if (!renderer) {
+        return;
+    }
+    int handle = std::clamp(resizeHandleSize, 1, std::min(rect->w, rect->h));
+    SDL_Rect handleRect{rect->x + rect->w - handle, rect->y + rect->h - handle, handle, handle};
+    CUtil::setRenderDrawColor(renderer, CColors::Yellow);
+    SDL_RenderFillRect(renderer, &handleRect);
+}
+
+bool CGamePanel::isResizable() { return resizable; }
+
+void CGamePanel::setResizable(bool _resizable) {
+    resizable = _resizable;
+    if (!resizable) {
+        endResize();
+    }
+}
+
+int CGamePanel::getResizeHandleSize() { return resizeHandleSize; }
+
+void CGamePanel::setResizeHandleSize(int _resizeHandleSize) { resizeHandleSize = std::max(_resizeHandleSize, 1); }
+
+bool CGamePanel::isResizing() { return resizing; }
+
+bool CGamePanel::isInResizeHandle(int x, int y) {
+    if (!resizable) {
+        return false;
+    }
+    auto rect = getSelfRect();
+    if (rect->w <= 0 || rect->h <= 0) {
+        return false;
+    }
+    int handle = std::clamp(resizeHandleSize, 1, std::min(rect->w, rect->h));
+    return x >= rect->w - handle && x <= rect->w && y >= rect->h - handle && y <= rect->h;
+}
+
+CGamePanel::ResizeBounds CGamePanel::getResizeBounds() {
+    ResizeBounds bounds{RESIZE_MIN_SIZE, RESIZE_MIN_SIZE, RESIZE_MAX_FALLBACK, RESIZE_MAX_FALLBACK};
+    if (auto layout = getLayout()) {
+        bounds.minW = std::max(RESIZE_MIN_SIZE, layout->getMinW());
+        bounds.minH = std::max(RESIZE_MIN_SIZE, layout->getMinH());
+    }
+    if (auto parent = getParent()) {
+        if (auto parentLayout = parent->getLayout()) {
+            auto parentRect = parentLayout->getRect(parent);
+            auto rect = getSelfRect();
+            // Keep the panel fully inside its parent: the max edge is the room left of the parent's
+            // right/bottom edge from the panel's fixed top-left corner.
+            int roomW = parentRect->w - (rect->x - parentRect->x);
+            int roomH = parentRect->h - (rect->y - parentRect->y);
+            bounds.maxW = std::max(bounds.minW, roomW);
+            bounds.maxH = std::max(bounds.minH, roomH);
+        }
+    }
+    return bounds;
+}
+
+bool CGamePanel::beginResize(int x, int y) {
+    if (!isInResizeHandle(x, y)) {
+        return false;
+    }
+    auto rect = getSelfRect();
+    // Latch the offset from the pointer to the panel's right/bottom edge so the drag is jump-free.
+    resizeGrabOffsetW = rect->w - x;
+    resizeGrabOffsetH = rect->h - y;
+    resizing = true;
+    return true;
+}
+
+void CGamePanel::updateResize(int x, int y) {
+    if (!resizing) {
+        return;
+    }
+    auto layout = getLayout();
+    if (!layout) {
+        endResize();
+        return;
+    }
+    auto bounds = getResizeBounds();
+    int newW = std::clamp(x + resizeGrabOffsetW, bounds.minW, bounds.maxW);
+    int newH = std::clamp(y + resizeGrabOffsetH, bounds.minH, bounds.maxH);
+    // Resize via runtime overrides so the serialized layout values stay intact (mirrors window scaling).
+    layout->setRuntimeW(newW);
+    layout->setRuntimeH(newH);
+}
+
+void CGamePanel::endResize() { resizing = false; }
+
+std::shared_ptr<SDL_Rect> CGamePanel::getSelfRect() {
+    auto layout = getLayout();
+    return layout ? layout->getRect(this->ptr<CGameGraphicsObject>()) : CUtil::rect(0, 0, 0, 0);
 }
 
 void CGamePanel::refreshViews() {

--- a/src/gui/panel/CGamePanel.cpp
+++ b/src/gui/panel/CGamePanel.cpp
@@ -49,10 +49,38 @@ bool CGamePanel::mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type,
 bool CGamePanel::mouseMotionEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int x, int y, int xrel,
                                   int yrel) {
     if (isResizing()) {
+        // If the pointer capture ended without this panel seeing the release (e.g. drag cancel or an
+        // externally released capture), drop the stale resize instead of resizing with no button held.
+        if (sharedPtr && !sharedPtr->isPointerCapturedBy(this->ptr<CGameGraphicsObject>())) {
+            endResize();
+            return false;
+        }
         updateResize(x, y);
         return true;
     }
     return false;
+}
+
+bool CGamePanel::event(std::shared_ptr<CGui> gui, SDL_Event *event) {
+    if (event && isAttachedToGui(gui) && isVisible()) {
+        // A press on the resize handle is claimed before child dispatch: children (e.g. list views)
+        // consume left button-downs even on empty cells, so a child covering the bottom-right corner
+        // would otherwise swallow the grab. Same for the matching release while a resize is active,
+        // which CGui routes through normal hit testing when it lands inside the captured panel.
+        if (event->type == SDL_MOUSEBUTTONDOWN && event->button.button == SDL_BUTTON_LEFT) {
+            auto rect = getSelfRect();
+            if (isInResizeHandle(event->button.x - rect->x, event->button.y - rect->y)) {
+                return mouseEvent(gui, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, event->button.x - rect->x,
+                                  event->button.y - rect->y);
+            }
+        }
+        if (event->type == SDL_MOUSEBUTTONUP && event->button.button == SDL_BUTTON_LEFT && isResizing()) {
+            auto rect = getSelfRect();
+            return mouseEvent(gui, SDL_MOUSEBUTTONUP, SDL_BUTTON_LEFT, event->button.x - rect->x,
+                              event->button.y - rect->y);
+        }
+    }
+    return CGameGraphicsObject::event(gui, event);
 }
 
 void CGamePanel::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect> rect, int frameTime) {
@@ -122,7 +150,23 @@ bool CGamePanel::beginResize(int x, int y) {
     if (!isInResizeHandle(x, y)) {
         return false;
     }
+    auto layout = getLayout();
+    if (!layout) {
+        return false;
+    }
     auto rect = getSelfRect();
+    // Pin the top-left corner for the whole drag: centered/right/bottom-aligned layouts recompute
+    // x/y from the current size, so runtime W/H alone would move the origin (and with it the
+    // panel-local pointer space) on every update. Latching runtime X/Y freezes the origin relative
+    // to the parent so the panel resizes from a stable corner.
+    auto parentOrigin = CUtil::rect(0, 0, 0, 0);
+    if (auto parent = getParent()) {
+        if (auto parentLayout = parent->getLayout()) {
+            parentOrigin = parentLayout->getRect(parent);
+        }
+    }
+    layout->setRuntimeX(rect->x - parentOrigin->x);
+    layout->setRuntimeY(rect->y - parentOrigin->y);
     // Latch the offset from the pointer to the panel's right/bottom edge so the drag is jump-free.
     resizeGrabOffsetW = rect->w - x;
     resizeGrabOffsetH = rect->h - y;

--- a/src/gui/panel/CGamePanel.h
+++ b/src/gui/panel/CGamePanel.h
@@ -71,6 +71,11 @@ class CGamePanel : public CGameGraphicsObject {
 
     bool isResizing();
 
+  protected:
+    // Claims resize-handle presses (and the matching release while a resize is active) before child
+    // dispatch, so a child covering the bottom-right corner cannot swallow the resize interaction.
+    bool event(std::shared_ptr<CGui> gui, SDL_Event *event) override;
+
   private:
     // Minimum edge length a resizable panel is ever clamped to, independent of the layout's own minW/minH.
     // Keeps the panel at least as large as its handle so the handle stays grabbable.

--- a/src/gui/panel/CGamePanel.h
+++ b/src/gui/panel/CGamePanel.h
@@ -24,7 +24,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 class CWidget;
 
 class CGamePanel : public CGameGraphicsObject {
-    V_META(CGamePanel, CGameGraphicsObject, vstd::meta::empty())
+    V_META(CGamePanel, CGameGraphicsObject, V_PROPERTY(CGamePanel, bool, resizable, isResizable, setResizable),
+           V_PROPERTY(CGamePanel, int, resizeHandleSize, getResizeHandleSize, setResizeHandleSize))
   public:
     CGamePanel();
 
@@ -32,9 +33,68 @@ class CGamePanel : public CGameGraphicsObject {
 
     bool mouseEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int button, int x, int y) override;
 
+    bool mouseMotionEvent(std::shared_ptr<CGui> sharedPtr, SDL_EventType type, int x, int y, int xrel,
+                          int yrel) override;
+
+    void renderObject(std::shared_ptr<CGui> reneder, std::shared_ptr<SDL_Rect> rect, int frameTime) override;
+
     void refreshViews();
 
     void awaitClosing();
 
     virtual void close();
+
+    // Opt-in user resize handle. Off by default so existing panels are unchanged: only a panel that
+    // explicitly opts in exposes a bottom-right drag handle that resizes it via runtime layout overrides.
+    bool isResizable();
+
+    void setResizable(bool _resizable);
+
+    int getResizeHandleSize();
+
+    void setResizeHandleSize(int _resizeHandleSize);
+
+    // True when panel-local (x, y) falls inside the bottom-right resize handle of the current rect.
+    // Always false while the panel is not resizable, so a non-opted-in panel never treats the corner
+    // specially.
+    bool isInResizeHandle(int x, int y);
+
+    // Pure resize-drag state machine driven in panel-local coordinates (pointer position relative to
+    // the panel's fixed top-left corner). beginResize latches the grab offset and returns whether a
+    // resize started; updateResize writes clamped runtime width/height onto the layout; endResize
+    // clears the state. These carry the geometry so they can be exercised without SDL rendering.
+    bool beginResize(int x, int y);
+
+    void updateResize(int x, int y);
+
+    void endResize();
+
+    bool isResizing();
+
+  private:
+    // Minimum edge length a resizable panel is ever clamped to, independent of the layout's own minW/minH.
+    // Keeps the panel at least as large as its handle so the handle stays grabbable.
+    static constexpr int RESIZE_MIN_SIZE = 32;
+    // Fallback maximum edge used when the panel has no parent rectangle to bound it (matches the GUI's
+    // logical maximum so a detached panel still cannot grow without limit).
+    static constexpr int RESIZE_MAX_FALLBACK = 7680;
+    static constexpr int DEFAULT_HANDLE_SIZE = 24;
+
+    struct ResizeBounds {
+        int minW;
+        int minH;
+        int maxW;
+        int maxH;
+    };
+
+    ResizeBounds getResizeBounds();
+
+    // Base CGameGraphicsObject::getRect() is private; resolve this panel's own rectangle through its layout.
+    std::shared_ptr<SDL_Rect> getSelfRect();
+
+    bool resizable = false;
+    int resizeHandleSize = DEFAULT_HANDLE_SIZE;
+    bool resizing = false;
+    int resizeGrabOffsetW = 0;
+    int resizeGrabOffsetH = 0;
 };

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -2368,6 +2368,67 @@ void test_dialog_panel_current_options_preserve_numeric_display_order() {
                 "dialog panel should display options from lowest dialog number to highest");
 }
 
+// Exercises the opt-in resize handle purely through geometry/state: no renderer, no real SDL input.
+// A default panel must ignore the handle entirely; an opted-in panel must resize from a bottom-right
+// handle drag and clamp within [min, parent] bounds without rewriting its serialized layout.
+void test_panel_opt_in_resize_handle_drag_resizes_within_bounds() {
+    auto parent = std::make_shared<CGameGraphicsObject>();
+    parent->setLayout(fixed_layout(0, 0, 800, 600));
+
+    auto panel = std::make_shared<CGamePanel>();
+    auto layout = fixed_layout(0, 0, 200, 150);
+    panel->setLayout(layout);
+    parent->addChild(panel);
+
+    // Default (not opted in): the corner is not a handle and a click there must not start a resize.
+    expect_true(!panel->isResizable(), "panels should not be resizable by default (opt-in only)");
+    expect_true(!panel->isInResizeHandle(195, 145),
+                "a non-resizable panel must not treat its bottom-right corner as a handle");
+    expect_true(!panel->beginResize(195, 145), "a non-resizable panel must not start a resize drag");
+    expect_true(!panel->isResizing(), "a non-resizable panel must never enter the resizing state");
+    // A left press on the corner is still consumed (modal) but changes no size.
+    expect_true(panel->mouseEvent(nullptr, SDL_MOUSEBUTTONDOWN, SDL_BUTTON_LEFT, 195, 145),
+                "a modal panel still consumes clicks even when resizing is disabled");
+    expect_rect(layout->getRect(panel), 0, 0, 200, 150,
+                "a non-resizable panel must keep its size after a corner click");
+
+    // Opt in and drive a handle drag directly (pointer coordinates are panel-local; top-left is fixed).
+    panel->setResizable(true);
+    expect_true(panel->isInResizeHandle(195, 145),
+                "an opted-in panel's bottom-right corner should hit-test as the resize handle");
+    expect_true(!panel->isInResizeHandle(10, 10), "the panel interior is not part of the resize handle");
+    expect_true(panel->beginResize(195, 145), "an opted-in panel should start a resize from the handle");
+    expect_true(panel->isResizing(), "beginResize should latch the resizing state");
+
+    // Grab offset was (200-195, 150-145) = (5, 5); dragging to (255, 195) => 260x200.
+    panel->updateResize(255, 195);
+    expect_rect(layout->getRect(panel), 0, 0, 260, 200, "dragging the handle should grow the panel jump-free");
+    expect_true(layout->getW() == "200" && layout->getH() == "150",
+                "runtime resize must not rewrite the serialized layout width/height");
+
+    // Shrinking past the minimum clamps to the floor (RESIZE_MIN_SIZE = 32).
+    panel->updateResize(0, 0);
+    expect_rect(layout->getRect(panel), 0, 0, 32, 32, "shrinking past the minimum should clamp to the size floor");
+
+    // Growing past the parent clamps to the room inside the parent rectangle (800x600 from origin).
+    panel->updateResize(5000, 5000);
+    expect_rect(layout->getRect(panel), 0, 0, 800, 600, "growing past the parent should clamp to the parent bounds");
+
+    panel->endResize();
+    expect_true(!panel->isResizing(), "endResize should clear the resizing state");
+    // After the drag ends, further motion must not keep resizing.
+    panel->updateResize(100, 100);
+    expect_rect(layout->getRect(panel), 0, 0, 800, 600, "motion after endResize must not change the size");
+
+    // A configured layout minimum raises the size floor above RESIZE_MIN_SIZE.
+    layout->setMinW(120);
+    layout->setMinH(90);
+    panel->beginResize(int(layout->getRect(panel)->w) - 1, int(layout->getRect(panel)->h) - 1);
+    panel->updateResize(0, 0);
+    expect_rect(layout->getRect(panel), 0, 0, 120, 90, "the layout minimum should raise the resize floor");
+    panel->endResize();
+}
+
 } // namespace
 
 int main() {
@@ -2381,6 +2442,7 @@ int main() {
     test_character_panel_sheet_lines_build_without_rendering_and_fail_closed();
     test_character_panel_sheet_lines_render_race_and_class_labels();
     test_dialog_panel_current_options_preserve_numeric_display_order();
+    test_panel_opt_in_resize_handle_drag_resizes_within_bounds();
     test_list_view_refreshes_from_generic_property_notifications();
     test_list_view_coalesces_property_refreshes_per_event_loop_tick();
     test_list_view_skips_queued_property_refresh_after_detach();

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -2429,6 +2429,104 @@ void test_panel_opt_in_resize_handle_drag_resizes_within_bounds() {
     panel->endResize();
 }
 
+// Drives the resize handle through real CGui event dispatch with a child covering the whole panel
+// (list views consume left button-downs even on empty cells, so before the panel-level interception
+// a covering child would swallow the grab). Also proves the resize state cannot go stale: a release
+// over the child still ends the resize, and a resize whose pointer capture ends externally is
+// dropped by the next motion instead of resizing with no button held.
+void test_panel_resize_handle_press_beats_covering_child_and_release_ends_capture() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    gui->setLayout(fixed_layout(0, 0, 800, 600));
+
+    auto panel = std::make_shared<CGamePanel>();
+    auto layout = fixed_layout(0, 0, 200, 150);
+    panel->setLayout(layout);
+    panel->setResizable(true);
+    gui->pushChild(panel);
+
+    auto child = std::make_shared<MouseEventRecorder>();
+    child->setLayout(fixed_layout(0, 0, 200, 150)); // covers the panel, including the handle corner
+    panel->pushChild(child);
+
+    // Press on the handle must start the resize instead of being consumed by the covering child.
+    SDL_Event down{};
+    down.type = SDL_MOUSEBUTTONDOWN;
+    down.button.button = SDL_BUTTON_LEFT;
+    down.button.x = 195;
+    down.button.y = 145;
+    expect_true(gui->event(&down), "a handle press should be handled by the panel");
+    expect_true(panel->isResizing(), "a handle press must start the resize even under a covering child");
+    expect_true(child->button_count == 0, "a handle press must not reach the covering child");
+    expect_true(gui->isPointerCapturedBy(panel), "a handle press should capture the pointer for the panel");
+
+    // Captured motion resizes the panel (grab offset was 5,5 so (255,195) => 260x200).
+    SDL_Event motion{};
+    motion.type = SDL_MOUSEMOTION;
+    motion.motion.x = 255;
+    motion.motion.y = 195;
+    gui->event(&motion);
+    expect_rect(layout->getRect(panel), 0, 0, 260, 200, "captured motion should resize the panel");
+    expect_true(child->motion_count == 0, "captured resize motion must not reach the covering child");
+
+    // Releasing inside the panel over the covering child must still end the resize and the capture.
+    SDL_Event up{};
+    up.type = SDL_MOUSEBUTTONUP;
+    up.button.button = SDL_BUTTON_LEFT;
+    up.button.x = 100;
+    up.button.y = 100;
+    gui->event(&up);
+    expect_true(!panel->isResizing(), "a release over a covering child must still end the resize");
+    expect_true(!gui->hasPointerCapture(), "a release over a covering child must still release the capture");
+    expect_rect(layout->getRect(panel), 0, 0, 260, 200, "the release must keep the resized rectangle");
+
+    // If the capture ends without the panel seeing the release, the next motion drops the stale
+    // resize instead of applying it.
+    down.button.x = 255;
+    down.button.y = 195;
+    gui->event(&down);
+    expect_true(panel->isResizing(), "a second handle press should start another resize");
+    gui->releasePointerCapture();
+    motion.motion.x = 230; // inside the panel, outside the covering child
+    motion.motion.y = 180;
+    gui->event(&motion);
+    expect_true(!panel->isResizing(), "losing the pointer capture must clear the resize state");
+    expect_rect(layout->getRect(panel), 0, 0, 260, 200, "a stale resize must not change the panel size");
+}
+
+// A centered layout recomputes x/y from the current size, so runtime W/H alone would move the
+// panel's origin (and its panel-local pointer space) on every drag update. The resize must pin the
+// top-left corner for the whole drag and keep it pinned after the drag ends.
+void test_panel_resize_centered_layout_keeps_origin_pinned() {
+    auto parent = std::make_shared<CGameGraphicsObject>();
+    parent->setLayout(fixed_layout(0, 0, 800, 600));
+
+    auto panel = std::make_shared<CGamePanel>();
+    auto layout = std::make_shared<CCenteredLayout>();
+    layout->setW("200");
+    layout->setH("150");
+    panel->setLayout(layout);
+    panel->setResizable(true);
+    parent->addChild(panel);
+
+    expect_rect(layout->getRect(panel), 300, 225, 200, 150, "the centered panel should start centered");
+
+    expect_true(panel->beginResize(195, 145), "the centered panel should start a resize from its handle");
+    panel->updateResize(255, 195);
+    expect_rect(layout->getRect(panel), 300, 225, 260, 200,
+                "growing a centered panel must keep its top-left corner pinned");
+    panel->updateResize(155, 120);
+    expect_rect(layout->getRect(panel), 300, 225, 160, 125,
+                "shrinking a centered panel must keep its top-left corner pinned");
+    panel->endResize();
+    expect_rect(layout->getRect(panel), 300, 225, 160, 125,
+                "the origin must stay pinned after the drag ends instead of re-centering");
+    expect_true(layout->getW() == "200" && layout->getH() == "150",
+                "pinning the origin must not rewrite the serialized centered layout");
+}
+
 } // namespace
 
 int main() {
@@ -2443,6 +2541,8 @@ int main() {
     test_character_panel_sheet_lines_render_race_and_class_labels();
     test_dialog_panel_current_options_preserve_numeric_display_order();
     test_panel_opt_in_resize_handle_drag_resizes_within_bounds();
+    test_panel_resize_handle_press_beats_covering_child_and_release_ends_capture();
+    test_panel_resize_centered_layout_keeps_origin_pinned();
     test_list_view_refreshes_from_generic_property_notifications();
     test_list_view_coalesces_property_refreshes_per_event_loop_tick();
     test_list_view_skips_queued_property_refresh_after_detach();


### PR DESCRIPTION
## Summary

Adds an opt-in, off-by-default resize-handle capability to the GUI panel base (`CGamePanel`) so a panel can be made user-resizable via a bottom-right drag handle. Existing panels are unchanged because the feature is gated behind an explicit `resizable` flag that defaults to `false`.

Mechanism and where it hooks in:
- New reflective properties on `CGamePanel`: `resizable` (bool, default `false`) and `resizeHandleSize` (int, default 24 px).
- Hit-testing (`isInResizeHandle`) recognizes the bottom-right handle square in panel-local coordinates.
- A left-button press inside the handle starts a jump-free resize drag (`beginResize`) and captures the pointer via the existing `CGui` pointer-capture path, so tracking continues even if the cursor leaves the panel rect. Drag motion (`updateResize`) and release (`endResize`) run the state machine.
- Resizing writes clamped runtime width/height onto the panel's `CLayout` using the same `setRuntimeW`/`setRuntimeH` runtime-override mechanism introduced for window scaling (PR #1424), so serialized layout values are never rewritten.
- Sizes are clamped to a minimum floor (and the layout's own `minW`/`minH`) and to the parent rectangle so the panel always stays inside its container.
- Opted-in panels paint a small handle marker in `renderObject`; non-opted-in panels render exactly as before.

Wiring lives in `CGamePanel::mouseEvent` / `mouseMotionEvent`; the resize geometry is implemented as pure, rendering-free methods so it can be unit-tested directly.

## Tests

Added `test_panel_opt_in_resize_handle_drag_resizes_within_bounds` in `tests/unit/test_gui.cpp` (registered in `main()`), exercising the resize logic purely through geometry/state with no real rendering or SDL input:
- A default (non-opted-in) panel does not treat its corner as a handle, does not start a resize, still consumes the modal click, and keeps its size.
- An opted-in panel hit-tests the handle, resizes jump-free from a handle drag, and clamps to the minimum size floor, the configured layout minimum, and the parent bounds.
- Runtime resize does not rewrite the serialized layout width/height, and motion after `endResize` does not change the size.

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_