### PR TITLE
[EPIC_08][STORY_05][SUBSTORY_01] Implement associated class metadata

### DIFF
--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -844,7 +844,13 @@ void init_game_module(py::module_ &m) {
         .def("setSubtypes", &CCreatureRace::setSubtypes, "Set the race's subtype tags.")
         .def("isPlayerSelectable", &CCreatureRace::isPlayerSelectable,
              "Whether the race is offered at character creation.")
-        .def("setPlayerSelectable", &CCreatureRace::setPlayerSelectable, "Set whether the race is player-selectable.");
+        .def("setPlayerSelectable", &CCreatureRace::setPlayerSelectable, "Set whether the race is player-selectable.")
+        .def("getAssociatedClasses", &CCreatureRace::getAssociatedClasses,
+             "Return the class ids that reinforce this race's natural role (future encounter-balance metadata).")
+        .def("setAssociatedClasses", &CCreatureRace::setAssociatedClasses,
+             "Set the associated class ids (empty ids are dropped).")
+        .def("isAssociatedClass", py::overload_cast<const std::string &>(&CCreatureRace::isAssociatedClass),
+             "Whether the class id is listed as reinforcing this race's natural role.");
 
     py::class_<CCreatureClass, CGameObject, std::shared_ptr<CCreatureClass>>(
         m, "CCreatureClass", "Creature class archetype definition (metadata only; not a spawnable creature).")

--- a/src/handler/CRngHandler.cpp
+++ b/src/handler/CRngHandler.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CGame.h"
 #include "core/CMap.h"
 #include "core/CUtil.h"
+#include "object/CCreatureRace.h"
 #include "object/CObject.h"
 
 #include <algorithm>
@@ -28,7 +29,43 @@ namespace {
 constexpr int MAX_RANDOM_VALUE = 1000;
 
 int clampRandomValue(int value) { return std::clamp(value, 0, MAX_RANDOM_VALUE); }
+
+// [EPIC_08][STORY_05] Design-gated associated-class encounter weights
+// (docs/design/creature_archetypes.md): a race/class pairing that reinforces the
+// race's natural role could weigh more heavily in encounter CR than an off-role
+// pairing. Both multipliers are pinned to the neutral value 1 until that balance
+// design is approved, so scaleEncounterPower is the identity for every
+// classification and the encounter power table stays bit-identical to the
+// pre-hook math for all existing content.
+constexpr int ASSOCIATED_CLASS_POWER_MULTIPLIER = 1;
+constexpr int NON_ASSOCIATED_CLASS_POWER_MULTIPLIER = 1;
 } // namespace
+
+CRngHandler::ClassAssociation CRngHandler::classifyClassAssociation(const std::shared_ptr<CCreature> &creature) {
+    if (!creature) {
+        return ClassAssociation::NoArchetype;
+    }
+    auto race = creature->getRace();
+    auto creatureClass = creature->getCreatureClass();
+    // Association is only defined for a full race/class pairing; legacy creatures
+    // (and race-only / class-only creatures) carry no archetype pairing to weigh.
+    if (!race || !creatureClass) {
+        return ClassAssociation::NoArchetype;
+    }
+    return race->isAssociatedClass(creatureClass) ? ClassAssociation::Associated : ClassAssociation::NonAssociated;
+}
+
+int CRngHandler::scaleEncounterPower(int power, ClassAssociation association) {
+    switch (association) {
+    case ClassAssociation::Associated:
+        return power * ASSOCIATED_CLASS_POWER_MULTIPLIER;
+    case ClassAssociation::NonAssociated:
+        return power * NON_ASSOCIATED_CLASS_POWER_MULTIPLIER;
+    case ClassAssociation::NoArchetype:
+    default:
+        return power;
+    }
+}
 
 std::set<std::shared_ptr<CItem>> CRngHandler::getRandomLoot(int value) const { return calculateRandomLoot(value); }
 
@@ -76,7 +113,10 @@ CRngHandler::CRngHandler(const std::shared_ptr<CGame> &game) : game(game) {
         }
         std::shared_ptr<CCreature> creature = game->createObject<CCreature>(type);
         if (creature) {
-            int power = creature->getSw();
+            // The associated-class hook is neutral today (multipliers pinned to 1), so
+            // this key equals the raw getSw() for every candidate; it only becomes a
+            // real CR weight once the associated-class balance design is approved.
+            int power = scaleEncounterPower(creature->getSw(), classifyClassAssociation(creature));
             creaturePowerTable.insert(std::make_pair(power, type));
         }
     }

--- a/src/handler/CRngHandler.h
+++ b/src/handler/CRngHandler.h
@@ -28,9 +28,24 @@ class CCreature;
 
 class CRngHandler : public CGameObject {
   public:
+    // [EPIC_08][STORY_05] How a creature's class relates to its race's natural role
+    // (docs/design/creature_archetypes.md): Associated when the race lists the class in
+    // its associatedClasses metadata, NonAssociated when it does not, NoArchetype when
+    // the creature lacks a race and/or class (every legacy creature).
+    enum class ClassAssociation { NoArchetype, Associated, NonAssociated };
+
     CRngHandler() = default;
 
     explicit CRngHandler(const std::shared_ptr<CGame> &map);
+
+    // Classifies the race/class pairing the encounter-scale hook below consumes.
+    static ClassAssociation classifyClassAssociation(const std::shared_ptr<CCreature> &creature);
+
+    // Future-gated encounter-scale hook: maps a creature's concrete power (getSw()) to
+    // its encounter power-table key by class association. Every association currently
+    // maps to the neutral multiplier 1 -- the returned power is bit-identical to the
+    // input for all content -- until the associated-class balance design is approved.
+    static int scaleEncounterPower(int power, ClassAssociation association);
 
     std::set<std::shared_ptr<CItem>> getRandomLoot(int value) const;
 

--- a/src/object/CCreatureRace.cpp
+++ b/src/object/CCreatureRace.cpp
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "CCreatureRace.h"
 #include "core/CStats.h"
+#include "object/CCreatureClass.h"
 #include "object/CInteraction.h"
 
 CCreatureRace::CCreatureRace() {}
@@ -56,3 +57,35 @@ void CCreatureRace::setSubtypes(std::set<std::string> value) { subtypes = value;
 bool CCreatureRace::isPlayerSelectable() { return playerSelectable; }
 
 void CCreatureRace::setPlayerSelectable(bool value) { playerSelectable = value; }
+
+std::set<std::string> CCreatureRace::getAssociatedClasses() { return associatedClasses; }
+
+// Null-safe: drop empty class ids so association queries and serialization stay
+// deterministic (an empty id can never name a configured class).
+void CCreatureRace::setAssociatedClasses(std::set<std::string> value) {
+    std::set<std::string> filtered;
+    for (const auto &classId : value) {
+        if (!classId.empty()) {
+            filtered.insert(classId);
+        }
+    }
+    associatedClasses = filtered;
+}
+
+bool CCreatureRace::isAssociatedClass(const std::string &classId) {
+    return !classId.empty() && associatedClasses.contains(classId);
+}
+
+// Resolves the class's configured identity the way the engine's configured-identity
+// helpers do (CGameObject::sameConfiguredType): prefer the typeId, fall back to the
+// name only when typeId is empty. Null classes are never associated.
+bool CCreatureRace::isAssociatedClass(const std::shared_ptr<CCreatureClass> &creatureClass) {
+    if (!creatureClass) {
+        return false;
+    }
+    std::string classId = creatureClass->getTypeId();
+    if (classId.empty()) {
+        classId = creatureClass->getName();
+    }
+    return isAssociatedClass(classId);
+}

--- a/src/object/CCreatureRace.h
+++ b/src/object/CCreatureRace.h
@@ -23,6 +23,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <set>
 #include <string>
 
+class CCreatureClass;
+
 class CInteraction;
 
 // CCreatureRace is a CGameObject-derived *metadata definition*, not a CCreature
@@ -39,7 +41,9 @@ class CCreatureRace : public CGameObject {
            V_PROPERTY(CCreatureRace, std::set<std::shared_ptr<CInteraction>>, actions, getActions, setActions),
            V_PROPERTY(CCreatureRace, std::string, creatureType, getCreatureType, setCreatureType),
            V_PROPERTY(CCreatureRace, std::set<std::string>, subtypes, getSubtypes, setSubtypes),
-           V_PROPERTY(CCreatureRace, bool, playerSelectable, isPlayerSelectable, setPlayerSelectable))
+           V_PROPERTY(CCreatureRace, bool, playerSelectable, isPlayerSelectable, setPlayerSelectable),
+           V_PROPERTY(CCreatureRace, std::set<std::string>, associatedClasses, getAssociatedClasses,
+                      setAssociatedClasses))
 
   public:
     CCreatureRace();
@@ -66,10 +70,24 @@ class CCreatureRace : public CGameObject {
 
     void setPlayerSelectable(bool value);
 
+    // [EPIC_08][STORY_05] D&D-inspired associated classes: the class ids (configured
+    // identity, e.g. "mageClass") that reinforce this race's natural role. Metadata
+    // only for now -- encounter scale treats associated and non-associated pairings
+    // identically until the balance design is approved. Defaults empty, so existing
+    // races and configs are unaffected.
+    std::set<std::string> getAssociatedClasses();
+
+    void setAssociatedClasses(std::set<std::string> value);
+
+    bool isAssociatedClass(const std::string &classId);
+
+    bool isAssociatedClass(const std::shared_ptr<CCreatureClass> &creatureClass);
+
   private:
     std::shared_ptr<CStats> baseStats = std::make_shared<CStats>();
     std::set<std::shared_ptr<CInteraction>> actions;
     std::string creatureType;
     std::set<std::string> subtypes;
     bool playerSelectable = false;
+    std::set<std::string> associatedClasses;
 };

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -2048,6 +2048,7 @@ void test_creature_race_metadata_round_trip() {
     race->setCreatureType("humanoid");
     race->setSubtypes({"human", "northerner"});
     race->setPlayerSelectable(true);
+    race->setAssociatedClasses({"mageClass", "cultistClass"});
     race->setLabel("Human");
     race->setDescription("The common folk of Nouraajd.");
 
@@ -2070,6 +2071,12 @@ void test_creature_race_metadata_round_trip() {
     expect_true(round_trip->getBaseStats() && round_trip->getBaseStats()->getStrength() == 7,
                 "base stats should survive the round-trip");
     expect_true(round_trip->getActions().size() == 1, "innate actions should survive the round-trip");
+    expect_true(round_trip->getAssociatedClasses() == std::set<std::string>({"mageClass", "cultistClass"}),
+                "associatedClasses metadata should survive the round-trip");
+    expect_true(round_trip->isAssociatedClass("mageClass"),
+                "a round-tripped race should still report a listed class as associated");
+    expect_true(!round_trip->isAssociatedClass("bruteClass"),
+                "a round-tripped race should still report an unlisted class as non-associated");
 
     // Null-safety: empty/null stats and null actions must not crash aggregation.
     auto bare = std::make_shared<CCreatureRace>();
@@ -2077,6 +2084,10 @@ void test_creature_race_metadata_round_trip() {
     expect_true(bare->getBaseStats() != nullptr, "null baseStats should normalize to an empty CStats");
     bare->setActions({nullptr});
     expect_true(bare->getActions().empty(), "null actions should be filtered out");
+    expect_true(bare->getAssociatedClasses().empty(),
+                "associatedClasses should default empty so existing races carry no association metadata");
+    bare->setAssociatedClasses({""});
+    expect_true(bare->getAssociatedClasses().empty(), "empty associated class ids should be filtered out");
 
     // A race definition is not a creature subtype, so it must never appear in the
     // CCreature subtype enumeration.

--- a/tests/unit/test_handler.cpp
+++ b/tests/unit/test_handler.cpp
@@ -1476,6 +1476,117 @@ void test_rng_handler_encounter_candidates_stay_in_stable_power_buckets() {
     objectHandler->unregisterConfig(highId);
 }
 
+// [EPIC_08][STORY_05][SUBSTORY_01] Associated-class metadata: future-gated encounter
+// scale hook. CCreatureRace.associatedClasses models D&D-inspired associated classes
+// (a class that reinforces the race's natural role), and CRngHandler's
+// classifyClassAssociation/scaleEncounterPower hook lets the encounter power table
+// DISTINGUISH associated from non-associated pairings. Balance is design-gated: the
+// multipliers behind scaleEncounterPower are pinned to the neutral value 1, so the
+// hook must be the identity for every classification and the encounter scale output
+// must stay bit-identical to the pre-hook math for all existing content (empty
+// metadata => zero effect). This test proves both halves of that acceptance.
+void test_rng_handler_distinguishes_associated_classes_with_neutral_scale() {
+    using ClassAssociation = CRngHandler::ClassAssociation;
+
+    // --- Capability (metadata): a race configured with associatedClasses reports the
+    // distinction for class ids and for class objects (configured-identity semantics).
+    auto race = std::make_shared<CCreatureRace>();
+    race->setAssociatedClasses({"mageClass"});
+
+    expect_true(race->isAssociatedClass("mageClass"), "a race should report a listed class id as associated");
+    expect_true(!race->isAssociatedClass("bruteClass"), "a race should report an unlisted class id as non-associated");
+    expect_true(!race->isAssociatedClass(std::string()), "an empty class id should never be associated");
+
+    auto mageClass = std::make_shared<CCreatureClass>();
+    mageClass->setTypeId("mageClass");
+    auto bruteClass = std::make_shared<CCreatureClass>();
+    bruteClass->setTypeId("bruteClass");
+    expect_true(race->isAssociatedClass(mageClass), "a class object should match by its configured typeId");
+    expect_true(!race->isAssociatedClass(bruteClass), "an off-role class object should not match");
+    auto namedOnlyClass = std::make_shared<CCreatureClass>();
+    namedOnlyClass->setName("mageClass");
+    expect_true(race->isAssociatedClass(namedOnlyClass),
+                "a class with no typeId should fall back to its name, matching configured-identity semantics");
+    expect_true(!race->isAssociatedClass(std::shared_ptr<CCreatureClass>()), "a null class is never associated");
+
+    // --- Capability (hook input): the encounter hook derives the right distinction
+    // from a creature's race/class pairing.
+    expect_true(CRngHandler::classifyClassAssociation(nullptr) == ClassAssociation::NoArchetype,
+                "a null creature carries no association to weigh");
+    auto creature = std::make_shared<CCreature>();
+    expect_true(CRngHandler::classifyClassAssociation(creature) == ClassAssociation::NoArchetype,
+                "a legacy creature (no race, no class) carries no association to weigh");
+    creature->setRace(race);
+    expect_true(CRngHandler::classifyClassAssociation(creature) == ClassAssociation::NoArchetype,
+                "a race-only creature has no race/class pairing to classify");
+    creature->setCreatureClass(mageClass);
+    expect_true(CRngHandler::classifyClassAssociation(creature) == ClassAssociation::Associated,
+                "a class listed in the race's associatedClasses should classify as Associated");
+    creature->setCreatureClass(bruteClass);
+    expect_true(CRngHandler::classifyClassAssociation(creature) == ClassAssociation::NonAssociated,
+                "a class missing from the race's associatedClasses should classify as NonAssociated");
+    auto emptyMetadataRace = std::make_shared<CCreatureRace>();
+    creature->setRace(emptyMetadataRace);
+    creature->setCreatureClass(mageClass);
+    expect_true(CRngHandler::classifyClassAssociation(creature) == ClassAssociation::NonAssociated,
+                "a race with default-empty associatedClasses should treat every class as non-associated");
+
+    // --- Neutrality (design-gated): the hook is the identity for EVERY classification
+    // and power, so the constructor's power-table key provably equals the raw getSw()
+    // no matter how a creature classifies (initial migration balance unchanged).
+    for (int power : {0, 1, 2, 4, 9, 40, 1000}) {
+        expect_true(CRngHandler::scaleEncounterPower(power, ClassAssociation::NoArchetype) == power,
+                    "legacy creatures must keep their raw power as the encounter power key");
+        expect_true(CRngHandler::scaleEncounterPower(power, ClassAssociation::Associated) == power,
+                    "the associated-class multiplier must stay neutral until the balance design is approved");
+        expect_true(CRngHandler::scaleEncounterPower(power, ClassAssociation::NonAssociated) == power,
+                    "the non-associated-class multiplier must stay neutral until the balance design is approved");
+    }
+
+    // --- Neutrality (existing content): for every encounter candidate the configured
+    // game registers, the hooked key the constructor computes equals the raw getSw(),
+    // so the creature power table is identical to the pre-hook build. Reconstructs the
+    // candidate set exactly as the constructor does (src/handler/CRngHandler.cpp),
+    // including the CPlayer exclusion.
+    auto game = load_empty_game();
+    auto objectHandler = game->getObjectHandler();
+
+    std::set<int> rawSwKeys;
+    for (const std::string &type : objectHandler->getAllSubTypes("CCreature")) {
+        auto resolvedClass = objectHandler->getType(objectHandler->getClass(type));
+        if (resolvedClass && resolvedClass->meta()->inherits("CPlayer")) {
+            continue;
+        }
+        auto prototype = game->createObject<CCreature>(type);
+        if (!prototype) {
+            continue;
+        }
+        const int hookedKey =
+            CRngHandler::scaleEncounterPower(prototype->getSw(), CRngHandler::classifyClassAssociation(prototype));
+        expect_true(hookedKey == prototype->getSw(),
+                    "every existing encounter candidate's hooked power key must equal its raw getSw()");
+        rawSwKeys.insert(prototype->getSw());
+    }
+
+    // The live handler (built with the hook in place) must still assemble encounters
+    // exclusively from the raw concrete sw buckets, exactly as before the hook.
+    CRngHandler rng_handler(game);
+    bool producedEncounter = false;
+    for (int attempt = 0; attempt < 64; attempt++) {
+        for (const auto &sampled : rng_handler.getRandomEncounter(40)) {
+            if (!sampled) {
+                continue;
+            }
+            producedEncounter = true;
+            expect_true(rawSwKeys.contains(sampled->getSw()),
+                        "encounter creatures must still be drawn from the raw concrete sw power buckets");
+            expect_true(sampled->getScale() == sampled->getLevel() + sampled->getSw(),
+                        "the neutral hook must preserve getScale() == level + sw for encounter creatures");
+        }
+    }
+    expect_true(producedEncounter, "the hooked power table should still assemble non-empty encounters");
+}
+
 std::shared_ptr<json> make_unit_player_config(int sw) {
     auto config = CJsonUtil::from_string("{\"class\":\"CPlayer\",\"properties\":{\"sw\":" + std::to_string(sw) + "}}",
                                          "unitPlayerSwConfig");
@@ -1782,6 +1893,7 @@ int main() {
     test_rng_handler_excludes_player_templates_from_encounters();
     test_rng_handler_captures_encounter_power_and_scale_baseline();
     test_rng_handler_encounter_candidates_stay_in_stable_power_buckets();
+    test_rng_handler_distinguishes_associated_classes_with_neutral_scale();
     test_creature_subtype_inventory_is_enumerable_on_loaded_game();
     test_event_handler_trigger_registration_uses_named_comparison_helpers();
     test_fight_handler_rejects_stale_and_cross_map_participants();


### PR DESCRIPTION
## Summary

Future-gated scaffolding for D&D-inspired associated classes (Future Mechanics / Encounter Balance). This lands the metadata and the capability only — no balance change is applied until the encounter-balance design is approved.

- **`CCreatureRace.associatedClasses`** (`src/object/CCreatureRace.h/.cpp`): new serializable `std::set<std::string>` V_META property (defaults empty, same pattern as `subtypes`), listing the class ids that reinforce the race's natural role. Query surface: `isAssociatedClass(const std::string &classId)` and `isAssociatedClass(const std::shared_ptr<CCreatureClass> &)` (configured-identity semantics: `typeId`, falling back to `name`). Empty ids are filtered on set, mirroring the existing null-safe setter conventions.
- **Neutral encounter-scale hook** (`src/handler/CRngHandler.h/.cpp`): `CRngHandler::ClassAssociation { NoArchetype, Associated, NonAssociated }`, `classifyClassAssociation(creature)` (a full race/class pairing is required; legacy creatures classify `NoArchetype`), and `scaleEncounterPower(power, association)`. The constructor now seeds `creaturePowerTable` through this hook. Both design-gated multipliers are pinned to the neutral value `1` (integer multiply), so every power-table key is bit-identical to the raw `getSw()` for all content — empty metadata means zero effect, and no balance number was invented.
- **pybind bindings** (`src/core/CModule.cpp`): expose `getAssociatedClasses` / `setAssociatedClasses` / `isAssociatedClass(classId)` on `CCreatureRace`, matching the existing binding style.

No config/content JSON changes (`scripts/validate_content.py` passes unchanged); deserialization stays additive-optional per the legacy fallback compatibility contract in `docs/design/creature_archetypes.md`.

## Tests

- `test_rng_handler_distinguishes_associated_classes_with_neutral_scale` (`tests/unit/test_handler.cpp`) proves both halves of the acceptance:
  - **Capability**: a race configured with `associatedClasses` distinguishes associated vs non-associated class ids and class objects (typeId and name-fallback identity), and the hook classifies `NoArchetype` / `Associated` / `NonAssociated` correctly from a creature's race/class pairing (including the empty-metadata race case).
  - **Neutrality**: `scaleEncounterPower` is the identity for every classification across a power spread; for every registered encounter candidate in the configured game (reconstructed exactly as the constructor does, including the CPlayer exclusion) the hooked key equals the raw `getSw()`; and the live handler still assembles encounters exclusively from the raw concrete sw buckets with `getScale() == level + sw` preserved — mirroring the deterministic assertions of the existing E01/S02 encounter power/scale baseline tests.
- `test_creature_race_metadata_round_trip` (`tests/unit/test_core.cpp`) extended: `associatedClasses` survives the CSerialization round-trip, defaults empty, and filters empty ids.

Validation run locally: `python3 scripts/validate_content.py --repo-root .` (passed), `clang-format` on all touched C++ files, `git diff --check` clean. Native test suites run in CI (no heavy local native build).

Worker implementation branch did not modify any queue workbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_