### PR TITLE
Fix Nouraajd quest, dialog, and retained-session regressions

### DIFF
--- a/res/game.py
+++ b/res/game.py
@@ -294,10 +294,11 @@ class CDialog(CDialogBase2):
                 reason="unknown_action",
             )
             logger(f"Rejected unknown dialog action: {action}")
-            return
+            return False
         try:
             record_playtest_trace("dialog_action", action=action, dialog=playtest_object_ref(self))
             callback()
+            return True
         except Exception as exc:
             record_playtest_trace(
                 "dialog_action_failed",
@@ -306,6 +307,7 @@ class CDialog(CDialogBase2):
                 error=type(exc).__name__,
             )
             logger(f"Dialog action failed closed: {action}: {exc}")
+            return False
 
     def invokeCondition(self, condition):
         callback = self._get_public_callback(condition)

--- a/res/maps/nouraajd/dialog2.json
+++ b/res/maps/nouraajd/dialog2.json
@@ -42,6 +42,7 @@
                   "number": 3,
                   "condition": "contract_completed",
                   "nextStateId": "COMPLETED_THANKS",
+                  "action": "accept_quest",
                   "text": "The cave is quiet now. The OctoBogz are dead."
                 }
               },

--- a/res/maps/nouraajd/script.py
+++ b/res/maps/nouraajd/script.py
@@ -502,13 +502,13 @@ def load(self, context):
             return _quest_system_from(self).is_cave_purged()
 
         def getObjective(self):
-            return "Use the returned relic to cleanse the OctoBogz cave, then report to Beren."
+            return "Return the holy relic to Beren and destroy the OctoBogz, then report back once both are done."
 
         def getReward(self):
             return "Opens the road to the ritual chapel."
 
         def getHint(self):
-            return "Clear the OctoBogz lair after the relic is back in Beren's hands."
+            return "Beren needs the relic back, and the OctoBogz must be dead before he can finish the cleansing."
 
         def onComplete(self):
             pass
@@ -521,7 +521,7 @@ def load(self, context):
         def getObjective(self):
             state = _quest_system_from(self).get_state("victor")
             if state == "encounter_active":
-                return "Defeat the cultists in the courtyard before Victor's daughter is taken."
+                return "Defeat the cult leader in the courtyard before Victor's daughter is taken."
             if state == "good_end":
                 return "Victor's daughter survived the courtyard rite."
             if state == "bad_end":

--- a/src/core/CGameContext.cpp
+++ b/src/core/CGameContext.cpp
@@ -5,7 +5,7 @@ Copyright (C) 2026  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-        (at your option) any later version.
+(at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/core/CGameContext.cpp
+++ b/src/core/CGameContext.cpp
@@ -5,7 +5,7 @@ Copyright (C) 2026  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+        (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -128,7 +128,9 @@ void CMapSessionStore::put(const std::string &mapName, const std::string &instan
     if (!map) {
         return;
     }
-    sessions[makeKey(mapName, instanceId)] = map;
+    const auto key = makeKey(mapName, instanceId);
+    sessions[key] = map;
+    returnCoordinates.erase(key);
 }
 
 void CMapSessionStore::put(const std::shared_ptr<CMap> &map, const std::string &instanceId) {
@@ -143,15 +145,33 @@ std::shared_ptr<CMap> CMapSessionStore::get(const std::string &mapName, const st
     return it != sessions.end() ? it->second : nullptr;
 }
 
+void CMapSessionStore::setReturnCoords(const std::string &mapName, const std::string &instanceId, Coords coords) {
+    const auto key = makeKey(mapName, instanceId);
+    if (sessions.contains(key)) {
+        returnCoordinates[key] = coords;
+    }
+}
+
+std::optional<Coords> CMapSessionStore::getReturnCoords(const std::string &mapName,
+                                                        const std::string &instanceId) const {
+    auto it = returnCoordinates.find(makeKey(mapName, instanceId));
+    return it != returnCoordinates.end() ? std::optional<Coords>(it->second) : std::nullopt;
+}
+
 bool CMapSessionStore::contains(const std::string &mapName, const std::string &instanceId) const {
     return sessions.find(makeKey(mapName, instanceId)) != sessions.end();
 }
 
 bool CMapSessionStore::evict(const std::string &mapName, const std::string &instanceId) {
-    return sessions.erase(makeKey(mapName, instanceId)) > 0;
+    const auto key = makeKey(mapName, instanceId);
+    returnCoordinates.erase(key);
+    return sessions.erase(key) > 0;
 }
 
-void CMapSessionStore::clear() { sessions.clear(); }
+void CMapSessionStore::clear() {
+    sessions.clear();
+    returnCoordinates.clear();
+}
 
 std::size_t CMapSessionStore::size() const { return sessions.size(); }
 

--- a/src/core/CGameContext.h
+++ b/src/core/CGameContext.h
@@ -5,7 +5,7 @@ Copyright (C) 2026  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-        (at your option) any later version.
+(at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/core/CGameContext.h
+++ b/src/core/CGameContext.h
@@ -5,7 +5,7 @@ Copyright (C) 2026  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+        (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -21,10 +21,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
 #include "core/CGlobal.h"
+#include "core/CUtil.h"
 
 class CGame;
 class CGuiHandler;
@@ -39,7 +41,8 @@ class CSlotConfig;
 
 // Context-owned cache of loaded maps that should outlive a single transition. Sessions are keyed by
 // map name plus an optional instance id so multiple live copies of the same map can be retained. The
-// store only retains and hands back maps; it does not change transition semantics on its own.
+// store also remembers the coordinate from which a retained session was left so reuse can return the
+// player to that session without replaying destination entry initialization.
 class CMapSessionStore {
   public:
     static std::string makeKey(const std::string &mapName, const std::string &instanceId = "");
@@ -49,6 +52,10 @@ class CMapSessionStore {
     void put(const std::shared_ptr<CMap> &map, const std::string &instanceId = "");
 
     std::shared_ptr<CMap> get(const std::string &mapName, const std::string &instanceId = "") const;
+
+    void setReturnCoords(const std::string &mapName, const std::string &instanceId, Coords coords);
+
+    std::optional<Coords> getReturnCoords(const std::string &mapName, const std::string &instanceId = "") const;
 
     bool contains(const std::string &mapName, const std::string &instanceId = "") const;
 
@@ -60,6 +67,7 @@ class CMapSessionStore {
 
   private:
     std::unordered_map<std::string, std::shared_ptr<CMap>> sessions;
+    std::unordered_map<std::string, Coords> returnCoordinates;
 };
 
 class CGameContext {

--- a/src/core/CSceneManager.cpp
+++ b/src/core/CSceneManager.cpp
@@ -5,7 +5,7 @@ Copyright (C) 2026  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+        (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -162,6 +162,7 @@ void CSceneManager::performMapChange(const std::shared_ptr<CGame> &game, const C
     try {
         transitionState = TransitionState::Transitioning;
         std::shared_ptr<CMap> oldMap = game->getMap();
+        std::shared_ptr<CPlayer> player = oldMap ? oldMap->getPlayer() : nullptr;
         json traceFields = json::object();
         if (CPlaytestTrace::enabled()) {
             traceFields["fromMap"] = oldMap ? oldMap->getMapName() : "";
@@ -170,11 +171,17 @@ void CSceneManager::performMapChange(const std::shared_ptr<CGame> &game, const C
         }
         std::shared_ptr<CMap> map;
         bool reusedSession = false;
+        std::optional<Coords> retainedReturnCoords;
         if (request.reuseLoadedMap) {
             auto store = game->getContext()->getMapSessionStore();
-            map = store->get(mapName, request.returnAnchor);
+            std::string matchedAnchor = request.returnAnchor;
+            map = store->get(mapName, matchedAnchor);
             if (!map && !request.returnAnchor.empty()) {
+                matchedAnchor.clear();
                 map = store->get(mapName);
+            }
+            if (map) {
+                retainedReturnCoords = store->getReturnCoords(mapName, matchedAnchor);
             }
             reusedSession = map != nullptr;
         }
@@ -182,20 +189,25 @@ void CSceneManager::performMapChange(const std::shared_ptr<CGame> &game, const C
             map = CMapLoader::loadNewMap(game, mapName);
         }
         if (request.retainSourceMap && oldMap) {
-            game->getContext()->getMapSessionStore()->put(oldMap, request.returnAnchor);
+            auto store = game->getContext()->getMapSessionStore();
+            store->put(oldMap, request.returnAnchor);
+            if (player) {
+                store->setReturnCoords(oldMap->getMapName(), request.returnAnchor, player->getCoords());
+            }
         }
         game->setMap(map);
         if (oldMap && game->getMap()) {
             // Transfer the existing player into the destination map without mutating the
             // source map. Detaching the player here would remove an object from the source
             // map mid-transition, which scene-manager regression tests assert must stay
-            // untouched (the source map is preserved so it can be revisited). attachPlayer
-            // still performs the canonical destination-side setup (controllers, entry
-            // placement, lifecycle triggers); the source map keeps its player reference.
-            std::shared_ptr<CPlayer> player = oldMap->getPlayer();
+            // untouched (the source map is preserved so it can be revisited). Explicit
+            // targetCoords always win; otherwise a reused retained session returns to the
+            // coordinate where it was left instead of replaying the destination entry tile.
             if (player) {
                 if (request.targetCoords) {
                     game->getMap()->attachPlayer(player, *request.targetCoords);
+                } else if (reusedSession && retainedReturnCoords) {
+                    game->getMap()->attachPlayer(player, *retainedReturnCoords);
                 } else {
                     game->getMap()->attachPlayer(player);
                 }

--- a/src/core/CSceneManager.cpp
+++ b/src/core/CSceneManager.cpp
@@ -5,7 +5,7 @@ Copyright (C) 2026  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-        (at your option) any later version.
+(at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/core/CSceneManager.h
+++ b/src/core/CSceneManager.h
@@ -5,7 +5,7 @@ Copyright (C) 2026  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-        (at your option) any later version.
+(at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/core/CSceneManager.h
+++ b/src/core/CSceneManager.h
@@ -5,7 +5,7 @@ Copyright (C) 2026  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+        (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -34,12 +34,14 @@ class CGameContext;
 struct CMapTransitionRequest {
     // Destination map name (a map directory under res/maps).
     std::string targetMap;
-    // Player placement on the destination map; std::nullopt places the player at the map entry.
+    // Explicit player placement on the destination map. When unset, a reused retained session
+    // restores the coordinate where that session was left; otherwise the destination map entry is used.
     std::optional<Coords> targetCoords;
     // Reuse an already-loaded destination session from CMapSessionStore instead of reloading it
     // from content. Falls back to a fresh load when no matching session is stored.
     bool reuseLoadedMap = false;
-    // Retain the source map in CMapSessionStore when leaving it, so it can be revisited later.
+    // Retain the source map in CMapSessionStore when leaving it, including the player's departure
+    // coordinate so a later reuse does not replay entry-only initialization.
     bool retainSourceMap = false;
     // Optional session anchor: a retained source session is stored under this instance id, and a
     // reuseLoadedMap lookup prefers this instance id before falling back to the default session.

--- a/src/gui/panel/CGameDialogPanel.cpp
+++ b/src/gui/panel/CGameDialogPanel.cpp
@@ -5,7 +5,7 @@ Copyright (C) 2025-2026  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-        (at your option) any later version.
+(at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/gui/panel/CGameDialogPanel.cpp
+++ b/src/gui/panel/CGameDialogPanel.cpp
@@ -5,7 +5,7 @@ Copyright (C) 2025-2026  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+        (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -163,8 +163,8 @@ void CGameDialogPanel::selectOption(const std::shared_ptr<CDialogOption> &option
         CPlaytestTrace::addMapContext(fields, getGame() ? getGame()->getMap() : nullptr);
         CPlaytestTrace::record("dialog_option_selected", fields);
     }
-    if (!option->getAction().empty()) {
-        dialog->invokeAction(option->getAction());
+    if (!option->getAction().empty() && !dialog->invokeActionChecked(option->getAction())) {
+        return;
     }
     currentStateId = option->getNextStateId().empty() ? "EXIT" : option->getNextStateId();
     reload();

--- a/src/object/CDialog.cpp
+++ b/src/object/CDialog.cpp
@@ -27,7 +27,7 @@ std::shared_ptr<CDialogState> CDialog::getState(std::string stateId) {
     return state != states.end() ? *state : nullptr;
 }
 
-void CDialog::invokeAction(std::string action) { invokeActionChecked(std::move(action)); }
+void CDialog::invokeAction(std::string action) { invokeActionChecked(action); }
 
 bool CDialog::invokeActionChecked(std::string action) {
     pybind11::gil_scoped_acquire gil;

--- a/src/object/CDialog.cpp
+++ b/src/object/CDialog.cpp
@@ -5,7 +5,7 @@ Copyright (C) 2025  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-        (at your option) any later version.
+(at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/object/CDialog.cpp
+++ b/src/object/CDialog.cpp
@@ -5,7 +5,7 @@ Copyright (C) 2025  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+        (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -27,11 +27,14 @@ std::shared_ptr<CDialogState> CDialog::getState(std::string stateId) {
     return state != states.end() ? *state : nullptr;
 }
 
-void CDialog::invokeAction(std::string action) {
+void CDialog::invokeAction(std::string action) { invokeActionChecked(std::move(action)); }
+
+bool CDialog::invokeActionChecked(std::string action) {
     pybind11::gil_scoped_acquire gil;
     if (auto override = CPythonOverrides::find_override(this, "invokeAction"); !override.is_none()) {
-        PY_SAFE(override(action); return;)
+        PY_SAFE_RET_VAL(return override(action).cast<bool>();, false)
     }
+    return false;
 }
 
 bool CDialog::invokeCondition(std::string condition) {

--- a/src/object/CDialog.h
+++ b/src/object/CDialog.h
@@ -5,7 +5,7 @@ Copyright (C) 2025  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-        (at your option) any later version.
+(at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/object/CDialog.h
+++ b/src/object/CDialog.h
@@ -5,7 +5,7 @@ Copyright (C) 2025  Andrzej Lis
 This program is free software: you can redistribute it and/or modify
         it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+        (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
         but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -98,6 +98,8 @@ class CDialog : public CGameObject {
     std::shared_ptr<CDialogState> getState(std::string state);
 
     virtual void invokeAction(std::string action);
+
+    bool invokeActionChecked(std::string action);
 
     virtual bool invokeCondition(std::string action);
 

--- a/tests/test_nouraajd_review_regressions.py
+++ b/tests/test_nouraajd_review_regressions.py
@@ -32,7 +32,11 @@ def _method(class_node, name):
 
 def _returned_string(method):
     for node in ast.walk(method):
-        if isinstance(node, ast.Return) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+        if (
+            isinstance(node, ast.Return)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
             return node.value.value
     raise AssertionError(f"missing literal string return in {method.name}")
 
@@ -97,7 +101,10 @@ class NouraajdReviewRegressionTest(unittest.TestCase):
         self.assertIn("getReturnCoords", context_h)
         self.assertIn("returnCoordinates", context_h)
         self.assertIn("returnCoordinates.clear();", context_cpp)
-        self.assertIn("store->setReturnCoords(oldMap->getMapName(), request.returnAnchor, player->getCoords())", scene_cpp)
+        self.assertIn(
+            "store->setReturnCoords(oldMap->getMapName(), request.returnAnchor, player->getCoords())",
+            scene_cpp,
+        )
         self.assertIn("reusedSession && retainedReturnCoords", scene_cpp)
         self.assertIn("game->getMap()->attachPlayer(player, *retainedReturnCoords)", scene_cpp)
 

--- a/tests/test_nouraajd_review_regressions.py
+++ b/tests/test_nouraajd_review_regressions.py
@@ -1,0 +1,147 @@
+import ast
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NOURAAJD_SCRIPT = REPO_ROOT / "res" / "maps" / "nouraajd" / "script.py"
+NOURAAJD_DIALOG2 = REPO_ROOT / "res" / "maps" / "nouraajd" / "dialog2.json"
+GAME_PY = REPO_ROOT / "res" / "game.py"
+DIALOG_H = REPO_ROOT / "src" / "object" / "CDialog.h"
+DIALOG_CPP = REPO_ROOT / "src" / "object" / "CDialog.cpp"
+DIALOG_PANEL_CPP = REPO_ROOT / "src" / "gui" / "panel" / "CGameDialogPanel.cpp"
+GAME_CONTEXT_H = REPO_ROOT / "src" / "core" / "CGameContext.h"
+GAME_CONTEXT_CPP = REPO_ROOT / "src" / "core" / "CGameContext.cpp"
+SCENE_MANAGER_CPP = REPO_ROOT / "src" / "core" / "CSceneManager.cpp"
+
+
+def _find_nested_class(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"missing class {name}")
+
+
+def _method(class_node, name):
+    for node in class_node.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"missing method {class_node.name}.{name}")
+
+
+def _returned_string(method):
+    for node in ast.walk(method):
+        if isinstance(node, ast.Return) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            return node.value.value
+    raise AssertionError(f"missing literal string return in {method.name}")
+
+
+class NouraajdReviewRegressionTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.script_source = NOURAAJD_SCRIPT.read_text(encoding="utf-8")
+        cls.script_tree = ast.parse(cls.script_source, filename=str(NOURAAJD_SCRIPT))
+        cls.game_source = GAME_PY.read_text(encoding="utf-8")
+        cls.game_tree = ast.parse(cls.game_source, filename=str(GAME_PY))
+
+    def test_octobogz_completed_dialog_settles_late_reward(self):
+        document = json.loads(NOURAAJD_DIALOG2.read_text(encoding="utf-8"))
+        states = document["dialog"]["properties"]["states"]
+        entry = next(state for state in states if state["properties"]["stateId"] == "ENTRY")
+        options = entry["properties"]["options"]
+        completed = next(
+            option
+            for option in options
+            if option.get("properties", {}).get("condition") == "contract_completed"
+        )
+        self.assertEqual("accept_quest", completed["properties"].get("action"))
+        self.assertEqual("COMPLETED_THANKS", completed["properties"].get("nextStateId"))
+
+        dialog_class = _find_nested_class(self.script_tree, "OctoBogzDialog")
+        accept = _method(dialog_class, "accept_quest")
+        calls = {
+            node.func.attr
+            for node in ast.walk(accept)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        self.assertIn("checkQuests", calls)
+
+    def test_dialog_action_dispatch_reports_failure_and_panel_does_not_advance(self):
+        dialog_class = _find_nested_class(self.game_tree, "CDialog")
+        invoke_action = _method(dialog_class, "invokeAction")
+        returned_constants = {
+            node.value.value
+            for node in ast.walk(invoke_action)
+            if isinstance(node, ast.Return) and isinstance(node.value, ast.Constant)
+        }
+        self.assertIn(False, returned_constants)
+        self.assertIn(True, returned_constants)
+
+        dialog_h = DIALOG_H.read_text(encoding="utf-8")
+        dialog_cpp = DIALOG_CPP.read_text(encoding="utf-8")
+        panel_cpp = DIALOG_PANEL_CPP.read_text(encoding="utf-8")
+        self.assertIn("bool invokeActionChecked(std::string action);", dialog_h)
+        self.assertIn("bool CDialog::invokeActionChecked(std::string action)", dialog_cpp)
+        self.assertIn("!dialog->invokeActionChecked(option->getAction())", panel_cpp)
+
+        guard = panel_cpp.index("!dialog->invokeActionChecked(option->getAction())")
+        advance = panel_cpp.index("currentStateId = option->getNextStateId().empty()")
+        self.assertLess(guard, advance)
+
+    def test_reused_retained_session_restores_departure_coordinate(self):
+        context_h = GAME_CONTEXT_H.read_text(encoding="utf-8")
+        context_cpp = GAME_CONTEXT_CPP.read_text(encoding="utf-8")
+        scene_cpp = SCENE_MANAGER_CPP.read_text(encoding="utf-8")
+        self.assertIn("setReturnCoords", context_h)
+        self.assertIn("getReturnCoords", context_h)
+        self.assertIn("returnCoordinates", context_h)
+        self.assertIn("returnCoordinates.clear();", context_cpp)
+        self.assertIn("store->setReturnCoords(oldMap->getMapName(), request.returnAnchor, player->getCoords())", scene_cpp)
+        self.assertIn("reusedSession && retainedReturnCoords", scene_cpp)
+        self.assertIn("game->getMap()->attachPlayer(player, *retainedReturnCoords)", scene_cpp)
+
+        explicit_target = scene_cpp.index("if (request.targetCoords)")
+        retained_target = scene_cpp.index("reusedSession && retainedReturnCoords")
+        entry_fallback = scene_cpp.index("game->getMap()->attachPlayer(player);", retained_target)
+        self.assertLess(explicit_target, retained_target)
+        self.assertLess(retained_target, entry_fallback)
+
+    def test_cleanse_quest_text_matches_order_independent_state_machine(self):
+        quest = _find_nested_class(self.script_tree, "CleanseCaveQuest")
+        objective = _returned_string(_method(quest, "getObjective"))
+        hint = _returned_string(_method(quest, "getHint"))
+        self.assertIn("Return the holy relic to Beren", objective)
+        self.assertIn("destroy the OctoBogz", objective)
+        self.assertNotIn("after the relic", hint)
+        self.assertIn("relic back", hint)
+        self.assertIn("OctoBogz must be dead", hint)
+
+    def test_victor_encounter_objective_names_actual_success_target(self):
+        quest = _find_nested_class(self.script_tree, "VictorQuest")
+        objective_method = _method(quest, "getObjective")
+        encounter_texts = [
+            node.value.value
+            for node in ast.walk(objective_method)
+            if isinstance(node, ast.Return)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+            and "courtyard" in node.value.value
+        ]
+        self.assertIn(
+            "Defeat the cult leader in the courtyard before Victor's daughter is taken.",
+            encounter_texts,
+        )
+
+        leader_trigger = _find_nested_class(self.script_tree, "CultLeaderQuestTrigger")
+        trigger_method = _method(leader_trigger, "trigger")
+        called_methods = {
+            node.func.attr
+            for node in ast.walk(trigger_method)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        self.assertIn("mark_victor_good_end", called_methods)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal
Fix all verified findings from the current-code Nouraajd review with minimal, backward-compatible changes.

## Root causes and changes

### OctoBogz late reward
Destroying `cave2` before accepting the travelers' contract moves `octobogz_contract` to `completed`. `OctoBogzDialog.accept_quest()` already intentionally supports this late-claim state, but the completed dialog branch never invoked it.

Fix: the `contract_completed` ENTRY option now invokes `accept_quest` before entering `COMPLETED_THANKS`. Existing quest insertion and `OCTOBOGZ_REWARD_CLAIMED` guards remain authoritative, so the 1000 gold + Shadow Blade payout remains single-claim.

### Failed dialog actions advancing state
`res/game.py` caught rejected/failed actions and returned normally; `CGameDialogPanel` advanced to `nextStateId` regardless.

Fix: Python action dispatch reports bool success, `CDialog` exposes a checked action path while retaining the existing `void invokeAction` API, and the panel advances only when the action succeeds.

### Retained Nouraajd session replaying entry initialization
`reuseLoadedMap` reattached the player at the destination entry when no explicit `targetCoords` were supplied. For Nouraajd this could replay entry-only initialization and reset quest state.

Fix: `CMapSessionStore` stores the player's departure coordinate alongside a retained map session. Reusing that retained session restores the stored coordinate. Placement precedence is explicit `targetCoords` > retained departure coordinate > normal map entry. Fresh/legacy transitions are unchanged.

### Beren cleanse journal mismatch
The state machine intentionally supports either order: return the relic then kill the OctoBogz, or kill them first then return the relic. The journal incorrectly required a post-relic cave clear.

Fix: objective/hint text now describes the actual order-independent requirement without changing quest states or rewards.

### Victor objective mismatch
The encounter's success trigger is the verified runtime actor `cultLeaderQuest`; remaining `victorCultist*` actors are encounter cleanup after the leader dies. The journal incorrectly said all cultists must be defeated.

Fix: the active objective now names the cult leader. Trigger names and reward behavior are unchanged.

## Verification added
`tests/test_nouraajd_review_regressions.py` is standard-library-only and checks:
- completed OctoBogz dialog invokes the existing late-claim action;
- action dispatch returns success/failure and panel advancement is guarded;
- retained session coordinate storage and placement precedence;
- CleanseCaveQuest text matches order-independent state transitions;
- Victor objective matches the `CultLeaderQuestTrigger` success target.

Normal repository gates should additionally run content validation, native compilation/tests, gameplay, UI, and path-selected coverage.

## Compatibility
No public quest IDs, object names, trigger names, dialog IDs, state IDs, item IDs, campaign outcomes, or existing transition defaults were renamed. Legacy `CGame::changeMap` behavior remains entry-based.