### PR TITLE
Route standalone chapter victories to the next map

### DIFF
--- a/res/maps/gravemoor/script.py
+++ b/res/maps/gravemoor/script.py
@@ -125,7 +125,7 @@ def load(self, context):
                     f"{SPARE_GOLD_REWARD} gold - and swears his ledgers to the Warden's cause. "
                     "The loyalists watch you spare him, and remember."
                 )
-            campaign.complete_scenario(self.getGame(), "spared")
+            campaign.complete_scenario(self.getGame(), "spared", fallback_map="usurpergate")
 
         def execute_voss(self):
             game_map = self.getGame().getMap()
@@ -137,7 +137,7 @@ def load(self, context):
                     f"The moor takes the traitor. His purse - {EXECUTE_GOLD_REWARD} gold - goes to the freed. "
                     "The loyalists watch you do it, and remember that too."
                 )
-            campaign.complete_scenario(self.getGame(), "executed")
+            campaign.complete_scenario(self.getGame(), "executed", fallback_map="usurpergate")
 
     @trigger(context, "onEnter", "quartermasterVoss")
     class VossTrigger(CTrigger):

--- a/res/maps/hearthfall/script.py
+++ b/res/maps/hearthfall/script.py
@@ -54,6 +54,7 @@ def load(self, context):
             if not game_map.getBoolProperty("victory_reported"):
                 return "Bring word of the captain's fall to Elder Maren."
             return "Hearthfall is free. The road leads north into the Gravemoor."
+
         def getReward(self):
             return f"{VICTORY_GOLD_REWARD} gold from the village's hidden purse, and the road north."
 
@@ -88,7 +89,7 @@ def load(self, context):
                     "Maren presses the village's hidden purse into your hands. 'The Gravemoor holds our people. "
                     "Bring them home, Warden.'"
                 )
-            campaign.complete_scenario(self.getGame(), "completed")
+            campaign.complete_scenario(self.getGame(), "completed", fallback_map="gravemoor")
 
     @trigger(context, "onEnter", "elderMaren")
     class ElderTrigger(CTrigger):
@@ -111,6 +112,4 @@ def load(self, context):
     @trigger(context, "onDestroy", "occupierGate")
     class GateSentryTrigger(CTrigger):
         def trigger(self, object, event):
-            object.getGame().getGuiHandler().showMessage(
-                "The gate sentry falls. The road into Hearthfall stands open."
-            )
+            object.getGame().getGuiHandler().showMessage("The gate sentry falls. The road into Hearthfall stands open.")

--- a/test.py
+++ b/test.py
@@ -5156,10 +5156,20 @@ def walkthrough_hearthfall_map():
     player.checkQuests()
     assert "hearthfallQuest" in completed_quest_names(player), "The Hearthfall quest should complete."
 
+    # Reporting the victory opens the road north: standalone play follows the
+    # fallback route to the Gravemoor once the chapter is complete.
+    captain_defeated = game_map.getBoolProperty("captain_defeated")
+    victory_reported = game_map.getBoolProperty("victory_reported")
+    scene_manager = g.getSceneManager()
+    assert scene_manager.getTransitionStateName() == "TransitionPending", "Victory should request the road north."
+    pump_event_loop(10)
+    assert g.getMap().mapName == "gravemoor", "Standalone victory should travel to the Gravemoor."
+    assert g.getMap().getPlayer() == player, "The same player should walk the road north."
+
     return {
-        "map": "hearthfall",
-        "captain_defeated": game_map.getBoolProperty("captain_defeated"),
-        "victory_reported": game_map.getBoolProperty("victory_reported"),
+        "map": g.getMap().mapName,
+        "captain_defeated": captain_defeated,
+        "victory_reported": victory_reported,
         "gold": player.getGold(),
         "quest_completed": "hearthfallQuest" in completed_quest_names(player),
     }
@@ -5201,11 +5211,22 @@ def walkthrough_gravemoor_map():
     player.checkQuests()
     assert "gravemoorQuest" in completed_quest_names(player), "The Gravemoor quest should complete."
 
+    # Passing judgment opens the road to the Usurper's Gate: standalone play
+    # follows the fallback route once the chapter is complete.
+    loyalists_freed = game_map.getNumericProperty("loyalists_freed")
+    voss_judged = game_map.getBoolProperty("voss_judged")
+    voss_spared = game_map.getBoolProperty("voss_spared")
+    scene_manager = g.getSceneManager()
+    assert scene_manager.getTransitionStateName() == "TransitionPending", "Judgment should request the road onward."
+    pump_event_loop(10)
+    assert g.getMap().mapName == "usurpergate", "Standalone judgment should travel to the Usurper's Gate."
+    assert g.getMap().getPlayer() == player, "The same player should walk the road onward."
+
     return {
-        "map": "gravemoor",
-        "loyalists_freed": game_map.getNumericProperty("loyalists_freed"),
-        "voss_judged": game_map.getBoolProperty("voss_judged"),
-        "voss_spared": game_map.getBoolProperty("voss_spared"),
+        "map": g.getMap().mapName,
+        "loyalists_freed": loyalists_freed,
+        "voss_judged": voss_judged,
+        "voss_spared": voss_spared,
         "gold": player.getGold(),
         "quest_completed": "gravemoorQuest" in completed_quest_names(player),
     }
@@ -17897,6 +17918,60 @@ class GameTest(unittest.TestCase):
                 "player_name": player.getName(),
                 "quests": quest_names(player),
                 "wands": player.countItems("magicWand"),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
+    def test_standalone_hearthfall_victory_travels_to_gravemoor(self):
+        g, game_map, player = load_game_map_with_player("hearthfall")
+        scene_manager = g.getSceneManager()
+
+        game_map.removeObjectByName("watchCaptain")
+        self.assertTrue(game_map.getBoolProperty("captain_defeated"))
+
+        g.createObject("elderDialog").report_victory()
+        self.assertEqual("TransitionPending", scene_manager.getTransitionStateName())
+        pump_event_loop(10)
+
+        self.assertEqual("gravemoor", g.getMap().mapName)
+        self.assertTrue(g.getMap().getPlayer() == player)
+        self.assertEqual("Idle", scene_manager.getTransitionStateName())
+
+        return True, json.dumps(
+            {
+                "current_map": g.getMap().mapName,
+                "manager": scene_manager.getTransitionStateName(),
+                "player_name": player.getName(),
+            },
+            sort_keys=True,
+        )
+
+    @game_test
+    def test_standalone_gravemoor_judgment_travels_to_usurpergate(self):
+        g, game_map, player = load_game_map_with_player("gravemoor")
+        scene_manager = g.getSceneManager()
+
+        for cage in ("loyalistCageWest", "loyalistCageEast", "loyalistCageNorth"):
+            definition = find_map_object_definition("gravemoor", cage)
+            player.moveTo(definition["x"] // 32, definition["y"] // 32, 0)
+            pump_event_loop(5)
+
+        voss = g.createObject("vossDialog")
+        self.assertTrue(voss.ready_to_judge())
+        voss.spare_voss()
+        self.assertEqual("TransitionPending", scene_manager.getTransitionStateName())
+        pump_event_loop(10)
+
+        self.assertEqual("usurpergate", g.getMap().mapName)
+        self.assertTrue(g.getMap().getPlayer() == player)
+        self.assertEqual("Idle", scene_manager.getTransitionStateName())
+
+        return True, json.dumps(
+            {
+                "current_map": g.getMap().mapName,
+                "manager": scene_manager.getTransitionStateName(),
+                "player_name": player.getName(),
             },
             sort_keys=True,
         )


### PR DESCRIPTION
## Summary
- In campaign play, `campaign.complete_scenario` routes a finished chapter to the next map through the manifest, but standalone map play (no active campaign) just stopped dead: Hearthfall's reported victory and Gravemoor's judgment ended the chapter with no way onward.
- The map scripts now pass the manifest-equivalent route as `fallback_map` — `hearthfall → gravemoor` on `"completed"`, `gravemoor → usurpergate` on `"spared"`/`"executed"` — so `complete_scenario`'s existing standalone fallback (`res/campaign.py`) travels the same road the Warden's Road campaign takes. No engine or campaign-module changes.
- The shared walkthrough helpers (`walkthrough_hearthfall_map`, `walkthrough_gravemoor_map`) now follow the transition and report the destination map, matching how the campaign drives these chapters.

## Regression tests
- `test_standalone_hearthfall_victory_travels_to_gravemoor`: standalone Hearthfall, defeat the captain, report to Elder Maren → asserts `TransitionPending`, then the map is `gravemoor` with the same player attached and the scene manager back to `Idle`.
- `test_standalone_gravemoor_judgment_travels_to_usurpergate`: standalone Gravemoor, open all three cages, spare Voss → asserts the transition lands on `usurpergate` with the same player.

## Validation
- `python3 scripts/validate_content.py --repo-root .` — passed.
- `cmake --build cmake-build-release --target _game -j$(nproc)` — clean.
- Targeted: both new tests, `test_map_walkthrough_hearthfall`, `test_map_walkthrough_gravemoor`, `test_wardens_road_campaign_mercy_route`, `test_wardens_road_campaign_wrath_route_clamps_gold`, `test_campaign_driver_routes_full_campaign_with_carryover` — all pass.
- `python3 test.py --suite gameplay` — pass (see below).
- Coverage step left to CI (`test.py` is coverage-relevant; poller run with `--require-step coverage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
