### PR TITLE
Restore CStats/CDamage pybind metadata registration (fixes red main)

### DIFF
--- a/src/core/CModule.cpp
+++ b/src/core/CModule.cpp
@@ -319,8 +319,20 @@ extern void initModule1();
 
 void register_python_binding_type_metadata() {
     // Metadata only (serializers/casts) — deliberately not builders, so gameplay types stay
-    // non-constructible until the native gameplay plugin actually loads. The row list is the
-    // shared plugin/CGameplayTypeTable.h; CStats/CDamage are covered by registerCoreTypes().
+    // non-constructible until the native gameplay plugin actually loads. The gameplay row list is
+    // the shared plugin/CGameplayTypeTable.h.
+    //
+    // CStats/CDamage are NOT gameplay table rows (they are core value types registered by
+    // registerCoreTypes), but their metadata must also be registered from this translation unit.
+    // On Linux this file is compiled into the _game extension rather than game_core (see
+    // GAME_CORE_SRC in CMakeLists.txt), so registering here populates the conversion tables the
+    // extension module itself resolves against. Dropping these two lines broke deserialization of
+    // the shared_ptr<CDamage>/shared_ptr<CStats> properties carried by items and creatures
+    // ("bad any_cast" while loading saved maps) on Linux only, while Windows kept working because
+    // there CModule.cpp is part of game_core.
+    CTypes::register_type_metadata<CStats, CGameObject>();
+    CTypes::register_type_metadata<CDamage, CGameObject>();
+
 #define FN_TYPE(T, ...) CTypes::register_type_metadata<T, __VA_ARGS__>();
 #define FN_WRAPPED(T, ...)                                                                                             \
     CTypes::register_type_metadata<T, __VA_ARGS__>();                                                                  \


### PR DESCRIPTION
Fixes the `test (python gameplay)` failure that has been red on `main` since PR #1488.

## Symptom
Every save-load test on the Linux job fails; the engine rejects the save with:

```
Rejected primary save: ... reason: failed to deserialize saved map:
Failed to deserialize property 'objects': Failed to deserialize property 'market':
Failed to deserialize property 'items': bad any_cast
```

## Root cause
PR #1488 consolidated `register_python_binding_type_metadata()` onto the shared
`CGameplayTypeTable.h` and dropped its two non-table lines:

```cpp
CTypes::register_type_metadata<CStats, CGameObject>();
CTypes::register_type_metadata<CDamage, CGameObject>();
```

on the assumption that `registerCoreTypes()` already covers them. That assumption holds
only on Windows: `CModule.cpp` is compiled into `game_core` there, but on Linux
`GAME_CORE_SRC` filters it out and it is compiled into the `_game` extension instead,
so these registrations populate the conversion tables the extension resolves against.

Items carry `shared_ptr<CDamage>` and creatures carry `shared_ptr<CStats>`, so the
missing conversions surface as `bad any_cast` the moment a saved map containing a
weapon or a market is deserialized — which is why the whole save/load suite went red
while the C++ unit tests, performance guard and campaign gates stayed green.

CStats/CDamage are core value types, not content-constructible gameplay types, so they
are restored as explicit lines rather than added as table rows — with a comment
recording the platform split so the next person does not "clean them up" again.

## Verification
- Local (Windows) build + the save-load and plugin-dispatch canaries pass — but note
  Windows cannot reproduce the bug, so **CI on this PR is the real verification**.
- A separate multi-agent audit of the #1488 squash-merge against pre-merge `main`
  confirmed no other collateral losses beyond `CCreatureClassTrack` (already fixed in #1489).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
