### PR TITLE
[EPIC_08][STORY_04][SUBSTORY_01] Model racial advancement separately from class level

### DIFF
--- a/docs/design/creature_archetypes.md
+++ b/docs/design/creature_archetypes.md
@@ -449,6 +449,24 @@ contribution is layered on top of (added after) the earlier sources. The
 ordering still matters for any non-commutative or selecting step (notably the
 main stat below) and to give a single, reproducible composition.
 
+### Racial advancement (racialLevel) — future-gated growth source
+
+Racial advancement is modeled **separately from the class-driven `level`**
+(EPIC_08/STORY_04/SUBSTORY_01): `CCreatureRace.racialLevelStats` is a
+hit-dice-style per-racial-level growth block and `CCreature.racialLevel` counts
+racial levels, distinct from `CCreature.level`. It folds in **between positions
+3 and 4** above (position "3a"): race-derived growth is the least-specific
+per-level source, so it opens the growth block ahead of
+`creatureClass.levelStats` and `creature.levelStats`, mirroring how
+`race.baseStats` leads the base block. Both default neutral (`racialLevel = 0`,
+empty progression), so the fold is a strict no-op for all existing content, and
+there is deliberately **no XP or level-up wiring** for `racialLevel` yet —
+raising it requires explicit XP/scale design and is deferred. The legacy path
+(`race == null`) has no racial source by construction. Pinned by
+`test_racial_progression_defaults_keep_composition_neutral` and
+`test_racial_level_composes_race_progression_independently_of_class_level` in
+`tests/unit/test_object.cpp`.
+
 ## Main stat selection (class first, then legacy creature baseStats)
 
 The composed block's **`mainStat`** is a *selected* (not accumulated) field. It

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -950,6 +950,16 @@ void CCreature::useItem(std::shared_ptr<CItem> item) {
 
 void CCreature::setLevel(int level) { this->level = level; }
 
+// Racial advancement (EPIC_08/STORY_04/SUBSTORY_01), modeled separately from the
+// class-driven `level`: racialLevel counts hit-dice-style racial levels and only
+// contributes when the creature's race defines racialLevelStats. It defaults to 0
+// (zero contribution) and deliberately has NO XP or level-up wiring yet -- gaining
+// racial levels requires explicit XP/scale design (deferred); today only
+// serialization and the composed-stat fold in buildComposedStats read it.
+int CCreature::getRacialLevel() { return racialLevel; }
+
+void CCreature::setRacialLevel(int value) { racialLevel = value; }
+
 int CCreature::getExpForLevel(int level) { return (level - 1) * level * 500; }
 
 void CCreature::removeQuestItem(std::shared_ptr<CItem> item) { removeItem(item, true); }
@@ -970,6 +980,7 @@ std::shared_ptr<CStats> CCreature::buildComposedStats() {
     //   1. race.baseStats
     //   2. creatureClass.baseStats
     //   3. creature.baseStats
+    //   3a. race.racialLevelStats per racialLevel (racial advancement; 0 by default)
     //   4. creatureClass.levelStats per level
     //   5. creature.levelStats per level
     //   6. template overlays (ordered) -- CCreatureTemplate.statAdjustments applied
@@ -1004,6 +1015,19 @@ std::shared_ptr<CStats> CCreature::buildComposedStats() {
     }
     // 3. creature.baseStats (concrete template's own base).
     ret->addBonus(getBaseStats());
+    // 3a. race.racialLevelStats per racialLevel -- racial advancement, modeled
+    // separately from the class-driven `level` (EPIC_08/STORY_04/SUBSTORY_01).
+    // Race-derived growth is the least-specific per-level source, so it opens the
+    // growth block ahead of creatureClass.levelStats and creature.levelStats,
+    // mirroring how race.baseStats leads the base block. No-op unless the race
+    // defines progression AND the creature has racial levels: the default
+    // racialLevel of 0 (and the default-empty progression) contributes nothing,
+    // so every existing creature composes bit-identically to today.
+    if (race && race->getRacialLevelStats()) {
+        for (int i = 0; i < racialLevel; i++) {
+            ret->addBonus(race->getRacialLevelStats());
+        }
+    }
     // 4. creatureClass.levelStats per level.
     if (creatureClass && creatureClass->getLevelStats()) {
         for (int i = 0; i < level; i++) {
@@ -1072,6 +1096,9 @@ std::shared_ptr<CStats> CCreature::buildLegacyStats() {
     // 1-2. race / creature-class baseStats: extension point (nothing to add yet).
     // 3. creature.baseStats (legacy concrete base).
     ret->addBonus(getBaseStats());
+    // 3a. racial advancement (race.racialLevelStats per racialLevel) is race-carried,
+    // so the legacy path (race == null) has no racial source by construction: a
+    // racialLevel on a legacy creature contributes nothing, exactly as before.
     // 4. creatureClass.levelStats per level: extension point (nothing to add yet).
     // 5. creature.levelStats per level (legacy concrete growth).
     for (int i = 0; i < level; i++) {

--- a/src/object/CCreature.h
+++ b/src/object/CCreature.h
@@ -56,6 +56,7 @@ class CCreature : public CMapObject, public CMoveable, public CVisitable {
 
     V_META(CCreature, CMapObject, V_PROPERTY(CCreature, int, exp, getExp, setExp),
            V_PROPERTY(CCreature, int, gold, getGold, setGold), V_PROPERTY(CCreature, int, level, getLevel, setLevel),
+           V_PROPERTY(CCreature, int, racialLevel, getRacialLevel, setRacialLevel),
            V_PROPERTY(CCreature, int, mana, getMana, setMana), V_PROPERTY(CCreature, int, hp, getHp, setHp),
            V_PROPERTY(CCreature, int, sw, getSw, setSw),
            V_PROPERTY(CCreature, CInteractionMap, levelling, getLevelling, setLevelling),
@@ -159,6 +160,15 @@ class CCreature : public CMapObject, public CMoveable, public CVisitable {
     int getLevel();
 
     void setLevel(int level);
+
+    // Racial advancement, modeled separately from the class-driven `level`
+    // (EPIC_08/STORY_04/SUBSTORY_01). Counts hit-dice-style racial levels that
+    // apply race->racialLevelStats once each in the composed-stat fold. Defaults
+    // to 0 (zero contribution) and has NO XP or level-up wiring yet; the class
+    // level semantics, XP curve, and levelUp flow are untouched.
+    int getRacialLevel();
+
+    void setRacialLevel(int value);
 
     void addExpScaled(int scale);
 
@@ -328,6 +338,9 @@ class CCreature : public CMapObject, public CMoveable, public CVisitable {
     int gold = 0;
     int exp = 0;
     int level = 0;
+    // Racial (hit-dice-style) level, distinct from the class-driven `level`.
+    // 0 by default so existing creatures compose bit-identically to today.
+    int racialLevel = 0;
     int sw = 0;
     int mana = 0;
     int hp = 0;

--- a/src/object/CCreatureRace.cpp
+++ b/src/object/CCreatureRace.cpp
@@ -89,3 +89,12 @@ bool CCreatureRace::isAssociatedClass(const std::shared_ptr<CCreatureClass> &cre
     }
     return isAssociatedClass(classId);
 }
+
+std::shared_ptr<CStats> CCreatureRace::getRacialLevelStats() { return racialLevelStats; }
+
+// Null-safe like setBaseStats: a missing racial progression normalizes to an
+// empty CStats (zero contribution), so the composed-stat fold never dereferences
+// a null definition and a race without progression stays strictly neutral.
+void CCreatureRace::setRacialLevelStats(std::shared_ptr<CStats> value) {
+    racialLevelStats = value ? value : std::make_shared<CStats>();
+}

--- a/src/object/CCreatureRace.h
+++ b/src/object/CCreatureRace.h
@@ -43,7 +43,9 @@ class CCreatureRace : public CGameObject {
            V_PROPERTY(CCreatureRace, std::set<std::string>, subtypes, getSubtypes, setSubtypes),
            V_PROPERTY(CCreatureRace, bool, playerSelectable, isPlayerSelectable, setPlayerSelectable),
            V_PROPERTY(CCreatureRace, std::set<std::string>, associatedClasses, getAssociatedClasses,
-                      setAssociatedClasses))
+                      setAssociatedClasses),
+           V_PROPERTY(CCreatureRace, std::shared_ptr<CStats>, racialLevelStats, getRacialLevelStats,
+                      setRacialLevelStats))
 
   public:
     CCreatureRace();
@@ -83,6 +85,10 @@ class CCreatureRace : public CGameObject {
 
     bool isAssociatedClass(const std::shared_ptr<CCreatureClass> &creatureClass);
 
+    std::shared_ptr<CStats> getRacialLevelStats();
+
+    void setRacialLevelStats(std::shared_ptr<CStats> value);
+
   private:
     std::shared_ptr<CStats> baseStats = std::make_shared<CStats>();
     std::set<std::shared_ptr<CInteraction>> actions;
@@ -90,4 +96,13 @@ class CCreatureRace : public CGameObject {
     std::set<std::string> subtypes;
     bool playerSelectable = false;
     std::set<std::string> associatedClasses;
+    // Hit-dice-style racial progression: the flat stat growth ONE racial level
+    // contributes, applied once per CCreature::racialLevel by the composed-stat
+    // fold. Racial advancement is modeled separately from the class-driven
+    // CCreature::level (EPIC_08/STORY_04/SUBSTORY_01) and is future-gated
+    // scaffolding: the default is an empty CStats, so a race without authored
+    // progression contributes exactly zero and every existing creature composes
+    // bit-identically to today. No XP or level-up flow raises racialLevel yet --
+    // that requires explicit XP/scale design and is deliberately deferred.
+    std::shared_ptr<CStats> racialLevelStats = std::make_shared<CStats>();
 };

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -2454,6 +2454,11 @@ void test_creature_clone_preserves_composed_archetypes() {
     auto race = game->createObject<CCreatureRace>("CCreatureRace");
     expect_true(race != nullptr, "CCreatureRace is registered and constructs in the loaded game");
     race->setCreatureType("humanoid");
+    // Racial advancement scaffolding (EPIC_08/STORY_04/SUBSTORY_01): author a racial
+    // progression on the race so the clone round-trip covers racialLevelStats too.
+    auto racialGrowth = std::make_shared<CStats>();
+    racialGrowth->setStamina(3);
+    race->setRacialLevelStats(racialGrowth);
 
     auto classUnlock = game->createObject<CInteraction>("CInteraction");
     expect_true(classUnlock != nullptr, "CInteraction is registered and constructs in the loaded game");
@@ -2490,6 +2495,7 @@ void test_creature_clone_preserves_composed_archetypes() {
     source->setCreatureClass(klass);
     source->setTemplates({overlay});
     source->setLevel(3);
+    source->setRacialLevel(2);
     source->setHp(11);
     source->setGold(5);
     // The unlock lives on the archetype, not on the creature's own actions.
@@ -2528,6 +2534,15 @@ void test_creature_clone_preserves_composed_archetypes() {
         expect_true(overlay->getOrder() == 10,
                     "mutating the clone's template overlay does not write back to the source's template");
     }
+
+    // Racial advancement round-trips through the serialize -> deserialize clone path
+    // like every other creature property: the racial level (distinct from the class
+    // level) and the race's racial progression survive the round trip.
+    expect_true(clone->getRacialLevel() == 2,
+                "the clone keeps the source's racialLevel through the serialize/deserialize round trip");
+    expect_true(clone->getRace()->getRacialLevelStats() != nullptr &&
+                    clone->getRace()->getRacialLevelStats()->getStamina() == 3,
+                "the clone's race keeps the authored racialLevelStats progression through the round trip");
 
     // Generated unique name distinct from the source.
     expect_true(!clone->getName().empty(), "the clone receives a generated name");

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -843,6 +843,209 @@ void test_creature_stat_precedence_orders_sources_and_main_stat() {
                 "removing the effects source should remove exactly its contribution from the composed stat");
 }
 
+void test_racial_progression_defaults_keep_composition_neutral() {
+    // [EPIC_08][STORY_04][SUBSTORY_01] Model racial advancement separately from class
+    // level -- NEUTRALITY. Racial advancement (CCreatureRace::racialLevelStats applied
+    // once per CCreature::racialLevel) is future-gated scaffolding: with the neutral
+    // defaults (racialLevel == 0 and/or an empty race progression) it contributes
+    // exactly zero, so every existing creature -- legacy or composed -- keeps a
+    // bit-identical stat block and the class level semantics are untouched. There is
+    // deliberately NO XP wiring for racialLevel, so nothing can raise it implicitly.
+    auto same_int_properties = [](const std::shared_ptr<CStats> &before, const std::shared_ptr<CStats> &after) {
+        bool same = before->getMainStat() == after->getMainStat();
+        before->meta()->for_all_properties(before, [&](auto property) {
+            if (property->value_type() != std::type_index(typeid(int))) {
+                return;
+            }
+            same = same && before->getProperty<int>(property->name()) == after->getProperty<int>(property->name());
+        });
+        return same;
+    };
+
+    // Shared legacy shape reused from the existing composition tests: base 10 int,
+    // +2 int per class level, level 3.
+    auto make_creature = []() {
+        auto creature = std::make_shared<CCreature>();
+        auto base = std::make_shared<CStats>();
+        base->setMainStat("intelligence");
+        base->setIntelligence(10);
+        base->setStamina(6);
+        creature->setBaseStats(base);
+        auto level_stats = std::make_shared<CStats>();
+        level_stats->setIntelligence(2);
+        creature->setLevelStats(level_stats);
+        creature->setLevel(3);
+        return creature;
+    };
+
+    // (a) Legacy creature (no race, no creatureClass): racialLevel alone must not
+    // contribute -- racial progression is race-carried, and the legacy path stays exact.
+    auto legacy = make_creature();
+    auto legacy_before = legacy->getStats();
+    expect_true(legacy->getRacialLevel() == 0, "racialLevel should default to 0 (zero contribution)");
+    expect_true(legacy_before->getIntelligence() == 10 + 3 * 2,
+                "the legacy creature should keep the exact legacy composition (base + level*levelStats)");
+    legacy->setRacialLevel(5);
+    expect_true(same_int_properties(legacy_before, legacy->getStats()),
+                "a racialLevel on a legacy creature (no race) must not change the composed stats");
+    expect_true(legacy->getLevel() == 3, "racialLevel must not disturb the class-driven level");
+
+    // (b) Composed creature whose race has NO authored racial progression: a nonzero
+    // racialLevel composes bit-identically (default-empty progression => zero growth).
+    auto composed = make_creature();
+    auto race = std::make_shared<CCreatureRace>();
+    composed->setRace(race);
+    auto composed_before = composed->getStats();
+    composed->setRacialLevel(4);
+    expect_true(same_int_properties(composed_before, composed->getStats()),
+                "racial levels over an empty race progression must contribute exactly zero");
+
+    // (c) Composed creature whose race HAS racial progression but racialLevel stays at
+    // the default 0: attaching the progression must not change anything.
+    auto gated = make_creature();
+    auto progressive_race = std::make_shared<CCreatureRace>();
+    gated->setRace(progressive_race);
+    auto gated_before = gated->getStats();
+    auto racial_growth = std::make_shared<CStats>();
+    racial_growth->setStamina(3);
+    racial_growth->setStrength(2);
+    progressive_race->setRacialLevelStats(racial_growth);
+    expect_true(same_int_properties(gated_before, gated->getStats()),
+                "race progression with the default racialLevel of 0 must contribute exactly zero");
+}
+
+void test_racial_level_composes_race_progression_independently_of_class_level() {
+    // [EPIC_08][STORY_04][SUBSTORY_01] Model racial advancement separately from class
+    // level -- CAPABILITY. A race configured with racialLevelStats plus a creature
+    // racialLevel of N composes exactly N * racialLevelStats, folded at the documented
+    // position (after all base sources, opening the per-level growth block ahead of
+    // creatureClass.levelStats and creature.levelStats). The racial contribution is
+    // independent of -- and coexists with -- the class level growth: changing the class
+    // level does not alter the racial contribution and vice versa.
+    auto creature = std::make_shared<CCreature>();
+
+    auto base = std::make_shared<CStats>();
+    base->setMainStat("intelligence");
+    base->setIntelligence(10);
+    base->setStamina(6);
+    base->setStrength(4);
+    creature->setBaseStats(base);
+
+    auto creature_growth = std::make_shared<CStats>();
+    creature_growth->setIntelligence(1);
+    creature->setLevelStats(creature_growth);
+
+    auto race_base = std::make_shared<CStats>();
+    race_base->setStamina(2);
+    auto racial_growth = std::make_shared<CStats>();
+    racial_growth->setStamina(3);
+    racial_growth->setStrength(2);
+    auto race = std::make_shared<CCreatureRace>();
+    race->setBaseStats(race_base);
+    race->setRacialLevelStats(racial_growth);
+    creature->setRace(race);
+
+    auto class_growth = std::make_shared<CStats>();
+    class_growth->setIntelligence(2);
+    class_growth->setStamina(1);
+    auto klass = std::make_shared<CCreatureClass>();
+    klass->setLevelStats(class_growth);
+    creature->setCreatureClass(klass);
+
+    const int class_level = 3;
+    const int racial_level = 2;
+    creature->setLevel(class_level);
+    creature->setRacialLevel(racial_level);
+
+    // Independently recompute the documented composition:
+    //   race.baseStats -> creature.baseStats -> racialLevel * race.racialLevelStats ->
+    //   class_level * (class levelStats + creature levelStats).
+    auto expected = std::make_shared<CStats>();
+    expected->setMainStat(base->getMainStat());
+    expected->addBonus(race_base);
+    expected->addBonus(base);
+    for (int i = 0; i < racial_level; ++i) {
+        expected->addBonus(racial_growth);
+    }
+    for (int i = 0; i < class_level; ++i) {
+        expected->addBonus(class_growth);
+    }
+    for (int i = 0; i < class_level; ++i) {
+        expected->addBonus(creature_growth);
+    }
+
+    auto actual = creature->getStats();
+    actual->meta()->for_all_properties(actual, [&](auto property) {
+        if (property->value_type() != std::type_index(typeid(int))) {
+            return;
+        }
+        int actual_value = actual->getProperty<int>(property->name());
+        int expected_value = expected->getProperty<int>(property->name());
+        if (actual_value != expected_value) {
+            std::cerr << "RACIAL STAT DIFF [" << property->name() << "] expected " << expected_value << " but got "
+                      << actual_value << "\n";
+        }
+        expect_true(actual_value == expected_value,
+                    "composed stats should fold racialLevel * race.racialLevelStats alongside (not instead of) "
+                    "the class level growth");
+    });
+    expect_true(actual->getMainStat() == "intelligence",
+                "racial progression is numeric-only and must not disturb the selected main stat");
+
+    // Independence, direction 1: raising the CLASS level adds exactly the class +
+    // creature growth -- the racial contribution stays constant.
+    creature->setLevel(class_level + 2);
+    auto after_class_levels = creature->getStats();
+    expect_true(after_class_levels->getIntelligence() == actual->getIntelligence() + 2 * (2 + 1),
+                "raising the class level should add exactly the class+creature growth per level");
+    expect_true(after_class_levels->getStamina() == actual->getStamina() + 2 * 1,
+                "raising the class level should not change the racial stamina contribution");
+    expect_true(after_class_levels->getStrength() == actual->getStrength(),
+                "raising the class level should leave the racial-only strength contribution untouched");
+
+    // Independence, direction 2: raising the RACIAL level adds exactly the racial
+    // growth -- the class-level contribution stays constant.
+    creature->setRacialLevel(racial_level + 3);
+    auto after_racial_levels = creature->getStats();
+    expect_true(after_racial_levels->getStamina() == after_class_levels->getStamina() + 3 * 3,
+                "raising the racial level should add exactly the racial stamina growth per racial level");
+    expect_true(after_racial_levels->getStrength() == after_class_levels->getStrength() + 3 * 2,
+                "raising the racial level should add exactly the racial strength growth per racial level");
+    expect_true(after_racial_levels->getIntelligence() == after_class_levels->getIntelligence(),
+                "raising the racial level should not alter the class-level intelligence contribution");
+    expect_true(creature->getLevel() == class_level + 2 && creature->getRacialLevel() == racial_level + 3,
+                "class level and racial level are distinct, independently stored fields");
+}
+
+void test_racial_level_round_trips_through_meta_property_binding() {
+    // [EPIC_08][STORY_04][SUBSTORY_01] Serialization: racialLevel (creature) and
+    // racialLevelStats (race) are declared V_META properties, so they round-trip
+    // through the same meta property binding save/clone serialization uses for
+    // every other creature property. Pin the binding both ways (setter -> property
+    // read, property write -> getter).
+    auto creature = std::make_shared<CCreature>();
+    expect_true(creature->getProperty<int>("racialLevel") == 0,
+                "the racialLevel meta property should expose the neutral default of 0");
+    creature->setProperty("racialLevel", 4);
+    expect_true(creature->getRacialLevel() == 4,
+                "writing the racialLevel meta property should reach the racial level field");
+    creature->setRacialLevel(7);
+    expect_true(creature->getProperty<int>("racialLevel") == 7,
+                "the racialLevel setter should be visible through the meta property binding");
+
+    auto race = std::make_shared<CCreatureRace>();
+    auto growth = std::make_shared<CStats>();
+    growth->setStamina(3);
+    race->setProperty("racialLevelStats", growth);
+    expect_true(race->getRacialLevelStats()->getStamina() == 3,
+                "writing the racialLevelStats meta property should reach the race progression field");
+    expect_true(race->getProperty<std::shared_ptr<CStats>>("racialLevelStats")->getStamina() == 3,
+                "the racialLevelStats meta property should read back the authored progression");
+    race->setRacialLevelStats(nullptr);
+    expect_true(race->getRacialLevelStats() != nullptr && race->getRacialLevelStats()->getStamina() == 0,
+                "a null racial progression should normalize to an empty (zero-contribution) CStats");
+}
+
 void test_creature_class_main_stat_is_authoritative_over_race() {
     // [EPIC_02][STORY_04][SUBSTORY_03] Make creatureClass authoritative for mainStat.
     // When a creature has a composed creatureClass declaring a main stat, that class main stat
@@ -2240,6 +2443,9 @@ int main() {
     test_equip_item_same_instance_is_noop_and_keeps_cursed_lock();
     test_no_archetype_creature_stats_keep_legacy_composition();
     test_creature_stat_precedence_orders_sources_and_main_stat();
+    test_racial_progression_defaults_keep_composition_neutral();
+    test_racial_level_composes_race_progression_independently_of_class_level();
+    test_racial_level_round_trips_through_meta_property_binding();
     test_creature_class_main_stat_is_authoritative_over_race();
     test_player_composed_stats_reflect_race_and_class_archetype();
     test_player_without_archetype_falls_back_to_base_stats();

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -851,6 +851,14 @@ void test_racial_progression_defaults_keep_composition_neutral() {
     // exactly zero, so every existing creature -- legacy or composed -- keeps a
     // bit-identical stat block and the class level semantics are untouched. There is
     // deliberately NO XP wiring for racialLevel, so nothing can raise it implicitly.
+    //
+    // The per-property comparison below reflects over CStats via getProperty<int>,
+    // which needs the CStats any-cast converter registered (see the registration
+    // note in test_racial_level_round_trips_through_meta_property_binding).
+    // Register it here explicitly so this test does not depend on test order.
+    CTypes::register_type<CGameObject>();
+    CTypes::register_type<CStats, CGameObject>();
+
     auto same_int_properties = [](const std::shared_ptr<CStats> &before, const std::shared_ptr<CStats> &after) {
         bool same = before->getMainStat() == after->getMainStat();
         before->meta()->for_all_properties(before, [&](auto property) {
@@ -922,6 +930,13 @@ void test_racial_level_composes_race_progression_independently_of_class_level() 
     // creatureClass.levelStats and creature.levelStats). The racial contribution is
     // independent of -- and coexists with -- the class level growth: changing the class
     // level does not alter the racial contribution and vice versa.
+    //
+    // The expected-vs-actual sweep below reflects over CStats via getProperty<int>,
+    // so register the CStats any-cast converter explicitly (idempotent; see the
+    // registration note in test_racial_level_round_trips_through_meta_property_binding).
+    CTypes::register_type<CGameObject>();
+    CTypes::register_type<CStats, CGameObject>();
+
     auto creature = std::make_shared<CCreature>();
 
     auto base = std::make_shared<CStats>();
@@ -1023,6 +1038,23 @@ void test_racial_level_round_trips_through_meta_property_binding() {
     // through the same meta property binding save/clone serialization uses for
     // every other creature property. Pin the binding both ways (setter -> property
     // read, property write -> getter).
+    //
+    // Reflective V_META access routes through vstd::any_cast converters that only
+    // exist for types registered via CTypes::register_type: property_impl::
+    // object_from_any (vstd/vmeta.h) casts the shared_ptr<CGameObject> handle from
+    // CGameObject::ptr() to the property's DECLARING type, and without the
+    // registered converter that cast falls through to std::any_cast and dies with
+    // bad_any_cast. This per-domain test binary does not run the full module type
+    // registration, so register the exact chain this test reflects over (CCreature,
+    // CCreatureRace, and the shared_ptr<CStats> property payload), the same way the
+    // equip and tooltip tests in this file register theirs. Registration is global
+    // and idempotent, so repeating it here is safe regardless of test order.
+    CTypes::register_type<CGameObject>();
+    CTypes::register_type<CMapObject, CGameObject>();
+    CTypes::register_type<CCreature, CMapObject, CGameObject>();
+    CTypes::register_type<CCreatureRace, CGameObject>();
+    CTypes::register_type<CStats, CGameObject>();
+
     auto creature = std::make_shared<CCreature>();
     expect_true(creature->getProperty<int>("racialLevel") == 0,
                 "the racialLevel meta property should expose the neutral default of 0");


### PR DESCRIPTION
## Summary

Future-gated scaffolding that models racial advancement separately from the class-driven level, with zero behavior change for all existing content (spec: keep current sw and single-level behavior; racial XP/scale design is explicitly deferred).

- **`CCreatureRace.racialLevelStats`** (new serializable `V_META` property): hit-dice-style per-racial-level stat growth. Defaults to an empty `CStats` (zero contribution); a null assignment normalizes to empty, matching the existing `setBaseStats` null-safety.
- **`CCreature.racialLevel`** (new serializable `V_META` property): counts racial levels, distinct from the existing class-driven `level`. Defaults to 0. It has **no XP or level-up wiring** — `exp`, `getExpForLevel`, and `levelUp` are untouched, so current class-level semantics are preserved exactly.
- **Composition fold point**: `buildComposedStats` applies `racialLevel * race.racialLevelStats` at position **3a** — after all flat base sources (`race.baseStats` → `creatureClass.baseStats` → `creature.baseStats`), opening the per-level growth block ahead of `creatureClass.levelStats` and `creature.levelStats`. Rationale: the stat precedence contract orders growth sources least- to most-specific, and race-derived growth is the least-specific growth source, mirroring how `race.baseStats` leads the base block. Numeric accumulation is additive, so the contract pins one reproducible order. The fold is gated (`race && racialLevelStats`, loop bounded by `racialLevel`) and is a strict no-op at the neutral defaults. The legacy path (`race == null`) has no racial source by construction, so legacy creatures are bit-identical.
- **Docs**: the "Creature stat precedence contract" in `docs/design/creature_archetypes.md` now documents the 3a fold point and the future-gated, no-XP status.

Neutrality proof: `racialLevel` defaults to 0 and `racialLevelStats` defaults to empty, so the new fold adds nothing for every existing creature (legacy or composed); no existing config declares either property, and deserialization assigns no default (per the legacy fallback compatibility contract).

## Tests

New native regression tests in `tests/unit/test_object.cpp` (wired into `main()`):

- `test_racial_progression_defaults_keep_composition_neutral` — bit-identical composed stats for (a) a legacy creature given a nonzero `racialLevel` (no race source), (b) a composed creature with a race but empty progression, and (c) a race with authored progression at the default `racialLevel` of 0.
- `test_racial_level_composes_race_progression_independently_of_class_level` — a race with `racialLevelStats` plus `racialLevel = N` composes exactly `N * racialLevelStats` at the documented position, coexisting with class/creature level growth; raising the class level leaves the racial contribution constant and vice versa; `mainStat` selection is undisturbed.
- `test_racial_level_round_trips_through_meta_property_binding` — `racialLevel` and `racialLevelStats` round-trip through the `V_META` property binding (the mechanism save/clone serialization uses), including null-progression normalization.
- Extended `test_creature_clone_preserves_composed_archetypes` (`tests/unit/test_core.cpp`) so the real serialize → deserialize clone round-trip covers `racialLevel` and the race's `racialLevelStats`.

Verification: `clang-format` applied; `git diff --check` clean; all changed translation units pass `g++ -std=c++23 -fsyntax-only` with project include paths. Full test execution is delegated to CI (no heavy local native builds).

Deferred by design: racial XP curve, level-up flow, and any content/config authoring for racial progression — the spec gates these on explicit XP/scale design.

Worker implementation branch did not modify any queue workbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_