### PR TITLE
[EPIC_08][STORY_03][SUBSTORY_01] Replace single creatureClass with ordered class-level records

### DIFF
--- a/docs/design/creature_archetypes.md
+++ b/docs/design/creature_archetypes.md
@@ -640,9 +640,19 @@ creature has an empty track set and keeps the single-class paths bit-identically
   level, default 0) and `order` (the ordering key, default 0).
 - **Attachment** — `CCreature.classTracks` (`std::set` V_PROPERTY, so track
   records serialize/clone exactly like the race/class/template references; no
-  bespoke serializer needed). Tracks apply in ascending `order`, ties broken by
-  configured identity then referenced-class identity
-  (`CCreature::getOrderedClassTracks`).
+  bespoke serializer needed). Tracks apply in ascending `order`; ties break on an
+  explicit chain that exhausts every stable configured field before touching
+  names: track `typeId`, then referenced-class `typeId`, then the per-track
+  `level`, then track/class names (`CCreature::getOrderedClassTracks`).
+  Config-referenced records always carry a stable `typeId`, so distinctly
+  configured tracks always order deterministically; same-order tracks that tie on
+  the whole configured chain (same class identity, same level) contribute
+  identically, so their relative order cannot change the composed result. The one
+  residual shape — same-order fully-anonymous tracks referencing *different*
+  anonymous inline classes — falls back to engine-generated names (stable within
+  a run and across save/load, but not across fresh loads) and is therefore
+  documented-unsupported: give such tracks distinct `order` keys or reference
+  their classes by id.
 - **Precedence vs the single `creatureClass`** — when `classTracks` is non-empty
   the tracks SUBSUME the single `creatureClass` for every class-derived
   contribution (base stats, level growth, actions, mainStat); the `creatureClass`
@@ -673,7 +683,8 @@ creature has an empty track set and keeps the single-class paths bit-identically
   to the contracts above. Pinned by
   `test_no_class_track_creature_composes_bit_identically_to_baseline`,
   `test_creature_class_tracks_fold_deterministically_in_order`,
-  `test_single_class_track_matches_single_creature_class` and
+  `test_single_class_track_matches_single_creature_class`,
+  `test_same_order_class_tracks_tie_break_deterministically` and
   `test_creature_class_track_metadata_round_trip` in
   `tests/unit/test_object.cpp`, plus the clone round-trip
   `test_creature_clone_preserves_class_tracks` in `tests/unit/test_core.cpp`.

--- a/docs/design/creature_archetypes.md
+++ b/docs/design/creature_archetypes.md
@@ -625,6 +625,59 @@ boss/cult status is expressly NOT modeled as a race.
   `test_creature_templates_do_not_replace_race_or_class` and
   `test_creature_template_metadata_round_trip` in `tests/unit/test_object.cpp`.
 
+# Multiclass class-track layer (future mechanics, EPIC_08)
+
+Status: Scaffolding (record object + composition hooks landed; no content uses
+it). Scope: support multiclass creatures by storing ORDERED class-level records
+alongside — not instead of — the single `creatureClass` reference. Every current
+creature has an empty track set and keeps the single-class paths bit-identically.
+
+- **Record object** — `CCreatureClassTrack` (`src/object/CCreatureClassTrack.h`),
+  a CGameObject-derived record like the other archetype definitions (registered
+  in `NativePlugin::register_creatures`, never spawnable, never a `CCreature`
+  subtype). Properties, all with neutral defaults: `creatureClass` (the class the
+  track advances; a null class contributes nothing), `level` (the per-track class
+  level, default 0) and `order` (the ordering key, default 0).
+- **Attachment** — `CCreature.classTracks` (`std::set` V_PROPERTY, so track
+  records serialize/clone exactly like the race/class/template references; no
+  bespoke serializer needed). Tracks apply in ascending `order`, ties broken by
+  configured identity then referenced-class identity
+  (`CCreature::getOrderedClassTracks`).
+- **Precedence vs the single `creatureClass`** — when `classTracks` is non-empty
+  the tracks SUBSUME the single `creatureClass` for every class-derived
+  contribution (base stats, level growth, actions, mainStat); the `creatureClass`
+  reference itself is preserved untouched (never replaced, still serialized).
+  This keeps mixed configurations deterministic: class contributions come from
+  exactly one source — the tracks when present, the single class otherwise. A
+  single track referencing class `K` with level `L` composes identically to the
+  legacy single `creatureClass = K` at creature level `L`.
+- **Stat growth merge** — `CCreature::buildComposedStats` folds, in ascending
+  track order, each track's `class.baseStats` at position 2 and each track's
+  `class.levelStats` multiplied by that TRACK's own `level` at position 4. All
+  other positions (race, creature base, racial advancement, creature levelStats,
+  templates, equipment, effects) are unchanged.
+- **Action merge** — `getEffectiveInteractions` replaces the single-class
+  positions 2-3 with the tracks in ascending order: each track contributes its
+  class's starting actions then its `levelling` unlocks gated by the TRACK's own
+  level. Later tracks win duplicate keys over earlier ones (same dedupe key as
+  the action merge contract), and the concrete creature's own levelling/actions
+  stay most specific, mirroring the template layer's semantics.
+- **Main stat rule** — the FIRST track (in `order`) whose class names a
+  non-empty `mainStat` is authoritative; if no track names one, the composed
+  block falls back to the legacy `creature.baseStats.mainStat`. With no tracks
+  the existing class-first/legacy-fallback rule is untouched.
+- **Deferred (not wired yet)** — XP/level-up flow for tracks: `levelUp()` still
+  advances only the legacy `level`; per-track levels change only via
+  configuration/serialization, exactly like `racialLevel` before its XP design.
+- **Neutrality invariant** — a creature with NO tracks composes bit-identically
+  to the contracts above. Pinned by
+  `test_no_class_track_creature_composes_bit_identically_to_baseline`,
+  `test_creature_class_tracks_fold_deterministically_in_order`,
+  `test_single_class_track_matches_single_creature_class` and
+  `test_creature_class_track_metadata_round_trip` in
+  `tests/unit/test_object.cpp`, plus the clone round-trip
+  `test_creature_clone_preserves_class_tracks` in `tests/unit/test_core.cpp`.
+
 # Developer guide: adding a race, a class, or a monster
 
 Status: Reference. Scope: the concrete, file-level steps for extending the

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -226,14 +226,27 @@ CREATURE_RACE_STATS_SCHEMA_CLASS = "CStats"
 # CCreatureRace and CCreatureClass configs are *referenced definitions* (a race or
 # class template carried by a creature via the "creatureClass"/race reference
 # property), never actors that can be instantiated onto a map or spawned at
-# runtime.  Any config whose effective engine class is one of these -- or which is
-# declared in the dedicated archetype config files -- must therefore be rejected
-# when used as a concrete spawn target: map object types, map tile types, and
-# createObject/addObjectByName script calls.
+# runtime.  The future-mechanics metadata layers (EPIC_08) are referenced
+# definitions in exactly the same sense: CCreatureTemplate overlays (carried via
+# the "templates" set) and CCreatureClassTrack multiclass records (carried via the
+# "classTracks" set) are registered as constructible CGameObjects but are never
+# spawnable actors -- runtime createObject<CMapObject> on one returns null and the
+# spawn is silently skipped.  Any config whose effective engine class is one of
+# these -- or which is declared in the dedicated archetype config files -- must
+# therefore be rejected when used as a concrete spawn target: map object types,
+# map tile types, and createObject/addObjectByName script calls.
 CREATURE_RACE_BASE_CLASS = "CCreatureRace"
 CREATURE_CLASS_BASE_CLASS = "CCreatureClass"
-CREATURE_ARCHETYPE_BASE_CLASSES = (CREATURE_RACE_BASE_CLASS, CREATURE_CLASS_BASE_CLASS)
-CREATURE_ARCHETYPE_DEFINITION_CONFIGS = (CREATURE_RACES_CONFIG, CREATURE_CLASSES_CONFIG)
+CREATURE_TEMPLATE_BASE_CLASS = "CCreatureTemplate"
+CREATURE_CLASS_TRACK_BASE_CLASS = "CCreatureClassTrack"
+CREATURE_TEMPLATES_CONFIG = "creature_templates.json"
+CREATURE_ARCHETYPE_BASE_CLASSES = (
+    CREATURE_RACE_BASE_CLASS,
+    CREATURE_CLASS_BASE_CLASS,
+    CREATURE_TEMPLATE_BASE_CLASS,
+    CREATURE_CLASS_TRACK_BASE_CLASS,
+)
+CREATURE_ARCHETYPE_DEFINITION_CONFIGS = (CREATURE_RACES_CONFIG, CREATURE_CLASSES_CONFIG, CREATURE_TEMPLATES_CONFIG)
 
 # CCreature.creatureClass reference resolution policy (EPIC_06/STORY_01/SUBSTORY_02).
 # A CCreature config carries its class template through the JSON *property*
@@ -4543,14 +4556,16 @@ class ContentValidator:
         return has_ref or (has_class and ("properties" in value or set(value) <= OBJECT_SCHEMA_KEYS))
 
     def _archetype_definition_ids(self, visible: dict[str, ConfigEntry]) -> set[str]:
-        """Resolve config ids that name a CCreatureRace/CCreatureClass *definition*.
+        """Resolve config ids that name an archetype/metadata *definition*.
 
         An id is an archetype definition when its effective engine class (following
-        ``ref`` chains) is one of CREATURE_ARCHETYPE_BASE_CLASSES or inherits from
+        ``ref`` chains) is one of CREATURE_ARCHETYPE_BASE_CLASSES (CCreatureRace,
+        CCreatureClass, CCreatureTemplate, CCreatureClassTrack) or inherits from
         one, or when it is a top-level entry declared in the dedicated archetype
-        config files (creature_races.json / creature_classes.json).  Such ids are
-        referenced definitions, not actors, so using them as a concrete spawn target
-        is rejected.  Resolution is purely structural -- never from id name strings.
+        config files (creature_races.json / creature_classes.json /
+        creature_templates.json).  Such ids are referenced definitions, not actors,
+        so using them as a concrete spawn target is rejected.  Resolution is purely
+        structural -- never from id name strings.
         """
         archetype_ids: set[str] = set()
         for key, entry in visible.items():
@@ -4589,7 +4604,7 @@ class ContentValidator:
             path,
             location,
             f'{label} "{name}" is a creature archetype definition '
-            f"(CCreatureRace/CCreatureClass) and cannot be used as a concrete spawn target",
+            f"({'/'.join(CREATURE_ARCHETYPE_BASE_CLASSES)}) and cannot be used as a concrete spawn target",
         )
         return True
 

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "CCreature.h"
 #include <algorithm>
+#include <tuple>
 #include <vector>
 
 #include "object/CCreatureClass.h"
@@ -1249,23 +1250,29 @@ void CCreature::setClassTracks(std::set<std::shared_ptr<CCreatureClassTrack>> va
 
 std::vector<std::shared_ptr<CCreatureClassTrack>> CCreature::getOrderedClassTracks() {
     std::vector<std::shared_ptr<CCreatureClassTrack>> ordered(classTracks.begin(), classTracks.end());
-    // Deterministic multiclass progression order: ascending `order` key, ties
-    // broken by the track's configured identity (typeId, then name), then by the
-    // referenced class's identity so inline anonymous records still fold in
-    // reproducibly (mirrors getOrderedTemplates).
+    // Deterministic multiclass progression order (docs/design/creature_archetypes.md,
+    // "Multiclass class-track layer"): ascending `order` key, ties broken by an
+    // explicit chain that exhausts every STABLE configured field before touching
+    // names -- track typeId, then referenced-class typeId, then the per-track level.
+    // Config-referenced records always carry a stable typeId, so any tie between
+    // distinctly configured tracks resolves on stable fields; two same-order tracks
+    // that tie on the whole configured chain (same class identity, same level)
+    // contribute identically to stats/actions/mainStat, so their relative order
+    // cannot change the composed result. Only after that do the track/class names
+    // participate: for inline anonymous records those names are engine-generated
+    // (stable within a run and across save/load, but not across fresh loads of the
+    // same authored config), so two same-order fully-anonymous tracks referencing
+    // DIFFERENT anonymous inline classes are a documented-unsupported authoring
+    // shape -- give such tracks distinct `order` keys or reference their classes
+    // by id.
     auto identity = [](const std::shared_ptr<CCreatureClassTrack> &track) {
-        std::string key = track->getTypeId().empty() ? track->getName() : track->getTypeId();
-        if (auto trackClass = track->getCreatureClass()) {
-            key += "/" + (trackClass->getTypeId().empty() ? trackClass->getName() : trackClass->getTypeId());
-        }
-        return key;
+        auto trackClass = track->getCreatureClass();
+        return std::make_tuple(track->getOrder(), track->getTypeId(),
+                               trackClass ? trackClass->getTypeId() : std::string(), track->getLevel(),
+                               track->getName(), trackClass ? trackClass->getName() : std::string());
     };
-    std::sort(ordered.begin(), ordered.end(), [&identity](const auto &lhs, const auto &rhs) {
-        if (lhs->getOrder() != rhs->getOrder()) {
-            return lhs->getOrder() < rhs->getOrder();
-        }
-        return identity(lhs) < identity(rhs);
-    });
+    std::sort(ordered.begin(), ordered.end(),
+              [&identity](const auto &lhs, const auto &rhs) { return identity(lhs) < identity(rhs); });
     return ordered;
 }
 

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <vector>
 
 #include "object/CCreatureClass.h"
+#include "object/CCreatureClassTrack.h"
 #include "object/CCreatureRace.h"
 #include "object/CCreatureTemplate.h"
 
@@ -170,6 +171,14 @@ std::set<std::shared_ptr<CInteraction>> CCreature::getEffectiveInteractions() {
     //   2. class starting actions   -- creatureClass.actions (null on legacy)
     //   3. class level unlocks       -- creatureClass.levelling entries unlocked
     //                                   up to the current level
+    //   2-3 multiclass variant       -- when classTracks is non-empty (future
+    //                                   mechanics, EPIC_08; empty on all current
+    //                                   content) the tracks SUBSUME the single
+    //                                   creatureClass: each track contributes its
+    //                                   class's starting actions then its level
+    //                                   unlocks gated by the TRACK's own level, in
+    //                                   ascending track `order`, so a later track
+    //                                   wins duplicate keys over an earlier one
     //   4. template overlays         -- CCreatureTemplate action additions, applied
     //                                   in ascending template `order` (future
     //                                   mechanics, EPIC_08; empty on all current
@@ -194,11 +203,12 @@ std::set<std::shared_ptr<CInteraction>> CCreature::getEffectiveInteractions() {
         return "N:" + action->getName();
     };
 
-    // Appends every levelling entry whose unlock level is at or below the current
-    // level. Keys are the level at which the entry unlocks (see getLevelAction /
-    // levelUp); a non-numeric key is treated as ungated so no configured action
-    // is silently dropped.
-    auto appendUnlockedLevelling = [&](const CInteractionMap &source) {
+    // Appends every levelling entry whose unlock level is at or below the given
+    // gate level. Keys are the level at which the entry unlocks (see
+    // getLevelAction / levelUp); a non-numeric key is treated as ungated so no
+    // configured action is silently dropped. Single-class and concrete sources
+    // gate on the creature `level`; a multiclass track gates on its own level.
+    auto appendUnlockedLevelling = [&](const CInteractionMap &source, int gateLevel) {
         for (const auto &[levelKey, action] : source) {
             if (!action) {
                 continue;
@@ -209,7 +219,7 @@ std::set<std::shared_ptr<CInteraction>> CCreature::getEffectiveInteractions() {
             } catch (...) {
                 unlockLevel = 0;
             }
-            if (unlockLevel <= level) {
+            if (unlockLevel <= gateLevel) {
                 ordered.push_back(action);
             }
         }
@@ -224,15 +234,33 @@ std::set<std::shared_ptr<CInteraction>> CCreature::getEffectiveInteractions() {
         }
     }
 
-    // 2. class starting actions.
-    if (creatureClass) {
+    // 2-3. class contributions. Non-empty class tracks (multiclass, future-only)
+    // subsume the single creatureClass: class actions come solely from the tracks,
+    // in ascending track order, each track's level unlocks gated by the track's
+    // own level. With no tracks (every current creature) the single-class path
+    // below runs untouched.
+    if (!classTracks.empty()) {
+        for (const auto &track : getOrderedClassTracks()) {
+            auto trackClass = track->getCreatureClass();
+            if (!trackClass) {
+                continue;
+            }
+            for (const auto &action : trackClass->getActions()) {
+                if (action) {
+                    ordered.push_back(action);
+                }
+            }
+            appendUnlockedLevelling(trackClass->getLevelling(), track->getLevel());
+        }
+    } else if (creatureClass) {
+        // 2. class starting actions.
         for (const auto &action : creatureClass->getActions()) {
             if (action) {
                 ordered.push_back(action);
             }
         }
         // 3. class level unlocks: the class's own levelling map, level-gated.
-        appendUnlockedLevelling(creatureClass->getLevelling());
+        appendUnlockedLevelling(creatureClass->getLevelling(), level);
     }
 
     // 4. template overlays: action additions in ascending template order, so a
@@ -247,7 +275,7 @@ std::set<std::shared_ptr<CInteraction>> CCreature::getEffectiveInteractions() {
     }
 
     // 5a. concrete template level unlocks: the creature's own levelling map.
-    appendUnlockedLevelling(levelling);
+    appendUnlockedLevelling(levelling, level);
 
     // 5b. concrete own actions: added last so they win duplicate-key conflicts.
     for (const auto &action : actions) {
@@ -983,6 +1011,13 @@ std::shared_ptr<CStats> CCreature::buildComposedStats() {
     //   3a. race.racialLevelStats per racialLevel (racial advancement; 0 by default)
     //   4. creatureClass.levelStats per level
     //   5. creature.levelStats per level
+    // Multiclass variant (future mechanics, EPIC_08; classTracks is empty on all
+    // current content): when the creature carries class-track records, the tracks
+    // SUBSUME the single creatureClass at positions 2 and 4 -- position 2 folds
+    // each track's class.baseStats in ascending track `order`, position 4 folds
+    // each track's class.levelStats multiplied by that TRACK's own level, in the
+    // same order -- so class-derived stats come solely and deterministically from
+    // the tracks. With no tracks, the single-class code runs untouched.
     //   6. template overlays (ordered) -- CCreatureTemplate.statAdjustments applied
     //      in ascending template `order`, AFTER the race/class/creature stack and
     //      before the external-modifier tail (future mechanics, EPIC_08; empty on
@@ -994,13 +1029,28 @@ std::shared_ptr<CStats> CCreature::buildComposedStats() {
     // set independently empty-guarded: usesArchetypeComposition() only guarantees
     // at least one of race / creatureClass / templates is present.
     std::shared_ptr<CStats> ret = std::make_shared<CStats>();
+    const auto orderedTracks = getOrderedClassTracks();
     // Main stat is a *selected* (not accumulated) field, so it must be set explicitly
     // (CStats::addBonus copies only numeric properties). The creatureClass is
     // authoritative for it (E02/S04/SS03): a class that names a main stat wins over the
     // legacy/race creature.baseStats main stat; with no class, or a class that leaves it
     // empty, this falls back to the legacy creature.baseStats main stat. The composed
     // path must apply this here because archetype creatures never run buildLegacyStats().
-    if (creatureClass && !creatureClass->getMainStat().empty()) {
+    // Multiclass rule: with non-empty classTracks the FIRST track (in `order`) whose
+    // class names a main stat is authoritative -- the tracks subsume the single
+    // creatureClass here too; if no track names one, this falls back to the legacy
+    // creature.baseStats main stat.
+    if (!orderedTracks.empty()) {
+        std::string trackMainStat;
+        for (const auto &track : orderedTracks) {
+            auto trackClass = track->getCreatureClass();
+            if (trackClass && !trackClass->getMainStat().empty()) {
+                trackMainStat = trackClass->getMainStat();
+                break;
+            }
+        }
+        ret->setMainStat(trackMainStat.empty() ? getBaseStats()->getMainStat() : trackMainStat);
+    } else if (creatureClass && !creatureClass->getMainStat().empty()) {
         ret->setMainStat(creatureClass->getMainStat());
     } else {
         ret->setMainStat(getBaseStats()->getMainStat());
@@ -1009,8 +1059,17 @@ std::shared_ptr<CStats> CCreature::buildComposedStats() {
     if (race && race->getBaseStats()) {
         ret->addBonus(race->getBaseStats());
     }
-    // 2. creatureClass.baseStats.
-    if (creatureClass && creatureClass->getBaseStats()) {
+    // 2. class baseStats: each track's class in ascending track order when tracks
+    // are present (subsuming the single creatureClass), otherwise the single
+    // creatureClass exactly as before.
+    if (!orderedTracks.empty()) {
+        for (const auto &track : orderedTracks) {
+            auto trackClass = track->getCreatureClass();
+            if (trackClass && trackClass->getBaseStats()) {
+                ret->addBonus(trackClass->getBaseStats());
+            }
+        }
+    } else if (creatureClass && creatureClass->getBaseStats()) {
         ret->addBonus(creatureClass->getBaseStats());
     }
     // 3. creature.baseStats (concrete template's own base).
@@ -1028,8 +1087,20 @@ std::shared_ptr<CStats> CCreature::buildComposedStats() {
             ret->addBonus(race->getRacialLevelStats());
         }
     }
-    // 4. creatureClass.levelStats per level.
-    if (creatureClass && creatureClass->getLevelStats()) {
+    // 4. class levelStats: each track's class.levelStats multiplied by that
+    // track's own level, in ascending track order, when tracks are present
+    // (subsuming the single creatureClass); otherwise the single
+    // creatureClass.levelStats per creature level exactly as before.
+    if (!orderedTracks.empty()) {
+        for (const auto &track : orderedTracks) {
+            auto trackClass = track->getCreatureClass();
+            if (trackClass && trackClass->getLevelStats()) {
+                for (int i = 0; i < track->getLevel(); i++) {
+                    ret->addBonus(trackClass->getLevelStats());
+                }
+            }
+        }
+    } else if (creatureClass && creatureClass->getLevelStats()) {
         for (int i = 0; i < level; i++) {
             ret->addBonus(creatureClass->getLevelStats());
         }
@@ -1161,6 +1232,43 @@ std::shared_ptr<CCreatureClass> CCreature::getCreatureClass() { return creatureC
 // A null creatureClass is valid: it marks a legacy (non-archetype) creature.
 void CCreature::setCreatureClass(std::shared_ptr<CCreatureClass> value) { creatureClass = value; }
 
+std::set<std::shared_ptr<CCreatureClassTrack>> CCreature::getClassTracks() { return classTracks; }
+
+// An empty class-track set is valid (and is the state of every current creature):
+// it keeps the single creatureClass path bit-identical. Null entries are dropped
+// so the ordered multiclass fold and serialization stay well-formed.
+void CCreature::setClassTracks(std::set<std::shared_ptr<CCreatureClassTrack>> value) {
+    std::set<std::shared_ptr<CCreatureClassTrack>> filtered;
+    for (const auto &track : value) {
+        if (track) {
+            filtered.insert(track);
+        }
+    }
+    classTracks = filtered;
+}
+
+std::vector<std::shared_ptr<CCreatureClassTrack>> CCreature::getOrderedClassTracks() {
+    std::vector<std::shared_ptr<CCreatureClassTrack>> ordered(classTracks.begin(), classTracks.end());
+    // Deterministic multiclass progression order: ascending `order` key, ties
+    // broken by the track's configured identity (typeId, then name), then by the
+    // referenced class's identity so inline anonymous records still fold in
+    // reproducibly (mirrors getOrderedTemplates).
+    auto identity = [](const std::shared_ptr<CCreatureClassTrack> &track) {
+        std::string key = track->getTypeId().empty() ? track->getName() : track->getTypeId();
+        if (auto trackClass = track->getCreatureClass()) {
+            key += "/" + (trackClass->getTypeId().empty() ? trackClass->getName() : trackClass->getTypeId());
+        }
+        return key;
+    };
+    std::sort(ordered.begin(), ordered.end(), [&identity](const auto &lhs, const auto &rhs) {
+        if (lhs->getOrder() != rhs->getOrder()) {
+            return lhs->getOrder() < rhs->getOrder();
+        }
+        return identity(lhs) < identity(rhs);
+    });
+    return ordered;
+}
+
 std::set<std::shared_ptr<CCreatureTemplate>> CCreature::getTemplates() { return templates; }
 
 // An empty template set is valid (and is the state of every current creature): it
@@ -1194,4 +1302,6 @@ std::vector<std::shared_ptr<CCreatureTemplate>> CCreature::getOrderedTemplates()
     return ordered;
 }
 
-bool CCreature::usesArchetypeComposition() { return race != nullptr || creatureClass != nullptr || !templates.empty(); }
+bool CCreature::usesArchetypeComposition() {
+    return race != nullptr || creatureClass != nullptr || !classTracks.empty() || !templates.empty();
+}

--- a/src/object/CCreature.h
+++ b/src/object/CCreature.h
@@ -47,6 +47,8 @@ class CCreatureRace;
 
 class CCreatureClass;
 
+class CCreatureClassTrack;
+
 class CCreatureTemplate;
 
 typedef std::map<std::string, std::shared_ptr<CInteraction>> CInteractionMap;
@@ -71,6 +73,8 @@ class CCreature : public CMapObject, public CMoveable, public CVisitable {
                       setFightController),
            V_PROPERTY(CCreature, std::shared_ptr<CCreatureRace>, race, getRace, setRace),
            V_PROPERTY(CCreature, std::shared_ptr<CCreatureClass>, creatureClass, getCreatureClass, setCreatureClass),
+           V_PROPERTY(CCreature, std::set<std::shared_ptr<CCreatureClassTrack>>, classTracks, getClassTracks,
+                      setClassTracks),
            V_PROPERTY(CCreature, std::set<std::shared_ptr<CCreatureTemplate>>, templates, getTemplates, setTemplates),
            V_PROPERTY(CCreature, bool, npc, isNpc, setNpc), V_METHOD(CCreature, getManaMax, int),
            V_METHOD(CCreature, getHpMax, int), V_METHOD(CCreature, getManaRegRate, int),
@@ -294,6 +298,21 @@ class CCreature : public CMapObject, public CMoveable, public CVisitable {
 
     void setCreatureClass(std::shared_ptr<CCreatureClass> value);
 
+    // Ordered multiclass class-track records (future mechanics, EPIC_08; empty on
+    // every current creature). Each CCreatureClassTrack pairs a CCreatureClass
+    // reference with a per-track level plus an `order` key. When the set is empty
+    // the single creatureClass path above is used untouched; when one or more
+    // tracks are present they SUBSUME the single creatureClass for class-derived
+    // contributions (stats, actions, mainStat) without replacing the reference.
+    std::set<std::shared_ptr<CCreatureClassTrack>> getClassTracks();
+
+    void setClassTracks(std::set<std::shared_ptr<CCreatureClassTrack>> value);
+
+    // The creature's class tracks in their defined application order: ascending
+    // `order` key, ties broken by configured identity so the multiclass fold is
+    // deterministic (mirrors getOrderedTemplates).
+    std::vector<std::shared_ptr<CCreatureClassTrack>> getOrderedClassTracks();
+
     // Optional template overlays (empty on every current creature). Templates are
     // CCreatureTemplate metadata definitions layered AFTER race/class composition;
     // they never replace the race or the creatureClass reference.
@@ -306,10 +325,10 @@ class CCreature : public CMapObject, public CMoveable, public CVisitable {
     // fold-in is deterministic.
     std::vector<std::shared_ptr<CCreatureTemplate>> getOrderedTemplates();
 
-    // True when this creature carries an archetype definition (race/creatureClass)
-    // or a template overlay. Composed stat/action/level behavior branches on this
-    // so partial migrations are explicit and creatures without archetypes or
-    // templates keep the legacy paths exactly.
+    // True when this creature carries an archetype definition (race/creatureClass),
+    // a class-track record, or a template overlay. Composed stat/action/level
+    // behavior branches on this so partial migrations are explicit and creatures
+    // without archetypes, tracks or templates keep the legacy paths exactly.
     bool usesArchetypeComposition();
 
   protected:
@@ -330,6 +349,8 @@ class CCreature : public CMapObject, public CMoveable, public CVisitable {
     std::shared_ptr<CCreatureRace> race;
 
     std::shared_ptr<CCreatureClass> creatureClass;
+
+    std::set<std::shared_ptr<CCreatureClassTrack>> classTracks;
 
     std::set<std::shared_ptr<CCreatureTemplate>> templates;
 

--- a/src/object/CCreatureClassTrack.cpp
+++ b/src/object/CCreatureClassTrack.cpp
@@ -1,0 +1,38 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "CCreatureClassTrack.h"
+#include "object/CCreatureClass.h"
+
+CCreatureClassTrack::CCreatureClassTrack() {}
+
+CCreatureClassTrack::~CCreatureClassTrack() {}
+
+std::shared_ptr<CCreatureClass> CCreatureClassTrack::getCreatureClass() { return creatureClass; }
+
+// A null class is valid: such a track is a degenerate record that contributes
+// nothing to the composed stats/actions (the fold-in null-guards it), so a
+// partially authored track never breaks composition or serialization.
+void CCreatureClassTrack::setCreatureClass(std::shared_ptr<CCreatureClass> value) { creatureClass = value; }
+
+int CCreatureClassTrack::getLevel() { return level; }
+
+void CCreatureClassTrack::setLevel(int value) { level = value; }
+
+int CCreatureClassTrack::getOrder() { return order; }
+
+void CCreatureClassTrack::setOrder(int value) { order = value; }

--- a/src/object/CCreatureClassTrack.h
+++ b/src/object/CCreatureClassTrack.h
@@ -1,0 +1,72 @@
+/*
+fall-of-nouraajd c++ dark fantasy game
+Copyright (C) 2026  Andrzej Lis
+
+This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "object/CGameObject.h"
+
+class CCreatureClass;
+
+// CCreatureClassTrack is a CGameObject-derived *record*, not a CCreature subtype:
+// one entry of a creature's ordered multiclass progression (future mechanics,
+// EPIC_08). Each track pairs a CCreatureClass reference with a per-track class
+// level, plus an `order` key so a creature's tracks fold in deterministically
+// (ascending order, ties broken by configured identity), mirroring how
+// CCreatureTemplate overlays are ordered.
+//
+// Compatibility contract: the track layer is FUTURE-ONLY scaffolding. Every
+// current creature has an empty CCreature.classTracks set and keeps the single
+// CCreature.creatureClass path bit-identically. When one or more tracks are
+// present they SUBSUME the single creatureClass for class-derived contributions
+// (stats, actions, mainStat); the creatureClass reference itself is preserved
+// untouched. See docs/design/creature_archetypes.md, "Multiclass class-track
+// layer".
+//
+// Neutral defaults: a bare track (null class, level 0) contributes nothing. Like
+// CCreatureRace/CCreatureClass/CCreatureTemplate it is never spawnable and never
+// enumerated as a CCreature subtype; it only carries data the composition layer
+// reads.
+class CCreatureClassTrack : public CGameObject {
+
+    V_META(CCreatureClassTrack, CGameObject,
+           V_PROPERTY(CCreatureClassTrack, std::shared_ptr<CCreatureClass>, creatureClass, getCreatureClass,
+                      setCreatureClass),
+           V_PROPERTY(CCreatureClassTrack, int, level, getLevel, setLevel),
+           V_PROPERTY(CCreatureClassTrack, int, order, getOrder, setOrder))
+
+  public:
+    CCreatureClassTrack();
+
+    virtual ~CCreatureClassTrack();
+
+    std::shared_ptr<CCreatureClass> getCreatureClass();
+
+    void setCreatureClass(std::shared_ptr<CCreatureClass> value);
+
+    int getLevel();
+
+    void setLevel(int value);
+
+    int getOrder();
+
+    void setOrder(int value);
+
+  private:
+    std::shared_ptr<CCreatureClass> creatureClass;
+    int level = 0;
+    int order = 0;
+};

--- a/src/plugin/NativePlugin.cpp
+++ b/src/plugin/NativePlugin.cpp
@@ -22,6 +22,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "core/CWrapper.h"
 #include "handler/CObjectHandler.h"
 #include "object/CCreatureClass.h"
+#include "object/CCreatureClassTrack.h"
 #include "object/CCreatureRace.h"
 #include "object/CCreatureTemplate.h"
 #include "object/CDialog.h"
@@ -166,6 +167,10 @@ bool register_creatures(const NativePluginHostV1 *host) {
     // The creature class definition is likewise a CGameObject-derived archetype,
     // not a CCreature, so it stays out of the encounter / subtype enumeration.
     registered = register_type<CCreatureClass, CGameObject>(game) && registered;
+    // The multiclass class-track record (EPIC_08 future mechanics) pairs a
+    // CCreatureClass reference with a per-track level; like the other metadata
+    // definitions it is never spawnable and never a CCreature subtype.
+    registered = register_type<CCreatureClassTrack, CGameObject>(game) && registered;
     // The template overlay definition (elite/undead/... variants, EPIC_08) is also
     // a CGameObject-derived metadata definition referenced via CCreature.templates;
     // it is never spawnable and never a CCreature subtype.

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -1757,6 +1757,66 @@ class ContentValidatorTest(unittest.TestCase):
             "cannot be used as a concrete spawn target",
         )
 
+    def test_creature_template_id_as_spawn_target_is_rejected(self):
+        # CCreatureTemplate overlays (EPIC_08) are referenced definitions carried via
+        # CCreature.templates; runtime createObject<CMapObject> on one returns null and
+        # silently skips the spawn, so the validator must reject them as spawn targets
+        # exactly like race/class definitions.
+        root = self.make_fixture()
+        write_json(
+            root / "res/config/creature_templates.json",
+            {"eliteTemplate": {"class": "CCreatureTemplate", "properties": {"label": "Elite"}}},
+        )
+        map_path = root / "res/maps/broken/map.json"
+        map_data = read_json(map_path)
+        map_data["layers"][1]["objects"][0]["type"] = "eliteTemplate"
+        write_json(map_path, map_data)
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/map.json",
+            "layers[1].objects[0].type",
+            'object type "eliteTemplate" is a creature archetype definition',
+            "cannot be used as a concrete spawn target",
+        )
+
+    def test_class_track_id_as_create_object_target_is_rejected(self):
+        # CCreatureClassTrack multiclass records (EPIC_08) are referenced definitions
+        # carried via CCreature.classTracks; they are constructible metadata, never
+        # spawnable actors, so a script spawn ref naming one must be rejected. Track
+        # records have no dedicated config file, so the guard must catch them purely by
+        # effective engine class.
+        root = self.make_fixture()
+        write_json(
+            root / "res/config/monsters.json",
+            {
+                "warriorTrack": {
+                    "class": "CCreatureClassTrack",
+                    "properties": {"label": "Warrior track", "level": 2},
+                }
+            },
+        )
+        script_path = root / "res/maps/broken/script.py"
+        script_path.write_text(
+            script_path.read_text(encoding="utf-8").replace(
+                'self.getGame().createObject("validMarket")',
+                'self.getGame().createObject("warriorTrack")',
+            ),
+            encoding="utf-8",
+        )
+
+        issues = validate_repo(root)
+
+        self.assertIssueContains(
+            issues,
+            "res/maps/broken/script.py",
+            'createObject("warriorTrack")',
+            'object ref or class "warriorTrack" is a creature archetype definition',
+            "cannot be used as a concrete spawn target",
+        )
+
     def test_concrete_creature_spawn_alongside_archetype_definitions_passes(self):
         root = self.make_fixture()
         write_json(

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -35,6 +35,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "gui/CSdlResources.h"
 #include "object/CCreature.h"
 #include "object/CCreatureClass.h"
+#include "object/CCreatureClassTrack.h"
 #include "object/CCreatureRace.h"
 #include "object/CCreatureTemplate.h"
 #include "object/CEffect.h"
@@ -2571,6 +2572,88 @@ void test_creature_clone_preserves_composed_archetypes() {
                 "mutating the clone's scalar state leaves the source unchanged");
 }
 
+// [EPIC_08][STORY_03][SUBSTORY_01] Multiclass class-track records round-trip
+// through the clone's serialize -> deserialize cycle like the race/class/template
+// references: the track set survives with each record's class reference, per-track
+// level and ordering key intact, and the clone owns independent track instances.
+// Uses the same loaded-game harness as the composed-archetype clone test above so
+// every property type the creature serializes through has a registered serializer.
+void test_creature_clone_preserves_class_tracks() {
+    auto game = CGameLoader::loadGame();
+    CGameLoader::startGame(game, "empty");
+
+    auto subtypes = game->getObjectHandler()->getAllSubTypes("CCreature");
+    expect_true(!subtypes.empty(), "a normally loaded game registers concrete CCreature subtypes to clone");
+    std::sort(subtypes.begin(), subtypes.end());
+    std::shared_ptr<CCreature> source;
+    for (const auto &type : subtypes) {
+        source = game->createObject<CCreature>(type);
+        if (source) {
+            break;
+        }
+    }
+    expect_true(source != nullptr, "a registered CCreature subtype constructs a concrete creature to clone");
+
+    // Register the track type in THIS test binary's CTypes registry first: on
+    // Windows the native plugin is a DLL with its own copy of the CTypes static
+    // registries, so the serializers the plugin registers for CCreatureClassTrack
+    // are invisible to the executable's serialize path (see the CCreatureTemplate
+    // note in the composed-archetype clone test above). Register the class type
+    // too so the nested creatureClass reference serializes regardless of which
+    // tests ran earlier in main().
+    CTypes::register_type_metadata<CCreatureClassTrack, CGameObject>();
+    CTypes::register_type_metadata<CCreatureClass, CGameObject>();
+
+    auto klass = game->createObject<CCreatureClass>("CCreatureClass");
+    expect_true(klass != nullptr, "CCreatureClass is registered and constructs in the loaded game");
+    klass->setMainStat("strength");
+    auto classGrowth = std::make_shared<CStats>();
+    classGrowth->setStrength(2);
+    klass->setLevelStats(classGrowth);
+
+    auto track = game->createObject<CCreatureClassTrack>("CCreatureClassTrack");
+    expect_true(track != nullptr, "CCreatureClassTrack is registered and constructs in the loaded game");
+    track->setCreatureClass(klass);
+    track->setLevel(2);
+    track->setOrder(10);
+
+    source->setName("classTrackSource");
+    source->setClassTracks({track});
+    source->setLevel(1);
+    expect_true(source->usesArchetypeComposition(), "a creature carrying a class track is composed");
+
+    auto clone = source->clone<CCreature>();
+    drain_event_loop();
+
+    expect_true(clone != nullptr, "cloning a class-tracked creature yields a CCreature instance");
+    expect_true(clone->usesArchetypeComposition(), "the clone remains composed after cloning");
+
+    // Track preserved: the record round-trips with its class reference, per-track
+    // level and ordering key. Guard the dereference so a dropped record reports a
+    // FAIL instead of dereferencing an empty set.
+    expect_true(clone->getClassTracks().size() == 1, "the clone retains the class-track record");
+    if (clone->getClassTracks().size() == 1) {
+        auto clonedTrack = *clone->getClassTracks().begin();
+        expect_true(clonedTrack->getLevel() == 2 && clonedTrack->getOrder() == 10,
+                    "the clone's track keeps its per-track level and ordering key");
+        expect_true(clonedTrack->getCreatureClass() != nullptr &&
+                        clonedTrack->getCreatureClass()->getMainStat() == "strength",
+                    "the clone's track keeps its class reference (mainStat identity)");
+        expect_true(clonedTrack->getCreatureClass() && clonedTrack->getCreatureClass()->getLevelStats() &&
+                        clonedTrack->getCreatureClass()->getLevelStats()->getStrength() == 2,
+                    "the clone's track keeps the referenced class's level growth");
+        // The clone owns an independent track instance: mutating it must not write
+        // back through to the source's record.
+        clonedTrack->setLevel(99);
+        expect_true(track->getLevel() == 2, "mutating the clone's track does not write back to the source's track");
+        if (clonedTrack->getCreatureClass()) {
+            clonedTrack->getCreatureClass()->setMainStat("intelligence");
+            expect_true(klass->getMainStat() == "strength",
+                        "mutating the clone's track class does not write back to the source's class");
+        }
+    }
+}
+
 // Build a CStats with the four primary attributes set (the others stay zero).
 static std::shared_ptr<CStats> archetype_stats(int strength, int agility, int stamina, int intelligence) {
     auto stats = std::make_shared<CStats>();
@@ -2735,6 +2818,7 @@ int main() {
     test_levelup_legacy_path_serializes_unlock_into_actions();
     test_levelup_composed_path_unlocks_via_effective_interactions_without_serializing();
     test_creature_clone_preserves_composed_archetypes();
+    test_creature_clone_preserves_class_tracks();
     test_creature_composed_stat_order();
     test_creature_composed_main_stat_selection();
 

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -26,6 +26,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "handler/CTooltipHandler.h"
 #include "object/CCreature.h"
 #include "object/CCreatureClass.h"
+#include "object/CCreatureClassTrack.h"
 #include "object/CCreatureRace.h"
 #include "object/CCreatureTemplate.h"
 #include "object/CDialog.h"
@@ -1644,6 +1645,408 @@ void test_creature_template_metadata_round_trip() {
                 "CCreatureTemplate must not be enumerated as a CCreature subtype");
 }
 
+void test_no_class_track_creature_composes_bit_identically_to_baseline() {
+    // [EPIC_08][STORY_03][SUBSTORY_01] Multiclass class-track records. Neutrality
+    // invariant: the track layer is FUTURE-ONLY, and a creature with NO class
+    // tracks (every creature on current content) composes bit-identically to the
+    // pre-track contracts -- both on the legacy path (no race/class) and on the
+    // composed single-class path. Explicitly assigning an empty track set must be
+    // exactly as neutral as never touching the property.
+
+    // Legacy creature: same source values as the pinned legacy composition tests.
+    auto legacy = std::make_shared<CCreature>();
+    auto legacyBase = std::make_shared<CStats>();
+    legacyBase->setMainStat("intelligence");
+    legacyBase->setIntelligence(10);
+    legacyBase->setStrength(4);
+    legacyBase->setStamina(6);
+    legacy->setBaseStats(legacyBase);
+    auto legacyLevelStats = std::make_shared<CStats>();
+    legacyLevelStats->setIntelligence(2);
+    legacyLevelStats->setStrength(1);
+    legacy->setLevelStats(legacyLevelStats);
+    const int legacyLevel = 3;
+    legacy->setLevel(legacyLevel);
+
+    legacy->setClassTracks({}); // explicit empty set == never configured
+    expect_true(legacy->getClassTracks().empty(), "an explicitly empty class-track set stays empty");
+    expect_true(!legacy->usesArchetypeComposition(),
+                "a creature with no race/class/templates and no class tracks must stay on the legacy stat path");
+
+    auto legacyExpected = std::make_shared<CStats>();
+    legacyExpected->setMainStat(legacyBase->getMainStat());
+    legacyExpected->addBonus(legacyBase);
+    for (int i = 0; i < legacyLevel; ++i) {
+        legacyExpected->addBonus(legacyLevelStats);
+    }
+    auto legacyActual = legacy->getStats();
+    expect_true(legacyActual->getMainStat() == legacyExpected->getMainStat(),
+                "no-track legacy creature getStats should keep the baseStats mainStat");
+    legacyActual->meta()->for_all_properties(legacyActual, [&](auto property) {
+        if (property->value_type() != std::type_index(typeid(int))) {
+            return;
+        }
+        expect_true(legacyActual->getProperty<int>(property->name()) ==
+                        legacyExpected->getProperty<int>(property->name()),
+                    "no-track legacy creature getStats should match the legacy composition bit-identically");
+    });
+
+    // Composed creature (race + single class): the single-class path is untouched
+    // by the (empty) track layer.
+    auto composed = std::make_shared<CCreature>();
+    auto composedBase = std::make_shared<CStats>();
+    composedBase->setMainStat("strength");
+    composedBase->setStrength(4);
+    composedBase->setIntelligence(6);
+    composed->setBaseStats(composedBase);
+    auto raceBase = std::make_shared<CStats>();
+    raceBase->setStrength(2);
+    raceBase->setStamina(3);
+    auto race = std::make_shared<CCreatureRace>();
+    race->setBaseStats(raceBase);
+    composed->setRace(race);
+    auto classBase = std::make_shared<CStats>();
+    classBase->setIntelligence(7);
+    auto classLevel = std::make_shared<CStats>();
+    classLevel->setIntelligence(2);
+    auto klass = std::make_shared<CCreatureClass>();
+    klass->setMainStat("intelligence");
+    klass->setBaseStats(classBase);
+    klass->setLevelStats(classLevel);
+    composed->setCreatureClass(klass);
+    const int composedLevel = 2;
+    composed->setLevel(composedLevel);
+
+    composed->setClassTracks({}); // explicit empty set == never configured
+
+    auto composedExpected = std::make_shared<CStats>();
+    composedExpected->setMainStat(klass->getMainStat());
+    composedExpected->addBonus(raceBase);
+    composedExpected->addBonus(classBase);
+    composedExpected->addBonus(composedBase);
+    for (int i = 0; i < composedLevel; ++i) {
+        composedExpected->addBonus(classLevel);
+    }
+    auto composedActual = composed->getStats();
+    expect_true(composedActual->getMainStat() == "intelligence",
+                "no-track composed creature keeps the class-authoritative mainStat");
+    composedActual->meta()->for_all_properties(composedActual, [&](auto property) {
+        if (property->value_type() != std::type_index(typeid(int))) {
+            return;
+        }
+        expect_true(composedActual->getProperty<int>(property->name()) ==
+                        composedExpected->getProperty<int>(property->name()),
+                    "no-track composed creature getStats should match the single-class composition bit-identically");
+    });
+    expect_true(composed->getEffectiveInteractions().empty(),
+                "an empty class-track set adds no actions to the effective interaction set");
+}
+
+void test_creature_class_tracks_fold_deterministically_in_order() {
+    // [EPIC_08][STORY_03][SUBSTORY_01] Capability: class tracks are an ORDERED
+    // multiclass progression. Stat growth folds each track's class.baseStats and
+    // class.levelStats x the TRACK's own level in ascending `order`; track actions
+    // merge in the same order (later tracks win duplicate keys, concrete creature
+    // actions stay most specific); the first track's class mainStat is
+    // authoritative; and the layer coexists with race/racialLevel/templates.
+    auto interaction = [](const std::string &typeId, const std::string &name) {
+        auto action = std::make_shared<CInteraction>();
+        action->setType("CInteraction");
+        action->setTypeId(typeId);
+        action->setName(name);
+        return action;
+    };
+
+    auto creature = std::make_shared<CCreature>();
+    auto base = std::make_shared<CStats>();
+    base->setMainStat("stamina");
+    base->setStamina(6);
+    base->setStrength(1);
+    base->setIntelligence(1);
+    creature->setBaseStats(base);
+    auto levelStats = std::make_shared<CStats>();
+    levelStats->setStamina(1);
+    creature->setLevelStats(levelStats);
+    const int level = 1;
+    creature->setLevel(level);
+
+    // Coexisting layers: race with racial advancement, plus a template overlay.
+    auto race = std::make_shared<CCreatureRace>();
+    auto raceBase = std::make_shared<CStats>();
+    raceBase->setStamina(2);
+    race->setBaseStats(raceBase);
+    auto racialGrowth = std::make_shared<CStats>();
+    racialGrowth->setStamina(3);
+    race->setRacialLevelStats(racialGrowth);
+    creature->setRace(race);
+    const int racialLevel = 2;
+    creature->setRacialLevel(racialLevel);
+
+    auto overlay = std::make_shared<CCreatureTemplate>();
+    auto overlayStats = std::make_shared<CStats>();
+    overlayStats->setStamina(4);
+    overlay->setStatAdjustments(overlayStats);
+    creature->setTemplates({overlay});
+
+    // Two class tracks with distinct ordering keys; inserted out of order to prove
+    // getOrderedClassTracks sorts by the `order` key, not insertion order.
+    auto warriorAttack = interaction("Attack", "warriorAttack");
+    auto warriorEmpower = interaction("Empower", "warriorEmpower");
+    auto warriorCleave = interaction("Cleave", "warriorCleave");
+    auto warrior = std::make_shared<CCreatureClass>();
+    warrior->setMainStat("strength");
+    auto warriorBase = std::make_shared<CStats>();
+    warriorBase->setStrength(2);
+    warrior->setBaseStats(warriorBase);
+    auto warriorGrowth = std::make_shared<CStats>();
+    warriorGrowth->setStrength(1);
+    warrior->setLevelStats(warriorGrowth);
+    warrior->setActions({warriorAttack, warriorEmpower});
+    warrior->setLevelling({{"2", warriorCleave}});
+
+    auto mageEmpower = interaction("Empower", "mageEmpower");
+    auto mage = std::make_shared<CCreatureClass>();
+    mage->setMainStat("intelligence");
+    auto mageBase = std::make_shared<CStats>();
+    mageBase->setIntelligence(4);
+    mage->setBaseStats(mageBase);
+    auto mageGrowth = std::make_shared<CStats>();
+    mageGrowth->setIntelligence(2);
+    mage->setLevelStats(mageGrowth);
+    mage->setActions({mageEmpower});
+
+    auto warriorTrack = std::make_shared<CCreatureClassTrack>();
+    warriorTrack->setTypeId("warriorTrack");
+    warriorTrack->setOrder(10);
+    warriorTrack->setCreatureClass(warrior);
+    warriorTrack->setLevel(3);
+
+    auto mageTrack = std::make_shared<CCreatureClassTrack>();
+    mageTrack->setTypeId("mageTrack");
+    mageTrack->setOrder(20);
+    mageTrack->setCreatureClass(mage);
+    mageTrack->setLevel(2);
+
+    creature->setClassTracks({mageTrack, warriorTrack});
+    expect_true(creature->usesArchetypeComposition(), "a creature carrying class tracks uses the composed stat path");
+
+    auto orderedTracks = creature->getOrderedClassTracks();
+    expect_true(orderedTracks.size() == 2 && orderedTracks[0] == warriorTrack && orderedTracks[1] == mageTrack,
+                "getOrderedClassTracks should sort tracks by ascending order key, not insertion order");
+
+    // Stats: each track folds its class.baseStats plus class.levelStats x its OWN
+    // track level; race base, racial advancement, the creature's own base/level
+    // growth and the template overlay all keep their documented positions.
+    auto stats = creature->getStats();
+    expect_true(stats->getStamina() ==
+                    2 /*race*/ + 6 /*base*/ + racialLevel * 3 /*racial*/ + level * 1 /*own growth*/ + 4 /*template*/,
+                "class tracks must not disturb race/racial/own-growth/template stat sources");
+    expect_true(stats->getStrength() == 1 /*base*/ + 2 /*warrior base*/ + 3 * 1 /*warrior growth x track level*/,
+                "the first track folds its class base stats and level growth by the track's own level");
+    expect_true(stats->getIntelligence() == 1 /*base*/ + 4 /*mage base*/ + 2 * 2 /*mage growth x track level*/,
+                "the second track folds its class base stats and level growth by the track's own level");
+    expect_true(stats->getMainStat() == "strength",
+                "the first track's class mainStat is authoritative over the creature's baseStats mainStat");
+
+    auto effectiveContains = [&creature](const std::shared_ptr<CInteraction> &action) {
+        auto effective = creature->getEffectiveInteractions();
+        return effective.find(action) != effective.end();
+    };
+
+    // Track level unlocks gate on the TRACK's level, not the creature level: the
+    // warrior unlock opens at class level 2 while the creature level is only 1.
+    expect_true(effectiveContains(warriorCleave),
+                "a track's class levelling unlocks gate on the track's own level, not the creature level");
+    // Later tracks win duplicate action keys over earlier tracks.
+    expect_true(effectiveContains(mageEmpower) && !effectiveContains(warriorEmpower),
+                "the later-ordered track should win duplicate action keys between tracks");
+
+    // The ordering key drives the fold-in: pushing the warrior track past the mage
+    // track flips both the duplicate-action winner and the authoritative mainStat.
+    warriorTrack->setOrder(30);
+    expect_true(effectiveContains(warriorEmpower) && !effectiveContains(mageEmpower),
+                "changing the order key must change the track application order");
+    expect_true(creature->getStats()->getMainStat() == "intelligence",
+                "changing the order key must move the mainStat authority to the new first track");
+    warriorTrack->setOrder(10);
+
+    // Concrete creature actions stay most specific over track class actions.
+    auto concreteAttack = interaction("Attack", "concreteAttack");
+    creature->addAction(concreteAttack);
+    expect_true(effectiveContains(concreteAttack) && !effectiveContains(warriorAttack),
+                "concrete creature actions should stay most specific over track class actions");
+}
+
+void test_single_class_track_matches_single_creature_class() {
+    // [EPIC_08][STORY_03][SUBSTORY_01] Single-class compatibility: one track
+    // referencing class K at level L composes exactly like the legacy single
+    // creatureClass = K at creature level L -- stats, mainStat and effective
+    // actions. And when tracks and the single creatureClass are BOTH set, the
+    // tracks subsume the single class's contributions without replacing the
+    // reference.
+    auto interaction = [](const std::string &typeId, const std::string &name) {
+        auto action = std::make_shared<CInteraction>();
+        action->setType("CInteraction");
+        action->setTypeId(typeId);
+        action->setName(name);
+        return action;
+    };
+
+    auto classAttack = interaction("Attack", "classAttack");
+    auto classUnlock = interaction("Cleave", "classUnlock");
+    auto klass = std::make_shared<CCreatureClass>();
+    klass->setMainStat("intelligence");
+    auto classBase = std::make_shared<CStats>();
+    classBase->setIntelligence(4);
+    classBase->setStamina(1);
+    klass->setBaseStats(classBase);
+    auto classGrowth = std::make_shared<CStats>();
+    classGrowth->setIntelligence(2);
+    klass->setLevelStats(classGrowth);
+    klass->setActions({classAttack});
+    klass->setLevelling({{"2", classUnlock}});
+
+    const int level = 2;
+    auto makeCreature = [&level]() {
+        auto creature = std::make_shared<CCreature>();
+        auto base = std::make_shared<CStats>();
+        base->setMainStat("strength");
+        base->setStrength(5);
+        base->setIntelligence(10);
+        creature->setBaseStats(base);
+        auto growth = std::make_shared<CStats>();
+        growth->setIntelligence(1);
+        creature->setLevelStats(growth);
+        creature->setLevel(level);
+        return creature;
+    };
+
+    // Baseline: legacy single creatureClass at creature level 2.
+    auto single = makeCreature();
+    single->setCreatureClass(klass);
+
+    // Equivalent: one class track (same class, track level == creature level).
+    auto track = std::make_shared<CCreatureClassTrack>();
+    track->setCreatureClass(klass);
+    track->setLevel(level);
+    auto tracked = makeCreature();
+    tracked->setClassTracks({track});
+
+    auto singleStats = single->getStats();
+    auto trackedStats = tracked->getStats();
+    expect_true(trackedStats->getMainStat() == singleStats->getMainStat(),
+                "a single class track selects the same authoritative mainStat as the single creatureClass");
+    trackedStats->meta()->for_all_properties(trackedStats, [&](auto property) {
+        if (property->value_type() != std::type_index(typeid(int))) {
+            return;
+        }
+        expect_true(trackedStats->getProperty<int>(property->name()) == singleStats->getProperty<int>(property->name()),
+                    "a single class track composes stats identically to the same single creatureClass");
+    });
+
+    auto actionKeys = [](const std::shared_ptr<CCreature> &creature) {
+        std::set<std::string> keys;
+        for (const auto &action : creature->getEffectiveInteractions()) {
+            keys.insert(action->getTypeId());
+        }
+        return keys;
+    };
+    expect_true(actionKeys(tracked) == actionKeys(single),
+                "a single class track exposes the same effective actions (starting + level unlocks) as the single "
+                "creatureClass");
+    expect_true(actionKeys(tracked).count("Cleave") == 1,
+                "the class level unlock is exposed in both the single-class and single-track compositions");
+
+    // Precedence when both are set: non-empty tracks subsume the single class's
+    // contributions -- setting an additional single creatureClass changes nothing
+    // -- while the reference itself is preserved, not replaced.
+    auto other = std::make_shared<CCreatureClass>();
+    other->setMainStat("stamina");
+    auto otherBase = std::make_shared<CStats>();
+    otherBase->setStamina(50);
+    other->setBaseStats(otherBase);
+    tracked->setCreatureClass(other);
+
+    auto subsumedStats = tracked->getStats();
+    expect_true(subsumedStats->getMainStat() == singleStats->getMainStat(),
+                "non-empty tracks keep mainStat authority over an additionally set single creatureClass");
+    subsumedStats->meta()->for_all_properties(subsumedStats, [&](auto property) {
+        if (property->value_type() != std::type_index(typeid(int))) {
+            return;
+        }
+        expect_true(subsumedStats->getProperty<int>(property->name()) ==
+                        singleStats->getProperty<int>(property->name()),
+                    "non-empty tracks subsume the single creatureClass stat contributions entirely");
+    });
+    expect_true(CGameObject::sameInstance(tracked->getCreatureClass(), other),
+                "the single creatureClass reference is preserved (not replaced) when tracks are present");
+}
+
+void test_creature_class_track_metadata_round_trip() {
+    // [EPIC_08][STORY_03][SUBSTORY_01] CCreatureClassTrack is a CGameObject-derived
+    // record that serializes like the other archetype definitions: its class
+    // reference, per-track level and ordering key (plus inherited label) survive a
+    // CSerialization round-trip, it deserializes back into a CCreatureClassTrack,
+    // and it is never enumerated as a CCreature subtype.
+    CTypes::register_type_metadata<CCreatureClassTrack, CGameObject>();
+    CTypes::register_type_metadata<CCreatureClass, CGameObject>();
+    CTypes::register_type_metadata<CStats, CGameObject>();
+    CTypes::register_type_metadata<CInteraction, CGameObject>();
+
+    auto game = std::make_shared<CGame>();
+    game->getObjectHandler()->registerType(CCreatureClassTrack::static_meta()->name(),
+                                           []() { return std::make_shared<CCreatureClassTrack>(); });
+    game->getObjectHandler()->registerType(CCreatureClass::static_meta()->name(),
+                                           []() { return std::make_shared<CCreatureClass>(); });
+    game->getObjectHandler()->registerType(CStats::static_meta()->name(), []() { return std::make_shared<CStats>(); });
+    game->getObjectHandler()->registerType(CInteraction::static_meta()->name(),
+                                           []() { return std::make_shared<CInteraction>(); });
+
+    // Neutral defaults: a bare track is a no-op record.
+    auto fresh = std::make_shared<CCreatureClassTrack>();
+    expect_true(fresh->getLevel() == 0 && fresh->getOrder() == 0, "level and order should default to the neutral 0");
+    expect_true(fresh->getCreatureClass() == nullptr,
+                "a fresh track carries no class reference (a null class contributes nothing)");
+
+    auto klass = std::make_shared<CCreatureClass>();
+    klass->setMainStat("strength");
+    auto classBase = std::make_shared<CStats>();
+    classBase->setStrength(3);
+    klass->setBaseStats(classBase);
+
+    auto track = std::make_shared<CCreatureClassTrack>();
+    track->setGame(game);
+    track->setCreatureClass(klass);
+    track->setLevel(3);
+    track->setOrder(10);
+    track->setLabel("Warrior track");
+
+    auto serialized = CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::serialize(track);
+    expect_true((*serialized)["class"].get<std::string>() == CCreatureClassTrack::static_meta()->name(),
+                "a serialized CCreatureClassTrack should keep its record class identity");
+
+    auto round_trip = std::dynamic_pointer_cast<CCreatureClassTrack>(
+        CSerializerFunction<std::shared_ptr<json>, std::shared_ptr<CGameObject>>::deserialize(game, serialized));
+    expect_true(round_trip != nullptr,
+                "a CCreatureClassTrack should deserialize back into a CCreatureClassTrack, not a creature");
+    expect_true(round_trip->getCreatureClass() != nullptr &&
+                    round_trip->getCreatureClass()->getMainStat() == "strength",
+                "the class reference (and its mainStat identity) should survive the round-trip");
+    expect_true(round_trip->getCreatureClass()->getBaseStats() &&
+                    round_trip->getCreatureClass()->getBaseStats()->getStrength() == 3,
+                "the referenced class's base stats should survive the round-trip");
+    expect_true(round_trip->getLevel() == 3, "the per-track level should survive the round-trip");
+    expect_true(round_trip->getOrder() == 10, "the ordering key should survive the round-trip");
+    expect_true(round_trip->getLabel() == "Warrior track", "inherited label should survive the round-trip");
+
+    // A track record is not a creature subtype, so it must never appear in the
+    // CCreature subtype enumeration (random encounters / spawn tables).
+    auto creatureSubtypes = game->getObjectHandler()->getAllSubTypes("CCreature");
+    expect_true(std::find(creatureSubtypes.begin(), creatureSubtypes.end(),
+                          CCreatureClassTrack::static_meta()->name()) == creatureSubtypes.end(),
+                "CCreatureClassTrack must not be enumerated as a CCreature subtype");
+}
+
 void test_creature_archetype_identity_accessors_use_fallbacks() {
     auto creature = std::make_shared<CCreature>();
 
@@ -2485,6 +2888,10 @@ int main() {
     test_creature_templates_compose_after_race_and_class_in_order();
     test_creature_templates_do_not_replace_race_or_class();
     test_creature_template_metadata_round_trip();
+    test_no_class_track_creature_composes_bit_identically_to_baseline();
+    test_creature_class_tracks_fold_deterministically_in_order();
+    test_single_class_track_matches_single_creature_class();
+    test_creature_class_track_metadata_round_trip();
     test_creature_archetype_identity_accessors_use_fallbacks();
     test_creature_effective_interactions_compose_and_dedupe_sources();
     test_creature_effective_interactions_compose_archetype_sources();

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -1982,6 +1982,76 @@ void test_single_class_track_matches_single_creature_class() {
                 "the single creatureClass reference is preserved (not replaced) when tracks are present");
 }
 
+void test_same_order_class_tracks_tie_break_deterministically() {
+    // [EPIC_08][STORY_03][SUBSTORY_01] Determinism for equal `order` keys: the
+    // tie-break chain exhausts every stable configured field before touching names
+    // -- track typeId, then referenced-class typeId, then per-track level -- so
+    // same-order tracks never fall to the backing set's pointer order. Each case
+    // asserts the fold order for BOTH insertion orders of the same two records.
+    auto orderedFor = [](const std::shared_ptr<CCreatureClassTrack> &a, const std::shared_ptr<CCreatureClassTrack> &b) {
+        auto creature = std::make_shared<CCreature>();
+        creature->setClassTracks({a, b});
+        auto forward = creature->getOrderedClassTracks();
+        creature->setClassTracks({b, a});
+        auto reversed = creature->getOrderedClassTracks();
+        expect_true(forward.size() == 2 && reversed.size() == 2 && forward[0] == reversed[0] &&
+                        forward[1] == reversed[1],
+                    "same-order tracks must sort identically regardless of insertion order");
+        return forward;
+    };
+
+    // Case 1: equal order, distinct track typeIds -- the track typeId decides.
+    auto klass = std::make_shared<CCreatureClass>();
+    klass->setTypeId("warriorClass");
+    auto trackA = std::make_shared<CCreatureClassTrack>();
+    trackA->setTypeId("aTrack");
+    trackA->setCreatureClass(klass);
+    auto trackB = std::make_shared<CCreatureClassTrack>();
+    trackB->setTypeId("bTrack");
+    trackB->setCreatureClass(klass);
+    auto byTypeId = orderedFor(trackA, trackB);
+    expect_true(byTypeId.size() == 2 && byTypeId[0] == trackA && byTypeId[1] == trackB,
+                "equal-order tracks tie-break on the track typeId first");
+
+    // Case 2: equal order, anonymous tracks, distinct class typeIds -- the
+    // referenced class's typeId decides.
+    auto mage = std::make_shared<CCreatureClass>();
+    mage->setTypeId("mageClass");
+    mage->setMainStat("intelligence");
+    auto warrior = std::make_shared<CCreatureClass>();
+    warrior->setTypeId("warriorClass");
+    warrior->setMainStat("strength");
+    auto mageTrack = std::make_shared<CCreatureClassTrack>();
+    mageTrack->setCreatureClass(mage);
+    auto warriorTrack = std::make_shared<CCreatureClassTrack>();
+    warriorTrack->setCreatureClass(warrior);
+    auto byClass = orderedFor(mageTrack, warriorTrack);
+    expect_true(byClass.size() == 2 && byClass[0] == mageTrack && byClass[1] == warriorTrack,
+                "anonymous equal-order tracks tie-break on the referenced class typeId");
+    // The stable tie-break drives observable composition: the first track's class
+    // mainStat is authoritative for both insertion orders.
+    auto creature = std::make_shared<CCreature>();
+    auto base = std::make_shared<CStats>();
+    base->setMainStat("stamina");
+    creature->setBaseStats(base);
+    creature->setClassTracks({warriorTrack, mageTrack});
+    expect_true(creature->getStats()->getMainStat() == "intelligence",
+                "mainStat authority follows the deterministic tie-break, not insertion or pointer order");
+
+    // Case 3: equal order, anonymous tracks of the SAME class -- the per-track
+    // level decides (ascending), keeping the fold reproducible; and because the
+    // class is the same, either relative order composes identical stats anyway.
+    auto low = std::make_shared<CCreatureClassTrack>();
+    low->setCreatureClass(warrior);
+    low->setLevel(1);
+    auto high = std::make_shared<CCreatureClassTrack>();
+    high->setCreatureClass(warrior);
+    high->setLevel(3);
+    auto byLevel = orderedFor(low, high);
+    expect_true(byLevel.size() == 2 && byLevel[0] == low && byLevel[1] == high,
+                "same-class equal-order tracks tie-break on the per-track level");
+}
+
 void test_creature_class_track_metadata_round_trip() {
     // [EPIC_08][STORY_03][SUBSTORY_01] CCreatureClassTrack is a CGameObject-derived
     // record that serializes like the other archetype definitions: its class
@@ -2891,6 +2961,7 @@ int main() {
     test_no_class_track_creature_composes_bit_identically_to_baseline();
     test_creature_class_tracks_fold_deterministically_in_order();
     test_single_class_track_matches_single_creature_class();
+    test_same_order_class_tracks_tie_break_deterministically();
     test_creature_class_track_metadata_round_trip();
     test_creature_archetype_identity_accessors_use_fallbacks();
     test_creature_effective_interactions_compose_and_dedupe_sources();


### PR DESCRIPTION
## Summary

Future-gated multiclass scaffolding per the spec ("support multiclass creatures by storing ordered class-level records rather than a single creatureClass pointer. Preserve single-class compatibility..."): ordered class-track records are introduced **alongside** the existing single `creatureClass` reference, with **zero behavior change** for existing content.

- **New record object** — `CCreatureClassTrack` (`src/object/CCreatureClassTrack.h/.cpp`), a CGameObject-derived metadata record like `CCreatureRace`/`CCreatureClass`/`CCreatureTemplate`: a `creatureClass` reference, a per-track `level`, and an `order` key, all with neutral defaults. Registered in `NativePlugin::register_creatures`, so it is constructible from config but never spawnable and never a `CCreature` subtype.
- **Attachment** — `CCreature.classTracks` (`std::set` V_PROPERTY, default empty), plus `getOrderedClassTracks()` (ascending `order`, configured-identity tie-break, mirroring `getOrderedTemplates`). Track records serialize/clone through the existing game-object container serialization — `src/core/CSerialization.cpp` needed **no changes**.
- **Multiclass merge semantics** (documented in `docs/design/creature_archetypes.md`, "Multiclass class-track layer"), exercised ONLY when tracks are present:
  - **Precedence** — non-empty tracks SUBSUME the single `creatureClass` for every class-derived contribution (base stats, level growth, actions, mainStat); the `creatureClass` reference itself is preserved untouched. Class contributions therefore always come from exactly one deterministic source.
  - **Stat growth** — `buildComposedStats` folds each track's `class.baseStats` (position 2) and `class.levelStats` × the TRACK's own level (position 4), in ascending track order. All other positions (race, creature base, racial advancement `3a`, creature levelStats, template overlay, equipment, effects) unchanged.
  - **Actions** — `getEffectiveInteractions` replaces the single-class positions 2-3 with the tracks in order: class starting actions then `levelling` unlocks gated by the TRACK's own level; later tracks win duplicate keys, concrete creature actions stay most specific (mirrors the template layer's documented semantics).
  - **mainStat** — the first track (in order) whose class names a non-empty mainStat is authoritative; otherwise fall back to the legacy `creature.baseStats.mainStat`. With no tracks the existing class-first rule is untouched.
- **Neutrality** — with an empty track set (every current creature and save), the legacy and single-class composed paths run through their original branches untouched and compose bit-identically; a single track referencing class K at level L composes identically to the legacy single `creatureClass = K` at creature level L.
- **Deferred** — XP/level-up wiring for track levels: `levelUp()` still advances only the legacy `level`; per-track levels change only via configuration/serialization (same staging as the `racialLevel` precedent).

## Tests

`tests/unit/test_object.cpp`:
- `test_no_class_track_creature_composes_bit_identically_to_baseline` — neutrality on both the legacy and the composed single-class path with an explicitly empty track set.
- `test_creature_class_tracks_fold_deterministically_in_order` — two out-of-order-inserted tracks fold by `order` key; per-track level gating of unlocks; later-track duplicate wins; order-key flip flips both the action winner and the mainStat authority; coexists with race/racialLevel/template layers; concrete actions stay most specific.
- `test_single_class_track_matches_single_creature_class` — one track ≡ the same single creatureClass (stats, mainStat, effective actions), and tracks subsume an additionally set single creatureClass while preserving the reference.
- `test_creature_class_track_metadata_round_trip` — record defaults and a full CSerialization round-trip of class ref + level + order + label; not enumerated as a CCreature subtype.

`tests/unit/test_core.cpp`:
- `test_creature_clone_preserves_class_tracks` — clone (serialize → deserialize) round-trip of a tracked creature in a fully loaded game, with executable-side `CTypes::register_type_metadata` for the new type (Windows DLL registry isolation) and guarded dereferences of the cloned set.

All changed TUs pass `g++ -std=c++23 -fsyntax-only`; `clang-format` applied; `git diff --check` clean; `scripts/validate_content.py` passes (no config touched).

Worker implementation branch did not modify any queue workbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdodZrjPToZ48BkaoAfmPn)_