### PR TITLE
Repair policy-gated auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,21 +8,39 @@ on:
       - completed
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
 
 jobs:
   enable-auto-merge:
-    if: >-
-      ${{
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'pull_request' &&
-        github.event.workflow_run.pull_requests[0] != null
-      }}
     runs-on: ubuntu-24.04
     steps:
-      - name: Enable squash auto-merge
+      - name: Check out trusted default branch policy
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Evaluate auto-merge policy
+        id: policy
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_URL: ${{ github.event.workflow_run.pull_requests[0].html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+          REPOSITORY: ${{ github.repository }}
+        run: >-
+          python3 scripts/auto_merge_policy.py
+          --event "$GITHUB_EVENT_PATH"
+          --repository "$REPOSITORY"
+          --github-output "$GITHUB_OUTPUT"
+
+      - name: Enable squash auto-merge
+        if: steps.policy.outputs.allow == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_NUMBER: ${{ steps.policy.outputs.pr_number }}
+          REPOSITORY: ${{ github.repository }}
+        run: >-
+          gh pr merge --auto --squash "$PR_NUMBER"
+          --repo "$REPOSITORY"
+          --match-head-commit "$HEAD_SHA"

--- a/scripts/auto_merge_policy.py
+++ b/scripts/auto_merge_policy.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Fail-closed policy gate for enabling pull-request auto-merge.
+
+This helper is intended to run from a trusted checkout of the repository's
+default branch.  It treats the ``workflow_run`` webhook as a pointer only and
+refetches every decision-bearing object from the explicitly named repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+try:
+    from scripts.ci_change_classifier import CI_AUTHORITY_PATH_PATTERNS, matchesAny
+except ModuleNotFoundError:  # Direct execution makes scripts/ the import root.
+    from ci_change_classifier import CI_AUTHORITY_PATH_PATTERNS, matchesAny
+
+
+REQUIRED_CONTEXTS = frozenset(("linux", "windows-deps", "windows"))
+REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+GH_API_TIMEOUT_SECONDS = 30
+
+
+class EvidenceError(RuntimeError):
+    """Evidence is malformed, ambiguous, or could not be verified."""
+
+    def __init__(self, reason: str, detail: str = "") -> None:
+        super().__init__(detail or reason)
+        self.reason = reason
+
+
+class ApiError(EvidenceError):
+    def __init__(self, path: str, detail: str) -> None:
+        super().__init__("api_error", f"gh api {path}: {detail}")
+        self.path = path
+        self.detail = detail
+
+
+@dataclass(frozen=True)
+class PolicyResult:
+    allow: bool
+    prNumber: int | None
+    reason: str
+
+
+JsonGetter = Callable[[str], Any]
+
+
+def _object(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise EvidenceError("malformed_evidence", f"{name} must be an object")
+    return value
+
+
+def _positiveInteger(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise EvidenceError("malformed_evidence", f"{name} must be a positive integer")
+    return value
+
+
+def _nonEmptyString(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise EvidenceError("malformed_evidence", f"{name} must be a non-empty string")
+    return value
+
+
+def _boolean(value: Any, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise EvidenceError("malformed_evidence", f"{name} must be a boolean")
+    return value
+
+
+def _repositoryName(payload: Mapping[str, Any], name: str) -> str:
+    repository = _object(payload.get("repository"), f"{name}.repository")
+    return _nonEmptyString(repository.get("full_name"), f"{name}.repository.full_name")
+
+
+def _pullRepositoryName(payload: Mapping[str, Any], name: str) -> str:
+    repository = _object(payload.get("repo"), f"{name}.repo")
+    return _nonEmptyString(repository.get("full_name"), f"{name}.repo.full_name")
+
+
+def _sameRepository(actual: str, expected: str) -> bool:
+    return actual.casefold() == expected.casefold()
+
+
+def _associationNumber(payload: Mapping[str, Any], name: str) -> int:
+    associations = payload.get("pull_requests")
+    if not isinstance(associations, list):
+        raise EvidenceError("malformed_evidence", f"{name}.pull_requests must be an array")
+    if len(associations) != 1:
+        raise EvidenceError(
+            "pr_association_count_not_one",
+            f"{name}.pull_requests contains {len(associations)} associations",
+        )
+    association = _object(associations[0], f"{name}.pull_requests[0]")
+    return _positiveInteger(association.get("number"), f"{name}.pull_requests[0].number")
+
+
+def _deny(reason: str, prNumber: int | None = None) -> PolicyResult:
+    return PolicyResult(False, prNumber, reason)
+
+
+class GhApi:
+    def get(self, path: str) -> Any:
+        try:
+            result = subprocess.run(
+                ["gh", "api", "--method", "GET", path],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=GH_API_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise ApiError(path, f"timed out after {GH_API_TIMEOUT_SECONDS} seconds") from exc
+        except OSError as exc:
+            raise ApiError(path, str(exc)) from exc
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+            raise ApiError(path, detail)
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise ApiError(path, f"invalid JSON: {exc}") from exc
+
+
+def _changedPaths(getJson: JsonGetter, repository: str, prNumber: int, expectedCount: int) -> tuple[str, ...]:
+    """Fetch all changed paths and include both sides of renames."""
+    if expectedCount < 0:
+        raise EvidenceError("malformed_evidence", "pull_request.changed_files must not be negative")
+
+    paths: list[str] = []
+    fileCount = 0
+    page = 1
+    while True:
+        payload = getJson(f"repos/{repository}/pulls/{prNumber}/files?per_page=100&page={page}")
+        if not isinstance(payload, list):
+            raise EvidenceError("malformed_evidence", "pull request files response must be an array")
+        fileCount += len(payload)
+        for index, item in enumerate(payload):
+            changedFile = _object(item, f"pull request file {index}")
+            paths.append(_nonEmptyString(changedFile.get("filename"), "pull request file filename"))
+            previous = changedFile.get("previous_filename")
+            if previous is not None:
+                paths.append(_nonEmptyString(previous, "pull request file previous_filename"))
+        if len(payload) < 100:
+            break
+        page += 1
+        if page > 31:
+            raise EvidenceError("changed_files_unverifiable", "pull request file pagination exceeded 3000 files")
+
+    if fileCount != expectedCount:
+        raise EvidenceError(
+            "changed_files_count_mismatch",
+            f"pull request reports {expectedCount} changed files but API returned {fileCount}",
+        )
+    return tuple(paths)
+
+
+def _requiredContexts(protection: Mapping[str, Any]) -> frozenset[str]:
+    statusChecks = protection.get("required_status_checks")
+    if not isinstance(statusChecks, dict):
+        return frozenset()
+    contexts = statusChecks.get("contexts")
+    checks = statusChecks.get("checks")
+    if not isinstance(contexts, list) or not isinstance(checks, list):
+        raise EvidenceError("malformed_evidence", "branch protection required status checks are malformed")
+
+    required: set[str] = set()
+    for context in contexts:
+        required.add(_nonEmptyString(context, "required status context"))
+    for index, check in enumerate(checks):
+        item = _object(check, f"required status check {index}")
+        required.add(_nonEmptyString(item.get("context"), f"required status check {index}.context"))
+    return frozenset(required)
+
+
+def evaluatePolicy(event: Mapping[str, Any], repository: str, getJson: JsonGetter) -> PolicyResult:
+    if not REPOSITORY_PATTERN.fullmatch(repository):
+        raise EvidenceError("invalid_repository", "--repository must be OWNER/REPO")
+
+    eventAction = _nonEmptyString(event.get("action"), "event.action")
+    if eventAction != "completed":
+        return _deny("workflow_not_completed")
+    eventRepository = _repositoryName(event, "event")
+    if not _sameRepository(eventRepository, repository):
+        return _deny("event_repository_mismatch")
+
+    eventRun = _object(event.get("workflow_run"), "event.workflow_run")
+    runId = _positiveInteger(eventRun.get("id"), "event.workflow_run.id")
+    eventPrNumber = _associationNumber(eventRun, "event.workflow_run")
+    eventHeadSha = _nonEmptyString(eventRun.get("head_sha"), "event.workflow_run.head_sha")
+    if not _sameRepository(_repositoryName(eventRun, "event.workflow_run"), repository):
+        return _deny("event_repository_mismatch", eventPrNumber)
+
+    run = _object(getJson(f"repos/{repository}/actions/runs/{runId}"), "workflow run")
+    if _positiveInteger(run.get("id"), "workflow_run.id") != runId:
+        raise EvidenceError("workflow_identity_unverifiable", "refetched workflow run ID differs")
+    if _associationNumber(run, "workflow_run") != eventPrNumber:
+        raise EvidenceError("workflow_identity_unverifiable", "refetched pull request association differs")
+    runHeadSha = _nonEmptyString(run.get("head_sha"), "workflow_run.head_sha")
+    if runHeadSha != eventHeadSha:
+        raise EvidenceError("workflow_identity_unverifiable", "refetched workflow head SHA differs")
+    if not _sameRepository(_repositoryName(run, "workflow_run"), repository):
+        return _deny("workflow_repository_mismatch", eventPrNumber)
+    runName = _nonEmptyString(run.get("name"), "workflow_run.name")
+    runPath = _nonEmptyString(run.get("path"), "workflow_run.path")
+    if runName != "build" or runPath != ".github/workflows/build.yml":
+        return _deny("workflow_identity_mismatch", eventPrNumber)
+    runStatus = _nonEmptyString(run.get("status"), "workflow_run.status")
+    if runStatus != "completed":
+        return _deny("workflow_not_completed", eventPrNumber)
+    runConclusion = _nonEmptyString(run.get("conclusion"), "workflow_run.conclusion")
+    if runConclusion != "success":
+        return _deny("workflow_not_successful", eventPrNumber)
+    runEvent = _nonEmptyString(run.get("event"), "workflow_run.event")
+    if runEvent != "pull_request":
+        return _deny("workflow_event_not_pull_request", eventPrNumber)
+
+    pr = _object(getJson(f"repos/{repository}/pulls/{eventPrNumber}"), "pull request")
+    if _positiveInteger(pr.get("number"), "pull_request.number") != eventPrNumber:
+        raise EvidenceError("pull_request_unverifiable", "refetched pull request number differs")
+    prState = _nonEmptyString(pr.get("state"), "pull_request.state")
+    if prState != "open":
+        return _deny("pr_not_open", eventPrNumber)
+    if _boolean(pr.get("draft"), "pull_request.draft"):
+        return _deny("pr_is_draft", eventPrNumber)
+
+    base = _object(pr.get("base"), "pull_request.base")
+    head = _object(pr.get("head"), "pull_request.head")
+    baseRef = _nonEmptyString(base.get("ref"), "pull_request.base.ref")
+    if baseRef != "main":
+        return _deny("pr_base_not_main", eventPrNumber)
+    if not _sameRepository(_pullRepositoryName(base, "pull_request.base"), repository):
+        return _deny("pr_base_repository_mismatch", eventPrNumber)
+    if not _sameRepository(_pullRepositoryName(head, "pull_request.head"), repository):
+        return _deny("pr_head_repository_mismatch", eventPrNumber)
+    if _nonEmptyString(head.get("sha"), "pull_request.head.sha") != runHeadSha:
+        return _deny("pr_head_sha_mismatch", eventPrNumber)
+
+    changedFiles = pr.get("changed_files")
+    if isinstance(changedFiles, bool) or not isinstance(changedFiles, int):
+        raise EvidenceError("malformed_evidence", "pull_request.changed_files must be an integer")
+    changedPaths = _changedPaths(getJson, repository, eventPrNumber, changedFiles)
+    if any(matchesAny(path, CI_AUTHORITY_PATH_PATTERNS) for path in changedPaths):
+        return _deny("authority_change", eventPrNumber)
+
+    repositorySettings = _object(getJson(f"repos/{repository}"), "repository settings")
+    if not _sameRepository(_nonEmptyString(repositorySettings.get("full_name"), "repository.full_name"), repository):
+        raise EvidenceError("repository_settings_unverifiable", "repository settings identity differs")
+    try:
+        defaultBranch = _nonEmptyString(repositorySettings.get("default_branch"), "repository.default_branch")
+    except EvidenceError as exc:
+        raise EvidenceError("repository_settings_unverifiable", str(exc)) from exc
+    if defaultBranch != "main":
+        return _deny("default_branch_not_main", eventPrNumber)
+    try:
+        allowAutoMerge = _boolean(repositorySettings.get("allow_auto_merge"), "repository.allow_auto_merge")
+    except EvidenceError as exc:
+        raise EvidenceError("repository_settings_unverifiable", str(exc)) from exc
+    if not allowAutoMerge:
+        return _deny("auto_merge_disabled", eventPrNumber)
+
+    branch = _object(getJson(f"repos/{repository}/branches/main"), "main branch")
+    if branch.get("name") != "main":
+        raise EvidenceError("branch_protection_unverifiable", "main branch identity differs")
+    try:
+        protected = _boolean(branch.get("protected"), "main.protected")
+    except EvidenceError as exc:
+        raise EvidenceError("branch_protection_unverifiable", str(exc)) from exc
+    if not protected:
+        return _deny("main_not_protected", eventPrNumber)
+
+    protection = _object(getJson(f"repos/{repository}/branches/main/protection"), "main branch protection")
+    if "required_status_checks" not in protection:
+        raise EvidenceError("branch_protection_unverifiable", "required_status_checks is missing")
+    statusChecks = protection["required_status_checks"]
+    if statusChecks is None:
+        return _deny("required_checks_not_strict", eventPrNumber)
+    if not isinstance(statusChecks, dict):
+        raise EvidenceError("branch_protection_unverifiable", "required_status_checks must be an object")
+    try:
+        strict = _boolean(statusChecks.get("strict"), "required_status_checks.strict")
+    except EvidenceError as exc:
+        raise EvidenceError("branch_protection_unverifiable", str(exc)) from exc
+    if not strict:
+        return _deny("required_checks_not_strict", eventPrNumber)
+    missing = REQUIRED_CONTEXTS - _requiredContexts(protection)
+    if missing:
+        return _deny("required_contexts_missing", eventPrNumber)
+
+    return PolicyResult(True, eventPrNumber, "allowed")
+
+
+def writeGithubOutput(path: Path, result: PolicyResult) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"allow={str(result.allow).lower()}\n")
+        handle.write(f"pr_number={result.prNumber or ''}\n")
+        handle.write(f"reason={result.reason}\n")
+
+
+def parseArgs(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event", required=True, help="Path to the workflow_run event JSON")
+    parser.add_argument("--repository", required=True, help="Explicit OWNER/REPO repository")
+    parser.add_argument("--github-output", required=True, help="GitHub Actions output file")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parseArgs(argv or sys.argv[1:])
+    result = PolicyResult(False, None, "malformed_event")
+    exitCode = 2
+    try:
+        with Path(args.event).open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if not isinstance(payload, dict):
+            raise EvidenceError("malformed_event", "event must be an object")
+        event = payload
+        result = evaluatePolicy(event, args.repository, GhApi().get)
+        exitCode = 0
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"auto_merge_policy: event could not be read: {exc}", file=sys.stderr)
+    except EvidenceError as exc:
+        result = PolicyResult(False, None, exc.reason)
+        print(f"auto_merge_policy: {exc}", file=sys.stderr)
+
+    try:
+        writeGithubOutput(Path(args.github_output), result)
+    except OSError as exc:
+        print(f"auto_merge_policy: output could not be written: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps({"allow": result.allow, "pr_number": result.prNumber, "reason": result.reason}, sort_keys=True))
+    return exitCode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_change_classifier.py
+++ b/scripts/ci_change_classifier.py
@@ -41,14 +41,16 @@ NATIVE_PATH_PATTERNS = (
     "vstd/*",
 )
 
-# Paths whose content can change how required validation is routed, polled, or
-# scored: the build workflow definition, the poller, and this classifier itself.
+# Paths whose content can change how required validation or auto-merge is
+# routed, polled, scored, or authorized.
 # A pull request that edits these files must not be allowed to classify its own
 # change as lightweight and thereby skip native/coverage validation. Touching any
 # of these forces strict native + coverage validation and human review, so the
 # authority for "what is required" never comes solely from PR-controlled logic.
 CI_AUTHORITY_PATH_PATTERNS = (
+    ".github/workflows/auto-merge.yml",
     ".github/workflows/build.yml",
+    "scripts/auto_merge_policy.py",
     "scripts/ci_change_classifier.py",
     "scripts/poll_pr_checks.py",
 )
@@ -168,8 +170,8 @@ class ChangeClassification:
 
     @property
     def humanReviewRequired(self) -> bool:
-        # Changes to the validation-authority files (workflow/poller/classifier)
-        # cannot be merged on PR-controlled logic alone; they require human review.
+        # Changes to validation or merge authority cannot be trusted solely from
+        # PR-controlled logic.
         return self.authorityChange
 
 

--- a/tests/test_auto_merge_policy.py
+++ b/tests/test_auto_merge_policy.py
@@ -1,0 +1,541 @@
+from __future__ import annotations
+
+import copy
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import auto_merge_policy
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPOSITORY = "owner/repository"
+RUN_ID = 9876
+PR_NUMBER = 321
+HEAD_SHA = "a" * 40
+
+
+def evidence() -> tuple[dict[str, object], dict[str, object]]:
+    association = {
+        "url": f"https://api.github.invalid/repos/{REPOSITORY}/pulls/{PR_NUMBER}",
+        "id": 123456,
+        "number": PR_NUMBER,
+        "head": {"ref": "feature", "sha": HEAD_SHA, "repo": {"id": 1001, "url": "https://api.github.invalid"}},
+        "base": {"ref": "main", "sha": "b" * 40, "repo": {"id": 1001, "url": "https://api.github.invalid"}},
+    }
+    event = {
+        "action": "completed",
+        "repository": {"full_name": REPOSITORY, "default_branch": "main"},
+        "workflow_run": {
+            "id": RUN_ID,
+            "head_sha": HEAD_SHA,
+            "repository": {"full_name": REPOSITORY},
+            # The real workflow_run association supplies a number and API URL,
+            # not an html_url.  The policy must never depend on html_url.
+            "pull_requests": [copy.deepcopy(association)],
+        },
+    }
+    run = {
+        "id": RUN_ID,
+        "name": "build",
+        "path": ".github/workflows/build.yml",
+        "status": "completed",
+        "conclusion": "success",
+        "event": "pull_request",
+        "head_sha": HEAD_SHA,
+        "repository": {"full_name": REPOSITORY},
+        "pull_requests": [copy.deepcopy(association)],
+    }
+    return event, run
+
+
+def pullRequest(*, changedFiles: int = 1) -> dict[str, object]:
+    return {
+        "number": PR_NUMBER,
+        "state": "open",
+        "draft": False,
+        "changed_files": changedFiles,
+        "base": {"ref": "main", "repo": {"full_name": REPOSITORY}},
+        "head": {"sha": HEAD_SHA, "repo": {"full_name": REPOSITORY}},
+    }
+
+
+class FakeApi:
+    def __init__(
+        self,
+        run: dict[str, object],
+        *,
+        pr: dict[str, object] | None = None,
+        files: list[dict[str, object]] | None = None,
+        settings: dict[str, object] | None = None,
+        branch: dict[str, object] | None = None,
+        protection: dict[str, object] | None = None,
+    ) -> None:
+        self.calls: list[str] = []
+        self.responses: dict[str, object] = {
+            f"repos/{REPOSITORY}/actions/runs/{RUN_ID}": run,
+            f"repos/{REPOSITORY}/pulls/{PR_NUMBER}": pr or pullRequest(),
+            f"repos/{REPOSITORY}/pulls/{PR_NUMBER}/files?per_page=100&page=1": (
+                files if files is not None else [{"filename": "docs/readme.md", "status": "modified"}]
+            ),
+            f"repos/{REPOSITORY}": (
+                settings
+                if settings is not None
+                else {"full_name": REPOSITORY, "default_branch": "main", "allow_auto_merge": True}
+            ),
+            f"repos/{REPOSITORY}/branches/main": branch if branch is not None else {"name": "main", "protected": True},
+            f"repos/{REPOSITORY}/branches/main/protection": (
+                protection
+                if protection is not None
+                else {
+                    "required_status_checks": {
+                        "strict": True,
+                        "contexts": ["linux", "windows-deps", "windows"],
+                        "checks": [],
+                    }
+                }
+            ),
+        }
+
+    def __call__(self, path: str) -> object:
+        self.calls.append(path)
+        if path not in self.responses:
+            raise auto_merge_policy.ApiError(path, "fixture has no response")
+        return copy.deepcopy(self.responses[path])
+
+
+class AutoMergePolicyTest(unittest.TestCase):
+    def evaluate(
+        self,
+        *,
+        event: dict[str, object] | None = None,
+        run: dict[str, object] | None = None,
+        api: FakeApi | None = None,
+    ) -> auto_merge_policy.PolicyResult:
+        defaultEvent, defaultRun = evidence()
+        return auto_merge_policy.evaluatePolicy(
+            event or defaultEvent,
+            REPOSITORY,
+            api or FakeApi(run or defaultRun),
+        )
+
+    def test_real_association_without_html_url_is_allowed(self) -> None:
+        result = self.evaluate()
+
+        self.assertTrue(result.allow)
+        self.assertEqual(PR_NUMBER, result.prNumber)
+        self.assertEqual("allowed", result.reason)
+
+    def test_absent_or_multiple_pr_associations_are_unverifiable(self) -> None:
+        for associations in ([], [{"number": PR_NUMBER}, {"number": PR_NUMBER + 1}]):
+            with self.subTest(count=len(associations)):
+                event, _run = evidence()
+                event["workflow_run"]["pull_requests"] = associations  # type: ignore[index]
+                with self.assertRaisesRegex(auto_merge_policy.EvidenceError, "associations") as caught:
+                    self.evaluate(event=event)
+                self.assertEqual("pr_association_count_not_one", caught.exception.reason)
+
+    def test_refetched_association_must_match_event(self) -> None:
+        event, run = evidence()
+        run["pull_requests"] = [{"number": PR_NUMBER + 1}]
+
+        with self.assertRaises(auto_merge_policy.EvidenceError) as caught:
+            self.evaluate(event=event, run=run)
+
+        self.assertEqual("workflow_identity_unverifiable", caught.exception.reason)
+
+    def test_wrong_action_event_repository_or_workflow_identity_is_denied(self) -> None:
+        event, run = evidence()
+        cases = []
+        wrongAction = copy.deepcopy(event)
+        wrongAction["action"] = "requested"
+        cases.append((wrongAction, run, "workflow_not_completed"))
+        wrongRepo = copy.deepcopy(event)
+        wrongRepo["repository"]["full_name"] = "other/repository"  # type: ignore[index]
+        cases.append((wrongRepo, run, "event_repository_mismatch"))
+        wrongWorkflowEvent = copy.deepcopy(run)
+        wrongWorkflowEvent["event"] = "push"
+        cases.append((event, wrongWorkflowEvent, "workflow_event_not_pull_request"))
+        wrongWorkflow = copy.deepcopy(run)
+        wrongWorkflow["name"] = "release"
+        cases.append((event, wrongWorkflow, "workflow_identity_mismatch"))
+        for eventPayload, runPayload, reason in cases:
+            with self.subTest(reason=reason):
+                result = self.evaluate(event=eventPayload, run=runPayload)
+                self.assertFalse(result.allow)
+                self.assertEqual(reason, result.reason)
+
+    def test_wrong_refetched_run_path_or_repository_is_denied(self) -> None:
+        event, run = evidence()
+        wrongPath = copy.deepcopy(run)
+        wrongPath["path"] = ".github/workflows/release.yml"
+        wrongRepository = copy.deepcopy(run)
+        wrongRepository["repository"]["full_name"] = "other/repository"  # type: ignore[index]
+        for payload, reason in (
+            (wrongPath, "workflow_identity_mismatch"),
+            (wrongRepository, "workflow_repository_mismatch"),
+        ):
+            with self.subTest(reason=reason):
+                result = self.evaluate(event=event, run=payload)
+                self.assertFalse(result.allow)
+                self.assertEqual(reason, result.reason)
+
+    def test_incomplete_or_unsuccessful_refetched_run_is_denied(self) -> None:
+        event, run = evidence()
+        for field, value, reason in (
+            ("status", "in_progress", "workflow_not_completed"),
+            ("conclusion", "failure", "workflow_not_successful"),
+        ):
+            with self.subTest(field=field):
+                changed = copy.deepcopy(run)
+                changed[field] = value
+                result = self.evaluate(event=event, run=changed)
+                self.assertEqual(reason, result.reason)
+
+    def test_event_and_refetched_head_sha_must_match(self) -> None:
+        event, run = evidence()
+        run["head_sha"] = "b" * 40
+
+        with self.assertRaises(auto_merge_policy.EvidenceError) as caught:
+            self.evaluate(event=event, run=run)
+
+        self.assertEqual("workflow_identity_unverifiable", caught.exception.reason)
+
+    def test_closed_and_draft_prs_are_denied(self) -> None:
+        event, run = evidence()
+        for field, value, reason in (
+            ("state", "closed", "pr_not_open"),
+            ("draft", True, "pr_is_draft"),
+        ):
+            with self.subTest(field=field):
+                pr = pullRequest()
+                pr[field] = value
+                result = self.evaluate(event=event, api=FakeApi(run, pr=pr))
+                self.assertEqual(reason, result.reason)
+
+    def test_wrong_base_or_fork_is_denied(self) -> None:
+        event, run = evidence()
+        cases: list[tuple[dict[str, object], str]] = []
+        wrongBase = pullRequest()
+        wrongBase["base"]["ref"] = "release"  # type: ignore[index]
+        cases.append((wrongBase, "pr_base_not_main"))
+        baseFork = pullRequest()
+        baseFork["base"]["repo"]["full_name"] = "fork/repository"  # type: ignore[index]
+        cases.append((baseFork, "pr_base_repository_mismatch"))
+        headFork = pullRequest()
+        headFork["head"]["repo"]["full_name"] = "fork/repository"  # type: ignore[index]
+        cases.append((headFork, "pr_head_repository_mismatch"))
+        for pr, reason in cases:
+            with self.subTest(reason=reason):
+                result = self.evaluate(event=event, api=FakeApi(run, pr=pr))
+                self.assertEqual(reason, result.reason)
+
+    def test_stale_pr_head_sha_is_denied(self) -> None:
+        event, run = evidence()
+        pr = pullRequest()
+        pr["head"]["sha"] = "b" * 40  # type: ignore[index]
+
+        result = self.evaluate(event=event, api=FakeApi(run, pr=pr))
+
+        self.assertEqual("pr_head_sha_mismatch", result.reason)
+
+    def test_disabled_auto_merge_is_denied(self) -> None:
+        event, run = evidence()
+        api = FakeApi(
+            run,
+            settings={"full_name": REPOSITORY, "default_branch": "main", "allow_auto_merge": False},
+        )
+
+        result = self.evaluate(event=event, api=api)
+
+        self.assertEqual("auto_merge_disabled", result.reason)
+
+    def test_default_branch_must_be_main(self) -> None:
+        event, run = evidence()
+        api = FakeApi(
+            run,
+            settings={"full_name": REPOSITORY, "default_branch": "develop", "allow_auto_merge": True},
+        )
+
+        result = self.evaluate(event=event, api=api)
+
+        self.assertEqual("default_branch_not_main", result.reason)
+
+    def test_unprotected_or_non_strict_main_is_denied(self) -> None:
+        event, run = evidence()
+        unprotected = FakeApi(run, branch={"name": "main", "protected": False})
+        result = self.evaluate(event=event, api=unprotected)
+        self.assertEqual("main_not_protected", result.reason)
+
+        nonStrict = FakeApi(
+            run,
+            protection={
+                "required_status_checks": {"strict": False, "contexts": list(auto_merge_policy.REQUIRED_CONTEXTS)}
+            },
+        )
+        result = self.evaluate(event=event, api=nonStrict)
+        self.assertEqual("required_checks_not_strict", result.reason)
+
+        noStatusChecks = FakeApi(run, protection={"required_status_checks": None})
+        result = self.evaluate(event=event, api=noStatusChecks)
+        self.assertEqual("required_checks_not_strict", result.reason)
+
+    def test_required_contexts_can_come_from_contexts_and_checks(self) -> None:
+        event, run = evidence()
+        protection = {
+            "required_status_checks": {
+                "strict": True,
+                "contexts": ["linux"],
+                "checks": [{"context": "windows-deps", "app_id": 1}, {"context": "windows", "app_id": 1}],
+            }
+        }
+
+        result = self.evaluate(event=event, api=FakeApi(run, protection=protection))
+
+        self.assertTrue(result.allow)
+
+    def test_missing_required_context_is_denied(self) -> None:
+        event, run = evidence()
+        protection = {"required_status_checks": {"strict": True, "contexts": ["linux", "windows"], "checks": []}}
+
+        result = self.evaluate(event=event, api=FakeApi(run, protection=protection))
+
+        self.assertEqual("required_contexts_missing", result.reason)
+
+    def test_malformed_contexts_or_checks_are_unverifiable(self) -> None:
+        event, run = evidence()
+        for statusChecks in (
+            {"strict": True, "contexts": "linux", "checks": []},
+            {"strict": True, "contexts": [], "checks": [{"context": None}]},
+            {"strict": True, "contexts": []},
+        ):
+            with self.subTest(statusChecks=statusChecks):
+                protection = {"required_status_checks": statusChecks}
+                with self.assertRaises(auto_merge_policy.EvidenceError) as caught:
+                    self.evaluate(event=event, api=FakeApi(run, protection=protection))
+                self.assertEqual("malformed_evidence", caught.exception.reason)
+
+    def test_authority_file_on_second_page_is_denied(self) -> None:
+        event, run = evidence()
+        firstPage = [{"filename": f"docs/file-{index}.md"} for index in range(100)]
+        api = FakeApi(run, pr=pullRequest(changedFiles=101), files=firstPage)
+        api.responses[f"repos/{REPOSITORY}/pulls/{PR_NUMBER}/files?per_page=100&page=2"] = [
+            {"filename": "scripts/auto_merge_policy.py"}
+        ]
+
+        result = self.evaluate(event=event, api=api)
+
+        self.assertEqual("authority_change", result.reason)
+
+    def test_rename_from_authority_file_is_denied(self) -> None:
+        event, run = evidence()
+        files = [{"filename": "scripts/renamed_policy.py", "previous_filename": ".github/workflows/auto-merge.yml"}]
+
+        result = self.evaluate(event=event, api=FakeApi(run, files=files))
+
+        self.assertEqual("authority_change", result.reason)
+
+    def test_changed_file_count_mismatch_is_unverifiable(self) -> None:
+        event, run = evidence()
+        api = FakeApi(run, pr=pullRequest(changedFiles=2))
+
+        with self.assertRaises(auto_merge_policy.EvidenceError) as caught:
+            self.evaluate(event=event, api=api)
+
+        self.assertEqual("changed_files_count_mismatch", caught.exception.reason)
+
+    def test_malformed_api_response_is_unverifiable(self) -> None:
+        event, run = evidence()
+        api = FakeApi(run)
+        api.responses[f"repos/{REPOSITORY}/pulls/{PR_NUMBER}"] = []
+
+        with self.assertRaises(auto_merge_policy.EvidenceError) as caught:
+            self.evaluate(event=event, api=api)
+
+        self.assertEqual("malformed_evidence", caught.exception.reason)
+
+    def runCli(
+        self,
+        event: object,
+        api: FakeApi,
+    ) -> tuple[int, dict[str, str], str]:
+        with tempfile.TemporaryDirectory() as tempDir:
+            eventPath = Path(tempDir) / "event.json"
+            outputPath = Path(tempDir) / "output"
+            eventPath.write_text(json.dumps(event), encoding="utf-8")
+            stderr = io.StringIO()
+            with patch.object(auto_merge_policy.GhApi, "get", side_effect=api):
+                with redirect_stdout(io.StringIO()), redirect_stderr(stderr):
+                    exitCode = auto_merge_policy.main(
+                        [
+                            "--event",
+                            str(eventPath),
+                            "--repository",
+                            REPOSITORY,
+                            "--github-output",
+                            str(outputPath),
+                        ]
+                    )
+            outputs = dict(line.split("=", 1) for line in outputPath.read_text(encoding="utf-8").splitlines())
+            return exitCode, outputs, stderr.getvalue()
+
+    def test_cli_writes_allowed_outputs_and_exits_zero(self) -> None:
+        event, run = evidence()
+
+        exitCode, outputs, stderr = self.runCli(event, FakeApi(run))
+
+        self.assertEqual(0, exitCode)
+        self.assertEqual({"allow": "true", "pr_number": str(PR_NUMBER), "reason": "allowed"}, outputs)
+        self.assertEqual("", stderr)
+
+    def test_cli_policy_denial_writes_outputs_and_exits_zero(self) -> None:
+        event, run = evidence()
+        pr = pullRequest()
+        pr["draft"] = True
+
+        exitCode, outputs, stderr = self.runCli(event, FakeApi(run, pr=pr))
+
+        self.assertEqual(0, exitCode)
+        self.assertEqual("false", outputs["allow"])
+        self.assertEqual(str(PR_NUMBER), outputs["pr_number"])
+        self.assertEqual("pr_is_draft", outputs["reason"])
+        self.assertEqual("", stderr)
+
+    def test_cli_malformed_event_writes_outputs_and_exits_nonzero(self) -> None:
+        _event, run = evidence()
+
+        exitCode, outputs, stderr = self.runCli([], FakeApi(run))
+
+        self.assertEqual(2, exitCode)
+        self.assertEqual({"allow": "false", "pr_number": "", "reason": "malformed_event"}, outputs)
+        self.assertIn("event must be an object", stderr)
+
+    def test_cli_api_failure_writes_outputs_and_exits_nonzero(self) -> None:
+        event, run = evidence()
+        api = FakeApi(run)
+        del api.responses[f"repos/{REPOSITORY}/actions/runs/{RUN_ID}"]
+
+        exitCode, outputs, stderr = self.runCli(event, api)
+
+        self.assertEqual(2, exitCode)
+        self.assertEqual("false", outputs["allow"])
+        self.assertEqual("api_error", outputs["reason"])
+        self.assertIn("fixture has no response", stderr)
+
+    def test_cli_malformed_decision_fields_exit_nonzero(self) -> None:
+        event, baselineRun = evidence()
+        cases: list[tuple[str, FakeApi]] = []
+        for field, value in (
+            ("name", None),
+            ("path", []),
+            ("status", None),
+            ("conclusion", None),
+            ("event", 7),
+        ):
+            run = copy.deepcopy(baselineRun)
+            run[field] = value
+            cases.append((f"run-{field}", FakeApi(run)))
+
+        for field, value in (("state", None), ("draft", "false")):
+            pr = pullRequest()
+            pr[field] = value
+            cases.append((f"pr-{field}", FakeApi(baselineRun, pr=pr)))
+        pr = pullRequest()
+        pr["base"]["ref"] = None  # type: ignore[index]
+        cases.append(("pr-base-ref", FakeApi(baselineRun, pr=pr)))
+        cases.append(
+            (
+                "protection-strict",
+                FakeApi(
+                    baselineRun,
+                    protection={"required_status_checks": {"contexts": [], "checks": []}},
+                ),
+            )
+        )
+
+        for name, api in cases:
+            with self.subTest(name=name):
+                exitCode, outputs, stderr = self.runCli(event, api)
+                self.assertEqual(2, exitCode)
+                self.assertEqual("false", outputs["allow"])
+                self.assertIn(outputs["reason"], ("malformed_evidence", "branch_protection_unverifiable"))
+                self.assertTrue(stderr)
+
+    def test_cli_missing_action_or_draft_exits_nonzero(self) -> None:
+        event, run = evidence()
+        missingAction = copy.deepcopy(event)
+        del missingAction["action"]
+        missingDraft = pullRequest()
+        del missingDraft["draft"]
+
+        for name, eventPayload, api in (
+            ("action", missingAction, FakeApi(run)),
+            ("draft", event, FakeApi(run, pr=missingDraft)),
+        ):
+            with self.subTest(name=name):
+                exitCode, outputs, stderr = self.runCli(eventPayload, api)
+                self.assertEqual(2, exitCode)
+                self.assertEqual("false", outputs["allow"])
+                self.assertEqual("malformed_evidence", outputs["reason"])
+                self.assertTrue(stderr)
+
+    def test_gh_api_timeout_is_unverifiable(self) -> None:
+        with patch.object(
+            auto_merge_policy.subprocess,
+            "run",
+            side_effect=auto_merge_policy.subprocess.TimeoutExpired(["gh", "api"], 30),
+        ):
+            with self.assertRaises(auto_merge_policy.ApiError) as caught:
+                auto_merge_policy.GhApi().get("repos/owner/repository")
+
+        self.assertEqual("api_error", caught.exception.reason)
+        self.assertIn("timed out after 30 seconds", str(caught.exception))
+
+    def test_cli_timeout_writes_api_error_and_exits_nonzero(self) -> None:
+        event, _run = evidence()
+        with tempfile.TemporaryDirectory() as tempDir:
+            eventPath = Path(tempDir) / "event.json"
+            outputPath = Path(tempDir) / "output"
+            eventPath.write_text(json.dumps(event), encoding="utf-8")
+            with patch.object(
+                auto_merge_policy.subprocess,
+                "run",
+                side_effect=auto_merge_policy.subprocess.TimeoutExpired(["gh", "api"], 30),
+            ):
+                with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                    exitCode = auto_merge_policy.main(
+                        [
+                            "--event",
+                            str(eventPath),
+                            "--repository",
+                            REPOSITORY,
+                            "--github-output",
+                            str(outputPath),
+                        ]
+                    )
+
+            outputs = dict(line.split("=", 1) for line in outputPath.read_text(encoding="utf-8").splitlines())
+            self.assertEqual(2, exitCode)
+            self.assertEqual("false", outputs["allow"])
+            self.assertEqual("api_error", outputs["reason"])
+
+    def test_workflow_uses_trusted_policy_and_explicit_merge_identity(self) -> None:
+        workflow = (REPO_ROOT / ".github/workflows/auto-merge.yml").read_text(encoding="utf-8")
+
+        self.assertIn("actions: read", workflow)
+        self.assertIn("actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0", workflow)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", workflow)
+        self.assertIn("python3 scripts/auto_merge_policy.py", workflow)
+        self.assertIn("if: steps.policy.outputs.allow == 'true'", workflow)
+        self.assertIn('gh pr merge --auto --squash "$PR_NUMBER"', workflow)
+        self.assertIn('--repo "$REPOSITORY"', workflow)
+        self.assertIn('--match-head-commit "$HEAD_SHA"', workflow)
+        self.assertNotIn("html_url", workflow)
+        self.assertNotIn("git ", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ci_change_classifier.py
+++ b/tests/test_ci_change_classifier.py
@@ -231,6 +231,16 @@ class CiChangeClassifierTest(unittest.TestCase):
                 self.assertTrue(classification.coverageNeeded)
                 self.assertTrue(classification.humanReviewRequired)
 
+    def test_auto_merge_workflow_and_policy_are_authority_changes(self) -> None:
+        for path in (".github/workflows/auto-merge.yml", "scripts/auto_merge_policy.py"):
+            with self.subTest(path=path):
+                classification = self.classify(path)
+                self.assertTrue(classification.authorityChange)
+                self.assertTrue(classification.nativeNeeded)
+                self.assertTrue(classification.coverageNeeded)
+                self.assertTrue(classification.humanReviewRequired)
+                self.assertEqual((path,), classification.authorityPaths)
+
     def test_authority_change_cannot_self_classify_as_lightweight(self) -> None:
         # A PR that only edits the routing/poller/classifier logic must not be able
         # to claim a lightweight (linux-only, no-coverage) validation class.


### PR DESCRIPTION
## What changed

- added a trusted-default-branch `auto_merge_policy.py` gate that resolves exactly one PR by number and refetches authoritative workflow, PR, repository, changed-file, and branch-protection evidence
- made malformed, ambiguous, timed-out, or otherwise unverifiable evidence fail nonzero while ordinary policy denials emit stable outputs and exit successfully
- required an open, non-draft, same-repository PR targeting `main` at the exact successful build SHA, repository auto-merge support, strict branch protection, and the `linux`, `windows-deps`, and `windows` contexts
- denied authority-file changes, including paginated files and rename origins
- changed the workflow to check out pinned trusted code and use only the verified number, explicit repository, and `--match-head-commit`
- marked the workflow and helper as validation-authority paths

## Why

The prior workflow read a missing `workflow_run.pull_requests[0].html_url`, so a successful build could reach an empty merge target. The new policy fails closed and prevents a stale or untrusted PR head from enabling auto-merge.

Queue identity: `[EPIC_09][STORY_01][SUBSTORY_01] Repair policy-gated auto-merge after successful build`  
Owner: `controller/ctrl-lis-2-ebaaae98/worker-auto-merge`  
Claim ID: `0b664ed0-24db-495f-af64-840bb5196cab`

## Validation

- `python3 -m unittest tests.test_auto_merge_policy tests.test_ci_change_classifier tests.security.test_configure_supply_chain` (66 passed)
- `python3 -m py_compile scripts/auto_merge_policy.py scripts/ci_change_classifier.py`
- `black -l 120 --check scripts/auto_merge_policy.py tests/test_auto_merge_policy.py`
- `python3 scripts/ci_change_classifier.py --path ...` (`authorityChange=true`, native + coverage + human review required)
- `git diff --check`
- `python3 scripts/pr_review_audit.py preflight --input /tmp/p0-preflight.json` (`verdict=allow`)

## Limitations / follow-up

- this authority PR must pass strict `linux`, `windows-deps`, `windows`, and coverage CI and be human-reviewed; it must not auto-merge itself
- live `main` protection is currently non-strict with no required contexts, so the repaired policy will deny auto-merge until an administrator separately configures strict protection and those three contexts
- the workflow-observation resolution receipt waits for a current-head PR to exercise the repaired workflow successfully
