### PR TITLE
[EPIC_05][STORY_03][SUBSTORY_04] Add rendering performance and screenshot tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -791,6 +791,7 @@ add_executable(performance_guard_tests
     tests/unit/test_pathfinder_performance.cpp
     tests/unit/test_engine_hotspot_performance.cpp
     tests/unit/test_serialization_performance.cpp
+    tests/unit/test_render_context_performance.cpp
 )
 if (WIN32)
     target_sources(performance_guard_tests PRIVATE $<TARGET_OBJECTS:game_core_objects>)

--- a/test.py
+++ b/test.py
@@ -1691,6 +1691,7 @@ XVFB_GAMEPLAY_CHILD_TESTS = (
     "test_fight_panel_select_interaction_cancels_on_sdl_quit",
     "test_screenshot_question_panel_has_rendered_pixels",
     "test_screenshot_quest_panel_with_active_quest_has_rendered_pixels",
+    "test_screenshot_repeated_render_frames_are_identical",
     "test_panel_harness_info_artifacts",
     "test_all_panel_root_layout_contracts",
     "test_all_top_level_panels_block_outside_map_clicks",
@@ -1719,6 +1720,7 @@ XVFB_BATCHABLE_CHILD_TESTS = {
     "test_window_resize_event_updates_gui_dimensions",
     "test_screenshot_question_panel_has_rendered_pixels",
     "test_screenshot_quest_panel_with_active_quest_has_rendered_pixels",
+    "test_screenshot_repeated_render_frames_are_identical",
     "test_panel_harness_info_artifacts",
     "test_all_panel_root_layout_contracts",
 }
@@ -20786,6 +20788,47 @@ class XvfbGameplayProcessTest(unittest.TestCase):
         player.addQuest("mainQuest")
         open_panel_for_screenshot(self, g, "questPanel", "CGameQuestPanel")
         assert_screenshot_has_rendered_pixels(self, g, "xvfb_quest_panel_screenshot")
+
+    def test_screenshot_repeated_render_frames_are_identical(self):
+        # Rendering regression guard for the CRenderContext copy path: an
+        # unchanged, isolated scene must reproduce the exact same frame when
+        # re-rendered, and the panel region must contain rendered pixels.
+        _, g, _, _ = create_xvfb_gameplay_session(self)
+        panel = open_panel_for_screenshot(self, g, "infoPanel", "CGameTextPanel")
+        panel.setStringProperty("text", "render context frame stability verification")
+        pump_event_loop(5)
+        try:
+            with isolated_gui_panel(g, panel):
+                panel_rect = resolved_rect(panel)
+                first_path = TEST_OUTPUT_DIR / "xvfb_repeated_render_first_frame.png"
+                try:
+                    first_data, first_width, first_height = capture_sdl_screenshot(first_path, g.getGui())
+                except RuntimeError as exc:
+                    self.skipTest(f"SDL renderer is not available for screenshot readback: {exc}")
+                pump_event_loop(5)
+                second_path = TEST_OUTPUT_DIR / "xvfb_repeated_render_second_frame.png"
+                second_data, second_width, second_height = capture_sdl_screenshot(second_path, g.getGui())
+        finally:
+            panel.close()
+            pump_event_loop(3)
+
+        self.assertEqual(gui_logical_size(g), (first_width, first_height))
+        self.assertEqual((first_width, first_height), (second_width, second_height))
+        self.assertTrue(first_path.exists())
+        self.assertGreater(first_path.stat().st_size, 0)
+        self.assertTrue(second_path.exists())
+        self.assertGreater(second_path.stat().st_size, 0)
+
+        panel_summary = screenshot_rect_summary(first_data, first_width, panel_rect)
+        panel_area = panel_rect[2] * panel_rect[3]
+        self.assertGreater(panel_summary["unique_rgb"], 3)
+        self.assertGreater(panel_summary["non_black_pixels"], panel_area // 100)
+
+        self.assertTrue(
+            first_data == second_data,
+            "Re-rendering an unchanged isolated panel scene produced a different frame; "
+            "the render context copy path is no longer deterministic.",
+        )
 
     def test_panel_harness_info_artifacts(self):
         _, g, _, _ = create_xvfb_gameplay_session(self)

--- a/tests/unit/test_performance.cpp
+++ b/tests/unit/test_performance.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 void run_pathfinder_performance_tests();
 void run_engine_hotspot_performance_tests();
 void run_serialization_performance_tests();
+void run_render_context_performance_tests();
 
 int main() {
     pybind11::scoped_interpreter guard{};
@@ -32,6 +33,7 @@ int main() {
     run_pathfinder_performance_tests();
     run_engine_hotspot_performance_tests();
     run_serialization_performance_tests();
+    run_render_context_performance_tests();
 
     return finish_tests();
 }

--- a/tests/unit/test_render_context_performance.cpp
+++ b/tests/unit/test_render_context_performance.cpp
@@ -1,0 +1,156 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "core/CUtil.h"
+#include "gui/CGui.h"
+#include "gui/CRenderContext.h"
+#include "gui/CSdlResources.h"
+#include "gui/object/CGameGraphicsObject.h"
+#include "test_harness.h"
+
+#include <cstddef>
+#include <memory>
+
+namespace {
+
+constexpr int SCENE_COLUMNS = 8;
+constexpr int SCENE_ROWS = 6;
+constexpr int SCENE_TILE_SIZE = 16;
+constexpr std::size_t SCENE_COPIES = static_cast<std::size_t>(SCENE_COLUMNS) * SCENE_ROWS;
+constexpr std::size_t BULK_COPY_COUNT = 512;
+
+// Deterministic scene object: exactly one render-context copy per rendered frame.
+class TextureBlitObject : public CGameGraphicsObject {
+  public:
+    TextureBlitObject(SDL_Texture *texture, SDL_Rect target) : texture(texture), target(target) {}
+
+    void renderObject(std::shared_ptr<CGui> gui, std::shared_ptr<SDL_Rect>, int) override {
+        gui->getRenderContext().copy(texture, nullptr, &target);
+    }
+
+  private:
+    SDL_Texture *texture;
+    SDL_Rect target;
+};
+
+std::shared_ptr<CGui> make_headless_gui() {
+    SDL_SetHint(SDL_HINT_VIDEODRIVER, "dummy");
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+    return std::make_shared<CGui>();
+}
+
+fn::sdl::TexturePtr make_solid_texture(const std::shared_ptr<CGui> &gui) {
+    auto surface = fn::sdl::SurfacePtr(
+        SDL_SAFE(SDL_CreateRGBSurfaceWithFormat(0, SCENE_TILE_SIZE, SCENE_TILE_SIZE, 32, SDL_PIXELFORMAT_RGBA32)));
+    if (!surface) {
+        return nullptr;
+    }
+    SDL_SAFE(SDL_FillRect(surface.get(), nullptr, SDL_MapRGBA(surface->format, 32, 96, 160, 255)));
+    return fn::sdl::TexturePtr(SDL_SAFE(SDL_CreateTextureFromSurface(gui->getRenderer(), surface.get())));
+}
+
+// Operation-count guard (no wall-clock timing): every valid copy request must
+// translate into exactly one attempted and one successful SDL copy, and every
+// invalid request must be skipped before reaching SDL without ever failing.
+void test_render_context_bulk_copy_accounting_is_exact() {
+    auto gui = make_headless_gui();
+    auto texture = make_solid_texture(gui);
+    expect_true(texture != nullptr, "render context perf guard should create a scene texture");
+    if (!texture) {
+        return;
+    }
+
+    auto &renderContext = gui->getRenderContext();
+    renderContext.resetStats();
+
+    SDL_Rect target = {1, 2, SCENE_TILE_SIZE, SCENE_TILE_SIZE};
+    for (std::size_t i = 0; i < BULK_COPY_COUNT; ++i) {
+        renderContext.copy(texture.get(), nullptr, &target);
+    }
+
+    const auto bulk = renderContext.getStats();
+    expect_true(bulk.attemptedCopies == BULK_COPY_COUNT, "bulk copies should attempt exactly one SDL copy each");
+    expect_true(bulk.successfulCopies == BULK_COPY_COUNT, "bulk copies of a valid texture should all succeed");
+    expect_true(bulk.failedCopies == 0, "bulk copies of a valid texture should never fail");
+    expect_true(bulk.skippedCopies == 0, "bulk copies of a valid texture should never be skipped");
+
+    renderContext.resetStats();
+    for (std::size_t i = 0; i < BULK_COPY_COUNT; ++i) {
+        renderContext.copy(nullptr, nullptr, &target);
+    }
+
+    const auto skipped = renderContext.getStats();
+    expect_true(skipped.attemptedCopies == BULK_COPY_COUNT, "null-texture copies should still be counted as attempts");
+    expect_true(skipped.skippedCopies == BULK_COPY_COUNT, "null-texture copies should be skipped before reaching SDL");
+    expect_true(skipped.successfulCopies == 0, "null-texture copies should never succeed");
+    expect_true(skipped.failedCopies == 0, "null-texture copies should be skipped, not failed");
+}
+
+// Frame-stability guard: rendering the same unchanged scene twice must produce
+// identical per-frame copy counts (no per-frame growth or hidden amplification),
+// with zero failed copies on the software renderer.
+void test_render_context_stable_scene_frame_copies_do_not_grow() {
+    auto gui = make_headless_gui();
+    auto texture = make_solid_texture(gui);
+    expect_true(texture != nullptr, "render context frame guard should create a scene texture");
+    if (!texture) {
+        return;
+    }
+
+    auto &renderContext = gui->getRenderContext();
+
+    renderContext.resetStats();
+    gui->render(0);
+    const auto baseline = renderContext.getStats();
+    expect_true(baseline.failedCopies == 0, "an empty gui frame should not fail any copies");
+
+    for (int row = 0; row < SCENE_ROWS; ++row) {
+        for (int column = 0; column < SCENE_COLUMNS; ++column) {
+            SDL_Rect target = {column * SCENE_TILE_SIZE, row * SCENE_TILE_SIZE, SCENE_TILE_SIZE, SCENE_TILE_SIZE};
+            gui->pushChild(std::make_shared<TextureBlitObject>(texture.get(), target));
+        }
+    }
+
+    renderContext.resetStats();
+    gui->render(0);
+    const auto first = renderContext.getStats();
+
+    renderContext.resetStats();
+    gui->render(0);
+    const auto second = renderContext.getStats();
+
+    expect_true(first.attemptedCopies == baseline.attemptedCopies + SCENE_COPIES,
+                "a stable scene frame should attempt exactly one copy per scene object");
+    expect_true(first.successfulCopies == first.attemptedCopies - first.skippedCopies,
+                "every non-skipped copy of a stable scene frame should succeed");
+    expect_true(first.failedCopies == 0, "a stable scene frame should not fail any copies");
+    expect_true(second.attemptedCopies == first.attemptedCopies,
+                "re-rendering an unchanged scene must not grow per-frame attempted copies");
+    expect_true(second.successfulCopies == first.successfulCopies,
+                "re-rendering an unchanged scene must not change per-frame successful copies");
+    expect_true(second.skippedCopies == first.skippedCopies,
+                "re-rendering an unchanged scene must not change per-frame skipped copies");
+    expect_true(second.failedCopies == 0, "re-rendering an unchanged scene must not fail any copies");
+}
+
+} // namespace
+
+void run_render_context_performance_tests() {
+    test_render_context_bulk_copy_accounting_is_exact();
+    test_render_context_stable_scene_frame_copies_do_not_grow();
+}


### PR DESCRIPTION
# Summary

Adds rendering performance and screenshot regression tests that lock in the CRenderContext wrapper's behavior (EPIC_05/STORY_03 follow-up to the copy/copyEx migration confirmed in #1429).

## Performance guard (native, `ctest -L performance`)

- New `tests/unit/test_render_context_performance.cpp`, compiled into the existing `performance_guard_tests` executable and wired into its `main` in `tests/unit/test_performance.cpp`, so it runs under the existing "performance guard (native)" CI step with no workflow changes.
- `test_render_context_bulk_copy_accounting_is_exact`: 512 valid copies must produce exactly 512 attempted and 512 successful SDL copies (no hidden amplification), and 512 null-texture copies must all be skipped before reaching SDL with zero failures.
- `test_render_context_stable_scene_frame_copies_do_not_grow`: renders a fixed 8x6 texture-blit scene through `CGui::render` twice; the first frame must attempt exactly one copy per scene object over the empty-frame baseline, and the second frame's attempted/successful/skipped counts must be identical to the first, with `failedCopies == 0` on both frames.
- Assertions count operations via the wrapper's stats counters (mirroring the existing operation-count performance guards); no wall-clock timing, so nothing is load- or CI-speed-sensitive.

## Screenshot regression (xvfb suite in `test.py`)

- New `XvfbGameplayProcessTest.test_screenshot_repeated_render_frames_are_identical`, registered in `XVFB_GAMEPLAY_CHILD_TESTS` and `XVFB_BATCHABLE_CHILD_TESTS`.
- Reuses the established capture machinery: `create_xvfb_gameplay_session`, `open_panel_for_screenshot`, `isolated_gui_panel` (removes the animating map so the scene is fully static), `capture_sdl_screenshot`, and `screenshot_rect_summary`.
- Captures the isolated info panel (fixed text, no RNG, no timing dependence) twice across pumped frames and asserts the two raw framebuffers are byte-identical, plus non-black-pixel/unique-color heuristics inside the panel rect. The repo has no golden-image pipeline, so this extends the strongest existing capture+assert pattern rather than inventing one.

## Tests

- `python3 -m py_compile test.py` passes; new Python code is `black -l 120` clean.
- `clang-format --dry-run --Werror` clean on the new/edited C++ files; `git diff --check` clean.
- Native `performance_guard_tests` and the xvfb suite are validated by CI (no heavy local builds run, per workflow).

Worker implementation branch did not modify any queue workbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_