### PR TITLE
[EPIC_10][STORY_02][SUBSTORY_01] Require boss defeat for four map finales

### DIFF
--- a/res/maps/kadath/script.py
+++ b/res/maps/kadath/script.py
@@ -17,7 +17,7 @@ def load(self, context):
         player.addQuest(quest_name)
 
     def quest_flags_default(game_map):
-        for flag in ("ascent_heard", "gate_opened", "throne_taken", "boss_woken"):
+        for flag in ("ascent_heard", "gate_opened", "throne_taken", "boss_woken", "boss_defeated"):
             if not hasattr(game_map, flag):
                 game_map.setBoolProperty(flag, False)
 
@@ -85,16 +85,22 @@ def load(self, context):
                 game_map.addObject(boss)
                 boss.moveTo(*BOSS_SPAWN)
                 game_map.setBoolProperty("boss_woken", True)
+            # Refresh objectives/completion so pickup-first ordering converges with a
+            # later boss defeat. The quest still needs the Crawling Chaos put down.
+            player.checkQuests()
 
     @register(context)
     class KadathAscentQuest(CQuest):
         def isCompleted(self):
-            return self.getGame().getMap().getBoolProperty("throne_taken")
+            game_map = self.getGame().getMap()
+            return game_map.getBoolProperty("throne_taken") and game_map.getBoolProperty("boss_defeated")
 
         def getObjective(self):
             game_map = self.getGame().getMap()
-            if game_map.getBoolProperty("throne_taken"):
+            if game_map.getBoolProperty("throne_taken") and game_map.getBoolProperty("boss_defeated"):
                 return "You wear the Onyx Signet of the Crawling Chaos. The dream will not release you unmarked."
+            if game_map.getBoolProperty("throne_taken"):
+                return "The Crawling Chaos walks the summit in your shape. Put the Messenger down to end the dream."
             if game_map.getBoolProperty("ascent_heard"):
                 return "Climb the basalt road to the onyx castle on the summit of Kadath."
             if game_map.getBoolProperty("gate_opened"):
@@ -157,7 +163,12 @@ def load(self, context):
     @trigger(context, "onDestroy", "theCrawlingChaosBoss")
     class CrawlingChaosTrigger(CTrigger):
         def trigger(self, obj, event):
+            game_map = obj.getGame().getMap()
+            game_map.setBoolProperty("boss_defeated", True)
             obj.getGame().getGuiHandler().showMessage(
                 "The last shape sloughs away and the Crawling Chaos withdraws into the dark between dreams. You "
                 "are still wearing his signet. Somewhere, in the ultimate void, an idiot flute keeps your time."
             )
+            # Boss-defeat transition: converge with the throne pickup so the finale
+            # completes once both requirements are met, in either order.
+            game_map.getPlayer().checkQuests()

--- a/res/maps/ninemarches/script.py
+++ b/res/maps/ninemarches/script.py
@@ -35,6 +35,7 @@ def load(self, context):
         "brass_gate_open",
         "crown_taken",
         "boss_woken",
+        "boss_defeated",
         "shrine_used",
         "witch_used",
         "mine_claimed",
@@ -232,19 +233,25 @@ def load(self, context):
                 game_map.addObject(boss)
                 boss.moveTo(*BOSS_SPAWN)
                 game_map.setBoolProperty("boss_woken", True)
+            # Refresh objectives/completion so pickup-first ordering converges with a
+            # later boss defeat. The quest still needs the Ninefold King put down.
+            player.checkQuests()
 
     # ---- Quests ----
     @register(context)
     class NineMarchesQuest(CQuest):
         def isCompleted(self):
-            return self.getGame().getMap().getBoolProperty("crown_taken")
+            game_map = self.getGame().getMap()
+            return game_map.getBoolProperty("crown_taken") and game_map.getBoolProperty("boss_defeated")
 
         def getObjective(self):
             game_map = self.getGame().getMap()
             chapter = int(game_map.getNumericProperty("chapter"))
             read = int(game_map.getNumericProperty("obelisks_read"))
+            if game_map.getBoolProperty("crown_taken") and game_map.getBoolProperty("boss_defeated"):
+                return "Chapter IV. You wear the Ninefold Crown, and the Crowned God is down. The Nine Marches are quiet at last."
             if game_map.getBoolProperty("crown_taken"):
-                return "Chapter IV. You wear the Ninefold Crown. End what the Ninefold Crowning began."
+                return "Chapter IV. You wear the Ninefold Crown. End what the Ninefold Crowning began - put down the Ninefold King."
             if read >= 6:
                 return "Chapter IV. All six obelisks are read. Dig the grave-crown at the Cyclopean Citadel."
             if chapter >= 2:
@@ -535,8 +542,13 @@ def load(self, context):
     @trigger(context, "onDestroy", "theNinefoldKingBoss")
     class NinefoldKingTrigger(CTrigger):
         def trigger(self, obj, event):
+            game_map = obj.getGame().getMap()
+            game_map.setBoolProperty("boss_defeated", True)
             obj.getGame().getGuiHandler().showMessage(
                 "The Crowned God falls, and nine circlets of black iron crack apart on the Citadel stones. For the "
                 "first time in nine hundred years the Nine Marches are only quiet - not waiting. You still wear a "
                 "shard of its crown; the marches will remember that, too."
             )
+            # Boss-defeat transition: converge with the crown pickup so the finale
+            # completes once both requirements are met, in either order.
+            game_map.getPlayer().checkQuests()

--- a/res/maps/sunderedmarch/script.py
+++ b/res/maps/sunderedmarch/script.py
@@ -19,7 +19,7 @@ def load(self, context):
         return player.hasItem(lambda it: it.getName() == item_name)
 
     def quest_flags_default(game_map):
-        for flag in ("gate_open", "crown_taken", "boss_woken", "shrine_used", "seer_started", "seer_done"):
+        for flag in ("gate_open", "crown_taken", "boss_woken", "boss_defeated", "shrine_used", "seer_started", "seer_done"):
             if not hasattr(game_map, flag):
                 game_map.setBoolProperty(flag, False)
         if not hasattr(game_map, "sigils_found"):
@@ -168,16 +168,22 @@ def load(self, context):
                 game_map.addObject(boss)
                 boss.moveTo(*BOSS_SPAWN)
                 game_map.setBoolProperty("boss_woken", True)
+            # Refresh objectives/completion so pickup-first ordering converges with a
+            # later boss defeat. The quest still needs the Barrow-Warlord put down.
+            player.checkQuests()
 
     @register(context)
     class SunderedMarchQuest(CQuest):
         def isCompleted(self):
-            return self.getGame().getMap().getBoolProperty("crown_taken")
+            game_map = self.getGame().getMap()
+            return game_map.getBoolProperty("crown_taken") and game_map.getBoolProperty("boss_defeated")
 
         def getObjective(self):
             game_map = self.getGame().getMap()
+            if game_map.getBoolProperty("crown_taken") and game_map.getBoolProperty("boss_defeated"):
+                return "The Crown of the Barrow-Warlord is yours and its king is down. The Sundered March is only quiet now."
             if game_map.getBoolProperty("crown_taken"):
-                return "You wear the Crown of the Barrow-Warlord. The March has its king; end what the cult began."
+                return "You wear the Crown of the Barrow-Warlord. The March has its king; end what the cult began - put down the Barrow-Warlord."
             found = game_map.getNumericProperty("sigils_found")
             if game_map.getBoolProperty("gate_open"):
                 return f"Read the three barrow-obelisks, then dig beneath the central barrow. ({found}/3 sigils read.)"
@@ -276,7 +282,12 @@ def load(self, context):
     @trigger(context, "onDestroy", "theBarrowWarlordBoss")
     class BarrowWarlordTrigger(CTrigger):
         def trigger(self, obj, event):
+            game_map = obj.getGame().getMap()
+            game_map.setBoolProperty("boss_defeated", True)
             obj.getGame().getGuiHandler().showMessage(
                 "The Crowned Barrow-Warlord falls a second and final time. The plague-crown cracks on the stones, "
                 "and for the first time in a hundred years the Sundered March is only quiet - not waiting."
             )
+            # Boss-defeat transition: converge with the crown pickup so the finale
+            # completes once both requirements are met, in either order.
+            game_map.getPlayer().checkQuests()

--- a/res/maps/vhulmarn/script.py
+++ b/res/maps/vhulmarn/script.py
@@ -17,7 +17,7 @@ def load(self, context):
         player.addQuest(quest_name)
 
     def quest_system_flags_default(game_map):
-        for flag in ("tithe_heard", "bell_tolled", "tithe_taken", "boss_woken"):
+        for flag in ("tithe_heard", "bell_tolled", "tithe_taken", "boss_woken", "boss_defeated"):
             if not hasattr(game_map, flag):
                 game_map.setBoolProperty(flag, False)
 
@@ -89,16 +89,22 @@ def load(self, context):
                 game_map.addObject(boss)
                 boss.moveTo(*BOSS_SPAWN)
                 game_map.setBoolProperty("boss_woken", True)
+            # Refresh objectives/completion so pickup-first ordering converges with a
+            # later boss defeat. The quest still needs the Nameless put down.
+            player.checkQuests()
 
     @register(context)
     class DrownedTitheQuest(CQuest):
         def isCompleted(self):
-            return self.getGame().getMap().getBoolProperty("tithe_taken")
+            game_map = self.getGame().getMap()
+            return game_map.getBoolProperty("tithe_taken") and game_map.getBoolProperty("boss_defeated")
 
         def getObjective(self):
             game_map = self.getGame().getMap()
-            if game_map.getBoolProperty("tithe_taken"):
+            if game_map.getBoolProperty("tithe_taken") and game_map.getBoolProperty("boss_defeated"):
                 return "You carry the Tiara of the Drowned Tithe. The deep knows your name now."
+            if game_map.getBoolProperty("tithe_taken"):
+                return "The deep has sent up the Nameless in your shape. Put it back beneath the tarn to end the tithe."
             if game_map.getBoolProperty("tithe_heard"):
                 return "Cross the pilgrim causeway to the cyclopean altar at the tarn's heart."
             return "Find someone in Vhul'Marn who still remembers what the town owed the deep."
@@ -158,7 +164,12 @@ def load(self, context):
     @trigger(context, "onDestroy", "theNamelessBoss")
     class NamelessTrigger(CTrigger):
         def trigger(self, obj, event):
+            game_map = obj.getGame().getMap()
+            game_map.setBoolProperty("boss_defeated", True)
             obj.getGame().getGuiHandler().showMessage(
                 "The Nameless folds back into the tarn, and for one held breath the drowned bell will not ring. "
                 "It is not death. The deep is patient, and the stars will come right again."
             )
+            # Boss-defeat transition: converge with the tithe pickup so the finale
+            # completes once both requirements are met, in either order.
+            game_map.getPlayer().checkQuests()

--- a/test.py
+++ b/test.py
@@ -4929,6 +4929,7 @@ def walkthrough_vhulmarn_map():
     game_map.removeObjectByName("theNamelessBoss")
     pump_event_loop(5)
     assert game_map.getBoolProperty("boss_defeated"), "Defeating The Nameless should record the boss defeat."
+    assert game_map.getObjectByName("theNamelessBoss") is None, "The defeated Nameless should be gone from the map."
     player.checkQuests()
     assert "drownedTitheQuest" in completed_quest_names(player), "The Drowned Tithe quest should complete."
 
@@ -4940,7 +4941,7 @@ def walkthrough_vhulmarn_map():
         "boss_woken": game_map.getBoolProperty("boss_woken"),
         "boss_defeated": game_map.getBoolProperty("boss_defeated"),
         "tiara_count": player.countItems("tiaraOfTheDrownedTithe"),
-        "boss_present": find_runtime_object(game_map, "theNamelessBoss") is not None,
+        "boss_present": game_map.getObjectByName("theNamelessBoss") is not None,
         "quest_completed": "drownedTitheQuest" in completed_quest_names(player),
     }
 
@@ -4985,6 +4986,7 @@ def walkthrough_kadath_map():
     game_map.removeObjectByName("theCrawlingChaosBoss")
     pump_event_loop(5)
     assert game_map.getBoolProperty("boss_defeated"), "Defeating the Crawling Chaos should record the boss defeat."
+    assert game_map.getObjectByName("theCrawlingChaosBoss") is None, "The defeated Crawling Chaos should be gone."
     player.checkQuests()
     assert "kadathAscentQuest" in completed_quest_names(player), "The Kadath ascent quest should complete."
 
@@ -4996,7 +4998,7 @@ def walkthrough_kadath_map():
         "boss_woken": game_map.getBoolProperty("boss_woken"),
         "boss_defeated": game_map.getBoolProperty("boss_defeated"),
         "signet_count": player.countItems("onyxSignetOfNyarlathotep"),
-        "boss_present": find_runtime_object(game_map, "theCrawlingChaosBoss") is not None,
+        "boss_present": game_map.getObjectByName("theCrawlingChaosBoss") is not None,
         "quest_completed": "kadathAscentQuest" in completed_quest_names(player),
     }
 
@@ -5056,6 +5058,7 @@ def walkthrough_sunderedmarch_map():
     game_map.removeObjectByName("theBarrowWarlordBoss")
     pump_event_loop(5)
     assert game_map.getBoolProperty("boss_defeated"), "Defeating the Barrow-Warlord should record the boss defeat."
+    assert game_map.getObjectByName("theBarrowWarlordBoss") is None, "The defeated Barrow-Warlord should be gone."
     player.checkQuests()
     assert "sunderedMarchQuest" in completed_quest_names(player), "The Sundered March quest should complete."
 
@@ -5067,7 +5070,7 @@ def walkthrough_sunderedmarch_map():
         "boss_woken": game_map.getBoolProperty("boss_woken"),
         "boss_defeated": game_map.getBoolProperty("boss_defeated"),
         "crown_count": player.countItems("barrowCrown"),
-        "boss_present": find_runtime_object(game_map, "theBarrowWarlordBoss") is not None,
+        "boss_present": game_map.getObjectByName("theBarrowWarlordBoss") is not None,
         "quest_completed": "sunderedMarchQuest" in completed_quest_names(player),
     }
 
@@ -5150,6 +5153,7 @@ def walkthrough_ninemarches_map():
     game_map.removeObjectByName("theNinefoldKingBoss")
     pump_event_loop(5)
     assert game_map.getBoolProperty("boss_defeated"), "Defeating the Ninefold King should record the boss defeat."
+    assert game_map.getObjectByName("theNinefoldKingBoss") is None, "The defeated Ninefold King should be gone."
     player.checkQuests()
     assert "ninemarchesQuest" in completed_quest_names(player), "The Nine Marches quest should complete."
 
@@ -5164,7 +5168,7 @@ def walkthrough_ninemarches_map():
         "boss_woken": game_map.getBoolProperty("boss_woken"),
         "boss_defeated": game_map.getBoolProperty("boss_defeated"),
         "crown_count": player.countItems("ninefoldCrown"),
-        "boss_present": find_runtime_object(game_map, "theNinefoldKingBoss") is not None,
+        "boss_present": game_map.getObjectByName("theNinefoldKingBoss") is not None,
         "quest_completed": "ninemarchesQuest" in completed_quest_names(player),
     }
 

--- a/test.py
+++ b/test.py
@@ -4919,6 +4919,16 @@ def walkthrough_vhulmarn_map():
     assert player.countItems("tiaraOfTheDrownedTithe") == tiaras_before + 1, "The tiara should enter the inventory."
     assert find_runtime_object(game_map, "theNamelessBoss") is not None, "The Nameless should rise on the altar."
 
+    # The finale requires the boss defeat as well as the pickup: the tiara alone must not complete it.
+    player.checkQuests()
+    assert (
+        "drownedTitheQuest" not in completed_quest_names(player)
+    ), "The Drowned Tithe quest must not complete on the tiara pickup alone."
+
+    # Defeating The Nameless (its onDestroy trigger) records the boss defeat and completes the finale.
+    game_map.removeObjectByName("theNamelessBoss")
+    pump_event_loop(5)
+    assert game_map.getBoolProperty("boss_defeated"), "Defeating The Nameless should record the boss defeat."
     player.checkQuests()
     assert "drownedTitheQuest" in completed_quest_names(player), "The Drowned Tithe quest should complete."
 
@@ -4928,6 +4938,7 @@ def walkthrough_vhulmarn_map():
         "bell_tolled": game_map.getBoolProperty("bell_tolled"),
         "tithe_taken": game_map.getBoolProperty("tithe_taken"),
         "boss_woken": game_map.getBoolProperty("boss_woken"),
+        "boss_defeated": game_map.getBoolProperty("boss_defeated"),
         "tiara_count": player.countItems("tiaraOfTheDrownedTithe"),
         "boss_present": find_runtime_object(game_map, "theNamelessBoss") is not None,
         "quest_completed": "drownedTitheQuest" in completed_quest_names(player),
@@ -4964,6 +4975,16 @@ def walkthrough_kadath_map():
     assert player.countItems("onyxSignetOfNyarlathotep") == signets_before + 1, "The signet should enter the inventory."
     assert find_runtime_object(game_map, "theCrawlingChaosBoss") is not None, "Nyarlathotep should rise at the throne."
 
+    # The finale requires the boss defeat as well as the pickup: the signet alone must not complete it.
+    player.checkQuests()
+    assert (
+        "kadathAscentQuest" not in completed_quest_names(player)
+    ), "The Kadath ascent quest must not complete on the signet pickup alone."
+
+    # Defeating the Crawling Chaos (its onDestroy trigger) records the boss defeat and completes the finale.
+    game_map.removeObjectByName("theCrawlingChaosBoss")
+    pump_event_loop(5)
+    assert game_map.getBoolProperty("boss_defeated"), "Defeating the Crawling Chaos should record the boss defeat."
     player.checkQuests()
     assert "kadathAscentQuest" in completed_quest_names(player), "The Kadath ascent quest should complete."
 
@@ -4973,6 +4994,7 @@ def walkthrough_kadath_map():
         "gate_opened": game_map.getBoolProperty("gate_opened"),
         "throne_taken": game_map.getBoolProperty("throne_taken"),
         "boss_woken": game_map.getBoolProperty("boss_woken"),
+        "boss_defeated": game_map.getBoolProperty("boss_defeated"),
         "signet_count": player.countItems("onyxSignetOfNyarlathotep"),
         "boss_present": find_runtime_object(game_map, "theCrawlingChaosBoss") is not None,
         "quest_completed": "kadathAscentQuest" in completed_quest_names(player),
@@ -5024,6 +5046,16 @@ def walkthrough_sunderedmarch_map():
         find_runtime_object(game_map, "theBarrowWarlordBoss") is not None
     ), "The Barrow-Warlord should rise at the dig."
 
+    # The finale requires the boss defeat as well as the pickup: the crown alone must not complete it.
+    player.checkQuests()
+    assert (
+        "sunderedMarchQuest" not in completed_quest_names(player)
+    ), "The Sundered March quest must not complete on the crown pickup alone."
+
+    # Defeating the Barrow-Warlord (its onDestroy trigger) records the boss defeat and completes the finale.
+    game_map.removeObjectByName("theBarrowWarlordBoss")
+    pump_event_loop(5)
+    assert game_map.getBoolProperty("boss_defeated"), "Defeating the Barrow-Warlord should record the boss defeat."
     player.checkQuests()
     assert "sunderedMarchQuest" in completed_quest_names(player), "The Sundered March quest should complete."
 
@@ -5033,6 +5065,7 @@ def walkthrough_sunderedmarch_map():
         "sigils_found": game_map.getNumericProperty("sigils_found"),
         "crown_taken": game_map.getBoolProperty("crown_taken"),
         "boss_woken": game_map.getBoolProperty("boss_woken"),
+        "boss_defeated": game_map.getBoolProperty("boss_defeated"),
         "crown_count": player.countItems("barrowCrown"),
         "boss_present": find_runtime_object(game_map, "theBarrowWarlordBoss") is not None,
         "quest_completed": "sunderedMarchQuest" in completed_quest_names(player),
@@ -5106,9 +5139,19 @@ def walkthrough_ninemarches_map():
     assert find_runtime_object(game_map, "theNinefoldKingBoss") is not None, "The Ninefold King should rise at the dig."
     assert game_map.getNumericProperty("chapter") == 4, "The dig should advance to the final chapter."
 
+    # The finale requires the boss defeat as well as the pickup: the crown alone must not complete it.
+    player.checkQuests()
+    assert (
+        "ninemarchesQuest" not in completed_quest_names(player)
+    ), "The Nine Marches quest must not complete on the crown pickup alone."
+    assert "haldaQuest" in completed_quest_names(player), "Ser Halda's companion quest should complete on recruit."
+
+    # Defeating the Ninefold King (its onDestroy trigger) records the boss defeat and completes the finale.
+    game_map.removeObjectByName("theNinefoldKingBoss")
+    pump_event_loop(5)
+    assert game_map.getBoolProperty("boss_defeated"), "Defeating the Ninefold King should record the boss defeat."
     player.checkQuests()
     assert "ninemarchesQuest" in completed_quest_names(player), "The Nine Marches quest should complete."
-    assert "haldaQuest" in completed_quest_names(player), "Ser Halda's companion quest should complete on recruit."
 
     return {
         "map": "ninemarches",
@@ -5119,6 +5162,7 @@ def walkthrough_ninemarches_map():
         "obelisks_read": game_map.getNumericProperty("obelisks_read"),
         "crown_taken": game_map.getBoolProperty("crown_taken"),
         "boss_woken": game_map.getBoolProperty("boss_woken"),
+        "boss_defeated": game_map.getBoolProperty("boss_defeated"),
         "crown_count": player.countItems("ninefoldCrown"),
         "boss_present": find_runtime_object(game_map, "theNinefoldKingBoss") is not None,
         "quest_completed": "ninemarchesQuest" in completed_quest_names(player),
@@ -17058,6 +17102,101 @@ class GameTest(unittest.TestCase):
     @game_test
     def test_map_walkthrough_ninemarches(self):
         return execute_walkthrough("ninemarches")
+
+    @game_test
+    def test_map_finales_require_boss_defeat_and_pickup(self):
+        # [EPIC_10][STORY_02][SUBSTORY_01] The four finale quests (Kadath, Vhul'Marn, Sundered
+        # March, Nine Marches) must require BOTH the artifact/throne/crown pickup and the named
+        # finale boss defeat before completing. Neither transition alone completes the quest, and
+        # both in either order do. While only the pickup is recorded the objective names the
+        # remaining boss requirement, completion is idempotent across repeated checkQuests, and
+        # the completed state survives a save/load round-trip. Flags are driven directly so the
+        # ordering matrix stays deterministic and fast (the full pickup->defeat path is covered
+        # by the per-map walkthroughs).
+        game = load_game_module()
+
+        def active_objective(pl, qid):
+            for quest in pl.getQuests():
+                quest_id = quest.getTypeId() if hasattr(quest, "getTypeId") else quest.getName()
+                if quest_id == qid:
+                    return quest.getObjective()
+            return None
+
+        finales = (
+            ("kadath", "kadathAscentQuest", "throne_taken"),
+            ("vhulmarn", "drownedTitheQuest", "tithe_taken"),
+            ("sunderedmarch", "sunderedMarchQuest", "crown_taken"),
+            ("ninemarches", "ninemarchesQuest", "crown_taken"),
+        )
+
+        results = {}
+        for map_name, quest_id, pickup in finales:
+            # --- pickup-first: the pickup alone must not complete the finale ---
+            g, game_map, player = load_game_map_with_player(map_name)
+            if quest_id not in quest_names(player):
+                player.addQuest(quest_id)
+
+            game_map.setBoolProperty("boss_defeated", False)
+            game_map.setBoolProperty(pickup, True)
+            player.checkQuests()
+            self.assertNotIn(
+                quest_id, completed_quest_names(player), f"{map_name}: pickup alone must not complete the finale"
+            )
+            # Objective reflects the remaining requirement (put the finale boss down).
+            objective = active_objective(player, quest_id)
+            self.assertTrue(objective, f"{map_name}: an active finale objective should be present")
+            self.assertIn("put", objective.lower(), f"{map_name}: objective should name the remaining boss: {objective!r}")
+
+            # Adding the boss defeat completes it.
+            game_map.setBoolProperty("boss_defeated", True)
+            player.checkQuests()
+            self.assertIn(
+                quest_id, completed_quest_names(player), f"{map_name}: pickup + boss defeat should complete the finale"
+            )
+
+            # Idempotent across repeated triggers: exactly one completion, never doubled.
+            for _ in range(3):
+                player.checkQuests()
+            self.assertEqual(
+                1, completed_quest_names(player).count(quest_id), f"{map_name}: finale completion must be idempotent"
+            )
+
+            # The completed finale survives a save/load round-trip.
+            save_name = unique_save_name(f"finale_{map_name}")
+            cleanup_save_slot(save_name)
+            try:
+                game.CMapLoader.save(game_map, save_name)
+                reloaded = game.CGameLoader.loadGame()
+                game.CGameLoader.loadSavedGame(reloaded, save_name)
+                reloaded_player = reloaded.getMap().getPlayer()
+                self.assertIn(
+                    quest_id,
+                    completed_quest_names(reloaded_player),
+                    f"{map_name}: finale completion should survive save/load",
+                )
+            finally:
+                cleanup_save_slot(save_name)
+
+            # --- defeat-first: the boss defeat alone must not complete the finale ---
+            _g2, game_map2, player2 = load_game_map_with_player(map_name)
+            if quest_id not in quest_names(player2):
+                player2.addQuest(quest_id)
+            game_map2.setBoolProperty(pickup, False)
+            game_map2.setBoolProperty("boss_defeated", True)
+            player2.checkQuests()
+            self.assertNotIn(
+                quest_id, completed_quest_names(player2), f"{map_name}: boss defeat alone must not complete the finale"
+            )
+            # Adding the pickup completes it in the reverse order.
+            game_map2.setBoolProperty(pickup, True)
+            player2.checkQuests()
+            self.assertIn(
+                quest_id, completed_quest_names(player2), f"{map_name}: boss defeat + pickup should complete the finale"
+            )
+
+            results[map_name] = {"quest": quest_id, "pickup_flag": pickup, "completed_both_orders": True}
+
+        return True, json.dumps(results, sort_keys=True)
 
     @game_test
     def test_map_walkthrough_hearthfall(self):


### PR DESCRIPTION
## Summary

Fixes the finale contracts in **kadath**, **vhulmarn**, **sunderedmarch**, and **ninemarches**. Previously each finale quest completed on the artifact/throne/crown pickup **alone**, before the named finale boss was defeated — the boss it spawned could be ignored entirely.

Each finale now requires **both** the pickup **and** the boss defeat before the main quest completes, converging regardless of order.

## Changes (per map: kadath / vhulmarn / sunderedmarch / ninemarches)

- Added a map-local `boss_defeated` flag to each map's default flag set (idempotent init).
- The finale quest's `isCompleted()` now requires the pickup flag **AND** `boss_defeated`.
- `getObjective()` names the remaining requirement — "put down the &lt;boss&gt;" — while only the pickup is recorded, and the finished text once both are done.
- The pickup event (throne/altar/dig) and the boss `onDestroy` trigger each set their flag and call `player.checkQuests()`, so **pickup-first** and **defeat-first** orderings both converge on completion.

| Map | pickup flag | finale boss | finale quest |
|-----|-------------|-------------|--------------|
| kadath | `throne_taken` | theCrawlingChaosBoss | kadathAscentQuest |
| vhulmarn | `tithe_taken` | theNamelessBoss | drownedTitheQuest |
| sunderedmarch | `crown_taken` | theBarrowWarlordBoss | sunderedMarchQuest |
| ninemarches | `crown_taken` | theNinefoldKingBoss | ninemarchesQuest |

## Tests

- The four per-map walkthroughs now assert the pickup alone does **not** complete the finale, then defeat the boss via its `onDestroy` trigger (`removeObjectByName`) and assert completion + the recorded `boss_defeated` flag.
- New focused GameTest `test_map_finales_require_boss_defeat_and_pickup` covers, on all four maps: both event orderings (pickup-first and defeat-first), the objective text naming the remaining boss, repeated-`checkQuests` idempotency (exactly one completion), and save/load of the completed state.

## Validation

- `python3 scripts/validate_content.py --repo-root .` → passed
- `python3 -m unittest tests.test_content_validator` → 194 OK
- AST parse of all four scripts and `test.py`; no tab indentation
- Full gameplay suite + coverage and native walkthroughs via CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b)_