### PR TITLE
[EPIC_05][STORY_02][SUBSTORY_04] Persist session-only panel geometry

### DIFF
--- a/src/gui/CGui.cpp
+++ b/src/gui/CGui.cpp
@@ -136,8 +136,38 @@ void CGui::shutdown() {
         }
     }
     setChildren({});
+    // The GUI shutdown is the session boundary (CGameContext drives it when the game session ends):
+    // user-adjusted panel geometry must not survive into the next session.
+    clearSessionPanelGeometry();
     _textureCache.clear();
     _textManager.clear();
+}
+
+void CGui::setSessionPanelGeometry(const std::string &panelType, const PanelGeometry &geometry) {
+    if (panelType.empty()) {
+        return;
+    }
+    sessionPanelGeometry[panelType] = geometry;
+}
+
+std::optional<CGui::PanelGeometry> CGui::getSessionPanelGeometry(const std::string &panelType) const {
+    auto found = sessionPanelGeometry.find(panelType);
+    if (found == sessionPanelGeometry.end()) {
+        return std::nullopt;
+    }
+    return found->second;
+}
+
+void CGui::clearSessionPanelGeometry() { sessionPanelGeometry.clear(); }
+
+void CGui::addChild(const std::shared_ptr<CGameGraphicsObject> &child) {
+    CGameGraphicsObject::addChild(child);
+    // A panel joining the GUI gets any geometry the user gave it earlier this session, so a
+    // closed/reopened or rebuilt panel keeps its adjusted size. The panel clamps against its
+    // current parent bounds, so a window resized in between cannot restore an out-of-range rect.
+    if (auto panel = vstd::cast<CGamePanel>(child)) {
+        panel->applySessionGeometry(this->ptr<CGui>());
+    }
 }
 
 bool CGui::isActive() const { return active.load(std::memory_order_acquire); }

--- a/src/gui/CGui.h
+++ b/src/gui/CGui.h
@@ -25,7 +25,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "object/CGameObject.h"
 
 #include <atomic>
+#include <map>
 #include <optional>
+#include <string>
 
 class CTextureCache;
 
@@ -80,6 +82,28 @@ class CGui : public CGameGraphicsObject {
     // false. This is the accessor every non-CGui call site (e.g. CListView) must use
     // to decide drag-vs-click, so the rule lives in exactly one place.
     static bool isDragActive(const DragSession &session);
+
+    // Session-only geometry remembered for user-resized panels, keyed by the panel's stable typeId
+    // (the config name CObjectHandler stamps on every created object). x/y are parent-relative (the
+    // same space as CLayout's runtime X/Y overrides); w/h are pixels. Deliberately NOT a reflective
+    // property: it can never be serialized into layout configs or save files, and it dies with this
+    // CGui (one CGui per game session), so user-adjusted geometry persists for the session only.
+    struct PanelGeometry {
+        int x = 0;
+        int y = 0;
+        int w = 0;
+        int h = 0;
+    };
+
+    void setSessionPanelGeometry(const std::string &panelType, const PanelGeometry &geometry);
+
+    std::optional<PanelGeometry> getSessionPanelGeometry(const std::string &panelType) const;
+
+    void clearSessionPanelGeometry();
+
+    // Re-applies session-recorded geometry the moment a panel joins the GUI, so a panel closed and
+    // reopened (or rebuilt) within the same session keeps its user-adjusted geometry.
+    void addChild(const std::shared_ptr<CGameGraphicsObject> &child) override;
 
     using CGameGraphicsObject::event;
     using CGameGraphicsObject::render;
@@ -174,6 +198,8 @@ class CGui : public CGameGraphicsObject {
                             const std::shared_ptr<CGameGraphicsObject> &object) const;
 
     std::optional<DragSession> dragSession;
+
+    std::map<std::string, PanelGeometry> sessionPanelGeometry;
 
     std::weak_ptr<CGameGraphicsObject> pointerCapture;
 

--- a/src/gui/object/CGameGraphicsObject.h
+++ b/src/gui/object/CGameGraphicsObject.h
@@ -99,7 +99,10 @@ class CGameGraphicsObject : public CGameObject {
 
     void setLayout(std::shared_ptr<CLayout> layout);
 
-    void addChild(const std::shared_ptr<CGameGraphicsObject> &child);
+    // Virtual so a container can observe children joining it (CGui re-applies session-recorded
+    // panel geometry on attach). Every attach path funnels through here (pushChild, setParent,
+    // setChildren), so an override sees each child exactly when it becomes reachable.
+    virtual void addChild(const std::shared_ptr<CGameGraphicsObject> &child);
 
     void pushChild(const std::shared_ptr<CGameGraphicsObject> &child);
 

--- a/src/gui/panel/CGamePanel.cpp
+++ b/src/gui/panel/CGamePanel.cpp
@@ -126,6 +126,12 @@ bool CGamePanel::isInResizeHandle(int x, int y) {
 }
 
 CGamePanel::ResizeBounds CGamePanel::getResizeBounds() {
+    auto rect = getSelfRect();
+    auto parentRect = getParentRect();
+    return getResizeBounds(rect->x - parentRect->x, rect->y - parentRect->y);
+}
+
+CGamePanel::ResizeBounds CGamePanel::getResizeBounds(int originX, int originY) {
     ResizeBounds bounds{RESIZE_MIN_SIZE, RESIZE_MIN_SIZE, RESIZE_MAX_FALLBACK, RESIZE_MAX_FALLBACK};
     if (auto layout = getLayout()) {
         bounds.minW = std::max(RESIZE_MIN_SIZE, layout->getMinW());
@@ -134,13 +140,10 @@ CGamePanel::ResizeBounds CGamePanel::getResizeBounds() {
     if (auto parent = getParent()) {
         if (auto parentLayout = parent->getLayout()) {
             auto parentRect = parentLayout->getRect(parent);
-            auto rect = getSelfRect();
             // Keep the panel fully inside its parent: the max edge is the room left of the parent's
-            // right/bottom edge from the panel's fixed top-left corner.
-            int roomW = parentRect->w - (rect->x - parentRect->x);
-            int roomH = parentRect->h - (rect->y - parentRect->y);
-            bounds.maxW = std::max(bounds.minW, roomW);
-            bounds.maxH = std::max(bounds.minH, roomH);
+            // right/bottom edge from the given parent-relative top-left origin.
+            bounds.maxW = std::max(bounds.minW, parentRect->w - originX);
+            bounds.maxH = std::max(bounds.minH, parentRect->h - originY);
         }
     }
     return bounds;
@@ -159,12 +162,7 @@ bool CGamePanel::beginResize(int x, int y) {
     // x/y from the current size, so runtime W/H alone would move the origin (and with it the
     // panel-local pointer space) on every update. Latching runtime X/Y freezes the origin relative
     // to the parent so the panel resizes from a stable corner.
-    auto parentOrigin = CUtil::rect(0, 0, 0, 0);
-    if (auto parent = getParent()) {
-        if (auto parentLayout = parent->getLayout()) {
-            parentOrigin = parentLayout->getRect(parent);
-        }
-    }
+    auto parentOrigin = getParentRect();
     layout->setRuntimeX(rect->x - parentOrigin->x);
     layout->setRuntimeY(rect->y - parentOrigin->y);
     // Latch the offset from the pointer to the panel's right/bottom edge so the drag is jump-free.
@@ -191,11 +189,65 @@ void CGamePanel::updateResize(int x, int y) {
     layout->setRuntimeH(newH);
 }
 
-void CGamePanel::endResize() { resizing = false; }
+void CGamePanel::endResize() {
+    if (!resizing) {
+        return;
+    }
+    resizing = false;
+    // The drag is over: remember the panel's runtime geometry for the rest of the session, so a
+    // closed/reopened (or rebuilt) panel with the same identity comes back with the same rectangle.
+    recordSessionGeometry();
+}
+
+void CGamePanel::recordSessionGeometry() {
+    auto gui = getGui();
+    if (!gui || getTypeId().empty() || !getLayout()) {
+        return;
+    }
+    auto rect = getSelfRect();
+    auto parentOrigin = getParentRect();
+    // Stored x/y are parent-relative (the space CLayout keeps runtime X/Y in); w/h are pixels. The
+    // store lives on the CGui only, so nothing here can reach a layout config or a save file.
+    gui->setSessionPanelGeometry(getTypeId(), {rect->x - parentOrigin->x, rect->y - parentOrigin->y, rect->w, rect->h});
+}
+
+void CGamePanel::applySessionGeometry(const std::shared_ptr<CGui> &gui) {
+    if (!gui || !resizable || getTypeId().empty()) {
+        return;
+    }
+    auto layout = getLayout();
+    if (!layout) {
+        return;
+    }
+    auto stored = gui->getSessionPanelGeometry(getTypeId());
+    if (!stored) {
+        return;
+    }
+    // Clamp exactly like a live resize, but against the CURRENT parent rectangle: the window (and
+    // with it the scaled runtime layout) may have changed since the geometry was recorded, and the
+    // restored panel must never land outside the new bounds. First keep the origin inside the parent
+    // with at least the minimum size of room, then clamp the edges to the room left from that origin.
+    auto originBounds = getResizeBounds(0, 0);
+    int x = std::clamp(stored->x, 0, std::max(0, originBounds.maxW - originBounds.minW));
+    int y = std::clamp(stored->y, 0, std::max(0, originBounds.maxH - originBounds.minH));
+    auto sizeBounds = getResizeBounds(x, y);
+    // Runtime overrides only: the serialized layout values stay untouched (mirrors the resize path).
+    layout->setRuntimeRect(x, y, std::clamp(stored->w, sizeBounds.minW, sizeBounds.maxW),
+                           std::clamp(stored->h, sizeBounds.minH, sizeBounds.maxH));
+}
 
 std::shared_ptr<SDL_Rect> CGamePanel::getSelfRect() {
     auto layout = getLayout();
     return layout ? layout->getRect(this->ptr<CGameGraphicsObject>()) : CUtil::rect(0, 0, 0, 0);
+}
+
+std::shared_ptr<SDL_Rect> CGamePanel::getParentRect() {
+    if (auto parent = getParent()) {
+        if (auto parentLayout = parent->getLayout()) {
+            return parentLayout->getRect(parent);
+        }
+    }
+    return CUtil::rect(0, 0, 0, 0);
 }
 
 void CGamePanel::refreshViews() {

--- a/src/gui/panel/CGamePanel.h
+++ b/src/gui/panel/CGamePanel.h
@@ -71,6 +71,12 @@ class CGamePanel : public CGameGraphicsObject {
 
     bool isResizing();
 
+    // Re-applies geometry recorded for this panel's typeId in the CGui session store, clamped like a
+    // live resize against the CURRENT parent bounds. Called by CGui when the panel is attached, so a
+    // reopened/rebuilt panel keeps its user-adjusted geometry for the session; a no-op for
+    // non-resizable panels, unknown identities, or an empty store.
+    void applySessionGeometry(const std::shared_ptr<CGui> &gui);
+
   protected:
     // Claims resize-handle presses (and the matching release while a resize is active) before child
     // dispatch, so a child covering the bottom-right corner cannot swallow the resize interaction.
@@ -94,8 +100,19 @@ class CGamePanel : public CGameGraphicsObject {
 
     ResizeBounds getResizeBounds();
 
+    // Bounds for a panel whose top-left corner sits at the given parent-relative origin. Shared by
+    // the live resize (current origin) and session-geometry re-apply (stored origin), so both clamp
+    // identically.
+    ResizeBounds getResizeBounds(int originX, int originY);
+
     // Base CGameGraphicsObject::getRect() is private; resolve this panel's own rectangle through its layout.
     std::shared_ptr<SDL_Rect> getSelfRect();
+
+    // The parent's rectangle, or an empty rect when the panel has no parent (or no parent layout).
+    std::shared_ptr<SDL_Rect> getParentRect();
+
+    // Records the panel's current runtime geometry into the GUI session store when a resize ends.
+    void recordSessionGeometry();
 
     bool resizable = false;
     int resizeHandleSize = DEFAULT_HANDLE_SIZE;

--- a/tests/unit/test_gui.cpp
+++ b/tests/unit/test_gui.cpp
@@ -2565,6 +2565,173 @@ void test_panel_resize_centered_layout_keeps_origin_pinned() {
                 "pinning the origin must not rewrite the serialized centered layout");
 }
 
+// Session-only geometry persistence: finishing a resize records the panel's runtime geometry in the
+// CGui session store (keyed by the panel's stable typeId), and a NEW panel instance with the same
+// identity gets it re-applied when it joins the GUI. Serialized layout values stay untouched, other
+// identities are unaffected, non-resizable panels never apply, and identity-less panels never record.
+void test_panel_session_geometry_restores_reopened_panel_same_identity_only() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    gui->setLayout(fixed_layout(0, 0, 800, 600));
+
+    auto panel = std::make_shared<CGamePanel>();
+    panel->setTypeId("questPanel");
+    panel->setResizable(true);
+    auto layout = fixed_layout(0, 0, 200, 150);
+    panel->setLayout(layout);
+    gui->pushChild(panel);
+    expect_rect(layout->getRect(panel), 0, 0, 200, 150, "attaching with an empty store must change nothing");
+
+    // Resize to 260x200 (grab offset 5,5) and finish the drag: endResize records the geometry.
+    panel->beginResize(195, 145);
+    panel->updateResize(255, 195);
+    panel->endResize();
+    expect_rect(layout->getRect(panel), 0, 0, 260, 200, "the drag should resize the live panel");
+
+    // Close the panel and reopen a brand-new instance with the same identity: geometry is restored.
+    panel->close();
+    expect_true(gui->findChild(panel) == nullptr, "close should detach the panel from the gui");
+    auto reopened = std::make_shared<CGamePanel>();
+    reopened->setTypeId("questPanel");
+    reopened->setResizable(true);
+    auto reopenedLayout = fixed_layout(0, 0, 200, 150);
+    reopened->setLayout(reopenedLayout);
+    gui->pushChild(reopened);
+    expect_rect(reopenedLayout->getRect(reopened), 0, 0, 260, 200,
+                "a reopened panel with the same identity should restore its session geometry");
+    expect_true(reopenedLayout->getX() == "0" && reopenedLayout->getY() == "0" && reopenedLayout->getW() == "200" &&
+                    reopenedLayout->getH() == "150",
+                "restoring session geometry must not rewrite any serialized layout value");
+    reopened->close();
+
+    // A different identity must not inherit the recorded geometry.
+    auto other = std::make_shared<CGamePanel>();
+    other->setTypeId("inventoryPanel");
+    other->setResizable(true);
+    auto otherLayout = fixed_layout(0, 0, 200, 150);
+    other->setLayout(otherLayout);
+    gui->pushChild(other);
+    expect_rect(otherLayout->getRect(other), 0, 0, 200, 150,
+                "a different panel identity must not receive another panel's geometry");
+    other->close();
+
+    // A panel without the resize opt-in must never have geometry applied, even for a known identity.
+    auto locked = std::make_shared<CGamePanel>();
+    locked->setTypeId("questPanel");
+    auto lockedLayout = fixed_layout(0, 0, 200, 150);
+    locked->setLayout(lockedLayout);
+    gui->pushChild(locked);
+    expect_rect(lockedLayout->getRect(locked), 0, 0, 200, 150,
+                "a non-resizable panel must not have session geometry applied");
+    locked->close();
+
+    // A panel with no stable identity records nothing when resized.
+    auto anonymous = std::make_shared<CGamePanel>();
+    anonymous->setResizable(true);
+    anonymous->setLayout(fixed_layout(0, 0, 200, 150));
+    gui->pushChild(anonymous);
+    anonymous->beginResize(195, 145);
+    anonymous->updateResize(255, 195);
+    anonymous->endResize();
+    anonymous->close();
+    expect_true(!gui->getSessionPanelGeometry(""), "a panel without a typeId must not record session geometry");
+}
+
+// Re-applied session geometry must clamp against the CURRENT parent bounds: if the window shrank
+// (window scaling rewrites the gui layout's runtime size) between the resize and the reopen, the
+// restored panel must land fully inside the new bounds instead of keeping an out-of-range rectangle.
+void test_panel_session_geometry_reapply_clamps_to_new_parent_bounds() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    gui->setLayout(fixed_layout(0, 0, 800, 600));
+
+    // A centered panel resized once records its pinned origin (300, 225) with the new 260x200 size.
+    auto panel = std::make_shared<CGamePanel>();
+    panel->setTypeId("questPanel");
+    panel->setResizable(true);
+    auto layout = std::make_shared<CCenteredLayout>();
+    layout->setW("200");
+    layout->setH("150");
+    panel->setLayout(layout);
+    gui->pushChild(panel);
+    panel->beginResize(195, 145);
+    panel->updateResize(255, 195);
+    panel->endResize();
+    expect_rect(layout->getRect(panel), 300, 225, 260, 200, "the resized centered panel keeps its pinned origin");
+    panel->close();
+
+    // Shrink the gui (the same runtime-override mechanism window scaling uses) and reopen the panel:
+    // the origin (300, 225) still fits, but the size clamps to the room left inside 400x300.
+    gui->setWidth(400);
+    gui->setHeight(300);
+    auto reopened = std::make_shared<CGamePanel>();
+    reopened->setTypeId("questPanel");
+    reopened->setResizable(true);
+    auto reopenedLayout = std::make_shared<CCenteredLayout>();
+    reopenedLayout->setW("200");
+    reopenedLayout->setH("150");
+    reopened->setLayout(reopenedLayout);
+    gui->pushChild(reopened);
+    expect_rect(reopenedLayout->getRect(reopened), 300, 225, 100, 75,
+                "restored geometry must clamp its size to the room left in the smaller parent");
+    reopened->close();
+
+    // Shrink further so even the recorded origin no longer fits: it clamps to leave the minimum
+    // 32x32 of room, and the size clamps to that remaining room.
+    gui->setWidth(320);
+    gui->setHeight(240);
+    auto cramped = std::make_shared<CGamePanel>();
+    cramped->setTypeId("questPanel");
+    cramped->setResizable(true);
+    auto crampedLayout = std::make_shared<CCenteredLayout>();
+    crampedLayout->setW("200");
+    crampedLayout->setH("150");
+    cramped->setLayout(crampedLayout);
+    gui->pushChild(cramped);
+    expect_rect(crampedLayout->getRect(cramped), 288, 208, 32, 32,
+                "a restored origin outside the new parent must clamp back inside with minimum room");
+    expect_true(crampedLayout->getW() == "200" && crampedLayout->getH() == "150",
+                "clamped re-apply must not rewrite the serialized centered layout");
+}
+
+// The geometry store is session-only: it lives on the CGui instance (one per game session) and is
+// cleared by CGui::shutdown(), the session boundary CGameContext drives when a game session ends.
+// A fresh CGui starts empty, so user-adjusted geometry can never leak across sessions (and, being a
+// plain non-reflective member, it can never be serialized to disk at all).
+void test_panel_session_geometry_clears_at_session_shutdown() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
+    auto gui = std::make_shared<CGui>();
+    gui->setLayout(fixed_layout(0, 0, 800, 600));
+
+    auto panel = std::make_shared<CGamePanel>();
+    panel->setTypeId("questPanel");
+    panel->setResizable(true);
+    panel->setLayout(fixed_layout(0, 0, 200, 150));
+    gui->pushChild(panel);
+    panel->beginResize(195, 145);
+    panel->updateResize(255, 195);
+    panel->endResize();
+
+    auto stored = gui->getSessionPanelGeometry("questPanel");
+    expect_true(stored.has_value(), "finishing a resize should record geometry in the session store");
+    expect_true(stored && stored->x == 0 && stored->y == 0 && stored->w == 260 && stored->h == 200,
+                "the recorded geometry should match the resized rectangle");
+
+    gui->shutdown();
+    expect_true(!gui->getSessionPanelGeometry("questPanel"),
+                "shutdown (the session boundary) must clear the session geometry store");
+
+    auto nextSession = std::make_shared<CGui>();
+    expect_true(!nextSession->getSessionPanelGeometry("questPanel"),
+                "a new session's GUI must not inherit geometry from a previous session");
+}
+
 } // namespace
 
 int main() {
@@ -2581,6 +2748,9 @@ int main() {
     test_panel_opt_in_resize_handle_drag_resizes_within_bounds();
     test_panel_resize_handle_press_beats_covering_child_and_release_ends_capture();
     test_panel_resize_centered_layout_keeps_origin_pinned();
+    test_panel_session_geometry_restores_reopened_panel_same_identity_only();
+    test_panel_session_geometry_reapply_clamps_to_new_parent_bounds();
+    test_panel_session_geometry_clears_at_session_shutdown();
     test_list_view_refreshes_from_generic_property_notifications();
     test_list_view_coalesces_property_refreshes_per_event_loop_tick();
     test_list_view_skips_queued_property_refresh_after_detach();


### PR DESCRIPTION
## Summary

Makes user-adjusted panel geometry from the opt-in resize handles (#1430) persist for the current game session only — a resized panel keeps its rectangle when it is closed/reopened or rebuilt within the same session, while nothing is ever serialized to layout configs or save files.

- **Session store on `CGui`** (`src/gui/CGui.h/.cpp`): `setSessionPanelGeometry` / `getSessionPanelGeometry` / `clearSessionPanelGeometry` over a plain `std::map<std::string, PanelGeometry>` keyed by the panel's stable `typeId` (the config name `CObjectHandler` stamps on every created object). The member is deliberately **outside `V_META` reflection**, so `CSerialization` can never write it into any config or save; it dies with the `CGui`, which is created once per game session (`CGameLoader::loadGui`).
- **Record on drag end** (`src/gui/panel/CGamePanel.cpp`): `endResize()` now records the panel's runtime rectangle (parent-relative x/y — the same space as `CLayout`'s runtime X/Y overrides — plus pixel w/h) into the GUI store. Panels without a gui or without a `typeId` record nothing.
- **Re-apply on attach**: `CGameGraphicsObject::addChild` is now virtual, and `CGui::addChild` re-applies stored geometry to any joining `CGamePanel` via `CGamePanel::applySessionGeometry`, which writes only `CLayout::setRuntimeRect` (serialized layout strings stay untouched, mirroring the resize path). Every attach path (`pushChild`, `setParent`, `setChildren`) funnels through `addChild`, so all panel-open flows are covered without touching call sites.
- **Window-scaling interaction**: re-apply clamps against the CURRENT parent rectangle using the #1430 bounds helper, now parameterized by origin (`getResizeBounds(originX, originY)`, shared verbatim with the live-resize clamp). The origin is clamped inside the parent with at least the 32px minimum of room, then the edges clamp to the room left — so geometry recorded before a window shrink can never restore an out-of-range rectangle.
- **Session boundary**: `CGui::shutdown()` (driven by `CGameContext` at session end) clears the store; a new game builds a fresh `CGui`, so state cannot leak across sessions.

## Tests

New unit tests in `tests/unit/test_gui.cpp` (registered in `main()`):

- `test_panel_session_geometry_restores_reopened_panel_same_identity_only` — resize, close, reopen a new instance with the same `typeId`: geometry restored; serialized layout values (`x/y/w/h` strings) unchanged; a different `typeId` gets nothing; a non-resizable panel never applies; an identity-less panel never records.
- `test_panel_session_geometry_reapply_clamps_to_new_parent_bounds` — a resized centered panel reopened after the gui shrank (same runtime-override mechanism window scaling uses) clamps its size to the remaining room, and a no-longer-fitting origin clamps back inside with minimum room; serialized centered layout untouched.
- `test_panel_session_geometry_clears_at_session_shutdown` — the drag records into the store, `shutdown()` (the session boundary) clears it, and a fresh `CGui` starts empty.

CI validates the build and full test suite.

Worker implementation branch did not modify any queue workbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_