### PR TITLE
Restore CCreatureClassTrack registration after plugin-system merge

### DIFF
--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -46,6 +46,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "../handler/CRngHandler.h"
 #include "../object/CCreature.h"
 #include "../object/CCreatureClass.h"
+#include "../object/CCreatureClassTrack.h"
 #include "../object/CCreatureRace.h"
 #include "../object/CCreatureTemplate.h"
 #include "../object/CDialog.h"

--- a/src/plugin/CGameplayTypeTable.h
+++ b/src/plugin/CGameplayTypeTable.h
@@ -73,12 +73,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     FN_TYPE(CRangeController, CController, CGameObject)                                            \
     FN_TYPE(CNpcRandomController, CController, CGameObject)                                        \
     FN_TYPE(CPlayerController, CController, CGameObject)                                           \
-    /* CCreatureRace/CCreatureClass/CCreatureTemplate are CGameObject-derived archetype        */  \
+    /* CCreatureRace/CCreatureClass/CCreatureClassTrack/CCreatureTemplate are CGameObject-derived archetype        */  \
     /* definitions, not CCreature subtypes, so configured IDs stay constructible while the     */  \
     /* classes stay out of random-encounter / getAllSubTypes("CCreature") enumeration.         */  \
     /* CCreatureTemplate is the elite/undead/... overlay referenced via CCreature.templates.   */  \
     FN_TYPE(CCreatureRace, CGameObject)                                                            \
     FN_TYPE(CCreatureClass, CGameObject)                                                           \
+    FN_TYPE(CCreatureClassTrack, CGameObject)                                                      \
     FN_TYPE(CCreatureTemplate, CGameObject)                                                        \
     FN_TYPE(CCreature, CMapObject, CGameObject)                                                    \
     FN_TYPE(CPlayer, CCreature, CMapObject, CGameObject)


### PR DESCRIPTION
## Root cause

PR #1488 replaced the hand-maintained gameplay registration lists with `src/plugin/CGameplayTypeTable.h`. During conflict resolution against current `main`, the newer `CCreatureClassTrack` registration from `src/plugin/NativePlugin.cpp` was not carried into that table.

The class remained referenced by `CCreature.classTracks` and by the content validator, but it was no longer registered as a content-constructible gameplay type. This also left the table consumer in `src/core/CModule.cpp` without the class header needed for metadata expansion.

## Changes

- add `CCreatureClassTrack -> CGameObject` to `FN_GAMEPLAY_TYPES`
- include `CCreatureClassTrack.h` in `CModule.cpp`
- keep the fix within the new single-source registration model introduced by #1488

## Verification

- `python3 scripts/validate_content.py --repo-root .`
- `python3 -m unittest tests.test_content_validator`
- branch diff contains only the two targeted source files

## Manual review

- confirm full C++ CI builds `plugin_registrar_unit_tests`; that suite expands the same type table and exercises constructibility
