### PR TITLE
[EPIC_10][STORY_03][SUBSTORY_01] Diverge the Warden mercy assault route

### DIFF
--- a/res/maps/usurpergate/script.py
+++ b/res/maps/usurpergate/script.py
@@ -19,6 +19,17 @@ def load(self, context):
 
     THRONE_GOLD_REWARD = 500
 
+    # Mercy-route divergence (wardensRoad/assault_mercy): Voss's ledgers bought the
+    # west approach, so these exact defenders stand down before the first
+    # introduction. Wrath and standalone play keep the full assault.
+    MERCY_ROUTE_DEFENDERS = ("curtainWallWest1", "curtainWallWest2", "housecarlWest")
+    MERCY_ARRIVAL_TEXT = (
+        "The Usurper's Gate - and the west curtain already lies open. Voss's ledgers named "
+        "every bribed housecarl and every weak stone, and the loyalists walk through a breach "
+        "the Usurper's own coin paid for. Mercy bought you this road; the throne is still "
+        "yours to take."
+    )
+
     def ensure_quest(player, quest_name):
         for quest in player.getQuests():
             if quest.getName() == quest_name:
@@ -26,9 +37,37 @@ def load(self, context):
         player.addQuest(quest_name)
 
     def usurpergate_flags_default(game_map):
-        for flag in ("usurpergate_intro", "usurper_defeated", "throne_taken", "throne_reward_claimed"):
+        for flag in (
+            "usurpergate_intro",
+            "usurper_defeated",
+            "throne_taken",
+            "throne_reward_claimed",
+            "mercy_route_applied",
+        ):
             if not game_map.getBoolProperty(flag):
                 game_map.setBoolProperty(flag, False)
+
+    def mercy_route_active(game):
+        # The active campaign scenario decides the route; standalone play (no
+        # active campaign) and the wrath branch keep the full assault.
+        store = campaign.state(game)
+        return (
+            store is not None
+            and store.active()
+            and store.campaign_id() == "wardensRoad"
+            and store.scenario() == "assault_mercy"
+        )
+
+    def apply_mercy_route(game_map):
+        # Idempotent across reloads and repeated start hooks: the persisted
+        # mercy_route_applied map flag guards the side effects, so the removal
+        # and the arrival copy happen exactly once per campaign run.
+        if game_map.getBoolProperty("mercy_route_applied"):
+            return False
+        for defender in MERCY_ROUTE_DEFENDERS:
+            game_map.removeAll(lambda ob, target=defender: ob.getName() == target)
+        game_map.setBoolProperty("mercy_route_applied", True)
+        return True
 
     @register(context)
     class UsurpergateStart(CEvent):
@@ -36,11 +75,19 @@ def load(self, context):
             if not event.getCause().isPlayer():
                 return
             game_map = self.getMap()
+            game = game_map.getGame()
             usurpergate_flags_default(game_map)
             if game_map.getBoolProperty("usurpergate_intro"):
                 return
             game_map.setBoolProperty("usurpergate_intro", True)
-            game_map.getGame().getGuiHandler().showMessage(self.getStringProperty("text"))
+            # Mercy route: stand down the bought west defenders BEFORE the first
+            # introduction, and show the mercy-specific arrival copy instead of
+            # the standard assault text. Wrath/standalone keep the full assault.
+            if mercy_route_active(game):
+                apply_mercy_route(game_map)
+                game.getGuiHandler().showMessage(MERCY_ARRIVAL_TEXT)
+            else:
+                game.getGuiHandler().showMessage(self.getStringProperty("text"))
             game_map.removeAll(lambda ob: ob.getName() == self.getName())
             ensure_quest(event.getCause(), "usurpergateQuest")
 

--- a/test.py
+++ b/test.py
@@ -18358,6 +18358,113 @@ class GameTest(unittest.TestCase):
         )
 
     @game_test
+    def test_usurpergate_mercy_route_diverges_from_wrath_and_standalone(self):
+        # [EPIC_10][STORY_03][SUBSTORY_01] The Warden's Road mercy finale must materially
+        # diverge from wrath: when the active campaign scenario is wardensRoad/assault_mercy,
+        # exactly curtainWallWest1, curtainWallWest2, and housecarlWest are removed BEFORE the
+        # first Usurpergate introduction, mercy_route_applied is recorded, and mercy-specific
+        # arrival copy is shown once. Wrath and standalone entry keep the full assault (all
+        # three defenders present, standard arrival text), the final Usurper/throne objective,
+        # and the 500-gold reward. Route application is idempotent across save/load.
+        game = load_game_module()
+        import campaign as campaign_module
+
+        mercy_defenders = ("curtainWallWest1", "curtainWallWest2", "housecarlWest")
+        kept_defenders = ("curtainWallEast1", "curtainWallEast2", "housecarlEast", "theUsurper")
+        start_definition = find_map_object_definition("usurpergate", "usurpergateStart")
+        throne_definition = find_map_object_definition("usurpergate", "obsidianThrone")
+
+        messages = []
+        original_show_message = game.CGuiHandler.showMessage
+        game.CGuiHandler.showMessage = lambda self_, message: messages.append(message)
+
+        def enter_start(g, player):
+            player.moveTo(start_definition["x"] // 32, start_definition["y"] // 32, 0)
+            pump_event_loop(5)
+
+        try:
+            # --- Standalone: no active campaign -> full assault, standard arrival text.
+            g, game_map, player = load_game_map_with_player("usurpergate")
+            enter_start(g, player)
+            for name in mercy_defenders + kept_defenders:
+                self.assertIsNotNone(game_map.getObjectByName(name), f"standalone keeps {name}")
+            self.assertFalse(game_map.getBoolProperty("mercy_route_applied"))
+            self.assertFalse(any("Voss's ledgers named" in m for m in messages), "no mercy copy standalone")
+
+            # --- Wrath: assault_wrath scenario -> full assault, standard arrival text.
+            messages.clear()
+            g2, map2, player2 = load_game_map_with_player("usurpergate")
+            campaign_module.CampaignStateStore(player2).begin("wardensRoad", "assault_wrath")
+            enter_start(g2, player2)
+            for name in mercy_defenders + kept_defenders:
+                self.assertIsNotNone(map2.getObjectByName(name), f"wrath keeps {name}")
+            self.assertFalse(map2.getBoolProperty("mercy_route_applied"))
+            self.assertFalse(any("Voss's ledgers named" in m for m in messages), "no mercy copy on wrath")
+
+            # --- Mercy: assault_mercy scenario -> the three named defenders stand down
+            # before the first introduction, the flag is recorded, mercy copy shows once.
+            messages.clear()
+            g3, map3, player3 = load_game_map_with_player("usurpergate")
+            store = campaign_module.CampaignStateStore(player3)
+            store.begin("wardensRoad", "assault_mercy")
+            for name in mercy_defenders:
+                self.assertIsNotNone(map3.getObjectByName(name), f"{name} present before intro")
+            enter_start(g3, player3)
+            for name in mercy_defenders:
+                self.assertIsNone(map3.getObjectByName(name), f"mercy removes {name}")
+            for name in kept_defenders:
+                self.assertIsNotNone(map3.getObjectByName(name), f"mercy keeps {name}")
+            self.assertTrue(map3.getBoolProperty("mercy_route_applied"))
+            mercy_copies = [m for m in messages if "Voss's ledgers named" in m]
+            self.assertEqual(1, len(mercy_copies), "mercy arrival copy shows exactly once")
+
+            # Repeated entry after the intro re-applies nothing (start event is consumed
+            # and the intro flag guards the hook).
+            messages.clear()
+            enter_start(g3, player3)
+            self.assertEqual([], [m for m in messages if "Voss's ledgers named" in m])
+
+            # Save/load: route flags persist and side effects are not reapplied.
+            save_name = unique_save_name("usurpergate_mercy_route")
+            cleanup_save_slot(save_name)
+            try:
+                game.CMapLoader.save(map3, save_name)
+                loaded_game = game.CGameLoader.loadGame()
+                game.CGameLoader.loadSavedGame(loaded_game, save_name)
+                loaded_map = loaded_game.getMap()
+                loaded_player = loaded_map.getPlayer()
+                self.assertTrue(loaded_map.getBoolProperty("mercy_route_applied"))
+                for name in mercy_defenders:
+                    self.assertIsNone(loaded_map.getObjectByName(name), f"{name} stays removed after reload")
+                for name in kept_defenders:
+                    self.assertIsNotNone(loaded_map.getObjectByName(name), f"{name} survives reload")
+
+                # The mercy route still ends the assault the same way: fell the Usurper,
+                # take the throne, and the 500-gold treasury reward is granted once.
+                gold_before = loaded_player.getGold()
+                loaded_map.removeObjectByName("theUsurper")
+                pump_event_loop(5)
+                self.assertTrue(loaded_map.getBoolProperty("usurper_defeated"))
+                loaded_player.moveTo(throne_definition["x"] // 32, throne_definition["y"] // 32, 0)
+                pump_event_loop(5)
+                self.assertTrue(loaded_map.getBoolProperty("throne_taken"))
+                self.assertEqual(gold_before + 500, loaded_player.getGold(), "throne reward stays 500 gold")
+            finally:
+                cleanup_save_slot(save_name)
+        finally:
+            game.CGuiHandler.showMessage = original_show_message
+
+        return True, json.dumps(
+            {
+                "mercy_removed": list(mercy_defenders),
+                "kept": list(kept_defenders),
+                "mercy_route_applied": True,
+                "throne_reward": 500,
+            },
+            sort_keys=True,
+        )
+
+    @game_test
     def test_quest_journal_shows_objectives_rewards_and_hints(self):
         game = load_game_module()
 


### PR DESCRIPTION
## Summary

Makes the Warden's Road **mercy** finale materially diverge from **wrath**: when the active campaign scenario is `wardensRoad/assault_mercy`, Voss's ledgers buy the west approach — the Usurpergate start hook stands down exactly `curtainWallWest1`, `curtainWallWest2`, and `housecarlWest` **before the first introduction**, records a persistent `mercy_route_applied` map flag, and shows mercy-specific arrival copy once. Wrath and standalone play keep the full assault.

## Changes

`res/maps/usurpergate/script.py`:
- `mercy_route_active(game)` — reads the active campaign scenario via `campaign.state(game)` (player-stored `campaign_id`/`campaign_scenario`); true only for an active `wardensRoad` campaign on `assault_mercy`.
- `apply_mercy_route(game_map)` — removes the three named defenders and sets `mercy_route_applied`; guarded by the persisted flag so reloads and repeated start hooks never reapply side effects.
- `UsurpergateStart.onEnter` — on the mercy route, applies the stand-down before the first introduction and shows the mercy arrival text instead of the standard assault copy; the existing `usurpergate_intro` guard keeps the copy to exactly one showing.
- `mercy_route_applied` added to the idempotent flag defaults.

Unchanged on all routes: the east defenders and the Usurper, the final Usurper/throne objective, and the once-only 500-gold treasury reward (`claim_once`).

## Tests

New GameTest `test_usurpergate_mercy_route_diverges_from_wrath_and_standalone`:
- **Standalone** (no campaign) and **wrath** (`assault_wrath` stamped): all defenders present, standard arrival copy, `mercy_route_applied` stays false.
- **Mercy** (`assault_mercy` stamped): the three named defenders present before the intro and removed after; east defenders + Usurper retained; flag recorded; mercy copy shown exactly once; repeated entry shows nothing new.
- **Save/load**: flag and removals persist; no reapplication; then Usurper defeat → throne → `throne_taken` and exactly +500 gold.

Existing end-to-end campaign tests (`test_wardens_road_campaign_mercy_route`, `..._wrath_route_clamps_gold`) continue to cover routing and gold clamp.

## Validation

- AST + repo indentation gate clean on both files; `validate_content.py` passed.
- Full gameplay suite via CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01WctWHcx4zSPNJDdKzUvK3b)_