### PR TITLE
[EPIC_01][STORY_04][SUBSTORY_01] #623 Add pull-request preflight duplicate and scope guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,16 @@ restarted controller never duplicates a claim, PR, merge, or DONE write. It is s
 workbook, git, or GitHub — and contradictory evidence fails closed to `recovery_required` rather than guessing a write.
 See `docs/codex-agent-queue.md` for the evidence schema and states.
 
+Before opening any implementation PR (especially after a restart), run the read-only preflight
+`python3 scripts/pr_review_audit.py preflight --input request.json`. It correlates the claim identity (issue name,
+claim ID, owner, intended head branch — built from the queue row with `issue_queue.preflightClaimPayload`) against a
+PR-state snapshot and returns one verdict: `allow`, `allow_replacement` (an explicit `replaces` PR number verified
+against the snapshot), `reject_duplicate_open` (a second open PR for the same live claim, head branch, or issue name),
+`already_delivered` (a merged PR for the same claim/head — proceed to terminal queue publication instead), or
+`cannot_verify` (missing claim identity or unverifiable replacement — fail closed, do not open the PR). Broad or
+out-of-scope diffs produce advisory warnings only, and title matches alone are never authoritative identity. The
+preflight never mutates the queue or any PR; exit code 0 means allowed, 1 means do not open the PR.
+
 Scarce local resources shared between concurrent controllers (heavy build/test/coverage jobs, Xvfb displays, TCP
 ports, build directories, memory budgets, MCP server slots) are coordinated through the resource broker built into the
 same script. `python3 scripts/controller_resource_audit.py probe` reports read-only availability

--- a/docs/codex-agent-queue.md
+++ b/docs/codex-agent-queue.md
@@ -12,7 +12,8 @@ concurrent controllers can be distinguished.
 - `planning/workflow_observations/` — immutable workflow-observation records and resolution receipts; not a task queue.
 - `scripts/issue_queue.py` — atomic claim/progress/completion CLI.
 - `scripts/write_leases.py` — separate write-lease CLI over `planning/write_leases.json`; see "Write leases" below.
-- `scripts/pr_review_audit.py` — read-only stale/open PR classification helper for merge, cleanup, and dispatch review.
+- `scripts/pr_review_audit.py` — read-only stale/open PR classification helper for merge, cleanup, and dispatch
+  review, plus the `preflight` duplicate/scope guard run before opening an implementation PR.
 - `scripts/workflow_observations.py` — read-only/append-only workflow-observation ledger CLI.
 - `scripts/worker_report.py` — versioned structured worker-report schema, identity/CI-SHA validation, and deterministic
   bounded restart-handoff CLI; see "Structured worker reports and restart handoffs" below.
@@ -496,6 +497,36 @@ Contradictory evidence (a merged claim PR against an unclaimed row, a DONE row w
 claim ID does not match) fails closed to `recovery_required` with the conflicting evidence instead of guessing a write;
 `reconcile` then exits non-zero so callers can branch. Read-only `snapshot`, `reconcile`, and `next-action` never call
 workbook save, git write commands, or GitHub mutations.
+
+## Pull-request preflight duplicate and scope guard
+
+A controller restart can lose track of an already-open or already-merged implementation PR. Before opening any
+implementation PR, run the read-only preflight built into `scripts/pr_review_audit.py`:
+
+```bash
+python3 scripts/pr_review_audit.py preflight --input request.json   # or pipe the request JSON on stdin
+```
+
+The request carries a `claim` identity (`issueName` and `claimId` required; `owner`, `headBranch`, `title`, and the
+claimed `targetFiles` optional — `issue_queue.preflightClaimPayload(task, headBranch=...)` builds it from the queue
+row), a `pullRequests` snapshot (each record may carry `number`, `state`, `merged`, `claimId`, `issueName`,
+`headBranch`, `title`), an optional `candidate.files` list for the intended diff, and an optional `replaces` PR number.
+The verdict is exactly one of:
+
+- `allow` — no open or merged PR matches this live claim; open the PR.
+- `allow_replacement` — an explicit `replaces` PR number was declared and verified against the snapshot by exact
+  identity; superseded-PR closure still requires explicit human approval.
+- `reject_duplicate_open` — a second open PR matches the same claim ID, head branch, or issue name; adopt it or
+  declare it with `replaces` instead of opening another.
+- `already_delivered` — a merged PR already delivered the same claim or head branch; skip to terminal queue
+  publication.
+- `cannot_verify` — the claim identity is missing or a declared replacement cannot be verified; fail closed and
+  collect evidence instead of opening the PR.
+
+Correlation is by exact identity; title collisions are advisory warnings only. Diff scope is advisory per the
+target-file-overlap policy: files outside the claimed target files, diffs over 25 files, or a workbook file in an
+implementation diff warn without rejecting. The preflight is deterministic and strictly read-only — it never mutates
+the queue workbook or any PR. Exit codes: 0 allowed, 1 not allowed, 2 invalid input.
 
 ## Structured worker reports and restart handoffs
 

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -599,6 +599,23 @@ git commit -m "$COMMIT_MESSAGE"
 git push -u origin "$IMPL_BRANCH"
 ```
 
+Before `gh pr create`, run the read-only duplicate/scope preflight and gate on its exit code. Build the claim identity
+from the queue row (`issue_queue.preflightClaimPayload`), snapshot open/merged PRs read-only, and never open a second
+PR for the same live claim:
+
+```bash
+gh pr list --state all --limit 100 \
+  --json number,state,title,headRefName,mergedAt > /tmp/pr-snapshot.json
+# Assemble request.json: {"claim": {issueName, claimId, owner, headBranch, targetFiles},
+#   "pullRequests": [...snapshot...], "candidate": {"files": [...changed files...]}}
+python3 scripts/pr_review_audit.py preflight --input request.json || exit_code=$?
+# exit 0: allow / allow_replacement (declare an explicit replacement with "replaces": <pr#> in request.json)
+# exit 1: reject_duplicate_open (adopt or replace the open PR), already_delivered (go to terminal publication),
+#         or cannot_verify (collect missing identity evidence). Do not open the PR; the preflight mutates nothing.
+```
+
+Scope findings (files outside the claimed target files, broad diffs) are advisory warnings, never rejections.
+
 Open a ready implementation pull request targeting `main` after focused local checks. Do not run or wait for local
 native builds, `ctest`, full Python suites, native performance guards, or local coverage when the GitHub Actions PR
 workflow can provide that evidence. Its body must include:

--- a/prompts/codex-queue-controller.md
+++ b/prompts/codex-queue-controller.md
@@ -608,10 +608,13 @@ gh pr list --state all --limit 100 \
   --json number,state,title,headRefName,mergedAt > /tmp/pr-snapshot.json
 # Assemble request.json: {"claim": {issueName, claimId, owner, headBranch, targetFiles},
 #   "pullRequests": [...snapshot...], "candidate": {"files": [...changed files...]}}
-python3 scripts/pr_review_audit.py preflight --input request.json || exit_code=$?
 # exit 0: allow / allow_replacement (declare an explicit replacement with "replaces": <pr#> in request.json)
 # exit 1: reject_duplicate_open (adopt or replace the open PR), already_delivered (go to terminal publication),
 #         or cannot_verify (collect missing identity evidence). Do not open the PR; the preflight mutates nothing.
+if ! python3 scripts/pr_review_audit.py preflight --input request.json; then
+  echo "preflight blocked PR creation; resolve the verdict before gh pr create"
+  exit 1
+fi
 ```
 
 Scope findings (files outside the claimed target files, broad diffs) are advisory warnings, never rejections.

--- a/scripts/issue_queue.py
+++ b/scripts/issue_queue.py
@@ -1343,6 +1343,24 @@ def taskPayload(task: TaskRecord, state: QueueState | None = None, now: datetime
     return payload
 
 
+def preflightClaimPayload(task: TaskRecord, headBranch: str | None = None) -> dict[str, Any]:
+    """Read-only claim identity in the exact shape `pr_review_audit.py preflight` consumes.
+
+    Correlates the queue row (issue name, claim ID, owner, claimed target files)
+    with the intended head branch so the controller can run the duplicate/scope
+    preflight before opening an implementation PR. Never mutates the workbook.
+    """
+    payload: dict[str, Any] = {
+        "issueName": task.issueName,
+        "claimId": str(task.values.get("Claim ID") or "").strip(),
+        "owner": str(task.values.get("Owner") or "").strip(),
+        "targetFiles": sorted(task.targetFiles),
+    }
+    if headBranch:
+        payload["headBranch"] = str(headBranch).strip()
+    return payload
+
+
 def ageMinutes(now: datetime, then: datetime | None) -> int | None:
     if then is None:
         return None
@@ -2011,17 +2029,13 @@ def buildParser() -> argparse.ArgumentParser:
         "propose", help="Append a new NOT_STARTED issue (e.g. an autonomously discovered bug)"
     )
     addCommonArguments(proposeParser)
-    proposeParser.add_argument(
-        "--issue-name", required=True, help="[EPIC_NN][STORY_NN][SUBSTORY_NN]<title>"
-    )
+    proposeParser.add_argument("--issue-name", required=True, help="[EPIC_NN][STORY_NN][SUBSTORY_NN]<title>")
     proposeParser.add_argument("--epic-title", required=True)
     proposeParser.add_argument("--story-title", required=True)
     proposeParser.add_argument("--substory-title", required=True)
     proposeParser.add_argument("--priority", required=True, help="P0, P1, or P2")
     proposeParser.add_argument("--component", required=True)
-    proposeParser.add_argument(
-        "--target-file", action="append", default=[], help="Target file/module; may be repeated"
-    )
+    proposeParser.add_argument("--target-file", action="append", default=[], help="Target file/module; may be repeated")
     proposeParser.add_argument("--issue-type", default="Bug")
     proposeParser.add_argument("--dependencies", default="None")
     proposeParser.add_argument("--description")
@@ -2030,9 +2044,7 @@ def buildParser() -> argparse.ArgumentParser:
     proposeParser.add_argument("--acceptance-file")
     proposeParser.add_argument("--validation")
     proposeParser.add_argument("--validation-file")
-    proposeParser.add_argument(
-        "--source-url", action="append", default=[], help="Evidence/source URL; may be repeated"
-    )
+    proposeParser.add_argument("--source-url", action="append", default=[], help="Evidence/source URL; may be repeated")
     proposeParser.add_argument("--sprint", default="None")
 
     listParser = subparsers.add_parser("list", help="List tasks")

--- a/scripts/pr_review_audit.py
+++ b/scripts/pr_review_audit.py
@@ -41,6 +41,21 @@ AUTO_MERGE_DISABLED_MARKERS = (
     "enablepullrequestautomerge",
 )
 
+# Pull-request preflight verdicts. The preflight is strictly read-only: it
+# correlates a claim identity against a PR-state snapshot and returns a verdict;
+# it never mutates the queue workbook or any pull request.
+PREFLIGHT_ALLOW = "allow"
+PREFLIGHT_ALLOW_REPLACEMENT = "allow_replacement"
+PREFLIGHT_REJECT_DUPLICATE_OPEN = "reject_duplicate_open"
+PREFLIGHT_ALREADY_DELIVERED = "already_delivered"
+PREFLIGHT_CANNOT_VERIFY = "cannot_verify"
+
+PREFLIGHT_ALLOWED_VERDICTS = frozenset({PREFLIGHT_ALLOW, PREFLIGHT_ALLOW_REPLACEMENT})
+
+# Advisory scope heuristic: warn (never reject) when the candidate diff exceeds
+# this many files, matching the queue's advisory target-file-overlap philosophy.
+BROAD_DIFF_FILE_LIMIT = 25
+
 
 @dataclass(frozen=True)
 class CheckSummary:
@@ -799,6 +814,238 @@ def auditPayload(records: Sequence[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def normalizeTitle(value: Any) -> str:
+    return " ".join(str(value or "").split()).lower()
+
+
+def parsePrNumber(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def prIsMerged(record: dict[str, Any]) -> bool:
+    state = normalizeToken(firstValue(record, "state", default=""))
+    return (
+        state == "merged"
+        or truthy(firstValue(record, "merged", "isMerged", default=False))
+        or bool(firstValue(record, "mergedAt", "merged_at", "mergeCommit", "merge_commit", default=None))
+    )
+
+
+def prHeadBranch(record: dict[str, Any]) -> str:
+    return str(
+        firstValue(record, "headBranch", "head_branch", "headRefName", "head_ref_name", "headRef", "branch", default="")
+        or ""
+    ).strip()
+
+
+def prClaimId(record: dict[str, Any]) -> str:
+    return str(firstValue(record, "claimId", "claim_id", default="") or "").strip()
+
+
+def prIssueName(record: dict[str, Any]) -> str:
+    return str(firstValue(record, "issueName", "issue", "linkedIssue", "linked_issue", default="") or "").strip()
+
+
+def duplicateRecord(record: dict[str, Any], number: int | None, reason: str, state: str) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": str(firstValue(record, "title", default="") or ""),
+        "headBranch": prHeadBranch(record),
+        "claimId": prClaimId(record),
+        "reason": reason,
+        "state": state,
+    }
+
+
+def preflightScopeWarnings(candidateFiles: Sequence[str], targetFiles: Sequence[str]) -> list[str]:
+    """Advisory-only diff scope heuristics; a broad scope warns but never rejects."""
+    warnings: list[str] = []
+    if not candidateFiles:
+        return warnings
+    if WORKBOOK_PATH in candidateFiles:
+        warnings.append(f"candidate diff touches the queue workbook {WORKBOOK_PATH}; implementation PRs must not")
+    targets = set(targetFiles)
+    if targets:
+        outOfScope = sorted(path for path in candidateFiles if path not in targets and path != WORKBOOK_PATH)
+        if outOfScope:
+            shown = ", ".join(outOfScope[:10])
+            suffix = ", ..." if len(outOfScope) > 10 else ""
+            warnings.append(
+                f"scope warning: {len(outOfScope)} changed file(s) outside the claimed target files: {shown}{suffix}"
+            )
+    if len(candidateFiles) > BROAD_DIFF_FILE_LIMIT:
+        warnings.append(
+            f"scope warning: broad diff with {len(candidateFiles)} changed files "
+            f"(advisory limit {BROAD_DIFF_FILE_LIMIT})"
+        )
+    return warnings
+
+
+def preflightRecommendedActions(verdict: str, reasons: Sequence[str]) -> list[str]:
+    if verdict == PREFLIGHT_REJECT_DUPLICATE_OPEN:
+        return ["do not open a second PR for this live claim; adopt the open PR or declare it with replaces"]
+    if verdict == PREFLIGHT_ALREADY_DELIVERED:
+        return ["do not re-deliver merged work; verify the merged PR and proceed to terminal queue publication"]
+    if verdict == PREFLIGHT_CANNOT_VERIFY:
+        return ["collect the missing claim identity or snapshot evidence before opening a PR"]
+    if verdict == PREFLIGHT_ALLOW_REPLACEMENT:
+        return ["open the replacement PR; request explicit human approval before closing the superseded PR"]
+    if reasons:
+        return ["resolve the listed reasons before opening the PR"]
+    return ["open the implementation PR for this claim"]
+
+
+def preflightVerdict(request: dict[str, Any]) -> dict[str, Any]:
+    """Read-only duplicate/scope preflight for opening an implementation PR.
+
+    Correlates the claim identity (issue name + claim ID + owner + intended head
+    branch) against a PR-state snapshot by exact identity. Title matching alone
+    is never authoritative. Missing identity fails closed to ``cannot_verify``
+    rather than guessing. The verdict never mutates the queue or any PR.
+    """
+    if not isinstance(request, dict):
+        raise ValueError("preflight request must be a JSON object")
+    claim = firstValue(request, "claim", "identity", default={})
+    if not isinstance(claim, dict):
+        claim = {}
+    issueName = str(firstValue(claim, "issueName", "issue", default="") or "").strip()
+    claimId = str(firstValue(claim, "claimId", "claim_id", default="") or "").strip()
+    owner = str(firstValue(claim, "owner", default="") or "").strip()
+    headBranch = prHeadBranch(claim)
+    intendedTitle = normalizeTitle(firstValue(claim, "title", "prTitle", "pr_title", default=""))
+    targetFiles = normalizeFiles({"files": firstValue(claim, "targetFiles", "target_files", default=())})
+    candidate = firstValue(request, "candidate", "diff", default={})
+    candidateFiles = normalizeFiles(candidate if isinstance(candidate, dict) else {})
+    replaces = parsePrNumber(firstValue(request, "replaces", "replacesPr", "replaces_pr", default=None))
+
+    rawRecords = firstValue(request, "pullRequests", "pull_requests", "prs", "snapshot", default=())
+    records = loadRecords(rawRecords if isinstance(rawRecords, list) else [])
+
+    reasons: list[str] = []
+    warnings: list[str] = []
+    claimEcho = {"issueName": issueName, "claimId": claimId, "owner": owner, "headBranch": headBranch}
+
+    def payload(verdict: str, openDup: list[dict[str, Any]], mergedDup: list[dict[str, Any]]) -> dict[str, Any]:
+        return {
+            "readOnly": True,
+            "verdict": verdict,
+            "allowed": verdict in PREFLIGHT_ALLOWED_VERDICTS,
+            "claim": claimEcho,
+            "replaces": replaces,
+            "openDuplicates": openDup,
+            "mergedDuplicates": mergedDup,
+            "reasons": list(dict.fromkeys(reasons)),
+            "warnings": list(dict.fromkeys(warnings)),
+            "recommendedActions": preflightRecommendedActions(verdict, reasons),
+        }
+
+    missing = [name for name, value in (("issueName", issueName), ("claimId", claimId)) if not value]
+    if missing:
+        reasons.append("claim identity is missing: " + ", ".join(missing) + "; cannot verify duplicates")
+        return payload(PREFLIGHT_CANNOT_VERIFY, [], [])
+    if not headBranch:
+        warnings.append("intended head branch is missing; head-branch duplicate detection is skipped")
+
+    openDuplicates: list[dict[str, Any]] = []
+    mergedDuplicates: list[dict[str, Any]] = []
+    replacesRecord: dict[str, Any] | None = None
+    replacesMatchesClaim = False
+    for record in records:
+        number = parsePrNumber(firstValue(record, "number", "prNumber", "id", default=None))
+        recordClaim = prClaimId(record)
+        recordIssue = prIssueName(record)
+        recordHead = prHeadBranch(record)
+        sameClaim = bool(recordClaim) and recordClaim == claimId
+        claimConflict = bool(recordClaim) and recordClaim != claimId
+        sameIssue = bool(recordIssue) and recordIssue == issueName
+        sameHead = bool(recordHead) and bool(headBranch) and recordHead == headBranch
+        # For replacement verification any exact identity link (claim id, issue
+        # name, or head branch) validates the declared target; title alone never does.
+        matchesClaim = sameClaim or sameIssue or sameHead
+        if replaces is not None and number == replaces:
+            replacesRecord = record
+            replacesMatchesClaim = matchesClaim
+        state = normalizeToken(firstValue(record, "state", default="open")) or "open"
+        merged = prIsMerged(record)
+        prLabel = f"#{number}" if number is not None else "with unknown number"
+
+        if merged:
+            if sameClaim or (sameHead and not claimConflict):
+                match = "claim id" if sameClaim else "head branch"
+                mergedDuplicates.append(
+                    duplicateRecord(record, number, f"merged PR matches the same {match}", "merged")
+                )
+            elif sameHead and claimConflict:
+                warnings.append(
+                    f"head branch {headBranch!r} was already merged by PR {prLabel} under a different claim id"
+                )
+            elif sameIssue:
+                warnings.append(
+                    f"merged PR {prLabel} references the same issue name under a different claim/head; "
+                    "verify the queue row before re-delivering"
+                )
+            continue
+        if state in OPEN_STATES:
+            if sameClaim:
+                openDuplicates.append(duplicateRecord(record, number, "open PR carries the same claim id", "open"))
+            elif sameHead:
+                openDuplicates.append(duplicateRecord(record, number, "open PR uses the same head branch", "open"))
+            elif sameIssue:
+                openDuplicates.append(duplicateRecord(record, number, "open PR references the same issue name", "open"))
+            elif intendedTitle and normalizeTitle(firstValue(record, "title", default="")) == intendedTitle:
+                # Title matching alone is never authoritative identity: advisory only.
+                warnings.append(f"title collision with open PR {prLabel}; titles are not authoritative identity")
+            continue
+        if sameClaim or sameHead or sameIssue:
+            warnings.append(f"closed unmerged PR {prLabel} previously matched this claim; verify it was superseded")
+
+    warnings.extend(preflightScopeWarnings(candidateFiles, targetFiles))
+
+    if replaces is not None:
+        # An explicit replacement must be verifiable against the snapshot and the
+        # claim identity; otherwise fail closed instead of trusting the flag.
+        if replacesRecord is None:
+            reasons.append(f"declared replacement PR #{replaces} is not present in the snapshot; cannot verify")
+            return payload(PREFLIGHT_CANNOT_VERIFY, openDuplicates, mergedDuplicates)
+        if not replacesMatchesClaim:
+            reasons.append(f"declared replacement PR #{replaces} does not match this claim identity; cannot verify")
+            return payload(PREFLIGHT_CANNOT_VERIFY, openDuplicates, mergedDuplicates)
+
+    uncoveredMerged = [dup for dup in mergedDuplicates if dup["number"] != replaces or dup["number"] is None]
+    if uncoveredMerged:
+        for dup in uncoveredMerged:
+            prLabel = f"#{dup['number']}" if dup["number"] is not None else "with unknown number"
+            reasons.append(f"merged PR {prLabel} already delivered this claim: {dup['reason']}")
+        return payload(PREFLIGHT_ALREADY_DELIVERED, openDuplicates, mergedDuplicates)
+    if mergedDuplicates:
+        warnings.append(f"explicit replacement of merged PR #{replaces} re-delivers already-merged work")
+
+    uncoveredOpen = [dup for dup in openDuplicates if dup["number"] != replaces or dup["number"] is None]
+    if replaces is None and uncoveredOpen:
+        for dup in uncoveredOpen:
+            prLabel = f"#{dup['number']}" if dup["number"] is not None else "with unknown number"
+            reasons.append(f"open PR {prLabel} duplicates this live claim: {dup['reason']}")
+        return payload(PREFLIGHT_REJECT_DUPLICATE_OPEN, openDuplicates, mergedDuplicates)
+    if replaces is not None and uncoveredOpen:
+        for dup in uncoveredOpen:
+            prLabel = f"#{dup['number']}" if dup["number"] is not None else "with unknown number"
+            reasons.append(
+                f"open PR {prLabel} duplicates this live claim and is not covered by the declared replacement"
+            )
+        return payload(PREFLIGHT_REJECT_DUPLICATE_OPEN, openDuplicates, mergedDuplicates)
+
+    if replaces is not None:
+        if not openDuplicates and not mergedDuplicates:
+            warnings.append(f"declared replacement PR #{replaces} is not currently a duplicate of this claim")
+        return payload(PREFLIGHT_ALLOW_REPLACEMENT, openDuplicates, mergedDuplicates)
+    return payload(PREFLIGHT_ALLOW, openDuplicates, mergedDuplicates)
+
+
 def staleColumn(review: dict[str, Any]) -> str:
     notes = [
         f"ignored stale {record['state']} attempt of {record['name']} (current: {record['effectiveState']})"
@@ -849,8 +1096,32 @@ def parseArgs(argv: Sequence[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def parsePreflightArgs(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="pr_review_audit.py preflight",
+        description="Read-only duplicate/scope preflight before opening an implementation PR.",
+    )
+    parser.add_argument("--input", help="JSON file containing the preflight request; defaults to stdin")
+    return parser.parse_args(argv)
+
+
+def preflightMain(argv: Sequence[str]) -> int:
+    args = parsePreflightArgs(argv)
+    try:
+        payload = preflightVerdict(readInput(args.input))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"pr_review_audit: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    # Non-zero without crashing lets shell callers gate PR creation on the verdict.
+    return 0 if payload["allowed"] else 1
+
+
 def main(argv: Sequence[str] | None = None) -> int:
-    args = parseArgs(argv or sys.argv[1:])
+    arguments = list(argv if argv is not None else sys.argv[1:])
+    if arguments and arguments[0] == "preflight":
+        return preflightMain(arguments[1:])
+    args = parseArgs(arguments)
     try:
         payload = auditPayload(loadRecords(readInput(args.input)))
     except (OSError, ValueError, json.JSONDecodeError) as exc:

--- a/scripts/pr_review_audit.py
+++ b/scripts/pr_review_audit.py
@@ -923,8 +923,17 @@ def preflightVerdict(request: dict[str, Any]) -> dict[str, Any]:
     candidateFiles = normalizeFiles(candidate if isinstance(candidate, dict) else {})
     replaces = parsePrNumber(firstValue(request, "replaces", "replacesPr", "replaces_pr", default=None))
 
-    rawRecords = firstValue(request, "pullRequests", "pull_requests", "prs", "snapshot", default=())
-    records = loadRecords(rawRecords if isinstance(rawRecords, list) else [])
+    rawRecords = firstValue(request, "pullRequests", "pull_requests", "prs", "snapshot", default=None)
+    snapshotError: str | None = None
+    records: list[dict[str, Any]] = []
+    if rawRecords is not None:
+        try:
+            # Reuse loadRecords so object-shaped snapshots (e.g. {"pullRequests":
+            # [...]}) keep their evidence. Unrecognized shapes fail closed to
+            # cannot_verify below; duplicate evidence is never silently discarded.
+            records = loadRecords(rawRecords)
+        except ValueError as exc:
+            snapshotError = str(exc)
 
     reasons: list[str] = []
     warnings: list[str] = []
@@ -947,6 +956,9 @@ def preflightVerdict(request: dict[str, Any]) -> dict[str, Any]:
     missing = [name for name, value in (("issueName", issueName), ("claimId", claimId)) if not value]
     if missing:
         reasons.append("claim identity is missing: " + ", ".join(missing) + "; cannot verify duplicates")
+        return payload(PREFLIGHT_CANNOT_VERIFY, [], [])
+    if snapshotError is not None:
+        reasons.append(f"pull-request snapshot has an unrecognized shape ({snapshotError}); cannot verify duplicates")
         return payload(PREFLIGHT_CANNOT_VERIFY, [], [])
     if not headBranch:
         warnings.append("intended head branch is missing; head-branch duplicate detection is skipped")

--- a/tests/test_issue_queue.py
+++ b/tests/test_issue_queue.py
@@ -273,6 +273,37 @@ class IssueQueueTest(unittest.TestCase):
         self.assertIn("dependencies-not-done", rejected[self.issue_c][0])
         self.assertNotIn("active-file-overlap", issue_queue.rejectionSummary(rejected))
 
+    def test_preflight_claim_payload_matches_pr_review_audit_contract(self) -> None:
+        from scripts import pr_review_audit
+
+        claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1")
+        state = issue_queue.loadQueue(self.workbook_path)
+        task = issue_queue.taskByName(state, claim["Issue Name"])
+
+        payload = issue_queue.preflightClaimPayload(task, headBranch="codex/e01-s01-ss02-head")
+
+        self.assertEqual(claim["Issue Name"], payload["issueName"])
+        self.assertEqual(claim["claimId"], payload["claimId"])
+        self.assertEqual("controller/subagent-1", payload["owner"])
+        self.assertEqual(["src/shared.cpp"], payload["targetFiles"])
+        self.assertEqual("codex/e01-s01-ss02-head", payload["headBranch"])
+
+        clean = pr_review_audit.preflightVerdict({"claim": payload, "pullRequests": []})
+        self.assertEqual("allow", clean["verdict"])
+        self.assertTrue(clean["readOnly"])
+
+        duplicate = pr_review_audit.preflightVerdict(
+            {
+                "claim": payload,
+                "pullRequests": [{"number": 42, "state": "open", "claimId": claim["claimId"]}],
+            }
+        )
+        self.assertEqual("reject_duplicate_open", duplicate["verdict"])
+
+        # The preflight consumed queue evidence without mutating the workbook row.
+        after = issue_queue.taskByName(issue_queue.loadQueue(self.workbook_path), claim["Issue Name"])
+        self.assertEqual(task.values, after.values)
+
     def test_target_file_overlap_advisory_keeps_unresolved_stale_claim_scope(self) -> None:
         claim = issue_queue.claimTask(self.workbook_path, owner="controller/subagent-1", leaseMinutes=30)
         self.set_claim_times(claim["Issue Name"], lease_minutes_from_now=30, updated_minutes_ago=241)

--- a/tests/test_pr_review_audit.py
+++ b/tests/test_pr_review_audit.py
@@ -1132,5 +1132,298 @@ class PrReviewAuditTest(unittest.TestCase):
             self.assertIn("#112", stdout.getvalue())
 
 
+class PrPreflightTest(unittest.TestCase):
+    ISSUE = "[EPIC_01][STORY_04][SUBSTORY_01] Add pull-request preflight duplicate and scope guard"
+    CLAIM_ID = "claim-623-abc"
+    OWNER = "controller/ctrl-a/subagent-1"
+    HEAD = "codex/e01-s04-ss01-preflight"
+
+    def claim(self, **overrides: object) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "issueName": self.ISSUE,
+            "claimId": self.CLAIM_ID,
+            "owner": self.OWNER,
+            "headBranch": self.HEAD,
+        }
+        payload.update(overrides)
+        return payload
+
+    def preflight(self, **request: object) -> dict[str, object]:
+        request.setdefault("claim", self.claim())
+        return pr_review_audit.preflightVerdict(request)
+
+    def test_no_snapshot_conflicts_allows_pr(self) -> None:
+        verdict = self.preflight(pullRequests=[])
+
+        self.assertEqual("allow", verdict["verdict"])
+        self.assertTrue(verdict["allowed"])
+        self.assertTrue(verdict["readOnly"])
+        self.assertEqual([], verdict["openDuplicates"])
+        self.assertEqual([], verdict["mergedDuplicates"])
+        self.assertEqual([], verdict["reasons"])
+
+    def test_second_open_pr_for_same_live_claim_is_rejected(self) -> None:
+        verdict = self.preflight(
+            pullRequests=[{"number": 1490, "state": "open", "claimId": self.CLAIM_ID, "headBranch": "codex/other-head"}]
+        )
+
+        self.assertEqual("reject_duplicate_open", verdict["verdict"])
+        self.assertFalse(verdict["allowed"])
+        self.assertEqual([1490], [dup["number"] for dup in verdict["openDuplicates"]])
+        self.assertIn("open PR #1490 duplicates this live claim: open PR carries the same claim id", verdict["reasons"])
+
+    def test_open_pr_with_same_issue_name_and_different_claim_is_rejected(self) -> None:
+        verdict = self.preflight(
+            pullRequests=[
+                {
+                    "number": 1491,
+                    "state": "open",
+                    "claimId": "stale-claim",
+                    "issueName": self.ISSUE,
+                    "headBranch": "codex/old",
+                }
+            ]
+        )
+
+        self.assertEqual("reject_duplicate_open", verdict["verdict"])
+        self.assertEqual("open PR references the same issue name", verdict["openDuplicates"][0]["reason"])
+
+    def test_open_pr_on_same_head_branch_is_rejected(self) -> None:
+        verdict = self.preflight(pullRequests=[{"number": 1492, "state": "open", "headRefName": self.HEAD}])
+
+        self.assertEqual("reject_duplicate_open", verdict["verdict"])
+        self.assertEqual("open PR uses the same head branch", verdict["openDuplicates"][0]["reason"])
+
+    def test_merged_pr_for_same_claim_short_circuits_as_already_delivered(self) -> None:
+        verdict = self.preflight(
+            pullRequests=[{"number": 1480, "state": "merged", "claimId": self.CLAIM_ID, "headBranch": self.HEAD}]
+        )
+
+        self.assertEqual("already_delivered", verdict["verdict"])
+        self.assertFalse(verdict["allowed"])
+        self.assertEqual([1480], [dup["number"] for dup in verdict["mergedDuplicates"]])
+        self.assertIn("terminal queue publication", verdict["recommendedActions"][0])
+
+    def test_merged_pr_on_same_head_without_claim_id_short_circuits(self) -> None:
+        verdict = self.preflight(
+            pullRequests=[{"number": 1481, "state": "closed", "merged": True, "branch": self.HEAD}]
+        )
+
+        self.assertEqual("already_delivered", verdict["verdict"])
+        self.assertEqual("merged PR matches the same head branch", verdict["mergedDuplicates"][0]["reason"])
+
+    def test_open_and_merged_prs_with_different_heads_and_claims_do_not_match(self) -> None:
+        verdict = self.preflight(
+            pullRequests=[
+                {
+                    "number": 1470,
+                    "state": "open",
+                    "claimId": "other-claim",
+                    "issueName": "[EPIC_02][STORY_01][SUBSTORY_01] Other",
+                    "headBranch": "codex/other",
+                },
+                {
+                    "number": 1471,
+                    "state": "merged",
+                    "claimId": "third-claim",
+                    "issueName": "[EPIC_03][STORY_01][SUBSTORY_01] Third",
+                    "headBranch": "codex/third",
+                },
+            ]
+        )
+
+        self.assertEqual("allow", verdict["verdict"])
+        self.assertEqual([], verdict["openDuplicates"])
+        self.assertEqual([], verdict["mergedDuplicates"])
+
+    def test_merged_same_head_under_different_claim_warns_but_allows(self) -> None:
+        verdict = self.preflight(
+            pullRequests=[{"number": 1482, "state": "merged", "claimId": "other-claim", "headBranch": self.HEAD}]
+        )
+
+        self.assertEqual("allow", verdict["verdict"])
+        self.assertTrue(any("under a different claim id" in warning for warning in verdict["warnings"]))
+
+    def test_explicit_replacement_of_open_duplicate_is_allowed(self) -> None:
+        verdict = self.preflight(
+            replaces=1490,
+            pullRequests=[{"number": 1490, "state": "open", "claimId": self.CLAIM_ID, "headBranch": "codex/old-head"}],
+        )
+
+        self.assertEqual("allow_replacement", verdict["verdict"])
+        self.assertTrue(verdict["allowed"])
+        self.assertEqual(1490, verdict["replaces"])
+        self.assertIn(
+            "request explicit human approval before closing the superseded PR", verdict["recommendedActions"][0]
+        )
+
+    def test_replacement_covers_only_declared_pr_and_other_open_duplicate_still_rejects(self) -> None:
+        verdict = self.preflight(
+            replaces=1490,
+            pullRequests=[
+                {"number": 1490, "state": "open", "claimId": self.CLAIM_ID},
+                {"number": 1493, "state": "open", "issueName": self.ISSUE},
+            ],
+        )
+
+        self.assertEqual("reject_duplicate_open", verdict["verdict"])
+        self.assertTrue(any("not covered by the declared replacement" in reason for reason in verdict["reasons"]))
+
+    def test_replacement_target_missing_from_snapshot_cannot_verify(self) -> None:
+        verdict = self.preflight(replaces=999, pullRequests=[])
+
+        self.assertEqual("cannot_verify", verdict["verdict"])
+        self.assertFalse(verdict["allowed"])
+        self.assertIn("declared replacement PR #999 is not present in the snapshot; cannot verify", verdict["reasons"])
+
+    def test_replacement_target_unrelated_to_claim_cannot_verify(self) -> None:
+        verdict = self.preflight(
+            replaces=1470,
+            pullRequests=[
+                {
+                    "number": 1470,
+                    "state": "open",
+                    "claimId": "other",
+                    "issueName": "[EPIC_02][STORY_01][SUBSTORY_01] Other",
+                    "headBranch": "codex/other",
+                }
+            ],
+        )
+
+        self.assertEqual("cannot_verify", verdict["verdict"])
+        self.assertIn(
+            "declared replacement PR #1470 does not match this claim identity; cannot verify", verdict["reasons"]
+        )
+
+    def test_replacement_of_merged_duplicate_allows_re_delivery_with_warning(self) -> None:
+        verdict = self.preflight(
+            replaces=1480,
+            pullRequests=[{"number": 1480, "state": "merged", "claimId": self.CLAIM_ID, "headBranch": self.HEAD}],
+        )
+
+        self.assertEqual("allow_replacement", verdict["verdict"])
+        self.assertIn("explicit replacement of merged PR #1480 re-delivers already-merged work", verdict["warnings"])
+
+    def test_title_collision_alone_is_advisory_not_rejecting(self) -> None:
+        verdict = self.preflight(
+            claim=self.claim(title="[EPIC_01][STORY_04][SUBSTORY_01] #623 Add preflight guard"),
+            pullRequests=[
+                {
+                    "number": 1494,
+                    "state": "open",
+                    "title": "[EPIC_01][STORY_04][SUBSTORY_01]  #623 add Preflight guard",
+                    "headBranch": "codex/unrelated",
+                }
+            ],
+        )
+
+        self.assertEqual("allow", verdict["verdict"])
+        self.assertEqual([], verdict["openDuplicates"])
+        self.assertIn("title collision with open PR #1494; titles are not authoritative identity", verdict["warnings"])
+
+    def test_missing_claim_identity_fails_closed_to_cannot_verify(self) -> None:
+        verdict = pr_review_audit.preflightVerdict(
+            {"claim": {"owner": self.OWNER, "headBranch": self.HEAD}, "pullRequests": []}
+        )
+
+        self.assertEqual("cannot_verify", verdict["verdict"])
+        self.assertFalse(verdict["allowed"])
+        self.assertIn("claim identity is missing: issueName, claimId; cannot verify duplicates", verdict["reasons"])
+
+    def test_missing_head_branch_is_warned_but_claim_matching_still_works(self) -> None:
+        verdict = self.preflight(
+            claim=self.claim(headBranch=""),
+            pullRequests=[{"number": 1490, "state": "open", "claimId": self.CLAIM_ID}],
+        )
+
+        self.assertEqual("reject_duplicate_open", verdict["verdict"])
+        self.assertTrue(any("head branch is missing" in warning for warning in verdict["warnings"]))
+
+    def test_out_of_scope_files_produce_advisory_scope_warning(self) -> None:
+        verdict = self.preflight(
+            claim=self.claim(targetFiles=["scripts/pr_review_audit.py", "tests/test_pr_review_audit.py"]),
+            candidate={"files": ["scripts/pr_review_audit.py", "src/core/CGameContext.cpp"]},
+            pullRequests=[],
+        )
+
+        self.assertEqual("allow", verdict["verdict"])
+        self.assertTrue(verdict["allowed"])
+        self.assertTrue(
+            any(
+                "outside the claimed target files: src/core/CGameContext.cpp" in warning
+                for warning in verdict["warnings"]
+            )
+        )
+
+    def test_broad_diff_file_count_warns_without_rejecting(self) -> None:
+        files = [f"src/generated/file_{index}.cpp" for index in range(pr_review_audit.BROAD_DIFF_FILE_LIMIT + 1)]
+        verdict = self.preflight(candidate={"files": files}, pullRequests=[])
+
+        self.assertEqual("allow", verdict["verdict"])
+        self.assertTrue(any("broad diff with" in warning for warning in verdict["warnings"]))
+
+    def test_workbook_in_candidate_diff_warns(self) -> None:
+        verdict = self.preflight(candidate={"files": [pr_review_audit.WORKBOOK_PATH]}, pullRequests=[])
+
+        self.assertEqual("allow", verdict["verdict"])
+        self.assertTrue(any("touches the queue workbook" in warning for warning in verdict["warnings"]))
+
+    def test_closed_unmerged_matching_pr_warns_but_allows(self) -> None:
+        verdict = self.preflight(pullRequests=[{"number": 1483, "state": "closed", "claimId": self.CLAIM_ID}])
+
+        self.assertEqual("allow", verdict["verdict"])
+        self.assertIn(
+            "closed unmerged PR #1483 previously matched this claim; verify it was superseded", verdict["warnings"]
+        )
+
+    def test_verdict_is_deterministic_and_side_effect_free(self) -> None:
+        request = {
+            "claim": self.claim(targetFiles=["scripts/pr_review_audit.py"]),
+            "candidate": {"files": ["scripts/pr_review_audit.py", "docs/extra.md"]},
+            "pullRequests": [
+                {"number": 1490, "state": "open", "claimId": self.CLAIM_ID},
+                {"number": 1480, "state": "merged", "claimId": self.CLAIM_ID, "headBranch": self.HEAD},
+            ],
+        }
+        snapshotBefore = json.dumps(request, sort_keys=True)
+
+        first = pr_review_audit.preflightVerdict(json.loads(snapshotBefore))
+        second = pr_review_audit.preflightVerdict(json.loads(snapshotBefore))
+
+        self.assertEqual(first, second)
+        self.assertEqual(snapshotBefore, json.dumps(request, sort_keys=True))
+        self.assertTrue(first["readOnly"])
+
+    def test_cli_preflight_subcommand_reports_verdict_and_exit_codes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            allowPath = Path(temp_dir) / "allow.json"
+            allowPath.write_text(
+                json.dumps({"claim": self.claim(), "pullRequests": []}),
+                encoding="utf-8",
+            )
+            rejectPath = Path(temp_dir) / "reject.json"
+            rejectPath.write_text(
+                json.dumps(
+                    {
+                        "claim": self.claim(),
+                        "pullRequests": [{"number": 1490, "state": "open", "claimId": self.CLAIM_ID}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exitCode = pr_review_audit.main(["preflight", "--input", str(allowPath)])
+            self.assertEqual(0, exitCode)
+            self.assertEqual("allow", json.loads(stdout.getvalue())["verdict"])
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exitCode = pr_review_audit.main(["preflight", "--input", str(rejectPath)])
+            self.assertEqual(1, exitCode)
+            self.assertEqual("reject_duplicate_open", json.loads(stdout.getvalue())["verdict"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pr_review_audit.py
+++ b/tests/test_pr_review_audit.py
@@ -1304,6 +1304,33 @@ class PrPreflightTest(unittest.TestCase):
         self.assertEqual("allow_replacement", verdict["verdict"])
         self.assertIn("explicit replacement of merged PR #1480 re-delivers already-merged work", verdict["warnings"])
 
+    def test_object_shaped_snapshot_with_open_duplicate_is_rejected(self) -> None:
+        verdict = self.preflight(
+            snapshot={"pullRequests": [{"number": 1490, "state": "open", "claimId": self.CLAIM_ID}]}
+        )
+
+        self.assertEqual("reject_duplicate_open", verdict["verdict"])
+        self.assertFalse(verdict["allowed"])
+        self.assertEqual([1490], [dup["number"] for dup in verdict["openDuplicates"]])
+
+    def test_object_shaped_snapshot_with_merged_duplicate_short_circuits(self) -> None:
+        verdict = self.preflight(
+            pullRequests={"nodes": [{"number": 1480, "state": "merged", "claimId": self.CLAIM_ID}]}
+        )
+
+        self.assertEqual("already_delivered", verdict["verdict"])
+        self.assertFalse(verdict["allowed"])
+        self.assertEqual([1480], [dup["number"] for dup in verdict["mergedDuplicates"]])
+
+    def test_unrecognized_snapshot_shape_fails_closed_to_cannot_verify(self) -> None:
+        for badSnapshot in ("not-a-list", [42], {"pullRequests": "still-not-a-list"}):
+            with self.subTest(snapshot=badSnapshot):
+                verdict = self.preflight(pullRequests=badSnapshot)
+
+                self.assertEqual("cannot_verify", verdict["verdict"])
+                self.assertFalse(verdict["allowed"])
+                self.assertTrue(any("snapshot has an unrecognized shape" in reason for reason in verdict["reasons"]))
+
     def test_title_collision_alone_is_advisory_not_rejecting(self) -> None:
         verdict = self.preflight(
             claim=self.claim(title="[EPIC_01][STORY_04][SUBSTORY_01] #623 Add preflight guard"),


### PR DESCRIPTION
## Summary

Controller restarts can lose track of already-open or merged implementation PRs; publication depends on correctly correlating the queue issue, claim ID, and PR. This adds a strictly read-only pull-request preflight to `scripts/pr_review_audit.py`:

- New `preflightVerdict()` module function and `preflight` CLI subcommand (`python3 scripts/pr_review_audit.py preflight --input request.json`, JSON in/out like `controller_reconciler.py`). The existing `--input/--format` audit CLI is unchanged.
- The request carries the claim identity (issue name + claim ID + owner + intended head branch + claimed target files), a PR-state snapshot, an optional `candidate.files` diff list, and an optional explicit `replaces` PR number.
- Deterministic verdict taxonomy:
  - `allow` — no open or merged PR matches the live claim.
  - `allow_replacement` — an explicit `replaces` PR number is declared and verified against the snapshot by exact identity (claim ID, issue name, or head branch — never title).
  - `reject_duplicate_open` — a second open PR exists for the same live claim (same claim ID, head branch, or issue name), and is not covered by a declared replacement.
  - `already_delivered` — a merged PR for the same claim/head already delivered the work; short-circuit to terminal queue publication.
  - `cannot_verify` — missing claim identity or an unverifiable replacement fails closed instead of guessing.
- Title collisions and broad diffs are advisory only: files outside the claimed target files, diffs over 25 files, or a workbook file in an implementation diff produce warnings, never rejections, matching the queue's advisory target-file-overlap policy.
- The guard is deterministic and side-effect-free: it evaluates evidence and returns a verdict; it never mutates the queue workbook or any PR. Exit codes 0 (allowed) / 1 (not allowed) / 2 (invalid input) let shell callers gate `gh pr create`.
- `issue_queue.preflightClaimPayload(task, headBranch=...)` builds the claim identity from a queue row in the exact request shape (read-only).
- Short doc updates in `AGENTS.md`, `docs/codex-agent-queue.md`, and `prompts/codex-queue-controller.md` describing when the controller runs the preflight (before every implementation `gh pr create`, especially after restarts).

Worker implementation branch did not modify any queue workbook.

## Tests

- `python3 -m unittest tests.test_pr_review_audit tests.test_issue_queue tests.test_controller_reconciler tests.test_poll_pr_checks tests.test_workbook_queue` — 237 tests, OK.
- New fixtures cover every acceptance case: open duplicate (same claim / same issue name / same head), merged duplicate (same claim, same head without claim id), different heads and claims not matching, explicit replacement (open, merged, partial coverage, missing-from-snapshot, unrelated target), title collision advisory, missing identity fail-closed, missing head branch warning, out-of-scope/broad-diff/workbook scope warnings, closed-unmerged advisory, determinism/side-effect-freedom, and CLI exit codes.
- Queue test `test_preflight_claim_payload_matches_pr_review_audit_contract` round-trips a claimed row into the preflight and verifies the workbook row is unmutated.
- `black --check -l 120`, `python3 -m py_compile`, and `git diff --check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_