### PR TITLE
Fix percentage restores + four more verified gameplay/engine bugs

### DIFF
--- a/res/maps/nouraajd/dialog2.json
+++ b/res/maps/nouraajd/dialog2.json
@@ -41,6 +41,7 @@
                 "properties": {
                   "number": 3,
                   "condition": "contract_completed",
+                  "action": "accept_quest",
                   "nextStateId": "COMPLETED_THANKS",
                   "text": "The cave is quiet now. The OctoBogz are dead."
                 }

--- a/res/plugins/interaction.py
+++ b/res/plugins/interaction.py
@@ -84,16 +84,15 @@ def load(self, context):
     @register(context)
     class Devour(CInteraction):
         def performAction(self, first, second):
-            crit = first.getStats().getNumericProperty("crit")
-            first.getStats().setNumericProperty("crit", 0)
-            dmg = first.getDmg()
+            # Devour never crits: ask getDmg to skip the crit roll. The old code tried to
+            # suppress crit by mutating first.getStats(), but getStats() returns a freshly
+            # composed copy on every call, so the mutation did nothing and Devour still crit.
+            dmg = first.getDmg(False)
             if dmg:
                 second.hurt(dmg)
-                # Heal 75% of the damage dealt directly: routing it through an
-                # integer percent of hpMax floors to healProc(0) (= full heal)
-                # whenever dmg * 75 < hpMax.
+                # Heal 75% of the damage dealt directly: routing it through an integer percent
+                # of hpMax floors to healProc(0) (= full heal) when dmg*75 < hpMax.
                 first.heal(max(1, dmg * 75 // 100))
-            first.getStats().setNumericProperty("crit", crit)
 
     @register(context)
     class FrostBolt(CInteraction):

--- a/res/plugins/interaction.py
+++ b/res/plugins/interaction.py
@@ -89,7 +89,10 @@ def load(self, context):
             dmg = first.getDmg()
             if dmg:
                 second.hurt(dmg)
-                first.healProc((dmg * 75) // max(first.getHpMax(), 1))
+                # Heal 75% of the damage dealt directly: routing it through an
+                # integer percent of hpMax floors to healProc(0) (= full heal)
+                # whenever dmg * 75 < hpMax.
+                first.heal(max(1, dmg * 75 // 100))
             first.getStats().setNumericProperty("crit", crit)
 
     @register(context)

--- a/src/core/CController.cpp
+++ b/src/core/CController.cpp
@@ -532,14 +532,23 @@ int expected_incoming_hit(const std::shared_ptr<CCreature> &me, const std::share
 // Heal items restore getPower() * 20% of max hp (res/plugins/potion.py), capped
 // by the hp actually missing. Returns the estimate for the strongest heal item
 // carried, i.e. the best single-turn hp swing a heal turn could buy.
-int strongest_heal_estimate(const std::shared_ptr<CCreature> &me) {
-    int bestPower = 0;
+// Estimates how much the heal potion the AI would actually drink restores. The
+// controller spends the LEAST powerful heal first (getLeastPowerfulItemWithTag), so the
+// gate must weigh that same potion: weighing the strongest would green-light a heal the
+// drunk potion cannot keep pace with, re-introducing net-loss chain-drinking.
+int consumed_heal_estimate(const std::shared_ptr<CCreature> &me) {
+    bool found = false;
+    int weakestPower = 0;
     for (const auto &item : me->getItems()) {
         if (item && item->hasTag(CTag::Heal)) {
-            bestPower = std::max(bestPower, item->getPower());
+            const int power = item->getPower();
+            if (!found || power < weakestPower) {
+                weakestPower = power;
+                found = true;
+            }
         }
     }
-    const int uncapped = bestPower * me->getHpMax() / 5;
+    const int uncapped = weakestPower * me->getHpMax() / 5;
     return std::min(uncapped, me->getHpMax() - me->getHp());
 }
 
@@ -554,7 +563,7 @@ bool heal_preserves_combatant(const std::shared_ptr<CCreature> &me, const std::s
     if (me->getHp() <= incoming) {
         return true;
     }
-    return strongest_heal_estimate(me) > incoming;
+    return consumed_heal_estimate(me) > incoming;
 }
 
 // Deterministic estimate of how much a single cast weakens the opponent, used to

--- a/src/core/CLoader.cpp
+++ b/src/core/CLoader.cpp
@@ -1267,7 +1267,7 @@ std::shared_ptr<CMap> CRandomMapGenerator::loadRandomMap(const std::shared_ptr<C
 void CRandomMapGenerator::generateEncounters(const std::shared_ptr<CGame> &game, std::shared_ptr<CMap> &map,
                                              const std::vector<rdg::Room> &rooms) {
     for (const auto &room : rooms) {
-        auto roomCoords = Coords(room.row + room.width / 2, room.col + room.height / 2, 0);
+        auto roomCoords = Coords(room.row + room.height / 2, room.col + room.width / 2, 0);
         if (roomCoords.getDist(map->getEntry()) > 5) {
             for (const auto &creature : game->getRngHandler()->getRandomEncounter(5)) {
                 map->addObject(creature, roomCoords);

--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -1128,8 +1128,8 @@ void init_game_module(py::module_ &m) {
         .def("onEquip", &CWeapon::onEquip, "Handle equip event.")
         .def("onUnequip", &CWeapon::onUnequip, "Handle unequip event.")
         .def("onUse", &CWeapon::onUse, "Handle use event.");
-    py::class_<CSmallWeapon, CWrapper<CSmallWeapon>, std::shared_ptr<CSmallWeapon>, CWeapon>(m, "CSmallWeapon",
-                                                                                            "Off-hand small weapon item.")
+    py::class_<CSmallWeapon, CWrapper<CSmallWeapon>, std::shared_ptr<CSmallWeapon>, CWeapon>(
+        m, "CSmallWeapon", "Off-hand small weapon item.")
         .def(py::init_alias<>());
 
     void (CCreature::*hurtInt)(int) = &CCreature::hurt;
@@ -1142,7 +1142,7 @@ void init_game_module(py::module_ &m) {
     void (CCreature::*removeQuestItem)(std::function<bool(std::shared_ptr<CItem>)>) = &CCreature::removeQuestItem;
     py::class_<CCreature, CMapObject, std::shared_ptr<CCreature>>(
         m, "CCreature", "Creature that can move, fight, and manage inventory.")
-        .def("getDmg", &CCreature::getDmg, "Roll outgoing attack damage.")
+        .def("getDmg", &CCreature::getDmg, py::arg("allowCrit") = true, "Roll outgoing attack damage.")
         .def("hurt", hurtInt, "Apply raw damage value (int).")
         .def("hurt", hurtDmg, "Apply structured CDamage object.")
         .def("hurt", hurtFloat, "Apply damage value (float), rounded to int.")

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -419,8 +419,10 @@ void CCreature::hurt(std::shared_ptr<CDamage> damage) {
     vstd::logger::debug(getType(), "took damage:", JSONIFY(damage));
 }
 
-int CCreature::getDmg() {
+int CCreature::getDmg(bool allowCrit) {
     auto stats = getStats();
+    // critDice is rolled unconditionally so the RNG stream stays identical whether or not
+    // crit is allowed; allowCrit only gates whether a rolled crit is applied.
     int critDice = rand() % 100;
     int attDice = rand() % 100;
     int dmgMin = std::min(stats->getDmgMin(), stats->getDmgMax());
@@ -429,7 +431,7 @@ int CCreature::getDmg() {
     dmg += stats->getDamage();
     attDice -= stats->getAttack();
     if (attDice < stats->getHit()) {
-        if (critDice < stats->getCrit()) {
+        if (allowCrit && critDice < stats->getCrit()) {
             dmg *= 2;
             vstd::logger::debug("Critical!");
         }

--- a/src/object/CCreature.cpp
+++ b/src/object/CCreature.cpp
@@ -350,7 +350,13 @@ void CCreature::heal(int i) {
 
 void CCreature::healProc(float i) {
     int tmp = hp;
-    heal(i / 100.0 * getHpMax());
+    int amount = i / 100.0 * getHpMax();
+    // A positive percentage must restore at least 1 hp: truncating to 0 would
+    // accidentally invoke heal(0), whose sentinel meaning is "restore to full".
+    if (i > 0 && amount == 0) {
+        amount = 1;
+    }
+    heal(amount);
     vstd::logger::debug(to_string(), "restored", hp - tmp, "hp");
 }
 
@@ -523,7 +529,13 @@ void CCreature::addMana(int i) {
 
 void CCreature::addManaProc(float i) {
     int tmp = mana;
-    addMana(i / 100.0 * getManaMax());
+    int amount = i / 100.0 * getManaMax();
+    // A positive percentage must restore at least 1 mana: truncating to 0 would
+    // accidentally invoke addMana(0), whose sentinel meaning is "restore to full".
+    if (i > 0 && amount == 0) {
+        amount = 1;
+    }
+    addMana(amount);
     vstd::logger::debug(to_string(), "restored", mana - tmp, "mana");
 }
 

--- a/src/object/CCreature.h
+++ b/src/object/CCreature.h
@@ -123,7 +123,7 @@ class CCreature : public CMapObject, public CMoveable, public CVisitable {
 
     void hurt(float i);
 
-    int getDmg();
+    int getDmg(bool allowCrit = true);
 
     int getScale();
 

--- a/test.py
+++ b/test.py
@@ -4936,8 +4936,8 @@ def walkthrough_vhulmarn_map():
 
     # The finale requires the boss defeat as well as the pickup: the tiara alone must not complete it.
     player.checkQuests()
-    assert (
-        "drownedTitheQuest" not in completed_quest_names(player)
+    assert "drownedTitheQuest" not in completed_quest_names(
+        player
     ), "The Drowned Tithe quest must not complete on the tiara pickup alone."
 
     # Defeating The Nameless (its onDestroy trigger) records the boss defeat and completes the finale.
@@ -4993,8 +4993,8 @@ def walkthrough_kadath_map():
 
     # The finale requires the boss defeat as well as the pickup: the signet alone must not complete it.
     player.checkQuests()
-    assert (
-        "kadathAscentQuest" not in completed_quest_names(player)
+    assert "kadathAscentQuest" not in completed_quest_names(
+        player
     ), "The Kadath ascent quest must not complete on the signet pickup alone."
 
     # Defeating the Crawling Chaos (its onDestroy trigger) records the boss defeat and completes the finale.
@@ -5065,8 +5065,8 @@ def walkthrough_sunderedmarch_map():
 
     # The finale requires the boss defeat as well as the pickup: the crown alone must not complete it.
     player.checkQuests()
-    assert (
-        "sunderedMarchQuest" not in completed_quest_names(player)
+    assert "sunderedMarchQuest" not in completed_quest_names(
+        player
     ), "The Sundered March quest must not complete on the crown pickup alone."
 
     # Defeating the Barrow-Warlord (its onDestroy trigger) records the boss defeat and completes the finale.
@@ -5159,8 +5159,8 @@ def walkthrough_ninemarches_map():
 
     # The finale requires the boss defeat as well as the pickup: the crown alone must not complete it.
     player.checkQuests()
-    assert (
-        "ninemarchesQuest" not in completed_quest_names(player)
+    assert "ninemarchesQuest" not in completed_quest_names(
+        player
     ), "The Nine Marches quest must not complete on the crown pickup alone."
     assert "haldaQuest" in completed_quest_names(player), "Ser Halda's companion quest should complete on recruit."
 
@@ -10022,6 +10022,79 @@ class GameTest(unittest.TestCase):
         self.assertEqual(missing, [])
 
         return True, ""
+
+    @game_test
+    def test_small_percentage_restores_do_not_collapse_into_full_restores(self):
+        # healProc/addManaProc used to truncate a small positive percentage to 0 and
+        # accidentally invoke the heal(0)/addMana(0) "restore to full" sentinels: a
+        # low-stamina Wayfarer ticking Wayfarer's Stride (2% hp regen per round) was
+        # fully healed every combat round instead of gaining 1 hp.
+        g, _game_map, player = load_game_map_with_player("test", "Wayfarer")
+        player.equipItem("0", None)
+        player.unequipArmor()
+        player.baseStats.stamina = 5
+
+        player.setMana(50)  # cover the cast's mana cost
+        stride = g.createObject("WayfarersStride")
+        stride.onAction(player, None)
+        effects = [e for e in player.getEffects() if e and e.getTypeId() == "WayfarersStrideEffect"]
+        self.assertEqual(1, len(effects))
+
+        # Measure the maxima with the buff active: its configureEffect bonus is part
+        # of the composed stats the regen tick sees.
+        hp_max = player.getHpMax()
+        stats = player.getStats()
+        mana_max = stats.getNumericProperty(stats.getStringProperty("mainStat")) * 7
+        # Precondition: the 2% tick lands in the truncation zone (2% of hpMax < 1).
+        self.assertEqual(0, int(2 / 100.0 * hp_max))
+
+        player.setHp(10)
+        player.setMana(5)
+        effects[0].onEffect()
+
+        self.assertEqual(11, player.getHp())
+        expected_mana_gain = int(6 / 100.0 * mana_max) or 1
+        self.assertEqual(min(5 + expected_mana_gain, mana_max), player.getMana())
+
+        return True, json.dumps({"hp_max": hp_max, "mana_max": mana_max}, sort_keys=True)
+
+    @game_test
+    def test_devour_heals_fraction_of_damage_dealt_not_full(self):
+        # Devour heals 75% of the damage dealt. The old formula converted that into
+        # an integer percent of hpMax, which floored to healProc(0) (= full heal)
+        # whenever dmg * 75 < hpMax -- a weak bite fully healed the devourer.
+        game = load_game_module()
+        g = game.CGameLoader.loadGame()
+        game.CGameLoader.startGame(g, "empty")
+
+        attacker = g.createObject("Sorcerer")
+        attacker.moveTo(0, 0, 0)
+        g.getMap().addObject(attacker)
+        attacker.equipItem("0", None)
+        attacker.unequipArmor()
+        attacker.baseStats.hit = 100
+        attacker.baseStats.crit = 0
+        attacker.baseStats.dmgMin = 1
+        attacker.baseStats.dmgMax = 1
+        attacker.baseStats.stamina = 20
+
+        defender = g.createObject("GoblinThief")
+        defender.moveTo(1, 0, 0)
+        g.getMap().addObject(defender)
+
+        hp_max = attacker.getHpMax()
+        # Precondition: a 1-damage bite is in the old full-heal zone (1 * 75 < hpMax).
+        self.assertGreater(hp_max, 75)
+
+        attacker.setHp(50)
+        devour = g.createObject("Devour")
+        devour.performAction(attacker, defender)
+
+        # dmg is deterministically 1 (dmgMin == dmgMax == 1, hit 100, crit 0), so the
+        # heal is max(1, 1 * 75 // 100) == 1, never a full restore.
+        self.assertEqual(51, attacker.getHp())
+
+        return True, json.dumps({"hp_max": hp_max}, sort_keys=True)
 
     def make_multi_enemy_combat_fixture(self):
         game = load_game_module()
@@ -17164,7 +17237,9 @@ class GameTest(unittest.TestCase):
             # Objective reflects the remaining requirement (put the finale boss down).
             objective = active_objective(player, quest_id)
             self.assertTrue(objective, f"{map_name}: an active finale objective should be present")
-            self.assertIn("put", objective.lower(), f"{map_name}: objective should name the remaining boss: {objective!r}")
+            self.assertIn(
+                "put", objective.lower(), f"{map_name}: objective should name the remaining boss: {objective!r}"
+            )
 
             # Adding the boss defeat completes it.
             game_map.setBoolProperty("boss_defeated", True)
@@ -18584,9 +18659,7 @@ class GameTest(unittest.TestCase):
             captured["returning"] = sorted(manifests)[0]
             self.assertEqual(sorted(manifests)[0], game.choose_campaign(g))
             self.assertEqual({cid: m["title"] for cid, m in manifests.items()}, captured["titles"])
-            self.assertEqual(
-                {cid: m.get("description", "") for cid, m in manifests.items()}, captured["descriptions"]
-            )
+            self.assertEqual({cid: m.get("description", "") for cid, m in manifests.items()}, captured["descriptions"])
             self.assertEqual({cid: len(m["scenarios"]) for cid, m in manifests.items()}, captured["counts"])
 
             captured["returning"] = ""
@@ -21827,9 +21900,7 @@ class XvfbGameplayProcessTest(unittest.TestCase):
                 )
                 panel.setStringProperty("body", body_text)
                 pump_event_loop(3)
-                text_data, _, _ = capture_sdl_screenshot(
-                    TEST_OUTPUT_DIR / "layout_campaign_panel_text.png", g.getGui()
-                )
+                text_data, _, _ = capture_sdl_screenshot(TEST_OUTPUT_DIR / "layout_campaign_panel_text.png", g.getGui())
                 text_bounds, changed = pixel_diff_bounds(empty_data, text_data, width, body_rect)
                 self.assertGreater(changed, 0, "campaign body text must render nonblank pixels")
                 assert_child_inside(self, "campaign body", body_rect, "rendered body", text_bounds)
@@ -21847,9 +21918,7 @@ class XvfbGameplayProcessTest(unittest.TestCase):
             lambda panel: None,
         )
         self.assertIn("body", regions)
-        self.assertFalse(
-            gui_contains_class(g, "CGameCampaignPanel"), "the action must dismiss the campaign screen"
-        )
+        self.assertFalse(gui_contains_class(g, "CGameCampaignPanel"), "the action must dismiss the campaign screen")
 
         # Usable after resize: a reopened campaign panel follows the new window size
         # (full-window at 800x600 after the resize event).

--- a/test.py
+++ b/test.py
@@ -10096,6 +10096,56 @@ class GameTest(unittest.TestCase):
 
         return True, json.dumps({"hp_max": hp_max}, sort_keys=True)
 
+    @game_test
+    def test_octobogz_completed_dialog_option_claims_stranded_bounty(self):
+        # Regression: clearing the OctoBogz cave BEFORE accepting the refugees' bounty completes
+        # the contract, which gated the accept option off -- so the late-claim path (accept_quest,
+        # guarded by OCTOBOGZ_REWARD_CLAIMED) was unreachable through the dialog and the 1000 gold
+        # + Shadow Blade reward was stranded forever, even as the refugees declared the debt "paid
+        # in full". The completed dialog option now carries the accept_quest action.
+        g, game_map, player = load_game_map_with_player("nouraajd")
+
+        game_map.removeObjectByName("cave2")
+        self.assertEqual("completed", game_map.getStringProperty("quest_state_octobogz_contract"))
+        # Clearing the cave must NOT silently pay the bounty; it is claimed by talking to the
+        # refugees (the intended late-claim design, per accept_quest).
+        self.assertFalse(game_map.getBoolProperty("OCTOBOGZ_REWARD_CLAIMED"))
+        self.assertNotIn("octoBogzQuest", quest_names(player))
+
+        # The completed branch's dialog option is wired to the late-claim action.
+        dialog_cfg = json.loads((REPO_ROOT / "res/maps/nouraajd/dialog2.json").read_text())
+        entry = next(
+            s["properties"]
+            for s in dialog_cfg["dialog"]["properties"]["states"]
+            if s["properties"]["stateId"] == "ENTRY"
+        )
+        completed_option = next(
+            o["properties"]
+            for o in entry["options"]
+            if o.get("properties", {}).get("condition") == "contract_completed"
+        )
+        self.assertEqual("accept_quest", completed_option.get("action"))
+
+        start_gold = player.getGold()
+        start_blades = player.countItems("ShadowBlade")
+
+        # Selecting that option runs its action on the dialog -> the late claim settles the bounty.
+        travelers = g.createObject("dialog")
+        travelers.invokeAction(completed_option["action"])
+
+        self.assertEqual(start_gold + 1000, player.getGold(), "the late claim must pay the 1000 gold bounty")
+        self.assertEqual(
+            start_blades + 1, player.countItems("ShadowBlade"), "the late claim must grant the Shadow Blade"
+        )
+        self.assertTrue(game_map.getBoolProperty("OCTOBOGZ_REWARD_CLAIMED"))
+
+        # Claim-once: invoking the action again must never double-pay.
+        travelers.invokeAction(completed_option["action"])
+        self.assertEqual(start_gold + 1000, player.getGold())
+        self.assertEqual(start_blades + 1, player.countItems("ShadowBlade"))
+
+        return True, json.dumps({"gold_delta": player.getGold() - start_gold}, sort_keys=True)
+
     def make_multi_enemy_combat_fixture(self):
         game = load_game_module()
 

--- a/tests/unit/test_controller.cpp
+++ b/tests/unit/test_controller.cpp
@@ -876,6 +876,28 @@ void test_monster_fight_controller_heals_when_heal_outpaces_incoming_damage() {
                 "monster fight controller should spend the least powerful heal item first");
 }
 
+void test_monster_fight_controller_gates_heal_on_the_potion_it_will_actually_drink() {
+    auto game = fight_fixture_game();
+    // hpMax 70, hp 35 (50%, so healing is on the table). The AI spends the WEAKEST heal
+    // first, so the gate must weigh that potion, not the strongest. A power-1 heal restores
+    // ~14; a power-5 heal restores ~35 (capped by missing hp). Against an expected 16 hp hit,
+    // the power-1 potion it would actually drink is a net loss, so the monster must attack
+    // instead -- the old strongest-potion gate green-lit that net-loss drink.
+    auto monster = fight_fixture_monster(game, 10, 35);
+    auto opponent = fight_fixture_hitter(game, 16);
+    auto weak = heal_potion(game, 1);
+    auto strong = heal_potion(game, 5);
+    monster->addItem(weak);
+    monster->addItem(strong);
+    monster->addAction(std::make_shared<CInteraction>());
+
+    auto controller = std::make_shared<CMonsterFightController>();
+    expect_true(controller->control(monster, opponent),
+                "monster should still take a turn (attack) when the drinkable heal cannot keep pace");
+    expect_true(monster->getItems().size() == 2 && monster->hasItem(weak) && monster->hasItem(strong),
+                "monster must not spend the weak heal the gate would drink when it is outpaced by the hit");
+}
+
 void test_monster_fight_controller_heals_when_next_hit_would_kill() {
     auto game = fight_fixture_game();
     // hpMax 70, hp 10: the expected 25 hp hit is lethal, so healing is the only play
@@ -1123,6 +1145,7 @@ int main() {
     test_monster_fight_controller_uses_mana_item_when_mana_is_low();
     test_monster_fight_controller_attacks_hard_hitter_instead_of_wasting_heal();
     test_monster_fight_controller_heals_when_heal_outpaces_incoming_damage();
+    test_monster_fight_controller_gates_heal_on_the_potion_it_will_actually_drink();
     test_monster_fight_controller_heals_when_next_hit_would_kill();
     test_monster_fight_controller_ranks_interactions_by_weakening();
     test_monster_fight_controller_applies_missing_self_buff();

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -2896,6 +2896,30 @@ void test_creature_get_dmg_hit_chance_is_not_inverted() {
     expect_true(highConnects == iterations, "attack=100 fully offsets a 0-99 dice roll, so every swing connects");
 }
 
+// getDmg(allowCrit) gates whether a rolled critical is applied. Interactions that must
+// never crit (e.g. Devour) pass allowCrit=false; the crit die is still consumed so the RNG
+// stream is identical either way. With hit=100 and crit=100 every swing connects and would
+// crit, so the flag deterministically decides between the doubled and un-doubled damage.
+void test_creature_get_dmg_allow_crit_flag_gates_the_crit_double() {
+    srand(20260701u);
+    auto stats = std::make_shared<CStats>();
+    stats->setMainStat("intelligence");
+    stats->setHit(100);  // always connects
+    stats->setCrit(100); // would always crit when crit is allowed
+    stats->setDmgMin(5);
+    stats->setDmgMax(5); // fixed base damage of exactly 5
+    stats->setDamage(0);
+    auto creature = std::make_shared<CCreature>();
+    creature->setBaseStats(stats);
+    creature->setLevelStats(std::make_shared<CStats>());
+    creature->setLevel(0); // getStats() == baseStats: no level/equipment/effect bonuses
+
+    for (int i = 0; i < 50; ++i) {
+        expect_true(creature->getDmg(true) == 10, "with crit allowed a guaranteed crit doubles 5 to 10");
+        expect_true(creature->getDmg(false) == 5, "with crit disallowed the same guaranteed-hit swing stays at 5");
+    }
+}
+
 // CInteraction routes its effect to the caster or the opponent via effectRoutesToCaster
 // (EPIC_06/STORY_01/SUBSTORY_02): an explicit selfTarget always routes to the caster, a
 // legacy Buff-tagged effect without selfTarget stays a self-buff, and every other effect
@@ -2961,6 +2985,7 @@ int main() {
     test_typed_engine_signal_still_fires_directly();
     test_effect_applies_for_exactly_its_duration_without_underflow();
     test_proc_restores_clamp_positive_percentages_away_from_full_restore_sentinel();
+    test_creature_get_dmg_allow_crit_flag_gates_the_crit_double();
     test_creature_get_dmg_hit_chance_is_not_inverted();
     test_interaction_effect_routes_to_caster_via_self_target();
     test_tooltip_handler_builds_labels_descriptions_and_item_bonuses();

--- a/tests/unit/test_object.cpp
+++ b/tests/unit/test_object.cpp
@@ -2923,6 +2923,35 @@ void test_interaction_effect_routes_to_caster_via_self_target() {
     expect_true(interaction->effectRoutesToCaster(buff), "selfTarget keeps a buff on the caster");
 }
 
+// healProc/addManaProc convert a percentage into an absolute restore amount, while
+// heal(0)/addMana(0) are the documented "restore to full" sentinels. A positive
+// percentage whose truncated amount is 0 (small percent and/or a low maximum) must
+// restore exactly 1 point instead of collapsing into the sentinel; an explicit 0
+// percentage keeps the full-restore call relied upon by existing callers.
+void test_proc_restores_clamp_positive_percentages_away_from_full_restore_sentinel() {
+    auto creature = std::make_shared<CCreature>();
+    creature->setBaseStats(stats_with_main(1, 1)); // hpMax = manaMax = 7
+
+    creature->setHp(3);
+    creature->healProc(2); // 2% of 7 truncates to 0
+    expect_true(creature->getHp() == 4, "a positive heal percentage must restore at least 1 hp, never heal to full");
+
+    creature->healProc(0);
+    expect_true(creature->getHp() == 7, "healProc(0) must keep the restore-to-full sentinel behavior");
+
+    creature->setHp(3);
+    creature->healProc(100);
+    expect_true(creature->getHp() == 7, "healProc(100) must still restore to full hp");
+
+    creature->setMana(2);
+    creature->addManaProc(4); // 4% of 7 truncates to 0
+    expect_true(creature->getMana() == 3,
+                "a positive mana percentage must restore at least 1 mana, never restore to full");
+
+    creature->addManaProc(0);
+    expect_true(creature->getMana() == 7, "addManaProc(0) must keep the restore-to-full sentinel behavior");
+}
+
 } // namespace
 
 int main() {
@@ -2931,6 +2960,7 @@ int main() {
     test_dynamic_property_cannot_spoof_typed_engine_signal();
     test_typed_engine_signal_still_fires_directly();
     test_effect_applies_for_exactly_its_duration_without_underflow();
+    test_proc_restores_clamp_positive_percentages_away_from_full_restore_sentinel();
     test_creature_get_dmg_hit_chance_is_not_inverted();
     test_interaction_effect_routes_to_caster_via_self_target();
     test_tooltip_handler_builds_labels_descriptions_and_item_bonuses();


### PR DESCRIPTION
Fixes a batch of bugs surfaced by a read-only audit of the engine and content, each confirmed by adversarial review and covered by a regression test. (All are independent, pre-existing bugs; they're bundled here because this session is scoped to a single branch.)

## Fixes

1. **Percentage restores collapse into the full-restore sentinel** (`src/object/CCreature.cpp`) — `heal(0)`/`addMana(0)` are the documented "restore to full" sentinels, but `healProc`/`addManaProc` truncated a small positive percentage to `0` and silently became a full heal (e.g. a level-1 Wayfarer's 2%/round Stride buff fully healing every round). A positive percentage now restores at least 1 point; an explicit `0` keeps the sentinel.

2. **`Devour` heals the wrong amount** (`res/plugins/interaction.py`) — `healProc((dmg*75)//hpMax)` floored to a full heal whenever `dmg*75 < hpMax`. Now heals `max(1, dmg*75//100)` directly (75% of damage dealt).

3. **Monster heal AI net-loss chain-drinking** (`src/core/CController.cpp`) — the "is a heal worthwhile" gate weighed the *strongest* heal potion, but the AI drinks the *weakest* first. It now gates on the potion actually consumed, so a monster no longer wastes a turn on a heal outpaced by the incoming hit.

4. **Random-map encounters spawn in walls** (`src/core/CLoader.cpp`) — the room-center `Coords` swapped `width`/`height`, so non-square rooms dropped encounters outside the room onto wall tiles. Fixed to `row + height/2, col + width/2`.

5. **`Devour` never crits** (`src/object/CCreature.{h,cpp}`, `src/core/CModule.cpp`, `res/plugins/interaction.py`) — the crit suppression mutated the throwaway copy returned by `getStats()` and did nothing. Added `getDmg(allowCrit=true)`; `Devour` passes `allowCrit=false`. The crit die is still rolled, so the RNG stream is byte-identical for every other caller.

6. **OctoBogz bounty reward stranded** (`res/maps/nouraajd/dialog2.json`) — clearing the cave before accepting the refugees' contract completes it, which gated the accept option (and its late-claim path) off, so the 1000 gold + Shadow Blade reward was unreachable even as the refugees declared the debt "paid in full". The completed dialog option now carries the `accept_quest` late-claim action (guarded by `OCTOBOGZ_REWARD_CLAIMED` against double-pay).

## Tests

Unit: sentinel clamp on hp/mana (`test_object.cpp`), `getDmg` allow-crit flag (`test_object.cpp`), heal-AI net-loss gate (`test_controller.cpp`). Gameplay (`test.py`): Stride-tick and Devour heal amounts, and the OctoBogz completed-option late claim (end-to-end via the dialog action).

## Not included (from the same audit)

Three findings were deliberately **deferred** and one **dropped** after investigation:
- *Encounter level-scaling* (`addExp` no-ops on freshly-spawned, hp-0 creatures) — the correct fix scales creatures to their intended power (a balance change worth design review) and is O(level²) via repeated level-ups, which blows the unit-test time budget; needs a batch level-up path.
- *Effect state not serialized* (`CEffect` drops `timeLeft`/`caster`/`victim`) — uncertain reachability (combat is synchronous), and it sits in the serialization subsystem currently being reworked; best addressed there.
- *Dialog-panel shared_ptr cycle* — the strong self-capture is load-bearing for the click mechanism through the blocking dialog; a `weak_ptr` fix breaks dialog interaction. The leak needs a proper lifecycle fix (e.g. clearing dynamic methods on close).
- *`CUtil::isIn` inclusive bounds* — **dropped**: the inclusive right/bottom edge is asserted by existing tests and is intentional.

## Validation

`validate_content.py`, `tests.test_content_validator` (194), `ctest -R for_unit_tests` (10/10) and `-L performance`, full `python3 test.py` (incl. the nouraajd xvfb walkthrough), and the coverage gate.

Note: `linux`/`windows`/`linux-coverage` CI currently fail on a **pre-existing `main` regression** (save/load + `teleporter2` deserialization from the #1488 plugin redesign), not on this branch — see prior comment. Will go green once `main` is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)