### PR TITLE
Enable auto-merge after successful CI

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,28 @@
+name: auto-merge
+
+on:
+  workflow_run:
+    workflows:
+      - build
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.pull_requests[0] != null
+      }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Enable squash auto-merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.workflow_run.pull_requests[0].html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

- add an `auto-merge` workflow triggered after the existing `build` workflow completes
- enable squash auto-merge only for successful pull-request runs
- use the repository-scoped `GITHUB_TOKEN` with minimal required permissions

## Behavior

When the `build` workflow succeeds for a pull request, GitHub schedules that PR for squash auto-merge. Any configured branch protection or ruleset requirements still apply before the merge is completed.