### PR TITLE
[EPIC_05][STORY_04][SUBSTORY_03] Migrate inventory/effects/quest views to the reactive refresh mechanism

### DIFF
--- a/src/gui/panel/CGameQuestPanel.cpp
+++ b/src/gui/panel/CGameQuestPanel.cpp
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CMap.h"
 #include "gui/CGui.h"
 #include "gui/CTextManager.h"
+#include "object/CPlayer.h"
 #include "object/CQuest.h"
 
 namespace {
@@ -64,13 +65,29 @@ void CGameQuestPanel::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SD
 }
 
 std::string CGameQuestPanel::getText(std::shared_ptr<CGui> ptr) {
-    std::string text = "";
-    auto game = ptr ? ptr->getGame() : nullptr;
+    // Reactive read path: the journal text is only rebuilt when the quest-change
+    // subscription (see refreshQuestSubscription) marked it stale, instead of
+    // re-walking the quest log on every rendered frame.
+    auto player = resolveQuestSource(ptr);
+    refreshQuestSubscription(player);
+    if (questTextDirty) {
+        cachedQuestText = buildText(player);
+        questTextDirty = false;
+    }
+    return cachedQuestText;
+}
+
+std::shared_ptr<CPlayer> CGameQuestPanel::resolveQuestSource(const std::shared_ptr<CGui> &gui) {
+    auto game = gui ? gui->getGame() : nullptr;
     auto map = game ? game->getMap() : nullptr;
-    auto player = map ? map->getPlayer() : nullptr;
+    return map ? map->getPlayer() : nullptr;
+}
+
+std::string CGameQuestPanel::buildText(const std::shared_ptr<CPlayer> &player) {
     if (!player) {
         return "No active quests.\n";
     }
+    std::string text = "";
     for (auto quest : player->getCompletedQuests()) {
         append_quest_line(text, quest, true);
     }
@@ -81,4 +98,31 @@ std::string CGameQuestPanel::getText(std::shared_ptr<CGui> ptr) {
         text = "No active quests.\n";
     }
     return text;
+}
+
+void CGameQuestPanel::refreshFromQuestsChanged() { questTextDirty = true; }
+
+void CGameQuestPanel::refreshQuestSubscription(const std::shared_ptr<CPlayer> &player) {
+    auto subscribed = subscribedQuestSource.lock();
+    if (subscribed == player) {
+        return;
+    }
+
+    // CPlayer records every quest-log mutation through recordDirectPropertyChanged
+    // ("quests" / "completedQuests"), which emits the derived "questsChanged" /
+    // "completedQuestsChanged" property channels this panel subscribes to — the same
+    // dynamic-property notification mechanism CListView refresh subscriptions ride on.
+    auto self = this->ptr<CGameQuestPanel>();
+    if (subscribed) {
+        subscribed->disconnect("questsChanged", self, "refreshFromQuestsChanged");
+        subscribed->disconnect("completedQuestsChanged", self, "refreshFromQuestsChanged");
+    }
+    subscribedQuestSource = player;
+    if (player) {
+        player->connect("questsChanged", self, "refreshFromQuestsChanged");
+        player->connect("completedQuestsChanged", self, "refreshFromQuestsChanged");
+    }
+    // The quest source changed (first resolve, detach, or a new player after a game
+    // load / map transition): whatever was cached belongs to the old source.
+    questTextDirty = true;
 }

--- a/src/gui/panel/CGameQuestPanel.cpp
+++ b/src/gui/panel/CGameQuestPanel.cpp
@@ -65,11 +65,11 @@ void CGameQuestPanel::renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SD
 }
 
 std::string CGameQuestPanel::getText(std::shared_ptr<CGui> ptr) {
-    // Reactive read path: the journal text is only rebuilt when the quest-change
-    // subscription (see refreshQuestSubscription) marked it stale, instead of
-    // re-walking the quest log on every rendered frame.
+    // Reactive read path: the journal text is only rebuilt when a change subscription
+    // (see refreshQuestSubscriptions) marked it stale, instead of re-walking the quest
+    // log on every rendered frame.
     auto player = resolveQuestSource(ptr);
-    refreshQuestSubscription(player);
+    refreshQuestSubscriptions(player, resolveQuestStateSource(ptr));
     if (questTextDirty) {
         cachedQuestText = buildText(player);
         questTextDirty = false;
@@ -81,6 +81,11 @@ std::shared_ptr<CPlayer> CGameQuestPanel::resolveQuestSource(const std::shared_p
     auto game = gui ? gui->getGame() : nullptr;
     auto map = game ? game->getMap() : nullptr;
     return map ? map->getPlayer() : nullptr;
+}
+
+std::shared_ptr<CGameObject> CGameQuestPanel::resolveQuestStateSource(const std::shared_ptr<CGui> &gui) {
+    auto game = gui ? gui->getGame() : nullptr;
+    return game ? game->getMap() : nullptr;
 }
 
 std::string CGameQuestPanel::buildText(const std::shared_ptr<CPlayer> &player) {
@@ -102,27 +107,55 @@ std::string CGameQuestPanel::buildText(const std::shared_ptr<CPlayer> &player) {
 
 void CGameQuestPanel::refreshFromQuestsChanged() { questTextDirty = true; }
 
-void CGameQuestPanel::refreshQuestSubscription(const std::shared_ptr<CPlayer> &player) {
-    auto subscribed = subscribedQuestSource.lock();
-    if (subscribed == player) {
-        return;
-    }
+void CGameQuestPanel::refreshFromMapPropertyChanged(std::string propertyName) { questTextDirty = true; }
 
+void CGameQuestPanel::refreshFromMapObjectChanged(Coords coords) { questTextDirty = true; }
+
+void CGameQuestPanel::refreshQuestSubscriptions(const std::shared_ptr<CPlayer> &player,
+                                                const std::shared_ptr<CGameObject> &questState) {
     // CPlayer records every quest-log mutation through recordDirectPropertyChanged
     // ("quests" / "completedQuests"), which emits the derived "questsChanged" /
     // "completedQuestsChanged" property channels this panel subscribes to — the same
     // dynamic-property notification mechanism CListView refresh subscriptions ride on.
-    auto self = this->ptr<CGameQuestPanel>();
-    if (subscribed) {
-        subscribed->disconnect("questsChanged", self, "refreshFromQuestsChanged");
-        subscribed->disconnect("completedQuestsChanged", self, "refreshFromQuestsChanged");
+    auto subscribedPlayer = subscribedQuestSource.lock();
+    if (subscribedPlayer != player) {
+        auto self = this->ptr<CGameQuestPanel>();
+        if (subscribedPlayer) {
+            subscribedPlayer->disconnect("questsChanged", self, "refreshFromQuestsChanged");
+            subscribedPlayer->disconnect("completedQuestsChanged", self, "refreshFromQuestsChanged");
+        }
+        subscribedQuestSource = player;
+        if (player) {
+            player->connect("questsChanged", self, "refreshFromQuestsChanged");
+            player->connect("completedQuestsChanged", self, "refreshFromQuestsChanged");
+        }
+        // The quest source changed (first resolve, detach, or a new player after a
+        // game load / map transition): whatever was cached belongs to the old source.
+        questTextDirty = true;
     }
-    subscribedQuestSource = player;
-    if (player) {
-        player->connect("questsChanged", self, "refreshFromQuestsChanged");
-        player->connect("completedQuestsChanged", self, "refreshFromQuestsChanged");
+
+    // Quest journal getters are arbitrary map scripts: their objective/reward/hint
+    // text derives from quest-state properties written on the map
+    // (QuestStateStore.set_state → setStringProperty("quest_state_*") →
+    // recordPropertyChanged → "propertyChanged") and from map object state advanced by
+    // gameplay. Membership signals alone would leave that text stale, so the map's
+    // generic propertyChanged channel plus the turnPassed / objectChanged typed
+    // signals (the same set CMapGraphicsObject subscribes to) conservatively
+    // invalidate the cache; the dirty flag keeps it to at most one rebuild per read.
+    auto subscribedState = subscribedQuestStateSource.lock();
+    if (subscribedState != questState) {
+        auto self = this->ptr<CGameQuestPanel>();
+        if (subscribedState) {
+            subscribedState->disconnect("propertyChanged", self, "refreshFromMapPropertyChanged");
+            subscribedState->disconnect("turnPassed", self, "refreshFromQuestsChanged");
+            subscribedState->disconnect("objectChanged", self, "refreshFromMapObjectChanged");
+        }
+        subscribedQuestStateSource = questState;
+        if (questState) {
+            questState->connect("propertyChanged", self, "refreshFromMapPropertyChanged");
+            questState->connect("turnPassed", self, "refreshFromQuestsChanged");
+            questState->connect("objectChanged", self, "refreshFromMapObjectChanged");
+        }
+        questTextDirty = true;
     }
-    // The quest source changed (first resolve, detach, or a new player after a game
-    // load / map transition): whatever was cached belongs to the old source.
-    questTextDirty = true;
 }

--- a/src/gui/panel/CGameQuestPanel.h
+++ b/src/gui/panel/CGameQuestPanel.h
@@ -19,11 +19,41 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "CGamePanel.h"
 
+class CPlayer;
+
 class CGameQuestPanel : public CGamePanel {
-    V_META(CGameQuestPanel, CGamePanel, vstd::meta::empty())
+    V_META(CGameQuestPanel, CGamePanel, V_METHOD(CGameQuestPanel, refreshFromQuestsChanged))
 
     void renderObject(std::shared_ptr<CGui> shared_ptr, std::shared_ptr<SDL_Rect> rect, int i) override;
 
   public:
     std::string getText(std::shared_ptr<CGui> ptr);
+
+    // Reactive slot (same signal channel CListView refresh subscriptions use): the
+    // subscribed player's quest data changed, so the cached journal text is stale and
+    // must be rebuilt on the next read. Repeated notifications within one event-loop
+    // turn coalesce naturally into a single rebuild through the dirty flag.
+    void refreshFromQuestsChanged();
+
+  protected:
+    // Resolves the player whose quest journal this panel renders. Virtual so tests can
+    // inject a player without booting a full map (mirrors CListView::resolveRefreshTarget).
+    virtual std::shared_ptr<CPlayer> resolveQuestSource(const std::shared_ptr<CGui> &gui);
+
+    // Builds the journal text from the player's active/completed quests. Virtual so
+    // tests can observe how often the text is actually rebuilt.
+    virtual std::string buildText(const std::shared_ptr<CPlayer> &player);
+
+  private:
+    // Keeps the quest-change subscription bound to the currently resolved player,
+    // reconnecting when the player changes (new game, map transition) and marking the
+    // cached text stale on any target change — the same follow-the-target contract
+    // CListView::refreshSubscriptions() implements.
+    void refreshQuestSubscription(const std::shared_ptr<CPlayer> &player);
+
+    std::weak_ptr<CGameObject> subscribedQuestSource;
+
+    std::string cachedQuestText;
+
+    bool questTextDirty = true;
 };

--- a/src/gui/panel/CGameQuestPanel.h
+++ b/src/gui/panel/CGameQuestPanel.h
@@ -22,36 +22,58 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 class CPlayer;
 
 class CGameQuestPanel : public CGamePanel {
-    V_META(CGameQuestPanel, CGamePanel, V_METHOD(CGameQuestPanel, refreshFromQuestsChanged))
+    V_META(CGameQuestPanel, CGamePanel, V_METHOD(CGameQuestPanel, refreshFromQuestsChanged),
+           V_METHOD(CGameQuestPanel, refreshFromMapPropertyChanged, void, std::string),
+           V_METHOD(CGameQuestPanel, refreshFromMapObjectChanged, void, Coords))
 
     void renderObject(std::shared_ptr<CGui> shared_ptr, std::shared_ptr<SDL_Rect> rect, int i) override;
 
   public:
     std::string getText(std::shared_ptr<CGui> ptr);
 
-    // Reactive slot (same signal channel CListView refresh subscriptions use): the
-    // subscribed player's quest data changed, so the cached journal text is stale and
-    // must be rebuilt on the next read. Repeated notifications within one event-loop
-    // turn coalesce naturally into a single rebuild through the dirty flag.
+    // Reactive slots (same signal channels CListView refresh subscriptions use): a
+    // subscribed source changed, so the cached journal text is stale and must be
+    // rebuilt on the next read. Repeated notifications within one event-loop turn
+    // coalesce naturally into a single rebuild through the dirty flag.
+    //
+    // refreshFromQuestsChanged serves the player's questsChanged/completedQuestsChanged
+    // membership signals and the map's no-argument turnPassed signal. The map slots
+    // exist because quest getObjective/getReward/getHint are arbitrary map scripts whose
+    // text derives from quest-state properties (QuestStateStore.set_state writes
+    // "quest_state_*" string properties on the map) and from map object state — the
+    // journal can change without any quest being added or completed, so quest-set
+    // membership signals alone are not a sufficient invalidation source.
     void refreshFromQuestsChanged();
+
+    void refreshFromMapPropertyChanged(std::string propertyName);
+
+    void refreshFromMapObjectChanged(Coords coords);
 
   protected:
     // Resolves the player whose quest journal this panel renders. Virtual so tests can
     // inject a player without booting a full map (mirrors CListView::resolveRefreshTarget).
     virtual std::shared_ptr<CPlayer> resolveQuestSource(const std::shared_ptr<CGui> &gui);
 
+    // Resolves the object carrying the quest-state signals the journal text derives
+    // from — the current map (propertyChanged / turnPassed / objectChanged). Virtual
+    // for tests, like resolveQuestSource.
+    virtual std::shared_ptr<CGameObject> resolveQuestStateSource(const std::shared_ptr<CGui> &gui);
+
     // Builds the journal text from the player's active/completed quests. Virtual so
     // tests can observe how often the text is actually rebuilt.
     virtual std::string buildText(const std::shared_ptr<CPlayer> &player);
 
   private:
-    // Keeps the quest-change subscription bound to the currently resolved player,
-    // reconnecting when the player changes (new game, map transition) and marking the
+    // Keeps the change subscriptions bound to the currently resolved player and map,
+    // reconnecting when either changes (new game, map transition) and marking the
     // cached text stale on any target change — the same follow-the-target contract
     // CListView::refreshSubscriptions() implements.
-    void refreshQuestSubscription(const std::shared_ptr<CPlayer> &player);
+    void refreshQuestSubscriptions(const std::shared_ptr<CPlayer> &player,
+                                   const std::shared_ptr<CGameObject> &questState);
 
     std::weak_ptr<CGameObject> subscribedQuestSource;
+
+    std::weak_ptr<CGameObject> subscribedQuestStateSource;
 
     std::string cachedQuestText;
 

--- a/test.py
+++ b/test.py
@@ -144,6 +144,7 @@ FAST_TEST_NAMES = {
     "McpServerTest.test_stdio_batch_handles_initialize_and_tool_listing",
     "PanelLayoutManifestTest.test_panel_layout_manifest_matches_panels_json",
     "PanelLayoutManifestTest.test_gui_window_is_created_resizable_with_minimum_size",
+    "PanelLayoutManifestTest.test_reactive_list_views_subscribe_to_model_signals",
 }
 GAMEPLAY_TEST_PREFIXES = (
     "ConsoleEventIsolationTest.",
@@ -20150,6 +20151,41 @@ class PanelLayoutManifestTest(unittest.TestCase):
             gui_source,
             r"SDL_SetWindowMinimumSize\s*\(\s*rawWindow\s*,\s*GUI_MIN_WIDTH\s*,\s*GUI_MIN_HEIGHT\s*\)",
         )
+
+    def test_reactive_list_views_subscribe_to_model_signals(self):
+        # EPIC_05/STORY_04 reactive refresh wiring: the inventory and effects list views
+        # must stay subscribed to their model change signals (refreshEvent +
+        # refreshObject on CListView) instead of relying on manual refresh calls. The
+        # quest view's reactive rebuild is covered by the C++ gui unit tests
+        # (test_quest_panel_rebuilds_text_only_when_quest_data_changes).
+        panel_defs = json.loads((REPO_ROOT / "res" / "config" / "panels.json").read_text())
+
+        def collect_list_views(node, results):
+            if isinstance(node, dict):
+                if node.get("class") == "CListView":
+                    results.append(node.get("properties", {}))
+                for value in node.values():
+                    collect_list_views(value, results)
+            elif isinstance(node, list):
+                for value in node:
+                    collect_list_views(value, results)
+
+        expected_subscriptions = {
+            ("inventoryPanel", "inventoryCollection"): "inventoryChanged",
+            ("inventoryPanel", "equippedCollection"): "equippedChanged",
+            ("creatureView", "getEffects"): "effectsChanged",
+        }
+        for (panel_id, collection), refresh_event in expected_subscriptions.items():
+            with self.subTest(panel=panel_id, collection=collection):
+                list_views = []
+                collect_list_views(panel_defs[panel_id], list_views)
+                properties = next(view for view in list_views if view.get("collection") == collection)
+                self.assertEqual(refresh_event, properties.get("refreshEvent"))
+                self.assertEqual("CScript", properties.get("refreshObject", {}).get("class"))
+                self.assertTrue(
+                    properties["refreshObject"]["properties"]["script"],
+                    "the refresh subscription needs a script resolving the observed model object",
+                )
 
     def test_panel_layout_manifest_matches_panels_json(self):
         panel_defs = json.loads((REPO_ROOT / "res" / "config" / "panels.json").read_text())

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -180,10 +180,18 @@ class QuestTextCountingPanel : public CGameQuestPanel {
   public:
     void setResolvedQuestSource(std::shared_ptr<CPlayer> player) { resolvedQuestSource = std::move(player); }
 
+    void setResolvedQuestStateSource(std::shared_ptr<CGameObject> questState) {
+        resolvedQuestStateSource = std::move(questState);
+    }
+
     int build_count = 0;
 
   protected:
     std::shared_ptr<CPlayer> resolveQuestSource(const std::shared_ptr<CGui> &) override { return resolvedQuestSource; }
+
+    std::shared_ptr<CGameObject> resolveQuestStateSource(const std::shared_ptr<CGui> &) override {
+        return resolvedQuestStateSource;
+    }
 
     std::string buildText(const std::shared_ptr<CPlayer> &player) override {
         ++build_count;
@@ -192,6 +200,8 @@ class QuestTextCountingPanel : public CGameQuestPanel {
 
   private:
     std::shared_ptr<CPlayer> resolvedQuestSource;
+
+    std::shared_ptr<CGameObject> resolvedQuestStateSource;
 };
 
 class DragCallbackPanel : public CGamePanel {
@@ -910,6 +920,71 @@ void test_quest_panel_resubscribes_when_quest_source_changes() {
     expect_true(panel->getText(gui).find("[Completed] Seal the second gate") != std::string::npos,
                 "quest panel should follow completed-quest changes on the new player");
     expect_true(panel->build_count == 3, "the new player's quest changes should drive rebuilds");
+}
+
+void test_quest_panel_rebuilds_when_quest_state_properties_change() {
+    // Quest objective/reward/hint text is derived by map scripts from quest-state
+    // properties (QuestStateStore.set_state writes "quest_state_*" on the map) and
+    // from map object/turn state — the quest set membership never changes in those
+    // transitions. The journal cache must invalidate through the map's propertyChanged
+    // / turnPassed / objectChanged channels, not only through quest membership.
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto game = create_gui_game(gui);
+    auto player = std::make_shared<CPlayer>();
+    auto quest_state = std::make_shared<CGameObject>();
+    auto panel = std::make_shared<QuestTextCountingPanel>();
+    panel->setLayout(fixed_layout(0, 0, 200, 100));
+    panel->setResolvedQuestSource(player);
+    panel->setResolvedQuestStateSource(quest_state);
+    gui->pushChild(panel);
+
+    auto quest = std::make_shared<CQuest>();
+    quest->setName("victorQuest");
+    quest->setDescription("Find Victor's missing daughter.");
+    quest->setObjective("Find Victor's missing daughter.");
+    player->setQuests({quest});
+    drain_event_loop();
+
+    const auto initial = panel->getText(gui);
+    expect_true(initial.find("Objective: Find Victor's missing daughter.") != std::string::npos,
+                "quest panel should render the initial state-derived objective");
+    expect_true(panel->build_count == 1, "the first read should build the journal once");
+
+    panel->getText(gui);
+    drain_event_loop();
+    panel->getText(gui);
+    expect_true(panel->build_count == 1, "the journal must stay cached while quest state is unchanged");
+
+    // Quest-state transition: the same quest object stays active (no membership
+    // change), only a state property on the quest-state source flips and the script
+    // would now derive different objective text.
+    quest->setObjective("Defeat the cultists in the courtyard.");
+    quest_state->setStringProperty("quest_state_victor", "encounter_active");
+    drain_event_loop();
+    const auto transitioned = panel->getText(gui);
+    expect_true(transitioned.find("Objective: Defeat the cultists in the courtyard.") != std::string::npos &&
+                    transitioned.find("Objective: Find Victor's missing daughter.") == std::string::npos,
+                "a quest-state property change must refresh state-derived journal text");
+    expect_true(panel->build_count == 2, "a quest-state property change should trigger exactly one rebuild");
+
+    // Turn-driven quest text (typed no-argument map signal).
+    quest->setHint("The cultists began their rite; hurry.");
+    quest_state->signal("turnPassed");
+    drain_event_loop();
+    expect_true(panel->getText(gui).find("Hint: The cultists began their rite; hurry.") != std::string::npos,
+                "a passed turn must refresh turn-derived journal text");
+    expect_true(panel->build_count == 3, "turnPassed should trigger exactly one rebuild");
+
+    // Object-driven quest text (typed map signal carrying coordinates).
+    quest->setObjective("Seal every siege gate (1/4 sealed).");
+    quest_state->signal("objectChanged", Coords(1, 2, 0));
+    drain_event_loop();
+    expect_true(panel->getText(gui).find("Objective: Seal every siege gate (1/4 sealed).") != std::string::npos,
+                "a map object change must refresh object-derived journal text");
+    expect_true(panel->build_count == 4, "objectChanged should trigger exactly one rebuild");
 }
 
 std::shared_ptr<CStats> player_stats() {
@@ -2552,6 +2627,7 @@ int main() {
     test_list_view_refresh_property_collision_fails_closed();
     test_quest_panel_rebuilds_text_only_when_quest_data_changes();
     test_quest_panel_resubscribes_when_quest_source_changes();
+    test_quest_panel_rebuilds_when_quest_state_properties_change();
     test_inventory_double_select_uses_selected_item_and_clears_selection();
     test_inventory_right_click_uses_usable_item_once_and_consumes_it();
     test_inventory_right_click_full_resource_item_not_consumed();

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -38,6 +38,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/panel/CGameFightPanel.h"
 #include "gui/panel/CGameInventoryPanel.h"
 #include "gui/panel/CGamePanel.h"
+#include "gui/panel/CGameQuestPanel.h"
 #define GAME_UNIT_TESTS
 #include "gui/panel/CGameDialogPanel.h"
 #undef GAME_UNIT_TESTS
@@ -48,6 +49,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CInteraction.h"
 #include "object/CItem.h"
 #include "object/CPlayer.h"
+#include "object/CQuest.h"
 #include "object/CTile.h"
 #include "test_harness.h"
 
@@ -166,6 +168,30 @@ class RefreshCountingListView : public CListView {
 
   private:
     std::shared_ptr<CGameObject> resolvedRefreshTarget;
+};
+
+// Counts quest-journal text rebuilds so the tests can assert the quest panel only
+// rebuilds when its underlying quest data actually changed (reactive refresh), never
+// per read/frame. Mirrors RefreshCountingListView: the quest source is injected so no
+// full map boot is needed.
+class QuestTextCountingPanel : public CGameQuestPanel {
+    V_META(QuestTextCountingPanel, CGameQuestPanel, vstd::meta::empty())
+
+  public:
+    void setResolvedQuestSource(std::shared_ptr<CPlayer> player) { resolvedQuestSource = std::move(player); }
+
+    int build_count = 0;
+
+  protected:
+    std::shared_ptr<CPlayer> resolveQuestSource(const std::shared_ptr<CGui> &) override { return resolvedQuestSource; }
+
+    std::string buildText(const std::shared_ptr<CPlayer> &player) override {
+        ++build_count;
+        return CGameQuestPanel::buildText(player);
+    }
+
+  private:
+    std::shared_ptr<CPlayer> resolvedQuestSource;
 };
 
 class DragCallbackPanel : public CGamePanel {
@@ -316,6 +342,8 @@ std::shared_ptr<CGame> create_gui_game(const std::shared_ptr<CGui> &gui) {
     type_registration::registerGuiTypes();
     type_registration::registerGuiPanelTypes();
     CTypes::register_type_metadata<RefreshCountingListView, CListView, CProxyTargetGraphicsObject, CGameGraphicsObject,
+                                   CGameObject>();
+    CTypes::register_type_metadata<QuestTextCountingPanel, CGameQuestPanel, CGamePanel, CGameGraphicsObject,
                                    CGameObject>();
     CTypes::register_type_metadata<DragCallbackPanel, CGamePanel, CGameGraphicsObject, CGameObject>();
     CTypes::register_type_metadata<WidgetCallbackPanel, CGamePanel, CGameGraphicsObject, CGameObject>();
@@ -785,6 +813,103 @@ void test_list_view_refresh_property_collision_fails_closed() {
     drain_event_loop();
     expect_true(list->refresh_count == after_initial_refresh + 1,
                 "a non-colliding configured refreshProperty must still refresh the list");
+}
+
+void test_quest_panel_rebuilds_text_only_when_quest_data_changes() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto game = create_gui_game(gui);
+    auto player = std::make_shared<CPlayer>();
+    auto panel = std::make_shared<QuestTextCountingPanel>();
+    panel->setLayout(fixed_layout(0, 0, 200, 100));
+    panel->setResolvedQuestSource(player);
+    gui->pushChild(panel);
+
+    auto active = std::make_shared<CQuest>();
+    active->setName("reactiveQuest");
+    active->setDescription("Recover the sunken sigil");
+    player->setQuests({active});
+    drain_event_loop();
+
+    const auto initial = panel->getText(gui);
+    expect_true(initial.find("[Active] Recover the sunken sigil") != std::string::npos,
+                "quest panel should render the active quest description");
+    expect_true(panel->build_count == 1, "the first quest journal read should build the text exactly once");
+
+    expect_true(panel->getText(gui) == initial, "repeated reads should serve the cached quest text");
+    drain_event_loop();
+    expect_true(panel->getText(gui) == initial, "cached quest text should survive idle event-loop turns");
+    expect_true(panel->build_count == 1, "quest text must not be rebuilt while the quest log is unchanged");
+
+    player->setNumericProperty("threat", 7);
+    drain_event_loop();
+    panel->getText(gui);
+    expect_true(panel->build_count == 1, "unrelated player property changes must not rebuild the quest text");
+
+    auto completed = std::make_shared<CQuest>();
+    completed->setName("finishedQuest");
+    completed->setDescription("Silence the bell tower");
+    player->setCompletedQuests({completed});
+    drain_event_loop();
+    const auto updated = panel->getText(gui);
+    expect_true(updated.find("[Completed] Silence the bell tower") != std::string::npos,
+                "quest panel should render newly completed quests after the change notification");
+    expect_true(updated.find("[Active] Recover the sunken sigil") != std::string::npos,
+                "quest panel should keep rendering still-active quests after a rebuild");
+    expect_true(panel->build_count == 2, "a quest-log change should trigger exactly one coalesced rebuild");
+}
+
+void test_quest_panel_resubscribes_when_quest_source_changes() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    auto game = create_gui_game(gui);
+    auto first_player = std::make_shared<CPlayer>();
+    auto second_player = std::make_shared<CPlayer>();
+    auto panel = std::make_shared<QuestTextCountingPanel>();
+    panel->setLayout(fixed_layout(0, 0, 200, 100));
+    panel->setResolvedQuestSource(first_player);
+    gui->pushChild(panel);
+
+    auto first_quest = std::make_shared<CQuest>();
+    first_quest->setName("firstQuest");
+    first_quest->setDescription("Chart the first road");
+    first_player->setQuests({first_quest});
+
+    expect_true(panel->getText(gui).find("Chart the first road") != std::string::npos,
+                "quest panel should render the first player's quest log");
+    expect_true(panel->build_count == 1, "the first player's journal should build once");
+
+    auto second_quest = std::make_shared<CQuest>();
+    second_quest->setName("secondQuest");
+    second_quest->setDescription("Chart the second road");
+    second_player->setQuests({second_quest});
+    panel->setResolvedQuestSource(second_player);
+
+    const auto swapped = panel->getText(gui);
+    expect_true(swapped.find("Chart the second road") != std::string::npos &&
+                    swapped.find("Chart the first road") == std::string::npos,
+                "quest panel should rebuild from the new player after the quest source changes");
+    expect_true(panel->build_count == 2, "swapping the quest source should rebuild the journal once");
+
+    first_quest->setDescription("Chart the forgotten road");
+    first_player->setQuests({first_quest});
+    drain_event_loop();
+    panel->getText(gui);
+    expect_true(panel->build_count == 2,
+                "quest changes on the disconnected previous player must not rebuild the journal");
+
+    auto second_completed = std::make_shared<CQuest>();
+    second_completed->setName("secondCompletedQuest");
+    second_completed->setDescription("Seal the second gate");
+    second_player->setCompletedQuests({second_completed});
+    drain_event_loop();
+    expect_true(panel->getText(gui).find("[Completed] Seal the second gate") != std::string::npos,
+                "quest panel should follow completed-quest changes on the new player");
+    expect_true(panel->build_count == 3, "the new player's quest changes should drive rebuilds");
 }
 
 std::shared_ptr<CStats> player_stats() {
@@ -2425,6 +2550,8 @@ int main() {
     test_list_view_refresh_event_compatibility();
     test_list_view_property_subscriptions_follow_resolved_target_and_null();
     test_list_view_refresh_property_collision_fails_closed();
+    test_quest_panel_rebuilds_text_only_when_quest_data_changes();
+    test_quest_panel_resubscribes_when_quest_source_changes();
     test_inventory_double_select_uses_selected_item_and_clears_selection();
     test_inventory_right_click_uses_usable_item_once_and_consumes_it();
     test_inventory_right_click_full_resource_item_not_consumed();


### PR DESCRIPTION
## Summary

EPIC_05/STORY_04 established a reactive GUI refresh mechanism in the earlier substories: `CListView` subscribes to model change signals (`refreshEvent`/`refreshOnPropertyChanged`/`refreshProperties` resolved via a `refreshObject` script) and coalesces the resulting rebuilds per event-loop turn. This substory brings the three named views onto it:

- **Quest view — migrated (this PR).** `CGameQuestPanel` rebuilt its journal text from scratch on every rendered frame. It now subscribes to the resolved player's `questsChanged` / `completedQuestsChanged` dynamic-property channels (the channels `CPlayer::recordDirectPropertyChanged("quests"/"completedQuests")` already emits) and serves cached text, rebuilding only when a change notification marks it stale. The subscription follows the resolved player and reconnects on new game / map transition, mirroring the `CListView::refreshSubscriptions()` follow-the-target contract; repeated notifications in one event-loop turn coalesce into a single rebuild through the dirty flag. Rendering output is unchanged.
- **Inventory view — already migrated** by the earlier substories (`refreshEvent: inventoryChanged` / `equippedChanged` + player-resolving `refreshObject` in `res/config/panels.json`). The panel's remaining manual `refreshViews()` calls are intentionally kept: they repaint panel-local selection state (`selectedInventory`/`selectedEquipped`) and cover `CCreature::equipItem`'s silent no-op paths (cursed-item lock, compound-artifact slot coverage), neither of which emits a change signal — so the reactive mechanism does not fully cover them and removing them would leave stale selection boxes.
- **Effects view — already migrated** (`refreshEvent: effectsChanged` on the `creatureView` effects list; `CCreature` signals `effectsChanged` on add/expire).

A new fast python test pins the panels.json reactive wiring of the two already-migrated views so it cannot regress silently.

## Tests

- `tests/unit/test_gui.cpp`:
  - `test_quest_panel_rebuilds_text_only_when_quest_data_changes` — first read builds once; repeated reads and idle event-loop turns serve the cache; unrelated player property changes do not rebuild; a quest-log change triggers exactly one coalesced rebuild with the updated contents.
  - `test_quest_panel_resubscribes_when_quest_source_changes` — swapping the resolved player rebuilds once from the new source; quest changes on the disconnected previous player no longer rebuild; the new player's changes drive rebuilds.
- `test.py`: `PanelLayoutManifestTest.test_reactive_list_views_subscribe_to_model_signals` (added to the fast suite) — asserts the inventory, equipped, and effects list views in `res/config/panels.json` keep their `refreshEvent` + `refreshObject` subscriptions.
- Existing coverage relied on and not regressed: the CListView subscription/coalescing/detach tests (including detached-list stale-callback handling) and the quest journal python tests (`test_quest_journal_shows_objectives_rewards_and_hints`, quest panel screenshot/layout/hotkey tests).
- Local checks: `clang-format -i` on changed C++ files, `black -l 120` clean on the added python, `py_compile`, `git diff --check`. Native build/tests validate in CI.

Worker implementation branch did not modify any queue workbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_